### PR TITLE
fix(install): avoid hitting rate limit on install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,6 @@ clean:
 .PHONY: release
 release:
 	GOVERSION=$$(go version) goreleaser --rm-dist
+	RELEASE=$(git tag -l --points-at HEAD)
+	VERSION=${RELEASE#v}
+	sed "s/# RELEASE=/RELEASE=\'$RELEASE\'/; s/# VERSION=/VERSION=\'$VERSION\'/" install_tpl.sh > install.sh

--- a/install_tpl.sh
+++ b/install_tpl.sh
@@ -105,10 +105,10 @@ function install {
   cd $TMP_DIR || fail "changing directory to $TMP_DIR failed"
 
   # Download and validate release
-  bash -c "$GET $GH_API/repos/$USER/$REPO/releases/latest" > latest || fail "downloading latest release metadata failed"
-  RELEASE=$(grep tag_name latest | cut -d'"' -f4)
-  VERSION=${RELEASE#v} # remove prefix "v"
-
+  # DO NOT REMOVE THE FOLLOWING TWO LINES. They are used to generate
+  # installation scripts for new releases.
+  # RELEASE=
+  # VERSION=
   echo "Installing $USER/$REPO $RELEASE..."
   RELEASE_URL="$GH/$USER/$REPO/releases/download/$RELEASE"
   bash -c "$GET $RELEASE_URL/${REPO}_${VERSION}_${OS}_${ARCH}.tar.gz" > release.tar.gz || fail "downloading release failed"


### PR DESCRIPTION
Fixes #180 by generating a new install.sh (from install_tpl.sh) for each new release. Does not (yet) fix the issue for Windows users, however.