### PR TITLE
testing (fossa test) use a test server to test fossa test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ bin/
 .vscode/
 coverage.txt
 cmd/fossa/fossa
-analyzers/gradle/testdata/.gradle
-analyzers/gradle/testdata/.project
-analyzers/gradle/testdata/.settings
+analyzers/gradle/testdata/discover-groovy/.gradle
+analyzers/gradle/testdata/discover-groovy/.project
+analyzers/gradle/testdata/discover-groovy/.settings

--- a/api/fossa/fossa.go
+++ b/api/fossa/fossa.go
@@ -24,7 +24,7 @@ func SetEndpoint(endpoint string) error {
 }
 
 func SetAPIKey(key string) *errors.Error {
-	if key == "" {
+	if key == "" && apiKey == "" {
 		return &errors.Error{
 			Type:            errors.User,
 			Troubleshooting: "A FOSSA API key is needed to run this command.",

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -39,7 +39,7 @@ const (
 	JSON           = "json"
 )
 
-const pollRequestDelay = 8 * time.Second
+var PollRequestDelay = 8 * time.Second
 
 var Cmd = cli.Command{
 	Name:   "test",
@@ -128,7 +128,7 @@ func CheckBuild(locator fossa.Locator, stop <-chan time.Time) (fossa.Build, erro
 		default:
 			build, err := fossa.GetLatestBuild(locator)
 			if _, ok := err.(api.TimeoutError); ok {
-				time.Sleep(pollRequestDelay)
+				time.Sleep(PollRequestDelay)
 				continue
 			}
 			if err != nil {
@@ -143,7 +143,7 @@ func CheckBuild(locator fossa.Locator, stop <-chan time.Time) (fossa.Build, erro
 			case "FAILED":
 				return build, fmt.Errorf("failed to analyze build #%d: %s (visit FOSSA or contact support@fossa.com)", build.ID, build.Error)
 			case "CREATED", "ASSIGNED", "RUNNING":
-				time.Sleep(pollRequestDelay)
+				time.Sleep(PollRequestDelay)
 			default:
 				return fossa.Build{}, fmt.Errorf("unknown task status: %s", build.Task.Status)
 			}
@@ -160,7 +160,7 @@ func CheckIssues(locator fossa.Locator, stop <-chan time.Time) (fossa.Issues, er
 		default:
 			issues, err := fossa.GetIssues(locator)
 			if _, ok := err.(api.TimeoutError); ok {
-				time.Sleep(pollRequestDelay)
+				time.Sleep(PollRequestDelay)
 				continue
 			}
 			if err != nil {
@@ -168,7 +168,7 @@ func CheckIssues(locator fossa.Locator, stop <-chan time.Time) (fossa.Issues, er
 			}
 			switch issues.Status {
 			case "WAITING":
-				time.Sleep(pollRequestDelay)
+				time.Sleep(PollRequestDelay)
 			case "SCANNED":
 				return issues, nil
 			default:

--- a/cmd/fossa/cmd/test/test_test.go
+++ b/cmd/fossa/cmd/test/test_test.go
@@ -81,5 +81,6 @@ func testSetup(endpoint, apiKey string) *cli.Context {
 
 	flagSet := &flag.FlagSet{}
 	flagSet.String("endpoint", endpoint, "")
+	flagSet.Int("timeout", 20, "")
 	return cli.NewContext(&cli.App{}, flagSet, &cli.Context{})
 }

--- a/cmd/fossa/cmd/test/test_test.go
+++ b/cmd/fossa/cmd/test/test_test.go
@@ -47,6 +47,7 @@ func TestSuccessfullTest(t *testing.T) {
 	defer ts.Close()
 
 	context := testSetup(ts.URL, "1")
+	test.PollRequestDelay = 2 * time.Second
 	err := test.Run(context)
 	assert.NoError(t, err)
 }
@@ -68,14 +69,12 @@ func testCustomTestServer(t *testing.T, server *mockServer) *httptest.Server {
 }
 
 func testSetup(endpoint, apiKey string) *cli.Context {
-	test.PollRequestDelay = 2 * time.Second
 	apiErr := fossa.SetAPIKey(apiKey)
 	if apiErr != nil {
 		log.Fatalf("Could not set api key: %s", apiErr)
 	}
 
 	flagSet := &flag.FlagSet{}
-	flagSet.Int("timeout", 100, "")
 	flagSet.String("endpoint", endpoint, "")
 	return cli.NewContext(&cli.App{}, flagSet, &cli.Context{})
 }

--- a/cmd/fossa/cmd/test/test_test.go
+++ b/cmd/fossa/cmd/test/test_test.go
@@ -1,0 +1,90 @@
+package test_test
+
+import (
+	"encoding/json"
+	"flag"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+
+	"github.com/fossas/fossa-cli/api/fossa"
+	"github.com/fossas/fossa-cli/cmd/fossa/cmd/test"
+)
+
+var orgID = rand.Intn(1000)
+
+// taskStatus is a struct that imitates the anonymous struct within fossa.Build
+type taskStatus struct {
+	Status string
+}
+
+type mockServer struct {
+	Responses []interface{}
+}
+
+// TestSuccessfullTest tests the `fossa test` test command and ensures that it properly
+// handles all responses.
+func testSuccessfullTest(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	fossa.SetAPIKey("1")
+	testLocator := fossa.Locator{Fetcher: "custom", Project: "tesRun", Revision: "123"}
+	serverTest := mockServer{
+		Responses: []interface{}{
+			fossa.Organization{OrganizationID: 1},
+			fossa.Build{Task: taskStatus{Status: "CREATED"}},
+			fossa.Build{Task: taskStatus{Status: "ASSIGNED"}},
+			fossa.Build{Task: taskStatus{Status: "RUNNING"}},
+			fossa.Build{Task: taskStatus{Status: "SUCCEEDED"}},
+			fossa.Issues{Status: "WAITING"},
+			fossa.Issues{Status: "SCANNED"},
+		},
+	}
+	ts := testCustomTestServer(t, testLocator, &serverTest)
+	defer ts.Close()
+	context := testContext(testLocator, ts.URL, "1")
+
+	test.PollRequestDelay = 2 * time.Second
+	err := test.Run(context)
+	assert.NoError(t, err)
+}
+
+// testCustomTestServer dequeues the first item in server.Responses, marshals it, and responds with it.
+func testCustomTestServer(t *testing.T, locator fossa.Locator, server *mockServer) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := server.Responses[0]
+		server.Responses = server.Responses[1:]
+		response, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %s", err)
+		}
+		_, err = w.Write(response)
+		if err != nil {
+			t.Fatalf("Failed to write response: %s", err)
+		}
+		return
+	}))
+}
+
+func testContext(locator fossa.Locator, endpoint, apiKey string) *cli.Context {
+	flagSet := &flag.FlagSet{}
+	flagSet.Int("timeout", 100, "")
+	rev, err := strconv.Atoi(locator.Revision)
+	if err != nil {
+		log.Warn(err.Error())
+	}
+	flagSet.Int("revision", rev, "")
+	flagSet.String("fetcher", locator.Fetcher, "")
+	flagSet.String("project", locator.Project, "")
+	flagSet.String("endpoint", endpoint, "")
+	return cli.NewContext(&cli.App{}, flagSet, &cli.Context{})
+}

--- a/cmd/fossa/cmd/test/test_test.go
+++ b/cmd/fossa/cmd/test/test_test.go
@@ -25,6 +25,12 @@ type mockServer struct {
 	Responses []interface{}
 }
 
+func (server *mockServer) nextResponse() interface{} {
+	resp := server.Responses[0]
+	server.Responses = server.Responses[1:]
+	return resp
+}
+
 // TestSuccessfullTest tests the `fossa test` test command and ensures that it properly
 // handles all responses in the path to a success.
 func TestSuccessfullTest(t *testing.T) {
@@ -55,8 +61,7 @@ func TestSuccessfullTest(t *testing.T) {
 // testCustomTestServer dequeues the first item in server.Responses, marshals it, and responds with it.
 func testCustomTestServer(t *testing.T, server *mockServer) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := server.Responses[0]
-		server.Responses = server.Responses[1:]
+		resp := server.nextResponse()
 		response, err := json.Marshal(resp)
 		if err != nil {
 			t.Fatalf("Failed to unmarshal JSON: %s", err)

--- a/cmd/fossa/cmd/test/test_test.go
+++ b/cmd/fossa/cmd/test/test_test.go
@@ -26,6 +26,9 @@ type mockServer struct {
 }
 
 func (server *mockServer) nextResponse() interface{} {
+	if len(server.Responses) == 0 {
+		return nil
+	}
 	resp := server.Responses[0]
 	server.Responses = server.Responses[1:]
 	return resp

--- a/cmd/fossa/cmd/test/test_test.go
+++ b/cmd/fossa/cmd/test/test_test.go
@@ -27,7 +27,7 @@ type mockServer struct {
 }
 
 // TestSuccessfullTest tests the `fossa test` test command and ensures that it properly
-// handles all responses.
+// handles all responses in the path to a success.
 func TestSuccessfullTest(t *testing.T) {
 	if testing.Short() {
 		return


### PR DESCRIPTION
This test ensures that `fossa test` correctly handles all successful API messages. I need to implement the new errors work throughout this code path in order to be able to test failure modes. 
The point of this PR was to create a testing server which could be used throughout the codebase into V2 development. This PR demonstrates how simple it is to create a test server and use it for anything. The most difficult part of this is configuration.

Once better errors are implemented here I am going to return and handle the failure modes and individual unit testing.

I think that a lot of the functions in this package could be extended to create a server test package but I am not going to do that until I build a couple more of these.