### PR TITLE
fix(upload) remove duplication of flags to fix upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,10 @@ jobs:
           command: |
             fossa analyze --debug > $ARTIFACTS/fossa-analyze-stdout 2> $ARTIFACTS/fossa-analyze-stderr
       - run:
+          name: Run FOSSA upload
+          command: |
+            fossa analyze --debug | fossa upload > $ARTIFACTS/fossa-upload-stdout 2> $ARTIFACTS/fossa-upload-stderr
+      - run:
           name: Run FOSSA license check
           command: |
             fossa test --debug > $ARTIFACTS/fossa-test-stdout 2> $ARTIFACTS/fossa-test-stderr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
       - run:
           name: Run FOSSA upload
           command: |
-            fossa analyze --debug | fossa upload > $ARTIFACTS/fossa-upload-stdout 2> $ARTIFACTS/fossa-upload-stderr
+            fossa analyze --output | fossa upload --debug > $ARTIFACTS/fossa-upload-stdout 2> $ARTIFACTS/fossa-upload-stderr
       - run:
           name: Run FOSSA license check
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - run:
           name: Install CLI
           command: |
-            curl https://raw.githubusercontent.com/fossas/fossa-cli/$CIRCLE_SHA1/install.sh | bash
+            make
       - run:
           name: Run FOSSA analysis
           command: |
@@ -119,6 +119,30 @@ jobs:
           name: Run FOSSA license check
           command: |
             fossa test --debug > $ARTIFACTS/fossa-test-stdout 2> $ARTIFACTS/fossa-test-stderr
+      - run:
+          name: Save artifacts
+          command: |
+            cp $(which fossa) $ARTIFACTS
+      - store_artifacts:
+          path: /tmp/artifacts
+  installer-test:
+    <<: *defaults
+    working_directory: /go/src/github.com/fossas/fossa-cli
+    docker:
+      - image: circleci/golang:1
+    steps:
+      - checkout
+      - run:
+          name: Make folders
+          command: mkdir -p $ARTIFACTS
+      - run:
+          name: Install CLI
+          command: |
+            curl https://raw.githubusercontent.com/fossas/fossa-cli/$CIRCLE_SHA1/install.sh | bash
+      - run:
+          name: Run FOSSA analysis
+          command: |
+            fossa analyze --debug > $ARTIFACTS/fossa-installer-analyze-stdout 2> $ARTIFACTS/fossa-installer-analyze-stderr
       - run:
           name: Save artifacts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           name: Make folders
           command: mkdir -p $ARTIFACTS
       - run:
-          name: Install CLI
+          name: Make CLI
           command: |
             make
       - run:
@@ -127,11 +127,9 @@ jobs:
           path: /tmp/artifacts
   installer-test:
     <<: *defaults
-    working_directory: /go/src/github.com/fossas/fossa-cli
     docker:
       - image: circleci/golang:1
     steps:
-      - checkout
       - run:
           name: Make folders
           command: mkdir -p $ARTIFACTS
@@ -142,7 +140,7 @@ jobs:
       - run:
           name: Run FOSSA analysis
           command: |
-            fossa analyze -o --debug > $ARTIFACTS/fossa-installer-analyze-stdout 2> $ARTIFACTS/fossa-installer-analyze-stderr
+            fossa help > $ARTIFACTS/fossa-installer-help-stdout 2> $ARTIFACTS/fossa-installer-help-stderr
       - run:
           name: Save artifacts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
           command: |
             curl https://raw.githubusercontent.com/fossas/fossa-cli/$CIRCLE_SHA1/install.sh | bash
       - run:
-          name: Run FOSSA analysis
+          name: Run FOSSA help
           command: |
             fossa help > $ARTIFACTS/fossa-installer-help-stdout 2> $ARTIFACTS/fossa-installer-help-stderr
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - run:
           name: Install CLI
           command: |
-            curl https://raw.githubusercontent.com/fossas/fossa-cli/$CIRCLE_SHA1/install.sh | bash
+            make build
       - run:
           name: Run FOSSA analysis
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,10 +116,6 @@ jobs:
           command: |
             fossa analyze --debug > $ARTIFACTS/fossa-analyze-stdout 2> $ARTIFACTS/fossa-analyze-stderr
       - run:
-          name: Run FOSSA upload
-          command: |
-            fossa analyze --output | fossa upload --debug > $ARTIFACTS/fossa-upload-stdout 2> $ARTIFACTS/fossa-upload-stderr
-      - run:
           name: Run FOSSA license check
           command: |
             fossa test --debug > $ARTIFACTS/fossa-test-stdout 2> $ARTIFACTS/fossa-test-stderr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
       - run:
           name: Run FOSSA analysis
           command: |
