### PR TITLE
Fix shasum failed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,7 @@ function install {
   echo "Installing $USER/$REPO $RELEASE..."
   RELEASE_URL="$GH/$USER/$REPO/releases/download/$RELEASE"
   FILE="${REPO}_${VERSION}_${OS}_${ARCH}.tar.gz"
-  bash -c "$GET $RELEASE_URL/${REPO}_${VERSION}_${OS}_${ARCH}.tar.gz" > release.tar.gz || fail "downloading release failed"
+  bash -c "$GET $RELEASE_URL/$FILE" > $FILE || fail "downloading release failed"
   bash -c "$GET $RELEASE_URL/${REPO}_${VERSION}_checksums.txt" > checksums.txt || fail "downloading checksums failed"
 
   if command -v shasum >/dev/null 2>&1; then


### PR DESCRIPTION
Later lines specifically refer to $FILE, but the release was downloaded as "release.tar.gz." Checking the shasum failed because the file was under that name. I doubt "> $FILE" is necessary, as there's no need to rename, but at least these changes allowed me to install FOSSA.

This change appears to already exist in https://github.com/fossas/fossa-cli/blob/master/install_template.sh, but was simply overlooked in this, install.sh.

