### PR TITLE
Link to CONTRIBUTING.md was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Check out the [User Guide](docs/user-guide.md) for more details.
 
 ## Development
 
-View our [Contribution Guidelines](CONTRIBUTING.md) to get started.
+View our [Contribution Guidelines](.github/CONTRIBUTING.md) to get started.
 
 Join our public [Slack Channel](https://slack.fossa.io).
 


### PR DESCRIPTION
The `README.md` linked to the file `./CONTRIBUTING.md`, but the file is actually in the `.github` directory.