-            fossa analyze --debug > $ARTIFACTS/fossa-installer-analyze-stdout 2> $ARTIFACTS/fossa-installer-analyze-stderr
+            fossa analyze -o --debug > $ARTIFACTS/fossa-installer-analyze-stdout 2> $ARTIFACTS/fossa-installer-analyze-stderr
       - run:
           name: Save artifacts
           command: |
@@ -158,3 +158,4 @@ workflows:
       - unit-test
       - integration-test
       - end-to-end-test
+      - installer-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - run:
           name: Install CLI
           command: |
-            make build
+            curl https://raw.githubusercontent.com/fossas/fossa-cli/$CIRCLE_SHA1/install.sh | bash
       - run:
           name: Run FOSSA analysis
           command: |

--- a/cmd/fossa/cmd/upload/upload.go
+++ b/cmd/fossa/cmd/upload/upload.go
@@ -124,24 +124,26 @@ func getInput(ctx *cli.Context, usingLocators bool) ([]fossa.SourceUnit, error) 
 }
 
 // Run executes the upload command.
-func Run(ctx *cli.Context) {
+func Run(ctx *cli.Context) error {
 	err := setup.SetContext(ctx)
 	if err != nil {
-		log.Fatalf("Could not initialize: %s", err.Error())
+		return errors.Wrap(err, "could not initialize")
 	}
 
 	data, err := getInput(ctx, ctx.Bool(Locators))
 	if err != nil {
-		log.Fatalf("Bad input: %s", err.Error())
+		return errors.Wrap(err, "bad input")
 	}
 
 	display.InProgress("Uploading...")
 	locator, err := Do(data)
 	if err != nil {
-		log.Fatalf("Upload failed: %s", err.Error())
+		return errors.Wrap(err, "upload failed")
 	}
 	display.ClearProgress()
 	fmt.Println(locator.ReportURL())
+
+	return nil
 }
 
 // Do performs a SourceUnit upload of the current project without other side

--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -63,7 +63,7 @@ var (
 	JIRAProjectKey  = "jira-project-key"
 	JIRAProjectKeyF = cli.StringFlag{Name: Short(JIRAProjectKey), Usage: "this repository's JIRA project key"}
 	Link            = "link"
-	LinkF           = cli.StringFlag{Name: Short(Link), Usage: "a link to attach to the current build"}
+	LinkF           = cli.StringFlag{Name: ShortUpper(Link), Usage: "a link to attach to the current build"}
 	Team            = "team"
 	TeamF           = cli.StringFlag{Name: ShortUpper(Team), Usage: "this repository's team inside your organization"}
 )

--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -63,7 +63,7 @@ var (
 	JIRAProjectKey  = "jira-project-key"
 	JIRAProjectKeyF = cli.StringFlag{Name: Short(JIRAProjectKey), Usage: "this repository's JIRA project key"}
 	Link            = "link"
-	LinkF           = cli.StringFlag{Name: ShortUpper(Link), Usage: "a link to attach to the current build"}
+	LinkF           = cli.StringFlag{Name: Short(Link), Usage: "a link to attach to the current build"}
 	Team            = "team"
 	TeamF           = cli.StringFlag{Name: ShortUpper(Team), Usage: "this repository's team inside your organization"}
 )

--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -52,7 +52,7 @@ func main() {
 			os.Exit(e.ExitCode())
 		default:
 			// TODO: port all log.Fatal to instead return an error.
-			log.Debugf("Error: %#v", err.Error())
+			log.Errorf(err.Error())
 			os.Exit(1)
 		}
 	}

--- a/cmd/fossa/main_test.go
+++ b/cmd/fossa/main_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,4 +12,17 @@ import (
 
 func TestMainProvidesDebugFlag(t *testing.T) {
 	assert.Contains(t, main.App.VisibleFlags(), flags.DebugF)
+}
+
+func TestNoDuplicateFlags(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			if strings.HasPrefix(r.(string), "upload flag redefined") {
+				assert.Fail(t, "duplicate flag detected", r)
+			} else {
+				panic(r)
+			}
+		}
+	}()
+	_ = main.App.Run([]string{"fossa", "upload"})
 }


### PR DESCRIPTION
In response to issue [#357]
Change link flag to an uppercase flag because fossa upload is also defining a lowercase `-l` flag.