### PR TITLE
Correctly set directory when modules are passed in from the command line

### DIFF
--- a/analyzers/cocoapods/cocoapods.go
+++ b/analyzers/cocoapods/cocoapods.go
@@ -47,6 +47,12 @@ func New(m module.Module) (*Analyzer, error) {
 	}
 	log.WithField("options", options).Debug("parsed analyzer options")
 
+	// Edge case: `Dir` is not set when passing module configurations from the command line.
+	// TODO: we really need to refactor the Module struct.
+	if m.Dir == "" {
+		m.Dir = m.BuildTarget
+	}
+
 	analyzer := Analyzer{
 		PodCmd:     podCmd,
 		PodVersion: podVersion,


### PR DESCRIPTION
There are probably other module types that need this fix too (in particular, any module types where we rely on `Dir` and where `BuildTarget` is semantically equivalent to `Dir`).