### PR TITLE
Add machine-readable output format to license report

### DIFF
--- a/cmd/fossa/cmd/report/licenses.go
+++ b/cmd/fossa/cmd/report/licenses.go
@@ -28,7 +28,8 @@ The following software have components provided under the terms of this license:
 `
 
 const (
-	JSON = "json"
+	JSON    = "json"
+	Unknown = "show-unknown"
 )
 
 var licensesCmd = cli.Command{

--- a/cmd/fossa/cmd/report/licenses.go
+++ b/cmd/fossa/cmd/report/licenses.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"encoding/json"
 	"fmt"
 	"text/template"
 
@@ -26,12 +27,17 @@ The following software have components provided under the terms of this license:
 {{end}}
 `
 
+const (
+	JSON = "json"
+)
+
 var licensesCmd = cli.Command{
 	Name:  "licenses",
 	Usage: "Generate licenses report",
 	Flags: flags.WithGlobalFlags(flags.WithAPIFlags(flags.WithOptions(flags.WithReportTemplateFlags([]cli.Flag{
 		// TODO: what does this actually do?
 		cli.BoolFlag{Name: flags.Short(Unknown), Usage: "include unknown licenses"},
+		cli.BoolFlag{Name: JSON, Usage: "format output as JSON"},
 	})))),
 	Action: licensesRun,
 }
@@ -80,6 +86,15 @@ func licensesRun(ctx *cli.Context) (err error) {
 		}
 	}
 	display.ClearProgress()
+
+	if ctx.Bool(JSON) {
+		output, err := json.Marshal(revs)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(output))
+		return nil
+	}
 
 	depsByLicense := make(map[string]map[string]fossa.Revision)
 	for _, rev := range revs {

--- a/cmd/fossa/cmd/report/report.go
+++ b/cmd/fossa/cmd/report/report.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fossas/fossa-cli/module"
 )
 
-var (
+const (
 	Unknown = "show-unknown"
 )
 

--- a/cmd/fossa/cmd/report/report.go
+++ b/cmd/fossa/cmd/report/report.go
@@ -10,10 +10,6 @@ import (
 	"github.com/fossas/fossa-cli/module"
 )
 
-const (
-	Unknown = "show-unknown"
-)
-
 var Cmd = cli.Command{
 	Name:  "report",
 	Usage: "Generate reports",


### PR DESCRIPTION
Adds a `--json` flag to `fossa report licenses` which outputs license data in JSON format.