### PR TITLE
Issue #247, fix how custom fetchers are handled

### DIFF
--- a/api/fossa/locator.go
+++ b/api/fossa/locator.go
@@ -18,18 +18,21 @@ type Locator struct {
 	Revision string `json:"revision"`
 }
 
+// String returns a locator converted to a string as a URL path for API access.
 func (l Locator) String() string {
-	if l.Fetcher != "git" {
-		if l.Fetcher == "archive" {
-			orgID, err := GetOrganizationID()
-			if err != nil {
-				log.Warnf("Could not get OrganizationID while constructing locator")
-			}
-			l.Project = orgID + "/" + l.Project
-		}
-		return l.Fetcher + "+" + l.Project + "$" + l.Revision
+	if l.Fetcher == "git" {
+		return "git+" + NormalizeGitURL(l.Project) + "$" + l.Revision
 	}
-	return "git+" + NormalizeGitURL(l.Project) + "$" + l.Revision
+
+	if l.Fetcher == "archive" || l.Fetcher == "custom" {
+		orgID, err := GetOrganizationID()
+		if err != nil {
+			log.Warnf("Could not get OrganizationID while constructing locator")
+		}
+		l.Project = orgID + "/" + l.Project
+	}
+
+	return l.Fetcher + "+" + l.Project + "$" + l.Revision
 }
 
 // URL calculates the FOSSA URL for a project's locator.

--- a/api/fossa/locator_test.go
+++ b/api/fossa/locator_test.go
@@ -35,3 +35,32 @@ func TestLocatorFetcher(t *testing.T) {
 		assert.Equal(t, tc.Fetcher, fossa.LocatorOf(id).Fetcher, tc.Fetcher)
 	}
 }
+
+func TestNormalizeGit(t *testing.T) {
+	//No idea what it should be yet
+
+}
+
+func TestStringCustom(t *testing.T) {
+	custom := fossa.Locator{
+		Fetcher:  "custom",
+		Project:  "6214/git@github.com:fossa/fossa-custom.git",
+		Revision: "SHAVALUE",
+	}
+
+	stringified := custom.String()
+	expected := "custom+6214/git@github.com:fossa/fossa-custom.git$SHAVALUE"
+	assert.Equal(t, stringified, expected)
+}
+
+func TestStringGit(t *testing.T) {
+	custom := fossa.Locator{
+		Fetcher:  "git",
+		Project:  "git@github.com:fossas/fossa-cli.git",
+		Revision: "SHAVALUE",
+	}
+
+	stringified := custom.String()
+	expected := "git+github.com/fossas/fossa-cli$SHAVALUE"
+	assert.Equal(t, stringified, expected)
+}

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -86,7 +86,7 @@ func Do(stop <-chan time.Time) (fossa.Issues, error) {
 		if err != nil {
 			return fossa.Issues{}, err
 		}
-		project.Project = orgID + "/" + fossa.NormalizeGitURL(project.Project)
+		project.Project = orgID + "/" + project.Project
 	}
 
 	_, err := CheckBuild(project, stop)

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -80,15 +80,6 @@ func Do(stop <-chan time.Time) (fossa.Issues, error) {
 		Revision: revision,
 	}
 
-	// Fixes https://github.com/fossas/fossa-cli/issues/181.
-	if project.Fetcher == "custom" {
-		orgID, err := fossa.GetOrganizationID()
-		if err != nil {
-			return fossa.Issues{}, err
-		}
-		project.Project = orgID + "/" + project.Project
-	}
-
 	_, err := CheckBuild(project, stop)
 	if err != nil {
 		log.Fatalf("Could not load build: %s", err.Error())


### PR DESCRIPTION
Expected format of locator URL is:
`/api/cli/custom+6214/git@github.com:zlav/pastport.git$SHAVALUE/latest_build`
Output with NormalizeGitURL:
`/api/cli/custom+6214/github.com/zlav/pastport$SHAVALUE/latest_build`
