### PR TITLE
fix(graph logic) fix logic that prevents a correct build graph from being uploaded.

### DIFF
--- a/analyzers/bower/bower.go
+++ b/analyzers/bower/bower.go
@@ -193,7 +193,7 @@ func recurseDeps(pkgMap map[pkg.ID]pkg.Package, p bower.Package) {
 		}
 		// Get direct imports.
 		var imports []pkg.Import
-		for name, i := range p.Dependencies {
+		for name, i := range dep.Dependencies {
 			imports = append(imports, pkg.Import{
 				Target: i.PkgMeta.TargetName + "@" + i.PkgMeta.TargetVersion,
 				Resolved: pkg.ID{

--- a/analyzers/python/pip.go
+++ b/analyzers/python/pip.go
@@ -56,7 +56,7 @@ func flattenTree(graph map[pkg.ID]pkg.Package, tree pip.DepTree) {
 		}
 		// Get direct imports.
 		var imports []pkg.Import
-		for _, i := range tree.Dependencies {
+		for _, i := range dep.Dependencies {
 			imports = append(imports, pkg.Import{
 				Resolved: pkg.ID{
 					Type:     pkg.Python,


### PR DESCRIPTION
References issue [#330].
Fixes the logic that creates dependency graphs and ensures deep dependencies will be treated as such.