### PR TITLE
Add custom upload command

### DIFF
--- a/cmd/fossa/analyze.go
+++ b/cmd/fossa/analyze.go
@@ -33,14 +33,15 @@ func analyzeCmd(c *cli.Context) {
 	}
 	analysisLogger.Debugf("Analysis complete: %#v", analysis)
 
+	normalModules, err := normalizeAnalysis(analysis)
+	if err != nil {
+		analysisLogger.Fatalf("Could not normalize build data: %s", err.Error())
+	}
+
 	if config.analyzeConfig.output {
-		normalModules, err := normalizeAnalysis(analysis)
-		if err != nil {
-			mainLogger.Fatalf("Could not normalize build data: %s", err.Error())
-		}
 		buildData, err := json.Marshal(normalModules)
 		if err != nil {
-			mainLogger.Fatalf("Could not marshal analysis results: %s", err.Error())
+			analysisLogger.Fatalf("Could not marshal analysis results: %s", err.Error())
 		}
 		fmt.Println(string(buildData))
 	}
@@ -50,7 +51,7 @@ func analyzeCmd(c *cli.Context) {
 		return
 	}
 
-	msg, err := doUpload(config, analysis)
+	msg, err := doUpload(config, normalModules)
 	if err != nil {
 		analysisLogger.Fatalf("Upload failed: %s", err.Error())
 	}

--- a/cmd/fossa/config.go
+++ b/cmd/fossa/config.go
@@ -136,6 +136,7 @@ type cliConfig struct {
 	analyzeConfig analyzeConfig
 	buildConfig   buildConfig
 	testConfig    testConfig
+	uploadConfig  uploadConfig
 }
 
 func makeLocator(project string, revision string) string {
@@ -201,6 +202,10 @@ func initialize(c *cli.Context) (cliConfig, error) {
 
 		testConfig: testConfig{
 			timeout: time.Duration(c.Int("timeout")) * time.Second,
+		},
+
+		uploadConfig: uploadConfig{
+			data: c.String("data"),
 		},
 	}
 

--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -96,6 +96,19 @@ func main() {
 				cli.BoolFlag{Name: "debug", Usage: debugUsage},
 			},
 		},
+		{
+			Name:   "upload",
+			Usage:  "Uploads user-provided test results to FOSSA",
+			Action: uploadCmd,
+			Flags: []cli.Flag{
+				cli.StringFlag{Name: "c, config", Usage: configUsage},
+				cli.StringFlag{Name: "p, project", Usage: projectUsage},
+				cli.StringFlag{Name: "r, revision", Usage: revisionUsage},
+				cli.StringFlag{Name: "e, endpoint", Usage: endpointUsage},
+				cli.StringFlag{Name: "d, data", Usage: "the user-provided build data to upload"},
+				cli.BoolFlag{Name: "debug", Usage: debugUsage},
+			},
+		},
 	}
 
 	app.Run(os.Args)
@@ -311,7 +324,12 @@ func defaultCmd(c *cli.Context) {
 	s.Stop()
 	s.Suffix = fmt.Sprintf(" Uploading build results (%d/%d)...", len(config.modules), len(config.modules))
 	s.Restart()
-	msg, err := doUpload(config, dependencies)
+
+	normalModules, err := normalizeAnalysis(dependencies)
+	if err != nil {
+		mainLogger.Fatalf("Could not normalize build data: %s", err.Error())
+	}
+	msg, err := doUpload(config, normalModules)
 	s.Stop()
 	if err != nil {
 		mainLogger.Fatalf("Upload failed: %s", err.Error())

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -160,6 +160,14 @@ Unresolved dependencies generally indicate an incomplete build or some other kin
 #### `--no-upload`
 Do not upload analysis results.
 
+## `fossa upload`
+
+Uploads user-provided build data to FOSSA. This allows users to manually provide a dependency list if their build system is too complex for FOSSA's default analyzer.
+
+### Flags
+#### `--data`
+The user-provided build data. See `fossa analyze --output` for an example of the correct build data format.
+
 <!-- ## `fossa report`
 
 Print the project's license report.


### PR DESCRIPTION
Implements #19.

Details:

- `doUpload` now takes a `normalizedBuild` instead of an `analysis`. Consumers of `doUpload` have been modified to accommodate this.
- `uploadCmd` allows users to specify a `normalizedBuild` to upload via `--data`.

Follow-up work:

1. This revealed a lot of common utilities that can be refactored.
2. We need to document the format for provided build data.