### PR TITLE
fix(builders): add maven dependency list fallback

### DIFF
--- a/analyzers/maven/maven.go
+++ b/analyzers/maven/maven.go
@@ -81,7 +81,7 @@ func (a *Analyzer) Discover(dir string) ([]module.Module, error) {
 				parsedArtifactName := filepath.Base(filepath.Dir(dir))
 				var parsedPom maven.Manifest
 				if err := files.ReadXML(&parsedPom, path, "pom.xml"); err != nil {
-					log.Logger.Debugf("Unable to parse modules through `mvn`: %#v %#v", err.Error(), err)
+					log.Logger.Debugf("Unable to parse modules through `pom.xml`: %#v %#v", err.Error(), err)
 					return nil
 				}
 

--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -10,13 +10,20 @@ import (
 )
 
 type Manifest struct {
-	Project     xml.Name `xml:"project"`
-	ArtifactID  string   `xml:"artifactId"`
-	GroupID     string   `xml:"groupId"`
-	Version     string   `xml:"version"`
-	Description string   `xml:"description"`
-	Name        string   `xml:"name"`
-	URL         string   `xml:"url"`
+	Project     xml.Name       `xml:"project"`
+	Parent      ParentManifest `xml:"parent"`
+	ArtifactID  string         `xml:"artifactId"`
+	GroupID     string         `xml:"groupId"`
+	Version     string         `xml:"version"`
+	Description string         `xml:"description"`
+	Name        string         `xml:"name"`
+	URL         string         `xml:"url"`
+}
+
+type ParentManifest struct {
+	ArtifactID string `xml:"artifactId"`
+	GroupID    string `xml:"groupId"`
+	Version    string `xml:"version"`
 }
 
 type Dependency struct {

--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -10,13 +10,13 @@ import (
 )
 
 type Manifest struct {
-	Project     xml.Name
-	ArtifactID  string
-	GroupID     string
-	Version     string
-	Description string
-	Name        string
-	URL         string
+	Project     xml.Name `xml:"project"`
+	ArtifactID  string   `xml:"artifactId"`
+	GroupID     string   `xml:"groupId"`
+	Version     string   `xml:"version"`
+	Description string   `xml:"description"`
+	Name        string   `xml:"name"`
+	URL         string   `xml:"url"`
 }
 
 type Dependency struct {

--- a/buildtools/maven/testdata/mvn_dependencylist-single
+++ b/buildtools/maven/testdata/mvn_dependencylist-single
@@ -1,0 +1,74 @@
+[INFO] Scanning for projects...
+[INFO]
+[INFO] ------------------------------------------------------------------------
+[INFO] Building StreamSets SSO 3.1.0.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO]
+[INFO] --- maven-dependency-plugin:2.8:list (default-cli) @ streamsets-sso ---
+[INFO]
+[INFO] The following files have been resolved:
+[INFO]    org.glassfish.jersey.bundles.repackaged:jersey-guava:jar:2.25.1:compile
+[INFO]    fr.xebia.extras:selma-processor:jar:0.13:provided
+[INFO]    io.dropwizard.metrics:metrics-core:jar:3.1.2:provided
+[INFO]    log4j:log4j:jar:1.2.17:provided
+[INFO]    org.eclipse.jetty:jetty-server:jar:9.4.2.v20170220:compile
+[INFO]    org.hamcrest:hamcrest-library:jar:1.3:test
+[INFO]    com.streamsets:streamsets-testing:jar:3.1.0.0-SNAPSHOT:test
+[INFO]    org.mockito:mockito-core:jar:1.10.19:test
+[INFO]    org.eclipse.jetty:jetty-io:jar:9.4.2.v20170220:compile
+[INFO]    org.eclipse.jetty:jetty-xml:jar:9.4.2.v20170220:compile
+[INFO]    org.glassfish.jersey.core:jersey-client:jar:2.25.1:compile
+[INFO]    com.squareup:javawriter:jar:2.5.0:provided
+[INFO]    org.glassfish.jersey.media:jersey-media-json-jackson:jar:2.25.1:compile
+[INFO]    org.javassist:javassist:jar:3.21.0-GA:compile
+[INFO]    org.glassfish.hk2:hk2-api:jar:2.5.0-b32:compile
+[INFO]    com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.8.9:compile
+[INFO]    commons-io:commons-io:jar:2.4:provided
+[INFO]    org.eclipse.jetty:jetty-webapp:jar:9.4.2.v20170220:compile
+[INFO]    org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO]    com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.8.9:compile
+[INFO]    javax.ws.rs:javax.ws.rs-api:jar:2.0.1:compile
+[INFO]    org.eclipse.jetty:jetty-security:jar:9.4.2.v20170220:compile
+[INFO]    com.fasterxml.jackson.core:jackson-annotations:jar:2.8.9:compile
+[INFO]    javax.validation:validation-api:jar:1.1.0.Final:compile
+[INFO]    fr.xebia.extras:selma:jar:0.13:compile
+[INFO]    org.glassfish.hk2:hk2-utils:jar:2.5.0-b32:compile
+[INFO]    org.eclipse.jetty:jetty-rewrite:jar:9.4.2.v20170220:compile
+[INFO]    org.glassfish.jersey.containers:jersey-container-servlet:jar:2.25.1:compile
+[INFO]    org.glassfish.jersey.core:jersey-server:jar:2.25.1:compile
+[INFO]    org.glassfish.jersey.core:jersey-common:jar:2.25.1:compile
+[INFO]    org.glassfish.hk2:hk2-locator:jar:2.5.0-b32:compile
+[INFO]    org.eclipse.jetty:jetty-client:jar:9.4.2.v20170220:compile
+[INFO]    com.fasterxml.jackson.core:jackson-databind:jar:2.8.9:compile
+[INFO]    org.jetbrains:annotations-java5:jar:15.0:provided
+[INFO]    org.glassfish.jersey.media:jersey-media-jaxb:jar:2.25.1:compile
+[INFO]    org.glassfish.hk2.external:aopalliance-repackaged:jar:2.5.0-b32:compile
+[INFO]    org.eclipse.jetty:jetty-servlet:jar:9.4.2.v20170220:compile
+[INFO]    org.glassfish.hk2.external:javax.inject:jar:2.5.0-b32:compile
+[INFO]    commons-codec:commons-codec:jar:1.10:compile
+[INFO]    javax.annotation:javax.annotation-api:jar:1.2:compile
+[INFO]    org.objenesis:objenesis:jar:2.1:test
+[INFO]    com.streamsets:streamsets-utils:jar:3.1.0.0-SNAPSHOT:provided
+[INFO]    com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.8.4:compile
+[INFO]    javax.inject:javax.inject:jar:1:compile
+[INFO]    javax.servlet:javax.servlet-api:jar:3.1.0:compile
+[INFO]    org.glassfish.hk2:osgi-resource-locator:jar:1.0.1:compile
+[INFO]    org.glassfish.jersey.ext:jersey-entity-filtering:jar:2.25.1:compile
+[INFO]    com.streamsets:streamsets-datacollector-api:jar:3.1.0.0-SNAPSHOT:provided
+[INFO]    org.eclipse.jetty:jetty-util:jar:9.4.2.v20170220:compile
+[INFO]    junit:junit:jar:4.12:test
+[INFO]    org.slf4j:slf4j-log4j12:jar:1.7.7:provided
+[INFO]    com.google.guava:guava:jar:18.0:compile
+[INFO]    org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.25.1:compile
+[INFO]    org.slf4j:slf4j-api:jar:1.7.7:provided
+[INFO]    org.eclipse.jetty:jetty-jaas:jar:9.4.2.v20170220:compile
+[INFO]    com.fasterxml.jackson.core:jackson-core:jar:2.8.9:compile
+[INFO]    org.eclipse.jetty:jetty-http:jar:9.4.2.v20170220:compile
+[INFO]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 1.482 s
+[INFO] Finished at: 2018-07-31T17:19:26-07:00
+[INFO] Final Memory: 18M/309M
+[INFO] ------------------------------------------------------------------------

--- a/cmd/fossa/cmd/init/init.go
+++ b/cmd/fossa/cmd/init/init.go
@@ -51,7 +51,7 @@ func Run(ctx *cli.Context) error {
 	}
 
 	if len(modules) > 0 {
-		log.Logger.Infof("Successfully wrote (%s) modules to config", len(modules))
+		log.Logger.Infof("Successfully wrote (%d) modules to config", len(modules))
 		return nil
 	}
 

--- a/cmd/fossa/cmd/init/init.go
+++ b/cmd/fossa/cmd/init/init.go
@@ -43,10 +43,19 @@ func Run(ctx *cli.Context) error {
 	if err != nil {
 		log.Logger.Fatalf("Could not run init: %s", err.Error())
 	}
+
 	err = config.WriteFile(modules)
 	if err != nil {
 		log.Logger.Fatalf("Could not write config: %s", err.Error())
+		return nil
 	}
+
+	if len(modules) > 0 {
+		log.Logger.Infof("Successfully wrote (%s) modules to config", len(modules))
+		return nil
+	}
+
+	log.Logger.Warning("Did not discover any modules for analysis")
 	return nil
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -67,7 +67,7 @@ func Init(interactive, debug bool) {
 	if debug {
 		stderrBackend.SetLevel(logging.DEBUG, "")
 	} else {
-		stderrBackend.SetLevel(logging.WARNING, "")
+		stderrBackend.SetLevel(logging.INFO, "")
 	}
 	logging.SetBackend(stderrBackend)
 }


### PR DESCRIPTION
haven't tested this yet, but it takes freaking forever for a large project -- maybe we want to have some sort of escape hatch or alternative method since dependency:list is very expensive

if dependency:list fails once, for instance, we can prevent it from executing for the rest of the Discover run, what do you think @ilikebits ?