### PR TITLE
Refactor/common build utils

### DIFF
--- a/.fossa.yaml
+++ b/.fossa.yaml
@@ -16,7 +16,7 @@ analyze:
   #     type: folder
   modules:
     - name: fossa-cli
-      path: github.com/fossas/fossa-cli/cmd/fossa
+      path: ./cmd/fossa
       type: gopackage
     # - name: vendored-jquery
     #   path: vendor/jquery-stuff/bower.json

--- a/build/bower.go
+++ b/build/bower.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/bmatcuk/doublestar"
@@ -18,16 +16,15 @@ import (
 
 var bowerLogger = logging.MustGetLogger("bower")
 
-// BowerComponent implements Dependency for BowerBuilder.
+// BowerComponent implements Dependency for BowerBuilder
 type BowerComponent struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
 }
 
-// Fetcher always returns bower for BowerComponent. TODO: Support git and other
-// dependency sources.
+// Fetcher always returns bower for BowerComponent
 func (m BowerComponent) Fetcher() string {
-	return "bower" // TODO: support git and etc...
+	return "bower" // TODO: support `git` and etc...
 }
 
 // Package returns the package name for BowerComponent
@@ -40,8 +37,7 @@ func (m BowerComponent) Revision() string {
 	return m.Version
 }
 
