### PR TITLE
test(yarn lockfile) improve fixture case coverage

### DIFF
--- a/buildtools/yarn/parse.go
+++ b/buildtools/yarn/parse.go
@@ -30,7 +30,7 @@ func FromProject(manifestPath string, lockFilePath string) (graph.Deps, error) {
 		return graph.Deps{}, nil
 	}
 
-	directDeps, err := directDepsFromManifest(manifestPath)
+	directDeps, err := lockfile.directDeps(manifestPath)
 	if err != nil {
 		return graph.Deps{}, nil
 	}
@@ -41,7 +41,8 @@ func FromProject(manifestPath string, lockFilePath string) (graph.Deps, error) {
 	}, nil
 }
 
-func directDepsFromManifest(manifestPath string) (pkg.Imports, error) {
+func (l yarnLockfile) directDeps(manifestPath string) (pkg.Imports, error) {
+	// PackageFromManifest requires node_modules, so we must use FromManifest. This does not guarantee resolved versions
 	manifest, err := npm.FromManifest(manifestPath)
 	if err != nil {
 		return pkg.Imports{}, nil
@@ -55,7 +56,7 @@ func directDepsFromManifest(manifestPath string) (pkg.Imports, error) {
 			Target: name,
 			Resolved: pkg.ID{
 				Name:     name,
-				Revision: revision,
+				Revision: l.resolve(name, revision),
 				Type:     pkg.NodeJS,
 			},
 		}

--- a/buildtools/yarn/parse.go
+++ b/buildtools/yarn/parse.go
@@ -80,7 +80,6 @@ func readLockfile(pathElems ...string) (yarnLockfile, error) {
 		return yarnLockfile{}, err
 	}
 	yamlCompatLockfile := r.ReplaceAll(fileContent, []byte(": \""))
-	println(string(fileContent))
 
 	err = yaml.Unmarshal(yamlCompatLockfile, &lockfile)
 	if err != nil {

--- a/buildtools/yarn/parse_test.go
+++ b/buildtools/yarn/parse_test.go
@@ -24,11 +24,24 @@ func TestSimpleLockfile(t *testing.T) {
 	deps, err := yarn.FromProject(filepath.Join("testdata", "package.json"), filepath.Join("testdata", "yarn.lock"))
 	assert.NoError(t, err)
 
-	assert.Len(t, deps.Direct, 1)
+	assert.Len(t, deps.Direct, 2)
 	assert.Len(t, deps.Transitive, 7)
 
-	assert.Equal(t, "chai", deps.Direct[0].Target)
-	assert.Equal(t, "4.1.2", deps.Direct[0].Resolved.Revision)
+	var chaiImport pkg.Import
+	var typeDetectImport pkg.Import
+
+	if deps.Direct[0].Target == "chai" {
+		chaiImport = deps.Direct[0]
+		typeDetectImport = deps.Direct[1]
+	} else {
+		chaiImport = deps.Direct[1]
+		typeDetectImport = deps.Direct[0]
+	}
+
+	assert.Equal(t, "chai", chaiImport.Target)
+	assert.Equal(t, "4.1.2", chaiImport.Resolved.Revision)
+	assert.Equal(t, "type-detect", typeDetectImport.Target)
+	assert.Equal(t, "3.0.0", typeDetectImport.Resolved.Revision)
 
 	AssertDeps(t, deps.Transitive, "assertion-error", "1.1.0")
 	AssertDeps(t, deps.Transitive, "check-error", "1.0.2")
@@ -36,6 +49,7 @@ func TestSimpleLockfile(t *testing.T) {
 	AssertDeps(t, deps.Transitive, "get-func-name", "2.0.0")
 	AssertDeps(t, deps.Transitive, "pathval", "1.1.0")
 	AssertDeps(t, deps.Transitive, "type-detect", "4.0.8")
+	AssertDeps(t, deps.Transitive, "type-detect", "3.0.0")
 	AssertDeps(t, deps.Transitive, "chai", "4.1.2")
 }
 

--- a/buildtools/yarn/parse_test.go
+++ b/buildtools/yarn/parse_test.go
@@ -25,7 +25,7 @@ func TestSimpleLockfile(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Len(t, deps.Direct, 2)
-	assert.Len(t, deps.Transitive, 7)
+	assert.Len(t, deps.Transitive, 8)
 
 	var chaiImport pkg.Import
 	var typeDetectImport pkg.Import

--- a/buildtools/yarn/testdata/package.json
+++ b/buildtools/yarn/testdata/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "chai": "4.1.2"
+    "chai": "4.1.2",
+    "type-detect": "^3.0.0"
   }
 }

--- a/buildtools/yarn/testdata/yarn.lock
+++ b/buildtools/yarn/testdata/yarn.lock
@@ -35,6 +35,10 @@ pathval@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
+type-detect@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-3.0.0.tgz#46d0cc8553abb7b13a352b0d6dea2fd58f2d9b55"
+
 type-detect@^4.0.0:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"


### PR DESCRIPTION
* `type-detect@^3.0.0` added as a direct dep to cause duped deps with different versions
  * because `^3.0.0` is unresolved, which uncovered an edge case with direct deps