### PR TITLE
fix(test): Correctly generate URLs for custom fetchers

### DIFF
--- a/api/fossa/users.go
+++ b/api/fossa/users.go
@@ -1,0 +1,26 @@
+package fossa
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+var UsersAPI = "/api/users/%s"
+
+type User struct {
+	OrganizationID int
+}
+
+func GetOrganizationID() (string, error) {
+	q := url.Values{}
+	q.Add("count", "1")
+
+	var users []User
+	_, err := GetJSON(fmt.Sprintf(UsersAPI, "?"+q.Encode()), &users)
+	if err != nil {
+		return "", err
+	}
+
+	return strconv.Itoa(users[0].OrganizationID), nil
+}

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -82,6 +82,15 @@ func Do(stop <-chan time.Time) ([]fossa.Issue, error) {
 		Revision: revision,
 	}
 
+	// Fixes https://github.com/fossas/fossa-cli/issues/181.
+	if project.Fetcher == "custom" {
+		orgID, err := fossa.GetOrganizationID()
+		if err != nil {
+			return nil, err
+		}
+		project.Project = orgID + "/" + fossa.NormalizeGitURL(project.Project)
+	}
+
 	_, err := CheckBuild(project, stop)
 	if err != nil {
 		log.Logger.Fatalf("Could not load build: %s", err.Error())


### PR DESCRIPTION
Fixes #181.

We should test this by adding `fossa test` on a `custom` fetcher project into our integration tests.