### PR TITLE
coveralls removed for forked repos and alternate junit test path added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,11 @@ unit-test:
 
 .PHONY: junit-test
 junit-test: $(GO_JUNIT_REPORT) $(GOVERALLS)
-	goveralls -v -service=circle-ci -repotoken=$(COVERALLS_TOKEN) -flags "-short" | go-junit-report
+	if [ "$($COVERALLS_TOKEN)" == "" ]; then \
+		goveralls -v -service=circle-ci -repotoken=$(COVERALLS_TOKEN) -flags "-short" | go-junit-report; \
+	else \
+		go test -v ./... | go-junit-report; \
+	fi;
 
 .PHONY: integration-test
 integration-test: docker-test


### PR DESCRIPTION
Coveralls causes an issue when run without an API token being present on forked repositories. This fix enables forked repositories with no coveralls token to correctly run unit tests with a junit report.