### PR TITLE
Pass -no-colors about as two separate arguments to sbt, not one

### DIFF
--- a/analyzers/scala/scala.go
+++ b/analyzers/scala/scala.go
@@ -44,7 +44,7 @@ func New(m module.Module) (*Analyzer, error) {
 	}
 
 	// Set SBT context variables
-	sbtCmd, sbtVersion, err := exec.Which("-no-colors about", os.Getenv("SBT_BINARY"), "sbt")
+	sbtCmd, sbtVersion, err := exec.WhichArgs([]string{"-no-colors", "about"}, os.Getenv("SBT_BINARY"), "sbt")
 	if err != nil {
 		// Is FOSSA_SBT_BINARY set?
 		log.WithError(err).Warn("could not find SBT binary")
@@ -80,7 +80,7 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 	log.WithField("dir", dir).Debug("discovering modules")
 
 	// Construct SBT instance (for listing projects).
-	sbtCmd, _, err := exec.Which("-no-colors about", os.Getenv("SBT_BINARY"), "sbt")
+	sbtCmd, _, err := exec.WhichArgs([]string{"-no-colors", "about"}, os.Getenv("SBT_BINARY"), "sbt")
 	if err != nil {
 		return nil, nil
 	}


### PR DESCRIPTION
This line:

```
sbtCmd, sbtVersion, err := exec.Which("-no-colors about", os.Getenv("SBT_BINARY"), "sbt")
```

appears to pass a single argument to `sbt`, `-no-colors about`. This is misinterpreted as an unknown command by sbt 1.1.5 and sbt 1.2.6. Sample output:

```
DEBUG done running callers=[/home/fossa/go/src/github.com/fossas/fossa-cli/exec/run.go:github.com/fossas/fossa-cli/exec.Run:46 /home/fossa/go/src/github.com/fossas/fossa-cli/exe\
c/which.go:github.com/fossas/fossa-cli/exec.WhichArgs.func1:17 /home/fossa/go/src/github.com/fossas/fossa-cli/exec/which.go:github.com/fossas/fossa-cli/exec.WhichWithResolver:37\
 /home/fossa/go/src/github.com/fossas/fossa-cli/exec/which.go:github.com/fossas/fossa-cli/exec.WhichArgs:16 /home/fossa/go/src/github.com/fossas/fossa-cli/exec/which.go:github.c\
om/fossas/fossa-cli/exec.Which:11 /home/fossa/go/src/github.com/fossas/fossa-cli/analyzers/scala/scala.go:github.com/fossas/fossa-cli/analyzers/scala.New:47 /home/fossa/go/src/g\
ithub.com/fossas/fossa-cli/analyzers/analyzer.go:github.com/fossas/fossa-cli/analyzers.New:71 /home/fossa/go/src/github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze/analyze.go:git\
hub.com/fossas/fossa-cli/cmd/fossa/cmd/analyze.Do:109 /home/fossa/go/src/github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze/analyze.go:github.com/fossas/fossa-cli/cmd/fossa/cmd/a\
nalyze.Run:48 /home/fossa/go/src/github.com/fossas/fossa-cli/cmd/fossa/main.go:main.Run:77 /home/fossa/go/src/github.com/fossas/fossa-cli/vendor/github.com/urfave/cli/app.go:git\
hub.com/fossas/fossa-cli/vendor/github.com/urfave/cli.HandleAction:490 /home/fossa/go/src/github.com/fossas/fossa-cli/vendor/github.com/urfave/cli/app.go:github.com/fossas/fossa\
-cli/vendor/github.com/urfave/cli.(*App).Run:264 /home/fossa/go/src/github.com/fossas/fossa-cli/cmd/fossa/main.go:main.main:48] stderr= stdout=# Executing command line:^M
java^M
-XX:ReservedCodeCacheSize=128m^M
-XX:MaxMetaspaceSize=256m^M
-Xms256m^M
-Xmx4096m^M
-jar^M
/usr/share/sbt/bin/sbt-launch.jar^M
-Dsbt.override.build.repos=true^M
-Dsbt.repository.config=./.sbtrepos^M
-Dsbt.watch.mode=polling^M
-Dsbt.boot.credentials=/home/travis/build/zendesk/custom_resources/.sbtcreds^M
"-no-colors about"^M
^M
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mLoading settings from _credentials.sbt,plugins.sbt ...^[[0m^M
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mLoading project definition from /home/travis/build/zendesk/custom_resources/project^[[0m^M
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mLoading settings from build.sbt ...^[[0m^M
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mLoading settings from build.sbt ...^[[0m^M
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mLoading settings from build.sbt ...^[[0m^M
^[[0m[^[[0m^[[0minfo^[[0m] ^[[0m^[[0mSet current project to custom_resources (in build file:/home/travis/build/zendesk/custom_resources/)^[[0m^M
^[[0m[^[[0m^[[33mwarn^[[0m] ^[[0m^[[0mThe `-` command is deprecated in favor of `onFailure` and will be removed in a later version^[[0m^M
^M
```

The fix appears to be to use the `WhichArgs` function instead of the `Which` function, and pass `-no-colors` and `about` as individual arguments.

/cc @plonergan
