### PR TITLE
fix(go): Use relative paths when discovering modules

### DIFF
--- a/analyzers/golang/discover_test.go
+++ b/analyzers/golang/discover_test.go
@@ -1,0 +1,20 @@
+package golang_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/fossas/fossa-cli/analyzers/golang"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiscoverUsesRelativePaths(t *testing.T) {
+	modules, err := golang.Discover(filepath.Join("..", ".."), nil)
+	assert.NoError(t, err)
+
+	t.Logf("%#v", modules)
+
+	for _, m := range modules {
+		assert.True(t, !filepath.IsAbs(m.Dir), "%#v is an absolute directory", m.Dir)
+	}
+}

--- a/analyzers/golang/discover_test.go
+++ b/analyzers/golang/discover_test.go
@@ -12,8 +12,6 @@ func TestDiscoverUsesRelativePaths(t *testing.T) {
 	modules, err := golang.Discover(filepath.Join("..", ".."), nil)
 	assert.NoError(t, err)
 
-	t.Logf("%#v", modules)
-
 	for _, m := range modules {
 		assert.True(t, !filepath.IsAbs(m.Dir), "%#v is an absolute directory", m.Dir)
 	}

--- a/analyzers/golang/discover_test.go
+++ b/analyzers/golang/discover_test.go
@@ -4,8 +4,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/fossas/fossa-cli/analyzers/golang"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/fossas/fossa-cli/analyzers/golang"
 )
 
 func TestDiscoverUsesRelativePaths(t *testing.T) {

--- a/buildtools/gocmd/go.go
+++ b/buildtools/gocmd/go.go
@@ -33,6 +33,7 @@ func Name(importPath string) string {
 // Go contains configuration information for the Go tool.
 type Go struct {
 	Cmd  string
+	Dir  string
 	OS   string
 	Arch string
 }
@@ -76,6 +77,7 @@ func (g *Go) List(pkgs []string) ([]Package, error) {
 	stdout, stderr, err := exec.Run(exec.Cmd{
 		Name: g.Cmd,
 		Argv: append([]string{"list", "-json"}, pkgs...),
+		Dir:  g.Dir,
 		WithEnv: map[string]string{
 			"GOOS":   g.OS,
 			"GOARCH": g.Arch,


### PR DESCRIPTION
Fixes #340.