### PR TITLE
Add Locators flag and data format

### DIFF
--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -113,6 +113,7 @@ func main() {
 				cli.StringFlag{Name: "p, project", Usage: projectUsage},
 				cli.StringFlag{Name: "r, revision", Usage: revisionUsage},
 				cli.StringFlag{Name: "e, endpoint", Usage: endpointUsage},
+				cli.BoolFlag{Name: "l, locators", Usage: "upload data in locator format instead of JSON"},
 				cli.StringFlag{Name: "d, data", Usage: "the user-provided build data to upload"},
 				cli.BoolFlag{Name: "debug", Usage: debugUsage},
 			},

--- a/cmd/fossa/upload.go
+++ b/cmd/fossa/upload.go
@@ -100,9 +100,25 @@ func uploadCmd(c *cli.Context) {
 	}
 
 	var data []normalizedModule
-	err = json.Unmarshal([]byte(conf.UploadCmd.Data), &data)
-	if err != nil {
-		uploadLogger.Fatalf("Could not parse user-provided build data: %s", err.Error())
+	if conf.UploadCmd.Locators {
+		var deps []normalizedDependency
+		lines := strings.Split(conf.UploadCmd.Data, "\n")
+		for _, line := range lines {
+			deps = append(deps, normalizedDependency{
+				Locator: line,
+			})
+		}
+		data = append(data, normalizedModule{
+			Build: normalizedBuild{
+				Succeeded:    true,
+				Dependencies: deps,
+			},
+		})
+	} else {
+		err = json.Unmarshal([]byte(conf.UploadCmd.Data), &data)
+		if err != nil {
+			uploadLogger.Fatalf("Could not parse user-provided build data: %s", err.Error())
+		}
 	}
 
 	msg, err := doUpload(conf, data)

--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,8 @@ type TestConfig struct {
 
 // UploadConfig specifies the config for the upload cmd
 type UploadConfig struct {
-	Data string
+	Locators bool
+	Data     string
 }
 
 // CLIConfig specifies the config available to the cli
@@ -128,7 +129,8 @@ func New(c *cli.Context) (CLIConfig, error) {
 		},
 
 		UploadCmd: UploadConfig{
-			Data: c.String("data"),
+			Locators: c.Bool("locators"),
+			Data:     c.String("data"),
 		},
 	}
 


### PR DESCRIPTION
The "locators" format allows users to specify newline-delimited locators rather than formatting their build data as JSON.

You can test this with: `fossa upload --locators --data="$(fossa analyze --output | jq '[ .[0].Build.Dependencies | map(.locator) ][0] | join("\n")' --raw-output)" --revision=$(git rev-parse master) --debug`