### PR TITLE
Add init and analyze flags to default command

### DIFF
--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -7,6 +7,31 @@ import (
 	"github.com/urfave/cli"
 )
 
+func Combine(sets ...[]cli.Flag) []cli.Flag {
+	flags := make(map[string]cli.Flag)
+	for _, s := range sets {
+		for _, f := range s {
+			name := f.GetName()
+			prev, ok := flags[name]
+			if ok {
+				if prev == f {
+					continue
+				} else {
+					panic(f)
+				}
+			} else {
+				flags[name] = f
+			}
+		}
+	}
+
+	var combined []cli.Flag
+	for _, f := range flags {
+		combined = append(combined, f)
+	}
+	return combined
+}
+
 func Short(name string) string {
 	return fmt.Sprintf("%c, %s", name[0], name)
 }

--- a/cmd/fossa/flags/flags_test.go
+++ b/cmd/fossa/flags/flags_test.go
@@ -1,0 +1,28 @@
+package flags_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+
+	"github.com/fossas/fossa-cli/cmd/fossa/flags"
+)
+
+func TestCombine(t *testing.T) {
+	fooFlag := cli.BoolFlag{Name: "foo", Usage: "bar"}
+	helloFlag := cli.BoolFlag{Name: "hello", Usage: "world"}
+
+	combined := flags.Combine(
+		[]cli.Flag{fooFlag},
+		[]cli.Flag{fooFlag, helloFlag},
+	)
+	assert.Equal(t, combined, []cli.Flag{fooFlag, helloFlag})
+
+	assert.Panics(t, func() {
+		flags.Combine(
+			[]cli.Flag{fooFlag},
+			[]cli.Flag{cli.BoolFlag{Name: "foo", Usage: "baz"}},
+		)
+	})
+}

--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -27,9 +27,11 @@ var App = cli.App{
 	Version:              version.String(),
 	Action:               Run,
 	EnableBashCompletion: true,
-	Flags: flags.WithGlobalFlags([]cli.Flag{
-		cli.BoolFlag{Name: flags.Short(analyze.ShowOutput), Usage: "run a complete analysis with output"},
-	}),
+	Flags: flags.Combine(
+		initc.Cmd.Flags,
+		analyze.Cmd.Flags,
+		flags.WithGlobalFlags(nil),
+	),
 	Commands: []cli.Command{
 		initc.Cmd,
 		build.Cmd,


### PR DESCRIPTION
This allows users to specify those flags in case they're running the default command.