### PR TITLE
fix(python) Add options support to requirements.txt parsing

### DIFF
--- a/buildtools/pip/pip.go
+++ b/buildtools/pip/pip.go
@@ -60,7 +60,7 @@ func FromFile(filename string) ([]Requirement, error) {
 	var reqs []Requirement
 	for _, line := range strings.Split(string(contents), "\n") {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "#") || trimmed == "" {
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "-") || trimmed == "" {
 			continue
 		}
 		log.WithField("line", line).Debug("parsing line")

--- a/buildtools/pip/pip_test.go
+++ b/buildtools/pip/pip_test.go
@@ -17,4 +17,6 @@ func TestFromFile(t *testing.T) {
 	assert.Contains(t, reqs, pip.Requirement{Name: "latest"})
 	assert.Contains(t, reqs, pip.Requirement{Name: "latestExtra"})
 	assert.Contains(t, reqs, pip.Requirement{Name: "notEqualOp", Revision: "3.0.0", Operator: ">="})
+	assert.NotContains(t, reqs, pip.Requirement{Name: "-r other-requirements.txt"})
+	assert.NotContains(t, reqs, pip.Requirement{Name: "--option test-option"})
 }

--- a/buildtools/pip/testdata/requirements.txt
+++ b/buildtools/pip/testdata/requirements.txt
@@ -1,3 +1,5 @@
+--option test-option
+-r other-requirements.txt
 simple==1.0.0
 extra[extra]==2.0.0
 latest


### PR DESCRIPTION
The requirements.txt parser does not currently acknowledge options or file references as distinct information. It uploads them as dependencies causing a missing dependency on the backend. This fixes that issue.
[Requirements.txt spec](https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format)