### PR TITLE
Support exclamation marks in Gemfile.lock

### DIFF
--- a/buildtools/bundler/lockfile.go
+++ b/buildtools/bundler/lockfile.go
@@ -50,8 +50,8 @@ func (r *Requirement) String() string {
 	return s
 }
 
-// ^(leading whitespace)(name)(optional: space + (version specifier) within parentheses)$
-var requirementsRegex = regexp.MustCompile("^( *?)(\\S+?)( \\((.*?)\\))?$")
+// ^(leading whitespace)(name)(optional: exclamation mark or (space + (version specifier) within parentheses (optional: exclamation mark)))$
+var requirementsRegex = regexp.MustCompile("^( *?)(\\S+?)(?:\\!?|( \\((.*?)\\)\\!?)?)$")
 
 // TODO: actually parse these. We ignore them right now, so I haven't bothered
 // implementing parsing logic.

--- a/buildtools/bundler/testdata/Gemfile.lock
+++ b/buildtools/bundler/testdata/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
     concurrent-ruby (1.0.5)
     concurrent-ruby (1.0.5-java)
     connection_pool (2.2.2)
-    cookiejar (0.3.3)
+    cookiejar (0.3.3)!
     crass (1.0.4)
     curses (1.0.2)
     daemons (1.2.6)
@@ -289,7 +289,7 @@ GEM
     jwt (2.1.0)
     kindlerb (1.2.0)
       mustache
-      nokogiri
+      nokogiri!
     libxml-ruby (3.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)


### PR DESCRIPTION
From [what I can find](https://groups.google.com/forum/#!topic/ruby-bundler/QxlNGzK3rEY), the exclamation mark indicates that the dependency is from a secondary source.

We probably want to capture this information in the future, but for now I've put it in a non-capturing group.