### PR TITLE
:new: added json support to fossa dependency report

### DIFF
--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -26,6 +26,7 @@ var commit string
 var goversion string
 
 const (
+	formatUsage               = "Format of the report output. Can be text (default) or json"
 	configUsage               = "path to config file (default: .fossa.{yml,yaml})"
 	fetcherUsage              = "type of fetcher to use for fossa. Default's to custom"
 	projectUsage              = "this repository's URL or VCS endpoint (default: VCS remote 'origin')"
@@ -128,6 +129,7 @@ func main() {
 			Usage:  "Generates a license report",
 			Action: reportCmd,
 			Flags: []cli.Flag{
+				cli.StringFlag{Name: "f, format", Usage: formatUsage, Value: "text"},
 				cli.StringFlag{Name: "c, config", Usage: configUsage},
 				cli.StringFlag{Name: "fetcher", Usage: fetcherUsage},
 				cli.StringFlag{Name: "p, project", Usage: projectUsage},

--- a/cmd/fossa/report.go
+++ b/cmd/fossa/report.go
@@ -16,6 +16,10 @@ import (
 	"github.com/fossas/fossa-cli/module"
 )
 
+const (
+	textFormat = "text"
+)
+
 type dependencyResponse struct {
 	Loc struct {
 		Package  string
@@ -60,7 +64,7 @@ func getDependencies(s *spinner.Spinner, endpoint, apiKey string, analyses []ana
 		log.Logger.Fatalf("Invalid API endpoint: %s", err.Error())
 	}
 
-	if format == "text" {
+	if format == textFormat {
 		s.Suffix = " Loading licenses..."
 	}
 	s.Start()
@@ -94,7 +98,7 @@ func getDependencies(s *spinner.Spinner, endpoint, apiKey string, analyses []ana
 					responses = append(responses, responsePage...)
 					locators = []string{}
 					s.Stop()
-					if format == "text" {
+					if format == textFormat {
 						s.Suffix = fmt.Sprintf(" Loading licenses (%d/%d done)...", len(responses), total)
 						s.Restart()
 					}
@@ -154,7 +158,7 @@ func reportCmd(c *cli.Context) {
 
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 
-	if conf.ReportCmd.Format == "text" {
+	if conf.ReportCmd.Format == textFormat {
 		s.Suffix = " Analyzing modules..."
 	}
 	s.Start()
@@ -168,7 +172,7 @@ func reportCmd(c *cli.Context) {
 	case "licenses":
 		reportLicenses(s, conf.Endpoint, conf.APIKey, analyses, conf.ReportCmd.Format)
 	case "dependencies":
-		if conf.ReportCmd.Format == "text" {
+		if conf.ReportCmd.Format == textFormat {
 			outMap := make(map[string][]module.Dependency)
 			for _, a := range analyses {
 				outMap[a.module.Name] = a.dependencies

--- a/config/init.go
+++ b/config/init.go
@@ -83,6 +83,7 @@ func New(c *cli.Context) (CLIConfig, error) {
 
 		ReportCmd: ReportConfig{
 			Type: c.String("type"),
+			Format: c.String("format"),
 		},
 
 		ConfigFilePath: c.String("config"),

--- a/config/types.go
+++ b/config/types.go
@@ -36,6 +36,7 @@ type UploadConfig struct {
 // ReportConfig specifies the config for the report command
 type ReportConfig struct {
 	Type string // Either "dependencies" or "licenses"
+	Format string // Either "text" or "json"
 }
 
 // CLIConfig specifies the config available to the cli


### PR DESCRIPTION
By using ` --format json -t dependencies`, a JSON file outputs the list of dependencies and their licenses.

Example:
```
[{
	"Loc": {
		"Package": "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider",
		"Revision": "2.9.4"
	},
	"Licenses": [{
		"spdx_id": "",
		"Title": "Apache-2.0",
		"FullText": ""
	}],
	"Project": {
		"Title": "Jackson-JAXRS-JSON",
		"URL": "git@github.com:FasterXML/jackson-jaxrs-providers.git/jackson-jaxrs-json-provider",
		"Authors": []
	}
}, {
	"Loc": {
		"Package": "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
		"Revision": "2.9.4"
	},
	"Licenses": [{
		"spdx_id": "",
		"Title": "Apache-2.0",
		"FullText": ""
	}],
...
```

I had to extract the `getDependencies` function, to be used across both `licenses` and `dependencies` report types.

I also had to "disable" the Spinner output in order to get a stream of valid JSON, though I'm sure there's a better way to achieve it.

Haven't done yet on the test side, will investigate this as next step, but feel free to suggest a solution here.

Looking forward to hearing your thoughts!