### PR TITLE
Fixes for Powershell install script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -5,6 +5,10 @@
     Download and install the latest available FOSSA release from GitHub.
 #>
 
+[CmdletBinding()]
+Param()
+
+$OldEAP = $ErrorActionPreference #Preserve the original value
 $ErrorActionPreference = "Stop"
 
 $github = "https://github.com"
@@ -34,7 +38,11 @@ $zipFile = "$TempDir\fossa-cli.zip"
 
 Expand-Archive -Path $zipFile -DestinationPath $extractDir -Force
 
-$ErrorActionPreference = "Continue"
+$ErrorActionPreference = $OldEAP
 
-Write-Verbose "Installed fossa-cli at: $extractDir\fossa-cli\fossa.exe"
-Write-Verbose "Get started by running: fossa.exe --help"
+$fossa = "$extractDir\fossa.exe"
+
+Write-Host "Installed fossa-cli at: $fossa"
+Write-Host "Get started by running: fossa.exe --help"
+
+Write-Output $fossa

--- a/install.ps1
+++ b/install.ps1
@@ -25,7 +25,7 @@ if ($releasePage -inotmatch 'href=\"(.*?releases\/download\/.*?windows.*?)\"')
 $downloadUri = "$github/$($Matches[1])"
 Write-Verbose "Downloading from: $downloadUri"
 
-$TempDir = Join-Path [System.IO.Path]::GetTempPath() "fossa-cli"
+$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "fossa-cli"
 if (![System.IO.Directory]::Exists($TempDir)) {[void][System.IO.Directory]::CreateDirectory($TempDir)}
 
 $zipFile = "$TempDir\fossa-cli.zip"


### PR DESCRIPTION
@xizhao I made some fixes to the Powershell install script. Also added support for Powershell streams, so someone could run `$fossa = install.ps1` and the variable will have the .exe path.