### PR TITLE
fix(python) requirements parses extras properly

### DIFF
--- a/buildtools/pip/pip.go
+++ b/buildtools/pip/pip.go
@@ -72,7 +72,7 @@ func FromFile(filename string) ([]Requirement, error) {
 			sections := strings.Split(trimmed, op)
 			if len(sections) == 2 {
 				reqs = append(reqs, Requirement{
-					Name:     sections[0],
+					Name:     checkForExtra(sections[0]),
 					Revision: sections[1],
 					Operator: op,
 				})
@@ -88,4 +88,23 @@ func FromFile(filename string) ([]Requirement, error) {
 	}
 
 	return reqs, nil
+}
+
+// https://www.python.org/dev/peps/pep-0508/#extras
+func checkForExtra(name string) string {
+	if strings.HasSuffix(name, "]") {
+		i := strings.Index(name, "[")
+		if i > 0 {
+			return name[:i]
+		}
+	}
+	return name
+
+	/* 	return strings.Split(name, "[")[0]
+	 */
+
+	/*  if strings.HasSuffix(name, "]") {
+		return strings.Split(name, "[")[0]
+	}
+	return name */
 }

--- a/buildtools/pip/pip.go
+++ b/buildtools/pip/pip.go
@@ -82,7 +82,7 @@ func FromFile(filename string) ([]Requirement, error) {
 		}
 		if !matched {
 			reqs = append(reqs, Requirement{
-				Name: trimmed,
+				Name: checkForExtra(trimmed),
 			})
 		}
 	}

--- a/buildtools/pip/pip.go
+++ b/buildtools/pip/pip.go
@@ -99,12 +99,4 @@ func checkForExtra(name string) string {
 		}
 	}
 	return name
-
-	/* 	return strings.Split(name, "[")[0]
-	 */
-
-	/*  if strings.HasSuffix(name, "]") {
-		return strings.Split(name, "[")[0]
-	}
-	return name */
 }

--- a/buildtools/pip/pip_test.go
+++ b/buildtools/pip/pip_test.go
@@ -1,0 +1,20 @@
+package pip_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fossas/fossa-cli/buildtools/pip"
+)
+
+func TestFromFile(t *testing.T) {
+	reqs, err := pip.FromFile("testdata/requirements.txt")
+	assert.NoError(t, err)
+	assert.Equal(t, 5, len(reqs))
+	assert.Contains(t, reqs, pip.Requirement{Name: "simple", Revision: "1.0.0", Operator: "=="})
+	assert.Contains(t, reqs, pip.Requirement{Name: "extra", Revision: "2.0.0", Operator: "=="})
+	assert.Contains(t, reqs, pip.Requirement{Name: "latest"})
+	assert.Contains(t, reqs, pip.Requirement{Name: "latestExtra"})
+	assert.Contains(t, reqs, pip.Requirement{Name: "notEqualOp", Revision: "3.0.0", Operator: ">="})
+}

--- a/buildtools/pip/testdata/requirements.txt
+++ b/buildtools/pip/testdata/requirements.txt
@@ -1,0 +1,5 @@
+simple==1.0.0
+extra[extra]==2.0.0
+latest
+latestExtra[security]
+notEqualOp>=3.0.0


### PR DESCRIPTION
In response to issue [#295].
This allows our `requirements.txt` parser to acknowledge extras as defined by [PEP 508](https://www.python.org/dev/peps/pep-0508/#extras).

The code I am most interested in hearing feedback on is the logic inside `checkForExtra()`. I can reduce this logic to a single line `return strings.Split(name, "[")[0]` but wanted to keep it verbose to improve readability.
