### PR TITLE
refactor(integration tests) abstract/simplify project initialization post cloning

### DIFF
--- a/analyzers/nodejs/integration_test.go
+++ b/analyzers/nodejs/integration_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	fixtures.InitializeProjects(nodeAnalyzerFixtureDir, projects, projectInitializer)
+	fixtures.Initialize(nodeAnalyzerFixtureDir, projects, projectInitializer)
 
 	exitCode := m.Run()
 	defer os.Exit(exitCode)
@@ -100,7 +100,7 @@ func projectInitializer(proj fixtures.Project, projectDir string) error {
 	}
 
 	if nodeModulesExist {
-		log.Debug("node modules already exists for " + proj.Name + "skipping initialization")
+		log.Debug("node_modules already exists for " + proj.Name + "skipping initialization")
 		return nil
 	}
 
@@ -114,9 +114,9 @@ func projectInitializer(proj fixtures.Project, projectDir string) error {
 	if err != nil {
 		log.Error(errOut)
 		log.Error("failed to run npm install on " + proj.Name)
+		return err
 	}
 
-	// save time on local
 	ymlAlreadyExists, err := files.Exists(filepath.Join(projectDir, ".fossa.yml"))
 	if err != nil {
 		return err
@@ -125,7 +125,6 @@ func projectInitializer(proj fixtures.Project, projectDir string) error {
 		return nil
 	}
 
-	// any key will work to prevent the "NEED KEY" error message
 	stdout, stderr, err := runfossa.Init(projectDir)
 	if err != nil {
 		log.Error("failed to run fossa init on " + proj.Name)

--- a/analyzers/nodejs/integration_test.go
+++ b/analyzers/nodejs/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"github.com/apex/log"
@@ -28,14 +27,24 @@ func TestMain(m *testing.M) {
 		return
 	}
 
+	log.SetLevel(log.DebugLevel)
+
 	err := fixtures.Clone(nodeAnalyzerFixtureDir, projects)
 	if err != nil {
 		panic(err)
 	}
 
-	err = initializeProjects(nodeAnalyzerFixtureDir)
-	if err != nil {
-		panic(err)
+	initializationErrors := fixtures.InitializeProjects(nodeAnalyzerFixtureDir, projects, projectInitializer)
+	initializationErrorFound := false
+	for projName, err := range initializationErrors {
+		if err != nil {
+			initializationErrorFound = true
+			log.Error("Error initializing node project" + projName + " " + err.Error())
+		}
+	}
+
+	if initializationErrorFound {
+		os.Exit(1)
 	}
 
 	exitCode := m.Run()
@@ -102,59 +111,46 @@ func assertProjectFixtureExists(t *testing.T, name string) {
 	assert.True(t, exists, name+" did not have its node modules installed")
 }
 
-func initializeProjects(testDir string) error {
-	var waitGroup sync.WaitGroup
-	waitGroup.Add(len(projects))
-
-	for _, project := range projects {
-		go func(proj fixtures.Project) {
-			defer waitGroup.Done()
-
-			projectDir := filepath.Join(testDir, proj.Name)
-			log.Debug("initializing " + projectDir)
-			nodeModulesExist, err := files.ExistsFolder(projectDir, "node_modules")
-			if err != nil {
-				panic(err)
-			}
-
-			if nodeModulesExist {
-				log.Debug("node modules already exists for " + proj.Name + "skipping initialization")
-				return
-			}
-
-			_, errOut, err := exec.Run(exec.Cmd{
-				Name:    "npm",
-				Argv:    []string{"install", "--production"},
-				Dir:     projectDir,
-				WithEnv: proj.Env,
-				Command: "npm",
-			})
-			if err != nil {
-				log.Error(errOut)
-				log.Error("failed to run npm install on " + proj.Name)
-			}
-
-			// save time on local
-			ymlAlreadyExists, err := files.Exists(filepath.Join(projectDir, ".fossa.yml"))
-			if err != nil {
-				panic(err)
-			}
-			if ymlAlreadyExists {
-				return
-			}
-
-			// any key will work to prevent the "NEED KEY" error message
-			stdout, stderr, err := runfossa.Init(projectDir)
-			if err != nil {
-				log.Error("failed to run fossa init on " + proj.Name)
-				log.Error(stdout)
-				log.Error(stderr)
-				log.Error(err.Error())
-				panic(err)
-			}
-		}(project)
+func projectInitializer(proj fixtures.Project, projectDir string) error {
+	nodeModulesExist, err := files.ExistsFolder(projectDir, "node_modules")
+	if err != nil {
+		panic(err)
 	}
-	waitGroup.Wait()
+
+	if nodeModulesExist {
+		log.Debug("node modules already exists for " + proj.Name + "skipping initialization")
+		return nil
+	}
+
+	stdOut, errOut, err := exec.Run(exec.Cmd{
+		Name:    "npm",
+		Argv:    []string{"install", "--production"},
+		Dir:     projectDir,
+		WithEnv: proj.Env,
+		Command: "npm",
+	})
+	if err != nil {
+		log.Error(stdOut + "\n" + errOut)
+		log.Error("failed to run npm install on " + proj.Name)
+	}
+
+	// save time on local
+	ymlAlreadyExists, err := files.Exists(filepath.Join(projectDir, ".fossa.yml"))
+	if err != nil {
+		return err
+	}
+	if ymlAlreadyExists {
+		return nil
+	}
+
+	// any key will work to prevent the "NEED KEY" error message
+	stdout, stderr, err := runfossa.Init(projectDir)
+	if err != nil {
+		log.Error("failed to run fossa init on " + proj.Name)
+		log.Error(stdout)
+		log.Error(stderr)
+		return err
+	}
 
 	return nil
 }

--- a/analyzers/nodejs/integration_test.go
+++ b/analyzers/nodejs/integration_test.go
@@ -112,7 +112,7 @@ func assertProjectFixtureExists(t *testing.T, name string) {
 func projectInitializer(proj fixtures.Project, projectDir string) error {
 	nodeModulesExist, err := files.ExistsFolder(projectDir, "node_modules")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	if nodeModulesExist {

--- a/analyzers/nodejs/integration_test.go
+++ b/analyzers/nodejs/integration_test.go
@@ -27,23 +27,7 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	err := fixtures.Clone(nodeAnalyzerFixtureDir, projects)
-	if err != nil {
-		panic(err)
-	}
-
-	initializationErrors := fixtures.InitializeProjects(nodeAnalyzerFixtureDir, projects, projectInitializer)
-	initializationErrorFound := false
-	for projName, err := range initializationErrors {
-		if err != nil {
-			initializationErrorFound = true
-			log.Error("Error initializing node project" + projName + " " + err.Error())
-		}
-	}
-
-	if initializationErrorFound {
-		os.Exit(1)
-	}
+	fixtures.InitializeProjects(nodeAnalyzerFixtureDir, projects, projectInitializer)
 
 	exitCode := m.Run()
 	defer os.Exit(exitCode)

--- a/analyzers/nodejs/integration_test.go
+++ b/analyzers/nodejs/integration_test.go
@@ -27,8 +27,6 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	log.SetLevel(log.DebugLevel)
-
 	err := fixtures.Clone(nodeAnalyzerFixtureDir, projects)
 	if err != nil {
 		panic(err)

--- a/analyzers/nodejs/integration_test.go
+++ b/analyzers/nodejs/integration_test.go
@@ -120,7 +120,7 @@ func projectInitializer(proj fixtures.Project, projectDir string) error {
 		return nil
 	}
 
-	stdOut, errOut, err := exec.Run(exec.Cmd{
+	_, errOut, err := exec.Run(exec.Cmd{
 		Name:    "npm",
 		Argv:    []string{"install", "--production"},
 		Dir:     projectDir,
@@ -128,7 +128,7 @@ func projectInitializer(proj fixtures.Project, projectDir string) error {
 		Command: "npm",
 	})
 	if err != nil {
-		log.Error(stdOut + "\n" + errOut)
+		log.Error(errOut)
 		log.Error("failed to run npm install on " + proj.Name)
 	}
 

--- a/testing/fixtures/fixtures.go
+++ b/testing/fixtures/fixtures.go
@@ -27,8 +27,8 @@ func Directory() string {
 // ProjectInitializerFunction defines how a single project should be initialized *after* it has already been cloned
 type ProjectInitializerFunction func(proj Project, projectDir string) error
 
-// InitializeProjects executes git clone in target directory and checksout the provided commit, then runts the initializerFn. This is done asynchronously for each provided project
-func InitializeProjects(baseDir string, projects []Project, initializerFn ProjectInitializerFunction) {
+// Initialize executes git clone in target directory and checksout the provided commit, then runts the initializerFn. This is done asynchronously for each provided project
+func Initialize(baseDir string, projects []Project, initializerFn ProjectInitializerFunction) {
 	baseDirExists, err := files.ExistsFolder(baseDir)
 	if err != nil {
 		panic(err)

--- a/testing/fixtures/fixtures.go
+++ b/testing/fixtures/fixtures.go
@@ -24,20 +24,23 @@ func Directory() string {
 	return filepath.Join(os.TempDir(), "fossa-cli-fixtures")
 }
 
-// Clone executes git clone in target directory and checksout the provided commit, or master if left ""
-func Clone(baseDir string, projects []Project) error {
+// ProjectInitializerFunction defines how a single project should be initialized *after* it has already been cloned
+type ProjectInitializerFunction func(proj Project, projectDir string) error
+
+// InitializeProjects executes git clone in target directory and checksout the provided commit, then runts the initializerFn. This is done asynchronously for each provided project
+func InitializeProjects(baseDir string, projects []Project, initializerFn ProjectInitializerFunction) {
 	baseDirExists, err := files.ExistsFolder(baseDir)
 	if err != nil {
-		return err
+		panic(err)
 	}
 	if baseDirExists {
 		println(baseDir + "already exists, assuming that clone has already been executed")
-		return nil
+		return
 	}
 
 	err = os.MkdirAll(baseDir, os.FileMode(0700))
 	if err != nil {
-		return err
+		panic(err)
 	}
 
 	var waitGroup sync.WaitGroup
@@ -66,43 +69,13 @@ func Clone(baseDir string, projects []Project) error {
 			if err != nil {
 				panic(err)
 			}
+
+			err = initializerFn(proj, projectDir)
+			if err != nil {
+				panic(err)
+			}
 		}(project)
 	}
 
 	waitGroup.Wait()
-
-	return nil
-}
-
-// ProjectInitializerFunction defines how a single project should be initialized *after* it has already been cloned
-type ProjectInitializerFunction func(proj Project, projectDir string) error
-
-// InitializeProjects initializes provided projects in parallel using the provided initialization function. Errors are returned as a map of the Project.Name to the error thrown
-func InitializeProjects(testDir string, projects []Project, projectInitializer ProjectInitializerFunction) map[string]error {
-	var waitGroup sync.WaitGroup
-	waitGroup.Add(len(projects))
-
-	threadsafeErrorsByProject := threadableErrorsByProject{
-		errorsByProject: make(map[string]error, len(projects)),
-	}
-
-	for _, project := range projects {
-		go func(proj Project) {
-			defer waitGroup.Done()
-			err := projectInitializer(proj, filepath.Join(testDir, proj.Name))
-
-			// separate the initialization step from locking to decrease time locking out other writers
-			threadsafeErrorsByProject.Lock()
-			threadsafeErrorsByProject.errorsByProject[proj.Name] = err
-			threadsafeErrorsByProject.Unlock()
-		}(project)
-	}
-	waitGroup.Wait()
-
-	return threadsafeErrorsByProject.errorsByProject
-}
-
-type threadableErrorsByProject struct {
-	sync.Mutex
-	errorsByProject map[string]error
 }

--- a/testing/fixtures/fixtures.go
+++ b/testing/fixtures/fixtures.go
@@ -89,8 +89,11 @@ func InitializeProjects(testDir string, projects []Project, projectInitializer P
 	for _, project := range projects {
 		go func(proj Project) {
 			defer waitGroup.Done()
+			err := projectInitializer(proj, filepath.Join(testDir, proj.Name))
+
+			// separate the initialization step from locking to decrease time locking out other writers
 			threadsafeErrorsByProject.Lock()
-			threadsafeErrorsByProject.errorsByProject[proj.Name] = projectInitializer(proj, filepath.Join(testDir, proj.Name))
+			threadsafeErrorsByProject.errorsByProject[proj.Name] = err
 			threadsafeErrorsByProject.Unlock()
 		}(project)
 	}


### PR DESCRIPTION
Most if not all of the integration test fixtures are going to need additional steps taken after `git clone` that can be optimized by running asynchronously. This abstractions effectively hides the async structure and creates an painless way of reporting errors during initialization