### PR TITLE
WIP Fix/resolver-fix 

### DIFF
--- a/analyzers/golang/analyze.go
+++ b/analyzers/golang/analyze.go
@@ -1,6 +1,8 @@
 package golang
 
 import (
+	"path/filepath"
+
 	"github.com/apex/log"
 
 	// Each of these build tools provides a resolver.Resolver
@@ -36,7 +38,12 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	switch a.Options.Strategy {
 	case "manifest:dep":
 		if a.Options.LockfilePath == "" {
-			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
+			log.Debug("dep manifest strategy specified without lockfile path")
+			a.Options.LockfilePath = filepath.Join(project.Manifest, "Gopkg.lock")
+		}
+		if a.Options.ManifestPath == "" {
+			log.Debug("dep manifest strategy specified without manifest path")
+			a.Options.ManifestPath = filepath.Join(project.Manifest, "Gopkg.toml")
 		}
 		depResolver := dep.Resolver{}
 		depResolver.Lockfile, err = dep.ReadLockfile(a.Options.LockfilePath)
@@ -51,7 +58,8 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		r = depResolver
 	case "manifest:gdm":
 		if a.Options.LockfilePath == "" {
-			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
+			log.Debug("gdm manifest strategy specified without lockfile path")
+			a.Options.LockfilePath = filepath.Join(project.Manifest, "Godeps")
 		}
 		r, err = gdm.New(a.Options.LockfilePath)
 		if err != nil {
@@ -59,7 +67,12 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		}
 	case "manifest:glide":
 		if a.Options.LockfilePath == "" {
-			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
+			log.Debug("glide manifest strategy specified without lockfile path")
+			a.Options.LockfilePath = filepath.Join(project.Manifest, "glide.lock")
+		}
+		if a.Options.ManifestPath == "" {
+			log.Debug("glide manifest strategy specified without manifest path")
+			a.Options.ManifestPath = filepath.Join(project.Manifest, "glide.yaml")
 		}
 		r, err = glide.New(a.Options.LockfilePath, a.Options.ManifestPath)
 		if err != nil {
@@ -67,7 +80,8 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		}
 	case "manifest:godep":
 		if a.Options.LockfilePath == "" {
-			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
+			log.Debug("godep manifest strategy specified without lockfile path")
+			a.Options.LockfilePath = filepath.Join(project.Manifest, "Godeps", "Godeps.json")
 		}
 		r, err = godep.New(a.Options.LockfilePath)
 		if err != nil {
@@ -75,7 +89,8 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		}
 	case "manifest:govendor":
 		if a.Options.LockfilePath == "" {
-			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
+			log.Debug("govendor manifest strategy specified without lockfile path")
+			a.Options.LockfilePath = filepath.Join(project.Manifest, "vendor", "vendor.json")
 		}
 		r, err = govendor.New(a.Options.LockfilePath)
 		if err != nil {
@@ -83,7 +98,8 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		}
 	case "manifest:vndr":
 		if a.Options.LockfilePath == "" {
-			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
+			log.Debug("vndr manifest strategy specified without lockfile path")
+			a.Options.LockfilePath = filepath.Join(project.Manifest, "vendor.conf")
 		}
 		r, err = vndr.New(a.Options.LockfilePath)
 		if err != nil {

--- a/analyzers/golang/analyze.go
+++ b/analyzers/golang/analyze.go
@@ -61,7 +61,9 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		if a.Options.LockfilePath == "" {
 			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
 		}
-		r, err = glide.FromFile(a.Options.LockfilePath)
+
+		r, err = glide.New(a.Options.LockfilePath)
+		// r, err = glide.FromFile(a.Options.LockfilePath)
 		if err != nil {
 			return graph.Deps{}, err
 		}

--- a/analyzers/golang/analyze.go
+++ b/analyzers/golang/analyze.go
@@ -77,7 +77,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		if a.Options.LockfilePath == "" {
 			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
 		}
-		r, err = govendor.FromFile(a.Options.LockfilePath)
+		r, err = govendor.New(a.Options.LockfilePath)
 		if err != nil {
 			return graph.Deps{}, err
 		}

--- a/analyzers/golang/analyze.go
+++ b/analyzers/golang/analyze.go
@@ -61,9 +61,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		if a.Options.LockfilePath == "" {
 			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
 		}
-
-		r, err = glide.New(a.Options.LockfilePath)
-		// r, err = glide.FromFile(a.Options.LockfilePath)
+		r, err = glide.New(a.Options.LockfilePath, a.Options.ManifestPath)
 		if err != nil {
 			return graph.Deps{}, err
 		}
@@ -71,7 +69,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		if a.Options.LockfilePath == "" {
 			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
 		}
-		r, err = godep.FromFile(a.Options.LockfilePath)
+		r, err = godep.New(a.Options.LockfilePath)
 		if err != nil {
 			return graph.Deps{}, err
 		}

--- a/analyzers/golang/analyze.go
+++ b/analyzers/golang/analyze.go
@@ -53,7 +53,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		if a.Options.LockfilePath == "" {
 			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
 		}
-		r, err = gdm.FromFile(a.Options.LockfilePath)
+		r, err = gdm.New(a.Options.LockfilePath)
 		if err != nil {
 			return graph.Deps{}, err
 		}
@@ -85,7 +85,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		if a.Options.LockfilePath == "" {
 			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
 		}
-		r, err = vndr.FromFile(a.Options.LockfilePath)
+		r, err = vndr.New(a.Options.LockfilePath)
 		if err != nil {
 			return graph.Deps{}, err
 		}

--- a/analyzers/golang/analyze.go
+++ b/analyzers/golang/analyze.go
@@ -38,10 +38,17 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		if a.Options.LockfilePath == "" {
 			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")
 		}
-		r, err = dep.New(a.Options.LockfilePath, a.Options.ManifestPath)
+		depResolver := dep.Resolver{}
+		depResolver.Lockfile, err = dep.ReadLockfile(a.Options.LockfilePath)
 		if err != nil {
 			return graph.Deps{}, err
 		}
+
+		depResolver.Manifest, err = dep.ReadManifest(a.Options.ManifestPath)
+		if err != nil {
+			return graph.Deps{}, err
+		}
+		r = depResolver
 	case "manifest:gdm":
 		if a.Options.LockfilePath == "" {
 			return graph.Deps{}, errors.New("manifest strategy specified without lockfile path")

--- a/analyzers/golang/resolver/lockfile.go
+++ b/analyzers/golang/resolver/lockfile.go
@@ -35,7 +35,7 @@ func FromLockfile(tool Type, dir string) (Resolver, error) {
 	case Gdm:
 		return gdm.New(dir)
 	case Glide:
-		return glide.New(dir)
+		return glide.New(filepath.Join(dir, "glide.lock"), filepath.Join(dir, "glide.yaml"))
 	case Godep:
 		return godep.New(dir)
 	case Govendor:

--- a/analyzers/golang/resolver/lockfile.go
+++ b/analyzers/golang/resolver/lockfile.go
@@ -37,7 +37,7 @@ func FromLockfile(tool Type, dir string) (Resolver, error) {
 	case Glide:
 		return glide.New(filepath.Join(dir, "glide.lock"), filepath.Join(dir, "glide.yaml"))
 	case Godep:
-		return godep.New(dir)
+		return godep.New(filepath.Join(dir, "Godeps", "Godeps.json"))
 	case Govendor:
 		return govendor.New(dir)
 	case Vndr:

--- a/analyzers/golang/resolver/lockfile.go
+++ b/analyzers/golang/resolver/lockfile.go
@@ -33,7 +33,7 @@ func FromLockfile(tool Type, dir string) (Resolver, error) {
 	case Dep:
 		return dep.New(filepath.Join(dir, "Gopkg.lock"), filepath.Join(dir, "Gopkg.toml"))
 	case Gdm:
-		return gdm.New(dir)
+		return gdm.New(filepath.Join(dir, "Godeps"))
 	case Glide:
 		return glide.New(filepath.Join(dir, "glide.lock"), filepath.Join(dir, "glide.yaml"))
 	case Godep:
@@ -41,7 +41,7 @@ func FromLockfile(tool Type, dir string) (Resolver, error) {
 	case Govendor:
 		return govendor.New(filepath.Join(dir, "vendor", "vendor.json"))
 	case Vndr:
-		return vndr.New(dir)
+		return vndr.New(filepath.Join(dir, "vendor.conf"))
 	default:
 		return nil, ErrResolverNotFound
 	}

--- a/analyzers/golang/resolver/lockfile.go
+++ b/analyzers/golang/resolver/lockfile.go
@@ -39,7 +39,7 @@ func FromLockfile(tool Type, dir string) (Resolver, error) {
 	case Godep:
 		return godep.New(filepath.Join(dir, "Godeps", "Godeps.json"))
 	case Govendor:
-		return govendor.New(dir)
+		return govendor.New(filepath.Join(dir, "vendor", "vendor.json"))
 	case Vndr:
 		return vndr.New(dir)
 	default:

--- a/buildtools/dep/dep.go
+++ b/buildtools/dep/dep.go
@@ -2,6 +2,7 @@
 package dep
 
 import (
+	"fmt"
 	"path"
 	"strings"
 
@@ -113,17 +114,28 @@ func readLockfile(filepath string) (lockfile, error) {
 		}
 	}
 
-	lock.normalized = normalized
-	return lock, nil
+	resolver.Lockfile.normalized = normalized
+	return resolver, nil
 }
 
-// readManifest returns a manifest using the provided filepath.
-func readManifest(filepath string) (manifest, error) {
-	var man manifest
-	err := files.ReadTOML(&man, filepath)
+// ReadLockFile accepts the filepath of a lockfile which it parses into a lockfile object
+func ReadLockfile(filepath string) (Lockfile, error) {
+	var lockfile Lockfile
+
+	err := files.ReadTOML(&lockfile, filepath)
 	if err != nil {
-		return manifest{}, errors.Wrap(err, "No manifest Gopkg.toml found")
+		return Lockfile{}, errors.New(fmt.Sprintf("No lockfile Gopkg.lock found: %+v", err))
+	}
+	return lockfile, nil
+}
+
+// ReadManifest accepts the filepath of a manifest which it parses into a manifest object
+func ReadManifest(filepath string) (Manifest, error) {
+	var manifest Manifest
+	err := files.ReadTOML(&manifest, filepath)
+	if err != nil {
+		return Manifest{}, errors.New(fmt.Sprintf("No manifest Gopkg.toml found: %+v", err))
 	}
 
-	return man, nil
+	return manifest, nil
 }

--- a/buildtools/dep/dep.go
+++ b/buildtools/dep/dep.go
@@ -71,7 +71,22 @@ func (m manifest) isIgnored(importpath string) bool {
 	return false
 }
 
+<<<<<<< HEAD
 // New constructs a golang.Resolver given the path to the manifest and lockfile.
+=======
+// Resolve returns the revision of an imported Go package contained within the
+// lockfile. If the package is not found, buildtools.ErrNoRevisionForPackage is
+// returned.
+func (l Lockfile) Resolve(importpath string) (pkg.Import, error) {
+	rev, ok := l.Normalized[importpath]
+	if !ok {
+		return pkg.Import{}, buildtools.ErrNoRevisionForPackage
+	}
+	return rev, nil
+}
+
+// New constructs a golang.Resolver
+>>>>>>> unit testing added for dep package
 func New(lockfilePath string, manifestPath string) (Resolver, error) {
 	var err error
 
@@ -114,7 +129,7 @@ func readLockfile(filepath string) (lockfile, error) {
 		}
 	}
 
-	resolver.Lockfile.normalized = normalized
+	resolver.Lockfile.Normalized = normalized
 	return resolver, nil
 }
 
@@ -124,7 +139,7 @@ func ReadLockfile(filepath string) (Lockfile, error) {
 
 	err := files.ReadTOML(&lockfile, filepath)
 	if err != nil {
-		return Lockfile{}, errors.New(fmt.Sprintf("No lockfile Gopkg.lock found: %+v", err))
+		return Lockfile{}, fmt.Errorf("No lockfile Gopkg.lock found: %+v", err)
 	}
 	return lockfile, nil
 }
@@ -134,7 +149,7 @@ func ReadManifest(filepath string) (Manifest, error) {
 	var manifest Manifest
 	err := files.ReadTOML(&manifest, filepath)
 	if err != nil {
-		return Manifest{}, errors.New(fmt.Sprintf("No manifest Gopkg.toml found: %+v", err))
+		return Manifest{}, fmt.Errorf("No manifest Gopkg.toml found: %+v", err)
 	}
 
 	return manifest, nil

--- a/buildtools/dep/dep_test.go
+++ b/buildtools/dep/dep_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+<<<<<<< HEAD
 func TestResolve(t *testing.T) {
 	resolver, err := dep.New("testdata/Gopkg.lock", "testdata/Gopkg.toml")
 	assert.Equal(t, err, nil)

--- a/buildtools/gdm/gdm.go
+++ b/buildtools/gdm/gdm.go
@@ -9,8 +9,8 @@ import (
 )
 
 // New constructs a gdm lockfile from a project directory.
-func New(dirname string) (gpm.Lockfile, error) {
-	ok, err := UsedIn(dirname)
+func New(lockfilePath string) (gpm.Lockfile, error) {
+	ok, err := UsedIn(lockfilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -18,7 +18,7 @@ func New(dirname string) (gpm.Lockfile, error) {
 		return nil, errors.New("directory does not use gdm")
 	}
 
-	lockfile, err := FromFile(dirname, "Godeps")
+	lockfile, err := FromFile(lockfilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -27,8 +27,8 @@ func New(dirname string) (gpm.Lockfile, error) {
 }
 
 // UsedIn checks whether gdm is used correctly within a project directory.
-func UsedIn(dirname string) (bool, error) {
-	return files.Exists(dirname, "Godeps")
+func UsedIn(lockfilePath string) (bool, error) {
+	return files.Exists(lockfilePath)
 }
 
 // FromFile constructs a gdm lockfile from a specific file.

--- a/buildtools/vndr/vndr.go
+++ b/buildtools/vndr/vndr.go
@@ -8,8 +8,8 @@ import (
 )
 
 // New constructs a vndr lockfile.
-func New(dirname string) (gpm.Lockfile, error) {
-	ok, err := UsedIn(dirname)
+func New(lockfilePath string) (gpm.Lockfile, error) {
+	ok, err := UsedIn(lockfilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -17,7 +17,7 @@ func New(dirname string) (gpm.Lockfile, error) {
 		return nil, errors.New("directory does not use vndr")
 	}
 
-	lockfile, err := gpm.FromFile(dirname, "vendor.conf")
+	lockfile, err := gpm.FromFile(lockfilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -26,8 +26,8 @@ func New(dirname string) (gpm.Lockfile, error) {
 }
 
 // UsedIn checks whether vndr is used correctly within a project folder.
-func UsedIn(dirname string) (bool, error) {
-	return files.Exists(dirname, "vendor.conf")
+func UsedIn(lockfilePath string) (bool, error) {
+	return files.Exists(lockfilePath)
 }
 
 func FromFile(filename string) (gpm.Lockfile, error) {


### PR DESCRIPTION
Bug fix inside of cli analyze.go and buildtools logic. Currently, when a user provides a custom manifest the resolver is initialized but never creates the normalized project map. More refactoring needs to be done until it can be merged.