### PR TITLE
Properly split arguments

### DIFF
--- a/exec/which.go
+++ b/exec/which.go
@@ -8,7 +8,7 @@ import (
 
 // Which picks a command out of a list of candidates.
 func Which(arg string, cmds ...string) (cmd string, output string, err error) {
-	return WhichArgs([]string{arg}, cmds...)
+	return WhichArgs(strings.Split(arg, " "), cmds...)
 }
 
 // WhichArgs is `Which` but passes multiple arguments to each candidate.


### PR DESCRIPTION
Arguments not properly whitespace-split may result in "two" arguments being considered as one unique, long string, and interpreted by the command to execute as one argument.