### PR TITLE
fix(make) fix conflict with auto generated file

### DIFF
--- a/buildtools/pip/bindata/bindata.go
+++ b/buildtools/pip/bindata/bindata.go
@@ -180,7 +180,6 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
 	"bindata": &bintree{nil, map[string]*bintree{
 		"pipdeptree.py": &bintree{bindataPipdeptreePy, map[string]*bintree{}},
@@ -233,3 +232,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+


### PR DESCRIPTION
We added an extra line to [bindata.go](https://github.com/fossas/fossa-cli/commit/249507264e4b80faad793c2314cfe4a57e539e1b#diff-4eaf995f5198ad0731ca03a3ee7f3a0d) and since then I have been getting a diff after I run make. The problem I assume is with editing `bindata.go`.