### PR TITLE
fix(module options) allow command line options for multi module builds

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,12 +9,24 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/fossas/fossa-cli/config"
+	"github.com/fossas/fossa-cli/vcs"
 )
 
 func TestInitWorksWithoutGitRepository(t *testing.T) {
-	err := os.Chdir("/")
+	// Change to a directory without Git repository.
+	cwd, err := os.Getwd()
 	assert.NoError(t, err)
+	err = os.Chdir("/")
+	assert.NoError(t, err)
+	defer func() {
+		os.Chdir(cwd)
+	}()
 
+	// Check that there actually is no Git repository.
+	_, _, err = vcs.Nearest(".")
+	assert.Error(t, err, vcs.ErrNoNearestVCS)
+
+	// Check that config.setContext doesn't break.
 	ctx := cli.NewContext(cli.NewApp(), flag.NewFlagSet("test", 0), nil)
 	err = config.SetContext(ctx)
 	assert.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,8 @@ func TestInitWorksWithoutGitRepository(t *testing.T) {
 	err = os.Chdir("/")
 	assert.NoError(t, err)
 	defer func() {
-		os.Chdir(cwd)
+		err = os.Chdir(cwd)
+		assert.NoError(t, err)
 	}()
 
 	// Check that there actually is no Git repository.

--- a/config/file.v1/file.go
+++ b/config/file.v1/file.go
@@ -1,10 +1,10 @@
 package v1
 
 import (
+	"github.com/apex/log"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/apex/log"
 	"github.com/fossas/fossa-cli/module"
 	"github.com/fossas/fossa-cli/pkg"
 )

--- a/config/keys.go
+++ b/config/keys.go
@@ -189,8 +189,12 @@ func Modules() ([]module.Module, error) {
 		return m, nil
 	}
 
-	// TODO: specifying zero modules should be an error (we should add a test for this)
-	return modulesWithOptions(file.Modules(), options), nil
+	modules := file.Modules()
+	if len(modules) == 0 {
+		return modules, errors.New("No modules provided")
+	}
+
+	return modulesWithOptions(modules, options), nil
 }
 
 // modulesWithOptions applies command line options to each module and overwrites conflicting options.

--- a/config/keys.go
+++ b/config/keys.go
@@ -189,17 +189,25 @@ func Modules() ([]module.Module, error) {
 		return m, nil
 	}
 
-	if l := len(options); l > 0 {
-		log.
-			WithFields(log.Fields{
-				"options": options,
-			}).
-			Warnf(
-				"Found %d options via flag, but modules are being loaded from configuration file. Ignoring options.",
-				len(options),
-			)
+	// TODO: specifying zero modules should be an error (we should add a test for this)
+	return modulesWithOptions(file.Modules(), options), nil
+}
+
+// modulesWithOptions applies command line options to each module and overwrites conflicting options.
+func modulesWithOptions(modules []module.Module, options map[string]interface{}) []module.Module {
+	if len(options) == 0 {
+		return modules
 	}
 
-	// TODO: specifying zero modules should be an error (we should add a test for this)
-	return file.Modules(), nil
+	for index := range modules {
+		if modules[index].Options == nil {
+			modules[index].Options = options
+		} else {
+			for key, val := range options {
+				modules[index].Options[key] = val
+			}
+		}
+	}
+
+	return modules
 }

--- a/config/keys.go
+++ b/config/keys.go
@@ -151,15 +151,7 @@ func Options() (map[string]interface{}, error) {
 
 func Modules() ([]module.Module, error) {
 	args := ctx.Args()
-	options, err := Options()
-	if err != nil {
-		return nil, err
-	}
-
-	log.WithFields(log.Fields{
-		"args":    args,
-		"options": options,
-	}).Debug("parsing modules")
+	log.WithFields(log.Fields{"args": args}).Debug("parsing modules")
 
 	// If arguments are present, prefer arguments over the configuration file.
 	if args.Present() {
@@ -178,40 +170,45 @@ func Modules() ([]module.Module, error) {
 			return nil, err
 		}
 
+		// Note that these parsed modules do not have any options set yet.
 		m := []module.Module{module.Module{
 			Name:        name,
 			Type:        mtype,
 			BuildTarget: name,
-			Options:     options,
 		}}
 
 		log.WithField("module", m).Debug("parsed module")
 		return m, nil
 	}
 
+	// Otherwise, get the modules from the configuration file.
 	modules := file.Modules()
 	if len(modules) == 0 {
 		return modules, errors.New("No modules provided")
 	}
 
-	return modulesWithOptions(modules, options), nil
-}
-
-// modulesWithOptions applies command line options to each module and overwrites conflicting options.
-func modulesWithOptions(modules []module.Module, options map[string]interface{}) []module.Module {
-	if len(options) == 0 {
-		return modules
+	// Parse options set via the command line.
+	options, err := Options()
+	if err != nil {
+		return nil, err
 	}
+	log.WithFields(log.Fields{"options": options}).Debug("parsing options")
 
-	for index := range modules {
-		if modules[index].Options == nil {
-			modules[index].Options = options
-		} else {
-			for key, val := range options {
-				modules[index].Options[key] = val
-			}
+	// Set options passed via the command line on all modules. For modules where
+	// this conflicts with a configuration file option, prefer the command line
+	// option.
+	for i, m := range modules {
+		if m.Options == nil {
+			modules[i].Options = make(map[string]interface{})
+		}
+
+		// We iterate over and copy the command-line options instead of setting the
+		// module options equal to avoid _unsetting_ module options that were set
+		// within the configuration file.
+		for key, val := range options {
+			modules[i].Options[key] = val
 		}
 	}
 
-	return modules
+	return modules, nil
 }

--- a/config/keys_test.go
+++ b/config/keys_test.go
@@ -12,19 +12,19 @@ import (
 )
 
 func TestModulesCommandLineOptions(t *testing.T) {
-	// Set the expected flags
+	// Set the expected flags.
 	flagSet := flag.NewFlagSet("test", 0)
 	flags.ConfigF.Apply(flagSet)
 	flags.OptionF.Apply(flagSet)
 
-	// Set the flag values
+	// Set the flag values.
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
 	err := ctx.Set(flags.Config, "testdata/test.yml")
 	assert.NoError(t, err)
 	err = ctx.Set(flags.Option, "allow-unresolved:true")
 	assert.NoError(t, err)
 
-	//Finalize the context
+	// Finalize the context.
 	err = config.SetContext(ctx)
 	assert.NoError(t, err)
 
@@ -40,7 +40,7 @@ func TestModulesCommandLineOptions(t *testing.T) {
 	assert.Equal(t, true, modules[1].Options["allow-unresolved"])
 	assert.Equal(t, "linux", modules[1].Options["os"])
 
-	// Test that command line options are preferred when they conflict.
+	// Test that command line options are preferred when they conflict config options.
 	assert.Equal(t, 1, len(modules[2].Options))
 	assert.Equal(t, true, modules[2].Options["allow-unresolved"])
 }

--- a/config/keys_test.go
+++ b/config/keys_test.go
@@ -44,3 +44,21 @@ func TestModulesCommandLineOptions(t *testing.T) {
 	assert.Equal(t, 1, len(modules[2].Options))
 	assert.Equal(t, true, modules[2].Options["allow-unresolved"])
 }
+func TestNoModulesError(t *testing.T) {
+	// Set the expected flags.
+	flagSet := flag.NewFlagSet("test", 0)
+	flags.ConfigF.Apply(flagSet)
+
+	// Set the flag values.
+	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
+	err := ctx.Set(flags.Config, "testdata/test_no_modules.yml")
+	assert.NoError(t, err)
+
+	// Finalize the context.
+	err = config.SetContext(ctx)
+	assert.NoError(t, err)
+
+	modules, err := config.Modules()
+	assert.EqualError(t, err, "No modules provided")
+	assert.Equal(t, 0, len(modules))
+}

--- a/config/keys_test.go
+++ b/config/keys_test.go
@@ -1,0 +1,44 @@
+package config_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+
+	"github.com/fossas/fossa-cli/cmd/fossa/flags"
+	"github.com/fossas/fossa-cli/config"
+)
+
+func TestModulesCommandLineOptions(t *testing.T) {
+	// Set the expected flags
+	flagSet := flag.NewFlagSet("test", 0)
+	flags.ConfigF.Apply(flagSet)
+	flags.OptionF.Apply(flagSet)
+
+	// Set the flag values
+	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
+	ctx.Set(flags.Config, "testdata/test.yml")
+	ctx.Set(flags.Option, "allow-unresolved:true")
+
+	//Finalize the context
+	err := config.SetContext(ctx)
+	assert.NoError(t, err)
+
+	modules, err := config.Modules()
+	assert.NoError(t, err)
+
+	// Test that command line options are set.
+	assert.Equal(t, 1, len(modules[0].Options))
+	assert.Equal(t, true, modules[0].Options["allow-unresolved"])
+
+	// Test that config file options are not overwritten.
+	assert.Equal(t, 2, len(modules[1].Options))
+	assert.Equal(t, true, modules[1].Options["allow-unresolved"])
+	assert.Equal(t, "linux", modules[1].Options["os"])
+
+	// Test that command line options are preferred when they conflict.
+	assert.Equal(t, 1, len(modules[2].Options))
+	assert.Equal(t, true, modules[2].Options["allow-unresolved"])
+}

--- a/config/keys_test.go
+++ b/config/keys_test.go
@@ -44,6 +44,7 @@ func TestModulesCommandLineOptions(t *testing.T) {
 	assert.Equal(t, 1, len(modules[2].Options))
 	assert.Equal(t, true, modules[2].Options["allow-unresolved"])
 }
+
 func TestNoModulesError(t *testing.T) {
 	// Set the expected flags.
 	flagSet := flag.NewFlagSet("test", 0)

--- a/config/keys_test.go
+++ b/config/keys_test.go
@@ -19,11 +19,13 @@ func TestModulesCommandLineOptions(t *testing.T) {
 
 	// Set the flag values
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
-	ctx.Set(flags.Config, "testdata/test.yml")
-	ctx.Set(flags.Option, "allow-unresolved:true")
+	err := ctx.Set(flags.Config, "testdata/test.yml")
+	assert.NoError(t, err)
+	err = ctx.Set(flags.Option, "allow-unresolved:true")
+	assert.NoError(t, err)
 
 	//Finalize the context
-	err := config.SetContext(ctx)
+	err = config.SetContext(ctx)
 	assert.NoError(t, err)
 
 	modules, err := config.Modules()

--- a/config/testdata/test.yml
+++ b/config/testdata/test.yml
@@ -1,0 +1,24 @@
+version: 1
+cli:
+  server: https://app.fossa.io
+  fetcher: custom
+  project: test-project
+analyze:
+  modules:
+  - name: no-options
+    target: .
+    path: .
+    type: go
+  - name: options
+    target: .
+    path: .
+    type: go
+    options:
+      os: linux
+  - name: overwrite-options
+    target: .
+    path: .
+    type: go
+    options:
+      allow-unresolved: false
+

--- a/config/testdata/test_no_modules.yml
+++ b/config/testdata/test_no_modules.yml
@@ -1,0 +1,5 @@
+version: 1
+cli:
+  server: https://app.fossa.io
+  fetcher: custom
+  project: test-project


### PR DESCRIPTION
Created in response to Issue [#346]
Currently, fossa-cli ignores options provided through the command line if modules are specified inside a fossa config file. This fix ensures that if an option is set manually it will apply to each module. If there is a conflict between a config specified option and a command line option, fossa will prioritize the command line option.