### PR TITLE
feat(integration tests) remove use of TestMain, replace with a threadsafe single execution ensured initializer

### DIFF
--- a/analyzers/nodejs/integration_test.go
+++ b/analyzers/nodejs/integration_test.go
@@ -1,7 +1,6 @@
 package nodejs_test
 
 import (
-	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,25 +19,15 @@ import (
 
 var nodeAnalyzerFixtureDir = filepath.Join(fixtures.Directory(), "nodejs", "analyzer")
 
-func TestMain(m *testing.M) {
-	// flags are not parsed at this point. In order to have testing.Short() read actually provided values, this must be executed
-	flag.Parse()
-	if testing.Short() {
-		return
-	}
-
-	fixtures.Initialize(nodeAnalyzerFixtureDir, projects, projectInitializer)
-
-	exitCode := m.Run()
-	defer os.Exit(exitCode)
-	// uncomment this if you need test files cleaned up locally
-	// defer cleanUp(nodeAnalyzerFixtureDir)
-}
-
 // While not testing the core functionality, this ensures that the tests have been setup correctly as needed for a prereq to run the analyzer steps
 // This test itself does not incur any overhead.
 func TestTestSetup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Integration tests do not run with -short testing flag")
+	}
 	t.Parallel()
+	fixtures.Initialize(nodeAnalyzerFixtureDir, projects, projectInitializer)
+
 	assertProjectFixtureExists(t, "puppeteer")
 	// faker has no deps
 	// assertProjectFixtureExists(t, "fakerjs")
@@ -52,12 +41,15 @@ func TestTestSetup(t *testing.T) {
 }
 
 func TestNodejsAnalysis(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Integration tests do not run with -short testing flag")
+	}
 	t.Parallel()
+	fixtures.Initialize(nodeAnalyzerFixtureDir, projects, projectInitializer)
 	for _, project := range projects {
 		proj := project
 		t.Run("Analysis:"+proj.Name, func(t *testing.T) {
 			t.Parallel()
-
 			module := module.Module{
 				Dir:         filepath.Join(nodeAnalyzerFixtureDir, proj.Name),
 				Type:        pkg.NodeJS,
@@ -93,7 +85,11 @@ func assertProjectFixtureExists(t *testing.T, name string) {
 	assert.True(t, exists, name+" did not have its node modules installed")
 }
 
+var counter = 0
+
 func projectInitializer(proj fixtures.Project, projectDir string) error {
+	println("PROJECT INITIALIZER CALL " + string(counter) + " " + proj.Name)
+	counter++
 	nodeModulesExist, err := files.ExistsFolder(projectDir, "node_modules")
 	if err != nil {
 		return err

--- a/analyzers/nodejs/integration_test.go
+++ b/analyzers/nodejs/integration_test.go
@@ -85,11 +85,7 @@ func assertProjectFixtureExists(t *testing.T, name string) {
 	assert.True(t, exists, name+" did not have its node modules installed")
 }
 
-var counter = 0
-
 func projectInitializer(proj fixtures.Project, projectDir string) error {
-	println("PROJECT INITIALIZER CALL " + string(counter) + " " + proj.Name)
-	counter++
 	nodeModulesExist, err := files.ExistsFolder(projectDir, "node_modules")
 	if err != nil {
 		return err


### PR DESCRIPTION
addresses #333 

tldr; a fixture is only initialized once, any other attempts to initialize the same fixture will wait until the first is complete and not execute redundant work.

By ensuring we can have multiple tests with the same fixture executed at the start, we can have more flexibly structured tests that can run in parallel.

This introduces some fairly complex logic, but it need only be created once. 