### PR TITLE
Implement Go module discovery

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -3,10 +3,10 @@
 version: 1
 cli:
   server: https://app.fossa.io
-  project: github.com/fossas/fossa-cli
+  project: git@github.com:fossas/fossa-cli.git
   fetcher: git
 analyze:
   modules:
-  - name: fossa-cli
-    path: ./cmd/fossa
-    type: gopackage
+  - name: fossa
+    path: cmd/fossa
+    type: go


### PR DESCRIPTION
I'm a bit worried here about using `go/parser` and `go/token` because of our previous issues with #63, but parsing should work consistently across Go versions because of the Go 1 compatibility promise.

This PR also uses `fossa init` to regenerate our configuration, as a sanity check.