### PR TITLE
fix(buildtools): add bower config constructor to apply defaults

### DIFF
--- a/buildtools/bower/config.go
+++ b/buildtools/bower/config.go
@@ -11,27 +11,29 @@ type Config struct {
 	Directory string `json:"directory"`
 }
 
+func NewConfig(cwd string) Config {
+	return Config{
+		CWD:       cwd,
+		Directory: filepath.Join(cwd, "bower_components"),
+	}
+}
+
 // TODO: this is nowhere near complete -- there's all sorts of crazy cascading
 // mechanisms that configure Bower.
 func ReadConfig(dir string) (Config, error) {
+	config := NewConfig(dir)
 	ok, err := files.Exists(dir, ".bowerrc")
-	if err != nil {
-		return Config{}, err
-	}
 	if ok {
 		return ReadConfigFile(filepath.Join(dir, ".bowerrc"))
 	}
-	return Config{
-		CWD:       dir,
-		Directory: filepath.Join(dir, "bower_components"),
-	}, nil
+	return config, err
 }
 
 func ReadConfigFile(filename string) (Config, error) {
-	var config Config
+	config := NewConfig(filepath.Dir(filename))
 	err := files.ReadJSON(&config, filename)
 	if err != nil {
-		return Config{}, err
+		return config, err
 	}
 	return config, nil
 }


### PR DESCRIPTION
This PR ensures configuration defaults to `bower_components` when unspecified by an existing but empty `.bowerrc` by implementing a constructor pattern.

Question, if the `.bowerrc` is empty, will `NewConfig(dir).CWD` be overwritten to be empty too?