-// BowerBuilder implements Builder for Bower.
-// These properties are public for the sake of serialization.
+// BowerBuilder implements Builder for Bower
 type BowerBuilder struct {
 	NodeCmd     string
 	NodeVersion string
@@ -50,117 +46,107 @@ type BowerBuilder struct {
 	BowerVersion string
 }
 
-// Initialize collects environment data for Bower builds
+// Initialize collects Node and Bower binaries
 func (builder *BowerBuilder) Initialize() error {
-	bowerLogger.Debugf("Initializing Bower builder...")
-	// Set Node context variables
-	nodeCmds := [3]string{os.Getenv("NODE_BINARY"), "node", "nodejs"}
-	for i := 0; true; i++ {
-		if i >= len(nodeCmds) {
-			return errors.New("could not find Nodejs binary (try setting $NODE_BINARY)")
-		}
-		if nodeCmds[i] == "" {
-			continue
-		}
+	bowerLogger.Debug("Initializing Bower builder...")
 
-		nodeVersionOutput, err := exec.Command(nodeCmds[i], "-v").Output()
-		if err == nil && nodeVersionOutput[0] == 'v' {
-			builder.NodeVersion = strings.TrimSpace(string(nodeVersionOutput))[1:]
-			builder.NodeCmd = nodeCmds[i]
-			break
-		}
+	// Set Node context variables
+	nodeCmd, nodeVersion, err := which("-v", os.Getenv("NODE_BINARY"), "node", "nodejs")
+	if err != nil {
+		return errors.New("could not find Node binary (try setting $NODE_BINARY)")
 	}
+	builder.NodeCmd = nodeCmd
+	builder.NodeVersion = nodeVersion
 
 	// Set Bower context variables
-	builder.BowerCmd = os.Getenv("Bower_BINARY")
-	if builder.BowerCmd == "" {
-		builder.BowerCmd = "bower"
-	}
-
-	bowerVersionOutput, err := exec.Command(builder.BowerCmd, "-v").Output()
-	if err == nil && len(bowerVersionOutput) >= 5 {
-		builder.BowerVersion = strings.TrimSpace(string(bowerVersionOutput))
-	}
-
-	if builder.BowerCmd == "" || builder.BowerVersion == "" {
+	bowerCmd, bowerVersion, err := which("-v", os.Getenv("BOWER_BINARY"), "bower")
+	if err != nil {
 		return errors.New("could not find Bower binary (try setting $BOWER_BINARY)")
 	}
+	builder.BowerCmd = bowerCmd
+	builder.BowerVersion = bowerVersion
 
-	bowerLogger.Debugf("Initialized Bower builder: %#v", builder)
-
+	bowerLogger.Debugf("Done initializing Bower builder: %#v", builder)
 	return nil
 }
 
+// Build runs `bower install --production` and cleans with `rm -rf bower_components`
 func (builder *BowerBuilder) Build(m module.Module, force bool) error {
-	bowerLogger.Debugf("Running Bower build...")
+	bowerLogger.Debug("Running Bower build...")
+
 	if force {
-		bowerLogger.Debug("`force` flag is set; clearing `bower_components`...")
-		cmd := exec.Command("rm", "-rf", "bower_components")
-		cmd.Dir = m.Dir
-		_, err := cmd.Output()
+		bowerLogger.Debug("`force` flag is set: running `rm -rf bower_components`...")
+		_, _, err := runLogged(bowerLogger, m.Dir, "rm", "-rf", "bower_components")
 		if err != nil {
 			return err
 		}
 	}
 
-	cmd := exec.Command(builder.BowerCmd, "install", "--production")
-	cmd.Dir = m.Dir
-	_, err := cmd.Output()
-	return err
+	_, _, err := runLogged(bowerLogger, m.Dir, builder.BowerCmd, "install", "--production")
+	if err != nil {
+		return err
+	}
+
+	bowerLogger.Debug("Done running Bower build.")
+	return nil
 }
 
+// Analyze reads package manifests at `$PROJECT/**/bower_components/*/.bower.json`
 func (builder *BowerBuilder) Analyze(m module.Module, _ bool) ([]module.Dependency, error) {
-	bowerLogger.Debugf("Running analysis on Bower module...")
+	bowerLogger.Debug("Running Bower analysis...")
+
+	// Find modules.
 	bowerComponents, err := doublestar.Glob(filepath.Join(m.Dir, "**", "bower_components", "*", ".bower.json"))
 	if err != nil {
 		return nil, err
 	}
-	bowerLogger.Debugf("Found %#v modules from globstar.", len(bowerComponents))
+	bowerLogger.Debugf("Found %#v modules from globstar: %#v", len(bowerComponents), bowerComponents)
 
+	// Read manifests.
 	var wg sync.WaitGroup
-	dependencies := make([]BowerComponent, len(bowerComponents))
+	deps := make([]module.Dependency, len(bowerComponents))
 	wg.Add(len(bowerComponents))
-
 	for i := 0; i < len(bowerComponents); i++ {
 		go func(modulePath string, index int, wg *sync.WaitGroup) {
 			defer wg.Done()
 
 			dependencyManifest, err := ioutil.ReadFile(modulePath)
 			if err != nil {
-				bowerLogger.Warningf("Error parsing Module: %#v", modulePath)
+				bowerLogger.Warningf("Error parsing .bower.json: %#v", modulePath)
 				return
 			}
 
 			// Write directly to a reserved index for thread safety
-			json.Unmarshal(dependencyManifest, &dependencies[index])
+			var bowerComponent BowerComponent
+			json.Unmarshal(dependencyManifest, &bowerComponent)
+			deps[index] = bowerComponent
 		}(bowerComponents[i], i, &wg)
 	}
-
 	wg.Wait()
 
-	var deps []module.Dependency
-	for i := 0; i < len(dependencies); i++ {
-		deps = append(deps, dependencies[i])
-	}
-
+	bowerLogger.Debugf("Done running Bower analysis: %#v", deps)
 	return deps, nil
 }
 
+// IsBuilt checks for the existence of `$PROJECT/bower_components`
 func (builder *BowerBuilder) IsBuilt(m module.Module, _ bool) (bool, error) {
-	bowerComponentsPath := filepath.Join(m.Dir, "bower_components")
-	bowerLogger.Debugf("Checking bower_components at %#v", bowerComponentsPath)
+	bowerLogger.Debug("Checking Bower build...")
+
 	// TODO: Check if the installed modules are consistent with what's in the
 	// actual manifest.
-	if _, err := os.Stat(bowerComponentsPath); err == nil {
-		return true, nil
+	ok, err := hasFile(m.Dir, "bower_components")
+	if err != nil {
+		return false, err
 	}
-	return false, nil
+	return ok, nil
 }
 
+// IsModule is not implemented
 func (builder *BowerBuilder) IsModule(target string) (bool, error) {
 	return false, errors.New("IsModule is not implemented for BowerBuilder")
 }
 
+// InferModule is not implemented
 func (builder *BowerBuilder) InferModule(target string) (module.Module, error) {
 	return module.Module{}, errors.New("InferModule is not implemented for BowerBuilder")
 }

--- a/build/bower.go
+++ b/build/bower.go
@@ -93,7 +93,7 @@ func (builder *BowerBuilder) Build(m module.Module, force bool) error {
 func (builder *BowerBuilder) Analyze(m module.Module, allowUnresolved bool) ([]module.Dependency, error) {
 	bowerLogger.Debugf("Running Bower analysis: %#v %#v", m, allowUnresolved)
 
-	// Find modules.
+	// Find manifests.
 	bowerComponents, err := doublestar.Glob(filepath.Join(m.Dir, "**", "bower_components", "*", ".bower.json"))
 	if err != nil {
 		return nil, fmt.Errorf("could not find Bower dependency manifests: %s", err.Error())

--- a/build/bower.go
+++ b/build/bower.go
@@ -45,7 +45,7 @@ type BowerBuilder struct {
 	BowerVersion string
 }
 
-// Initialize collects Node and Bower binaries
+// Initialize collects metadata on Node and Bower binaries
 func (builder *BowerBuilder) Initialize() error {
 	bowerLogger.Debug("Initializing Bower builder...")
 

--- a/build/common.go
+++ b/build/common.go
@@ -3,6 +3,7 @@ package build
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -78,7 +79,7 @@ func runLogged(logger *logging.Logger, dir string, name string, arg ...string) (
 	if err != nil {
 		cmd := strings.Join(append([]string{name}, arg...), " ")
 		logger.Debugf("Running `%s` failed: %#v %#v", cmd, err, stderr)
-		return "", "", err
+		return "", "", fmt.Errorf("running `%s` failed: %#v %#v", cmd, err, stderr)
 	}
 	return stdout, stderr, nil
 }

--- a/build/common.go
+++ b/build/common.go
@@ -2,8 +2,10 @@ package build
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +13,8 @@ import (
 
 	logging "github.com/op/go-logging"
 )
+
+var commonLogger = logging.MustGetLogger("common")
 
 // Utilities for finding files and manifests
 func hasFile(elem ...string) (bool, error) {
@@ -21,7 +25,7 @@ func hasFile(elem ...string) (bool, error) {
 	return !os.IsNotExist(err), err
 }
 
-func orPredicates(predicates ...stopPredicate) stopPredicate {
+func orPredicates(predicates ...fileChecker) fileChecker {
 	return func(path string) (bool, error) {
 		for _, predicate := range predicates {
 			ok, err := predicate(path)
@@ -36,9 +40,9 @@ func orPredicates(predicates ...stopPredicate) stopPredicate {
 	}
 }
 
-type stopPredicate func(path string) (bool, error)
+type fileChecker func(path string) (bool, error)
 
-func findAncestor(stopWhen stopPredicate, path string) (string, bool, error) {
+func findAncestor(stopWhen fileChecker, path string) (string, bool, error) {
 	absPath, err := filepath.Abs(path)
 	if absPath == string(filepath.Separator) {
 		return "", false, nil
@@ -74,14 +78,41 @@ func runInDir(dir string, name string, arg ...string) (string, string, error) {
 	return string(stdout), stderr.String(), err
 }
 
+// Utilities for debug logging
 func runLogged(logger *logging.Logger, dir string, name string, arg ...string) (string, string, error) {
+	cmd := strings.Join(append([]string{name}, arg...), " ")
+	logger.Debugf("Running `%s`...", cmd)
 	stdout, stderr, err := runInDir(dir, name, arg...)
 	if err != nil {
-		cmd := strings.Join(append([]string{name}, arg...), " ")
 		logger.Debugf("Running `%s` failed: %#v %#v", cmd, err, stderr)
 		return "", "", fmt.Errorf("running `%s` failed: %#v %#v", cmd, err, stderr)
 	}
+	logger.Debugf("Done running `%s`: %#v %#v", stdout, stderr)
 	return stdout, stderr, nil
+}
+
+func parseLogged(logger *logging.Logger, file string, v interface{}) error {
+	return parseLoggedWithUnmarshaller(logger, file, v, json.Unmarshal)
+}
+
+type unmarshaller func(data []byte, v interface{}) error
+
+func parseLoggedWithUnmarshaller(logger *logging.Logger, file string, v interface{}, unmarshal unmarshaller) error {
+	logger.Debugf("Parsing %s...", file)
+
+	contents, err := ioutil.ReadFile(file)
+	if err != nil {
+		logger.Debugf("Error reading %s: %s", file, err.Error())
+		return err
+	}
+	err = unmarshal(contents, v)
+	if err != nil {
+		logger.Debugf("Error parsing %s: %#v %#v", file, err, contents)
+		return err
+	}
+
+	logger.Debugf("Done parsing %s.", file)
+	return nil
 }
 
 // Utilities for detecting which binary to use
@@ -93,16 +124,20 @@ func whichWithResolver(cmds []string, getVersion versionResolver) (string, strin
 		if err == nil {
 			return cmd, version, nil
 		}
+		commonLogger.Debugf("Tried resolving `%s` but did not work: %#v %#v", cmd, err, version)
 	}
 	return "", "", errors.New("could not resolve version")
 }
 
 func which(versionFlags string, cmds ...string) (string, string, error) {
 	return whichWithResolver(cmds, func(cmd string) (string, error) {
-		version, _, err := run(cmd, strings.Split(versionFlags, " ")...)
+		stdout, stderr, err := run(cmd, strings.Split(versionFlags, " ")...)
 		if err != nil {
 			return "", err
 		}
-		return version, nil
+		if stdout == "" {
+			return stderr, nil
+		}
+		return stdout, nil
 	})
 }

--- a/build/common.go
+++ b/build/common.go
@@ -1,0 +1,107 @@
+package build
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	logging "github.com/op/go-logging"
+)
+
+// Utilities for finding files and manifests
+func hasFile(elem ...string) (bool, error) {
+	_, err := os.Stat(filepath.Join(elem...))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return !os.IsNotExist(err), err
+}
+
+func orPredicates(predicates ...stopPredicate) stopPredicate {
+	return func(path string) (bool, error) {
+		for _, predicate := range predicates {
+			ok, err := predicate(path)
+			if err != nil {
+				return false, err
+			}
+			if ok {
+				return ok, nil
+			}
+		}
+		return false, nil
+	}
+}
+
+type stopPredicate func(path string) (bool, error)
+
+func findAncestor(stopWhen stopPredicate, path string) (string, bool, error) {
+	absPath, err := filepath.Abs(path)
+	if absPath == string(filepath.Separator) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	stop, err := stopWhen(absPath)
+	if err != nil {
+		return "", false, err
+	}
+	if stop {
+		return absPath, true, nil
+	}
+	return findAncestor(stopWhen, filepath.Dir(path))
+}
+
+// Utilities around `exec.Command`
+func run(name string, arg ...string) (string, string, error) {
+	var stderr bytes.Buffer
+	cmd := exec.Command(name, arg...)
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	return string(stdout), stderr.String(), err
+}
+
+func runInDir(dir string, name string, arg ...string) (string, string, error) {
+	var stderr bytes.Buffer
+	cmd := exec.Command(name, arg...)
+	cmd.Dir = dir
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	return string(stdout), stderr.String(), err
+}
+
+func runLogged(logger *logging.Logger, dir string, name string, arg ...string) (string, string, error) {
+	stdout, stderr, err := runInDir(dir, name, arg...)
+	if err != nil {
+		cmd := strings.Join(append([]string{name}, arg...), " ")
+		logger.Debugf("Running `%s` failed: %#v %#v", cmd, err, stderr)
+		return "", "", err
+	}
+	return stdout, stderr, nil
+}
+
+// Utilities for detecting which binary to use
+type versionResolver func(cmd string) (string, error)
+
+func whichWithResolver(cmds []string, getVersion versionResolver) (string, string, error) {
+	for _, cmd := range cmds {
+		version, err := getVersion(cmd)
+		if err == nil {
+			return cmd, version, nil
+		}
+	}
+	return "", "", errors.New("could not resolve version")
+}
+
+func which(versionFlags string, cmds ...string) (string, string, error) {
+	return whichWithResolver(cmds, func(cmd string) (string, error) {
+		version, _, err := run(cmd, strings.Split(versionFlags, " ")...)
+		if err != nil {
+			return "", err
+		}
+		return version, nil
+	})
+}

--- a/build/composer.go
+++ b/build/composer.go
@@ -37,11 +37,11 @@ func (m ComposerPackage) Revision() string {
 
 // ComposerBuilder implements Builder for Composer (composer.json) builds
 type ComposerBuilder struct {
-	ComposerCmd     string
-	ComposerVersion string
-
 	PHPCmd     string
 	PHPVersion string
+
+	ComposerCmd     string
+	ComposerVersion string
 }
 
 // Initialize collects PHP and Composer binaries

--- a/build/composer.go
+++ b/build/composer.go
@@ -51,7 +51,7 @@ func (builder *ComposerBuilder) Initialize() error {
 	// Set PHP context variables
 	phpCmd, phpVersion, err := which("-v", os.Getenv("PHP_BINARY"), "php")
 	if err != nil {
-		return errors.New("could not find PHP binary (try setting $PHP_BINARY)")
+		return fmt.Errorf("could not find PHP binary (try setting $PHP_BINARY): %s", err.Error())
 	}
 	builder.PHPCmd = phpCmd
 	builder.PHPVersion = phpVersion
@@ -59,7 +59,7 @@ func (builder *ComposerBuilder) Initialize() error {
 	// Set Composer context variables
 	composerCmd, composerVersion, err := which("-V", os.Getenv("COMPOSER_BINARY"), "composer")
 	if err != nil {
-		return errors.New("could not find Composer binary (try setting $COMPOSER_BINARY)")
+		return fmt.Errorf("could not find Composer binary (try setting $COMPOSER_BINARY): %s", err.Error())
 	}
 	builder.ComposerCmd = composerCmd
 	builder.ComposerVersion = composerVersion
@@ -73,7 +73,6 @@ func (builder *ComposerBuilder) Build(m module.Module, force bool) error {
 	composerLogger.Debug("Running Composer build: %#v %#v", m, force)
 
 	if force {
-		composerLogger.Debug("`force` flag is set: running `rm -rf vendor`...")
 		_, _, err := runLogged(composerLogger, m.Dir, "rm", "-rf", "vendor")
 		if err != nil {
 			return fmt.Errorf("could not remove Composer cache: %s", err.Error())

--- a/build/composer.go
+++ b/build/composer.go
@@ -44,7 +44,7 @@ type ComposerBuilder struct {
 	ComposerVersion string
 }
 
-// Initialize collects PHP and Composer binaries
+// Initialize collects metadata on PHP and Composer binaries
 func (builder *ComposerBuilder) Initialize() error {
 	composerLogger.Debug("Initializing Composer builder...")
 

--- a/build/composer.go
+++ b/build/composer.go
@@ -81,7 +81,7 @@ func (builder *ComposerBuilder) Build(m module.Module, force bool) error {
 
 	_, _, err := runLogged(composerLogger, m.Dir, builder.ComposerCmd, "install", "--prefer-dist", "--no-dev")
 	if err != nil {
-		return fmt.Errorf("could not remove Composer build: %s", err.Error())
+		return fmt.Errorf("could not run Composer build: %s", err.Error())
 	}
 
 	composerLogger.Debug("Done running Composer build.")

--- a/build/golang.go
+++ b/build/golang.go
@@ -72,7 +72,7 @@ type GoBuilder struct {
 	// make by caching results within private fields of `GoBuilder`.
 }
 
-// Initialize gathers environment context.
+// Initialize collects metadata on Go, Dep, Glide, Godep, Govendor, and Vndr binaries.
 func (builder *GoBuilder) Initialize() error {
 	goLogger.Debug("Initializing Go builder...")
 
@@ -204,6 +204,7 @@ func (builder *GoBuilder) Build(m module.Module, force bool) error {
 	}
 	goLogger.Debugf("Found project folder for Go build: %#v", projectFolder)
 
+	// Run build tools
 	err = runGoTool(projectFolder, hasDepManifest, "dep ensure", "rm -rf vendor Gopkg.lock", force)
 	if err != nil {
 		return err

--- a/build/maven.go
+++ b/build/maven.go
@@ -2,8 +2,8 @@ package build
 
 import (
 	"errors"
+	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -43,74 +43,65 @@ type MavenBuilder struct {
 	JavaVersion string
 }
 
+// Initialize collects Java and Maven binaries
 func (builder *MavenBuilder) Initialize() error {
-	builder.MvnCmd = string(os.Getenv("MVN_BINARY"))
-	if builder.MvnCmd == "" {
-		builder.MvnCmd = "mvn"
-	}
+	mavenLogger.Debug("Initializing Maven builder...")
 
-	mavenVersionOutput, err := exec.Command(builder.MvnCmd, "-v").Output()
+	// Set Java context variables
+	javaCmd, javaVersion, err := which("-version", os.Getenv("JAVA_BINARY"), "java")
 	if err != nil {
-		return err
+		return fmt.Errorf("could not find Java binary (try setting $JAVA_BINARY): %s", err.Error())
 	}
-	if len(mavenVersionOutput) >= 10 { // x.x.x
-		outputMatchRe := regexp.MustCompile(`Apache Maven ([0-9]+\.[0-9]+\.[0-9]+)`)
-		match := outputMatchRe.FindStringSubmatch(strings.TrimSpace(string(mavenVersionOutput)))
-		if len(match) == 2 {
-			builder.MvnVersion = match[1]
-		}
+	builder.JavaCmd = javaCmd
+	builder.JavaVersion = javaVersion
+
+	// Set Maven context variables
+	mavenCmd, mavenVersion, err := which("--version", os.Getenv("MAVEN_BINARY"), "mvn")
+	if err != nil {
+		return fmt.Errorf("could not find Maven binary (try setting $MAVEN_BINARY): %s", err.Error())
 	}
+	builder.MvnCmd = mavenCmd
+	builder.MvnVersion = mavenVersion
 
-	if builder.MvnCmd == "" || builder.MvnVersion == "" {
-		return errors.New("could not find mvn (try setting $MVN_BINARY)")
-	}
-
-	// TODO: collect Java information
-
+	mavenLogger.Debugf("Done initializing Maven builder: %#v", builder)
 	return nil
 }
 
+// Build runs `mvn install -DskipTests -Drat.skip=trucould not removee` and cleans with `mvn clean`
 func (builder *MavenBuilder) Build(m module.Module, force bool) error {
-	mavenLogger.Debugf("Running Maven build")
+	mavenLogger.Debugf("Running Maven build: %#v %#v", m, force)
+
 	if force {
-		mavenLogger.Debugf("`force` flag is set: clearing install cache.")
-		mavenLogger.Debugf("Running `mvn clean`...")
-		cmd := exec.Command(builder.MvnCmd, "clean")
-		cmd.Dir = m.Dir
-		output, err := cmd.Output()
-		mavenLogger.Debugf("...running `mvn clean` done: %#v", string(output))
+		_, _, err := runLogged(mavenLogger, m.Dir, builder.MvnCmd, "clean")
 		if err != nil {
-			return err
+			return fmt.Errorf("could not remove Maven cache: %s", err.Error())
 		}
 	}
 
-	mavenLogger.Debugf("Running `mvn install -DskipTests -Drat.skip=true`...")
-	cmd := exec.Command(builder.MvnCmd, "install", "-DskipTests", "-Drat.skip=true")
-	cmd.Dir = m.Dir
-	output, err := cmd.Output()
-	mavenLogger.Debugf("...running `mvn install -DskipTests -Drat.skip=true` done: %#v", string(output))
+	_, _, err := runLogged(mavenLogger, m.Dir, builder.MvnCmd, "install", "-DskipTests", "-Drat.skip=true")
 	if err != nil {
-		return err
+		return fmt.Errorf("could not run Maven build: %s", err.Error())
 	}
 
+	mavenLogger.Debug("Done running Maven build.")
 	return nil
 }
 
-func (builder *MavenBuilder) Analyze(m module.Module, _ bool) ([]module.Dependency, error) {
-	mavenLogger.Debugf("Running Maven analysis")
-	cmd := exec.Command(builder.MvnCmd, "dependency:list")
-	cmd.Dir = m.Dir
-	output, err := cmd.Output()
+// Analyze parses the output of `mvn dependency:list`
+func (builder *MavenBuilder) Analyze(m module.Module, allowUnresolved bool) ([]module.Dependency, error) {
+	mavenLogger.Debugf("Running Maven analysis: %#v %#v", m, allowUnresolved)
+
+	output, _, err := runLogged(mavenLogger, m.Dir, builder.MvnCmd, "dependency:list")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not get dependency list from Maven: %s", err.Error())
 	}
 
 	deps := []module.Dependency{}
 	outputMatchRe := regexp.MustCompile(`\[INFO\]    ([^:]+):([^:]+):(jar|war|java-source|):([^:]+)`)
-	for _, bundleListLn := range strings.Split(string(output), "\n") {
-		bundleListLn = strings.TrimSpace(bundleListLn)
-		if len(bundleListLn) > 0 {
-			match := outputMatchRe.FindStringSubmatch(bundleListLn)
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) > 0 {
+			match := outputMatchRe.FindStringSubmatch(trimmed)
 			if len(match) == 5 {
 				deps = append(deps, module.Dependency(MavenArtifact{
 					Name:    match[1] + ":" + match[2],
@@ -120,30 +111,33 @@ func (builder *MavenBuilder) Analyze(m module.Module, _ bool) ([]module.Dependen
 		}
 	}
 
+	mavenLogger.Debugf("Done running Maven analysis: %#v", deps)
 	return deps, nil
 }
 
-// IsBuilt checks whether dependencies are ready for scanning.
-func (builder *MavenBuilder) IsBuilt(m module.Module, _ bool) (bool, error) {
-	mavenLogger.Debugf("Running `mvn dependency:list` for IsBuilt...")
-	cmd := exec.Command(builder.MvnCmd, "dependency:list")
-	cmd.Dir = m.Dir
-	output, err := cmd.Output()
-	outStr := string(output)
-	mavenLogger.Debugf("...running `mvn dependency:list` done: %#v", outStr)
+// IsBuilt checks whether `mvn dependency:list` produces output.
+func (builder *MavenBuilder) IsBuilt(m module.Module, allowUnresolved bool) (bool, error) {
+	mavenLogger.Debugf("Checking Maven build: %#v %#v", m, allowUnresolved)
+
+	output, _, err := runLogged(mavenLogger, m.Dir, builder.MvnCmd, "dependency:list")
 	if err != nil {
-		if strings.Index(outStr, "Could not find artifact") != -1 {
+		if strings.Index(output, "Could not find artifact") != -1 {
 			return false, nil
 		}
 		return false, err
 	}
-	return outStr != "", nil
+	isBuilt := output != ""
+
+	mavenLogger.Debugf("Done checking Maven build: %#v", isBuilt)
+	return isBuilt, nil
 }
 
+// IsModule is not implemented
 func (builder *MavenBuilder) IsModule(target string) (bool, error) {
 	return false, errors.New("IsModule is not implemented for MavenBuilder")
 }
 
+// InferModule is not implemented
 func (builder *MavenBuilder) InferModule(target string) (module.Module, error) {
 	return module.Module{}, errors.New("InferModule is not implemented for MavenBuilder")
 }

--- a/build/maven.go
+++ b/build/maven.go
@@ -36,11 +36,11 @@ func (m MavenArtifact) Revision() string {
 
 // MavenBuilder implements Builder for Apache Maven (*.pom.xml) builds
 type MavenBuilder struct {
-	MvnCmd     string
-	MvnVersion string
-
 	JavaCmd     string
 	JavaVersion string
+
+	MvnCmd     string
+	MvnVersion string
 }
 
 // Initialize collects Java and Maven binaries

--- a/build/maven.go
+++ b/build/maven.go
@@ -7,8 +7,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/fossas/fossa-cli/module"
 	logging "github.com/op/go-logging"
+
+	"github.com/fossas/fossa-cli/module"
 )
 
 var mavenLogger = logging.MustGetLogger("maven")
@@ -43,7 +44,7 @@ type MavenBuilder struct {
 	MvnVersion string
 }
 
-// Initialize collects Java and Maven binaries
+// Initialize collects metadata on Java and Maven binaries
 func (builder *MavenBuilder) Initialize() error {
 	mavenLogger.Debug("Initializing Maven builder...")
 

--- a/build/nodejs.go
+++ b/build/nodejs.go
@@ -1,13 +1,10 @@
 package build
 
 import (
-	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/bmatcuk/doublestar"
@@ -46,8 +43,8 @@ type NodeJSBuilder struct {
 	NodeCmd     string
 	NodeVersion string
 
-	NpmCmd     string
-	NpmVersion string
+	NPMCmd     string
+	NPMVersion string
 
 	YarnCmd     string
 	YarnVersion string
@@ -56,139 +53,114 @@ type NodeJSBuilder struct {
 // Initialize collects environment data for Nodejs builds
 func (builder *NodeJSBuilder) Initialize() error {
 	nodejsLogger.Debugf("Initializing Nodejs builder...")
-	// Set NodeJS context variables
-	nodeCmds := [3]string{os.Getenv("NODE_BINARY"), "node", "nodejs"}
-	for i := 0; true; i++ {
-		if i >= len(nodeCmds) {
-			return errors.New("could not find Nodejs binary (try setting $NODE_BINARY)")
-		}
-		if nodeCmds[i] == "" {
-			continue
-		}
 
-		nodeVersionOutput, err := exec.Command(nodeCmds[i], "-v").Output()
-		if err == nil && nodeVersionOutput[0] == 'v' {
-			builder.NodeVersion = strings.TrimSpace(string(nodeVersionOutput))[1:]
-			builder.NodeCmd = nodeCmds[i]
-			break
-		}
+	// Set NodeJS context variables
+	nodeCmd, nodeVersion, err := which("-v", os.Getenv("NODE_BINARY"), "node", "nodejs")
+	if err != nil {
+		return fmt.Errorf("could not find Node binary (try setting $NODE_BINARY): %s", err.Error())
 	}
+	builder.NodeCmd = nodeCmd
+	builder.NodeVersion = nodeVersion
 
 	// Set NPM context variables
-	builder.NpmCmd = os.Getenv("NPM_BINARY")
-	if builder.NpmCmd == "" {
-		builder.NpmCmd = "npm"
-	}
-
-	npmVersionOutput, err := exec.Command(builder.NpmCmd, "-v").Output()
-	if err == nil && len(npmVersionOutput) >= 5 {
-		builder.NpmVersion = strings.TrimSpace(string(npmVersionOutput))
-	}
+	npmCmd, npmVersion, npmErr := which("-v", os.Getenv("NPM_BINARY"), "npm")
+	builder.NPMCmd = npmCmd
+	builder.NPMVersion = npmVersion
 
 	// Set Yarn context variables
-	builder.YarnCmd = string(os.Getenv("YARN_BINARY"))
-	if builder.YarnCmd == "" {
-		builder.YarnCmd = "yarn"
-	}
-	yarnVersionOutput, err := exec.Command(builder.YarnCmd, "-v").Output()
-	if err == nil && len(yarnVersionOutput) >= 5 {
-		builder.YarnVersion = strings.TrimSpace(string(yarnVersionOutput))
-	}
+	yarnCmd, yarnVersion, yarnErr := which("-v", os.Getenv("YARN_BINARY"), "yarn")
+	builder.YarnCmd = yarnCmd
+	builder.YarnVersion = yarnVersion
 
-	if (builder.NpmCmd == "" || builder.NpmVersion == "") && (builder.YarnCmd == "" || builder.YarnVersion == "") {
-		return errors.New("could not find NPM binary or Yarn binary (try setting $NPM_BINARY or $YARN_BINARY)")
+	if npmErr != nil && yarnErr != nil {
+		return fmt.Errorf("no supported Nodejs build tools detected (try setting $NPM_BINARY or $YARN_BINARY): %#v %#v", npmErr, yarnErr)
 	}
 
 	nodejsLogger.Debugf("Initialized Nodejs builder: %#v", builder)
-
 	return nil
 }
 
+// Build runs either `yarn install --production --frozen-lockfile` or `npm install --production` and cleans with `rm -rf node_modules`
 func (builder *NodeJSBuilder) Build(m module.Module, force bool) error {
-	nodejsLogger.Debugf("Running Nodejs build...")
+	nodejsLogger.Debugf("Running Nodejs build: %#v %#v", m, force)
+
 	if force {
-		nodejsLogger.Debug("`force` flag is set; clearing `node_modules`...")
-		cmd := exec.Command("rm", "-rf", "node_modules")
-		cmd.Dir = m.Dir
-		_, err := cmd.Output()
+		_, _, err := runLogged(nodejsLogger, m.Dir, "rm", "-rf", "node_modules")
 		if err != nil {
-			return err
+			return fmt.Errorf("could not remove Nodejs cache: %s", err.Error())
 		}
 	}
 
 	// Prefer Yarn where possible
-	if _, err := os.Stat(filepath.Join(m.Dir, "yarn.lock")); err == nil {
-		nodejsLogger.Debugf("Yarn lockfile detected.")
-		if builder.YarnCmd == "" {
-			return errors.New("Yarn lockfile found but could not find Yarn binary (try setting $YARN_BINARY)")
+	if ok, err := hasFile(m.Dir, "yarn.lock"); err == nil && ok {
+		_, _, err := runLogged(nodejsLogger, m.Dir, builder.YarnCmd, "install", "--production", "--frozen-lockfile")
+		if err != nil {
+			return fmt.Errorf("could not run Yarn build: %s", err.Error())
 		}
-
-		// TODO(xizhao): Verify compatible yarn versions
-		nodejsLogger.Debugf("Running `yarn install --production --frozen-lockfile`.")
-		cmd := exec.Command(builder.YarnCmd, "install", "--production", "--frozen-lockfile")
-		cmd.Dir = m.Dir
-		_, err := cmd.Output()
-		return err
+	} else {
+		_, _, err := runLogged(nodejsLogger, m.Dir, builder.NPMCmd, "install", "--production")
+		if err != nil {
+			return fmt.Errorf("could not run NPM build: %s", err.Error())
+		}
 	}
 
-	cmd := exec.Command(builder.NpmCmd, "install", "--production")
-	cmd.Dir = m.Dir
-	_, err := cmd.Output()
-	return err
+	nodejsLogger.Debug("Done running Nodejs build.")
+	return nil
 }
 
-func (builder *NodeJSBuilder) Analyze(m module.Module, _ bool) ([]module.Dependency, error) {
-	nodejsLogger.Debugf("Running analysis on Nodejs module...")
+// Analyze reads dependency manifests at `$PROJECT/**/node_modules/*/package.json`
+func (builder *NodeJSBuilder) Analyze(m module.Module, allowUnresolved bool) ([]module.Dependency, error) {
+	nodejsLogger.Debugf("Running Nodejs analysis: %#v %#v", m, allowUnresolved)
+
+	// Find manifests.
 	nodeModules, err := doublestar.Glob(filepath.Join(m.Dir, "**", "node_modules", "*", "package.json"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not find Nodejs dependency manifests: %s", err.Error())
 	}
-	nodejsLogger.Debugf("Found %#v modules from globstar.", len(nodeModules))
+	nodejsLogger.Debugf("Found %#v modules from globstar: %#v", len(nodeModules), nodeModules)
 
+	// Read manifests.
 	var wg sync.WaitGroup
-	dependencies := make([]NodeModule, len(nodeModules))
+	deps := make([]module.Dependency, len(nodeModules))
 	wg.Add(len(nodeModules))
-
 	for i := 0; i < len(nodeModules); i++ {
 		go func(modulePath string, index int, wg *sync.WaitGroup) {
 			defer wg.Done()
 
-			dependencyManifest, err := ioutil.ReadFile(modulePath)
-			if err != nil {
-				nodejsLogger.Warningf("Error parsing Module: %#v", modulePath)
-				return
-			}
+			var nodeModule NodeModule
+			parseLogged(nodejsLogger, modulePath, &nodeModule)
 
 			// Write directly to a reserved index for thread safety
-			json.Unmarshal(dependencyManifest, &dependencies[index])
+			deps[index] = nodeModule
 		}(nodeModules[i], i, &wg)
 	}
-
 	wg.Wait()
 
-	var deps []module.Dependency
-	for i := 0; i < len(dependencies); i++ {
-		deps = append(deps, dependencies[i])
-	}
-
+	nodejsLogger.Debugf("Done running Nodejs analysis: %#v", deps)
 	return deps, nil
 }
 
-func (builder *NodeJSBuilder) IsBuilt(m module.Module, _ bool) (bool, error) {
-	nodeModulesPath := filepath.Join(m.Dir, "node_modules")
-	nodejsLogger.Debugf("Checking node_modules at %#v", nodeModulesPath)
+// IsBuilt checks for the existence of `$PROJECT/node_modules`
+func (builder *NodeJSBuilder) IsBuilt(m module.Module, allowUnresolved bool) (bool, error) {
+	nodejsLogger.Debugf("Checking Nodejs build: %#v %#v", m, allowUnresolved)
+
 	// TODO: Check if the installed modules are consistent with what's in the
 	// actual manifest.
-	if _, err := os.Stat(nodeModulesPath); err == nil {
-		return true, nil
+	isBuilt, err := hasFile(m.Dir, "node_modules")
+	if err != nil {
+		return false, fmt.Errorf("could not find Nodejs dependencies folder: %s", err.Error())
 	}
-	return false, nil
+
+	nodejsLogger.Debugf("Done checking Nodejs build: %#v", isBuilt)
+	return isBuilt, nil
 }
 
+// IsModule is not implemented
 func (builder *NodeJSBuilder) IsModule(target string) (bool, error) {
 	return false, errors.New("IsModule is not implemented for NodeJSBuilder")
 }
 
+// InferModule is not implemented
 func (builder *NodeJSBuilder) InferModule(target string) (module.Module, error) {
 	return module.Module{}, errors.New("InferModule is not implemented for NodeJSBuilder")
 }

--- a/build/nodejs.go
+++ b/build/nodejs.go
@@ -50,9 +50,9 @@ type NodeJSBuilder struct {
 	YarnVersion string
 }
 
-// Initialize collects environment data for Nodejs builds
+// Initialize collects metadata on Node, NPM, and Yarn binaries
 func (builder *NodeJSBuilder) Initialize() error {
-	nodejsLogger.Debugf("Initializing Nodejs builder...")
+	nodejsLogger.Debug("Initializing Nodejs builder...")
 
 	// Set NodeJS context variables
 	nodeCmd, nodeVersion, err := which("-v", os.Getenv("NODE_BINARY"), "node", "nodejs")

--- a/build/sbt.go
+++ b/build/sbt.go
@@ -8,8 +8,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/fossas/fossa-cli/module"
 	logging "github.com/op/go-logging"
+
+	"github.com/fossas/fossa-cli/module"
 )
 
 var sbtLogger = logging.MustGetLogger("sbt")

--- a/build/sbt.go
+++ b/build/sbt.go
@@ -1,11 +1,9 @@
 package build
 
 import (
-	"bytes"
 	"errors"
+	"fmt"
 	"os"
-	"os/exec"
-	"regexp"
 	"strings"
 
 	logging "github.com/op/go-logging"
@@ -48,94 +46,61 @@ type SBTBuilder struct {
 	JavaVersion string
 }
 
-// Initialize collects environment data for SBT builds
+// Initialize collects metadata on Java and SBT binaries
 func (builder *SBTBuilder) Initialize() error {
 	sbtLogger.Debugf("Initializing SBT builder...")
 
-	builder.SBTCmd = string(os.Getenv("SBT_BINARY"))
-	if builder.SBTCmd == "" {
-		builder.SBTCmd = "sbt"
-	}
-	sbtAboutOutput, err := exec.Command(builder.SBTCmd, "-no-colors", "about").Output()
+	// Set Java context variables
+	javaCmd, javaVersion, err := which("-version", os.Getenv("JAVA_BINARY"), "java")
 	if err != nil {
-		return err
+		return fmt.Errorf("could not find Java binary (try setting $JAVA_BINARY): %s", err.Error())
 	}
+	builder.JavaCmd = javaCmd
+	builder.JavaVersion = javaVersion
 
-	lines := strings.Split(string(sbtAboutOutput), "\n")
-	matcher := regexp.MustCompile(`^\[info\] This is sbt (.*?)$`)
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		matches := matcher.FindStringSubmatch(line)
-		if len(matches) == 2 {
-			builder.SBTVersion = matches[1]
-		}
-	}
-
-	builder.JavaCmd = string(os.Getenv("JAVA_BINARY"))
-	if builder.JavaCmd == "" {
-		builder.JavaCmd = "java"
-	}
-	var javaVersionOutput bytes.Buffer
-	cmd := exec.Command(builder.JavaCmd, "-version")
-	cmd.Stderr = &javaVersionOutput
-	_, err = cmd.Output()
+	// Set SBT context variables
+	sbtCmd, sbtVersion, err := which("-no-colors about", os.Getenv("SBT_BINARY"), "sbt")
 	if err != nil {
-		return err
+		return fmt.Errorf("could not find SBT binary (try setting $SBT_BINARY): %s", err.Error())
 	}
-	builder.JavaVersion = javaVersionOutput.String()
-
-	if builder.SBTCmd == "" || builder.SBTVersion == "" {
-		return errors.New("could not find sbt (try setting $SBT_BINARY)")
-	}
+	builder.SBTCmd = sbtCmd
+	builder.SBTVersion = sbtVersion
 
 	sbtLogger.Debugf("Initialized SBT builder: %#v", builder)
 	return nil
 }
 
+// Build runs `sbt compile` and cleans with `sbt clean`
 func (builder *SBTBuilder) Build(m module.Module, force bool) error {
-	sbtLogger.Debugf("Running SBT build on %#v", m)
+	sbtLogger.Debugf("Running SBT build: %#v %#v", m, force)
+
 	if force {
-		sbtLogger.Debugf("`force` flag is set; running `%s clean`...", builder.SBTCmd)
-		cmd := exec.Command(builder.SBTCmd, "clean")
-		cmd.Dir = m.Dir
-		output, err := cmd.Output()
+		_, _, err := runLogged(sbtLogger, m.Dir, builder.SBTCmd, "clean")
 		if err != nil {
-			sbtLogger.Debugf("`%s clean` failed; output: %#v", builder.SBTCmd, string(output))
-			return err
+			return fmt.Errorf("could not remove SBT cache: %s", err.Error())
 		}
-		sbtLogger.Debugf("Done running `%s clean`.", builder.SBTCmd)
 	}
 
-	sbtLogger.Debugf("Running `%s compile`...", builder.SBTCmd)
-	cmd := exec.Command(builder.SBTCmd, "compile")
-	cmd.Dir = m.Dir
-	output, err := cmd.Output()
+	_, _, err := runLogged(sbtLogger, m.Dir, builder.SBTCmd, "compile")
 	if err != nil {
-		sbtLogger.Debugf("`%s compile` failed; output: %#v", builder.SBTCmd, string(output))
-		return err
+		return fmt.Errorf("could not run SBT build: %s", err.Error())
 	}
-	sbtLogger.Debugf("Done running `%s compile`.", builder.SBTCmd)
 
-	sbtLogger.Debugf("Done running SBT build.")
+	sbtLogger.Debug("Done running SBT build.")
 	return nil
 }
 
-func (builder *SBTBuilder) Analyze(m module.Module, _ bool) ([]module.Dependency, error) {
-	sbtLogger.Debugf("Running SBT analysis on %#v", m)
-	sbtLogger.Debugf("Running `%s -no-colors dependencyList`...", builder.SBTCmd)
-	cmd := exec.Command(builder.SBTCmd, "-no-colors", "dependencyList")
-	cmd.Dir = m.Dir
-	output, err := cmd.Output()
-	outStr := string(output)
-	if err != nil {
-		sbtLogger.Debugf("`%s -no-colors dependencyList` failed; output: %#v", builder.SBTCmd, outStr)
-		return nil, err
-	}
-	sbtLogger.Debugf("Done running `%s -no-colors dependencyList`.", builder.SBTCmd)
+// Analyze parses the output of `sbt -no-colors dependencyList`
+func (builder *SBTBuilder) Analyze(m module.Module, allowUnresolved bool) ([]module.Dependency, error) {
+	sbtLogger.Debugf("Running SBT analysis: %#v %#v", m, allowUnresolved)
 
-	sbtLogger.Debugf("Parsing SBT output...")
+	output, _, err := runLogged(sbtLogger, m.Dir, builder.SBTCmd, "-no-colors", "dependencyList")
+	if err != nil {
+		return nil, fmt.Errorf("could not get dependency list from SBT: %s", err.Error())
+	}
+
 	deps := []module.Dependency{}
-	for _, line := range strings.Split(outStr, "\n") {
+	for _, line := range strings.Split(output, "\n") {
 		if strings.Index(line, "[info] Loading ") != -1 ||
 			strings.Index(line, "[info] Resolving ") != -1 ||
 			strings.Index(line, "[info] Set ") != -1 ||
@@ -158,37 +123,31 @@ func (builder *SBTBuilder) Analyze(m module.Module, _ bool) ([]module.Dependency
 			deps = append(deps, dep)
 		}
 	}
-	sbtLogger.Debugf("Done parsing SBT output.")
 
 	sbtLogger.Debugf("Done running SBT analysis: %#v", deps)
 	return deps, nil
 }
 
 // IsBuilt checks whether dependencies are ready for scanning.
-func (builder *SBTBuilder) IsBuilt(m module.Module, _ bool) (bool, error) {
-	sbtLogger.Debugf("Checking SBT IsBuilt on %#v", m)
+func (builder *SBTBuilder) IsBuilt(m module.Module, allowUnresolved bool) (bool, error) {
+	sbtLogger.Debugf("Checking SBT build: %#v %#v", m, allowUnresolved)
 
-	sbtLogger.Debugf("Running `%s -no-colors dependencyList`...", builder.SBTCmd)
-	cmd := exec.Command(builder.SBTCmd, "-no-colors", "dependencyList")
-	cmd.Dir = m.Dir
-	output, err := cmd.Output()
-	outStr := string(output)
+	output, _, err := runLogged(sbtLogger, m.Dir, builder.SBTCmd, "-no-colors", "dependencyList")
 	if err != nil {
-		sbtLogger.Debugf("`%s -no-colors dependencyList` failed; output: %#v", builder.SBTCmd, outStr)
-		return false, err
+		return false, fmt.Errorf("could not get dependency list from SBT: %s", err.Error())
 	}
-	sbtLogger.Debugf("Done running `%s -no-colors dependencyList`.", builder.SBTCmd)
+	isBuilt := output != ""
 
-	isBuilt := outStr != ""
-	sbtLogger.Debugf("Done checking SBT IsBuilt: %#v", isBuilt)
-
+	sbtLogger.Debugf("Done checking SBT build: %#v", isBuilt)
 	return isBuilt, nil
 }
 
+// IsModule is not implemented
 func (builder *SBTBuilder) IsModule(target string) (bool, error) {
 	return false, errors.New("IsModule is not implemented for SBTBuilder")
 }
 
+// InferModule is not implemented
 func (builder *SBTBuilder) InferModule(target string) (module.Module, error) {
 	return module.Module{}, errors.New("InferModule is not implemented for SBTBuilder")
 }

--- a/cmd/fossa/config.go
+++ b/cmd/fossa/config.go
@@ -96,6 +96,8 @@ func setDefaultValues(c configFileV1) (configFileV1, error) {
 
 	// Infer default locator and project from `git`.
 	if c.CLI.Locator == "" {
+		// TODO: this needs to happen in the module directory, not the working
+		// directory
 		repo, err := git.PlainOpen(".")
 		if err == nil {
 			project := c.CLI.Project

--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -261,6 +261,8 @@ func resolveModuleConfig(moduleConfig moduleConfig) (module.Builder, module.Modu
 		if err != nil {
 			return nil, m, err
 		}
+	case "gopackage":
+		fallthrough
 	case "golang":
 		fallthrough
 	case "go":
@@ -354,7 +356,7 @@ func defaultCmd(c *cli.Context) {
 
 		isBuilt, err := builder.IsBuilt(module, config.analyzeConfig.allowUnresolved)
 		if err != nil {
-			mainLogger.Fatalf("Could not determine whether module %s is built.", module.Name)
+			mainLogger.Fatalf("Could not determine whether module %s is built: %s", module.Name, err.Error())
 		}
 
 		if !isBuilt {

--- a/module/module.go
+++ b/module/module.go
@@ -38,6 +38,9 @@ type Module struct {
 	// Dir is the absolute path to the module's working directory (the directory
 	// you would normally run the build command from).
 	Dir string
+
+	// TODO: add project and revision, because different modules might belong to
+	// different projects
 }
 
 // A Builder is an implementation of functionality for different build systems.

--- a/test/fixtures/golang/godep/Godeps/Godeps.json
+++ b/test/fixtures/golang/godep/Godeps/Godeps.json
@@ -42,10 +42,6 @@
 			"Rev": "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
 		},
 		{
-			"ImportPath": "github.com/google/btree",
-			"Rev": "7d79101e329e5a3adf994758c578dab82b90c017"
-		},
-		{
 			"ImportPath": "github.com/google/gofuzz",
 			"Rev": "44d81051d367757e1c7c6a5a86423ece9afcf63c"
 		},
@@ -62,31 +58,18 @@
 			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
 		},
 		{
-			"ImportPath": "github.com/gregjones/httpcache",
-			"Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
-		},
-		{
-			"ImportPath": "github.com/gregjones/httpcache/diskcache",
-			"Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
-		},
-		{
 			"ImportPath": "github.com/json-iterator/go",
 			"Comment": "1.0.4-7-g13f8643",
 			"Rev": "13f86432b882000a51c6e610c620974462691a97"
 		},
 		{
-			"ImportPath": "github.com/juju/ratelimit",
-			"Rev": "5b9ff866471762aa2ab2dced63c9fb6f53921342"
-		},
-		{
-			"ImportPath": "github.com/peterbourgon/diskv",
-			"Comment": "v2.0.1",
-			"Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
-		},
-		{
 			"ImportPath": "github.com/spf13/pflag",
 			"Comment": "v1.0.0-10-g4c012f6",
 			"Rev": "4c012f6dcd9546820e378d0bdda4d8fc772cdfea"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "1c05540f6879653db88113bc4a2b70aec4bd491f"
 		},
 		{
 			"ImportPath": "golang.org/x/net/http2",
@@ -119,6 +102,10 @@
 		{
 			"ImportPath": "golang.org/x/text/unicode/norm",
 			"Rev": "b19bf474d317b857955b12035d2c5acb57ce8b01"
+		},
+		{
+			"ImportPath": "golang.org/x/time/rate",
+			"Rev": "f51c12702a4d776e4c1fa9b0fabab841babae631"
 		},
 		{
 			"ImportPath": "gopkg.in/inf.v0",


### PR DESCRIPTION
Refactors builders to use standard common utilities for tasks like parsing manifests, running commands, and logging.

Fixes #20.