### PR TITLE
fix (fossa report licenses) change the way that we find dependency license information.

### DIFF
--- a/api/fossa/revisions.go
+++ b/api/fossa/revisions.go
@@ -45,6 +45,16 @@ type Project struct {
 // RevisionsAPI is the API endpoint for revisions.
 const RevisionsAPI = "/api/revisions/%s"
 
+// RevisionsDependenciesAPI is the API endpoint to retrieve transitive dependencies of a revision.
+const RevisionsDependenciesAPI = "/api/revisions/%s/dependencies"
+
+// GetRevisionDependencies returns all transitive dependencies for a project revision.
+func GetRevisionDependencies(locator Locator) ([]Revision, error) {
+	var revisions []Revision
+	_, err := GetJSON(fmt.Sprintf(RevisionsDependenciesAPI, url.PathEscape(locator.OrgString())), &revisions)
+	return revisions, err
+}
+
 // GetRevision loads a single revision.
 func GetRevision(locator Locator) (Revision, error) {
 	var revision Revision
@@ -74,9 +84,6 @@ func GetRevision(locator Locator) (Revision, error) {
 // GetRevisions loads many revisions in batched requests.
 func GetRevisions(locators []Locator) (revs []Revision, err error) {
 	var locs []string
-	for _, loc := range locators {
-		locs = append(locs, loc.String())
-	}
 
 	// Split locators into chunks of 20 (this is an API limitation).
 	chunks := make([][]string, 0)

--- a/cmd/fossa/cmd/report/licenses.go
+++ b/cmd/fossa/cmd/report/licenses.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/fossas/fossa-cli/cmd/fossa/display"
+	"github.com/apex/log"
 	"github.com/urfave/cli"
 
-	"github.com/apex/log"
 	"github.com/fossas/fossa-cli/api/fossa"
+	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
+	"github.com/fossas/fossa-cli/cmd/fossa/setup"
+	"github.com/fossas/fossa-cli/config"
+	"github.com/fossas/fossa-cli/errors"
 )
 
 const defaultLicenseReportTemplate = `# 3rd-Party Software License Notice
@@ -44,49 +47,22 @@ var licensesCmd = cli.Command{
 }
 
 func licensesRun(ctx *cli.Context) (err error) {
-	analyzed, err := analyzeModules(ctx)
+	err = setup.SetContext(ctx)
 	if err != nil {
-		log.Fatalf("Could not analyze modules: %s", err.Error())
+		log.Fatalf("Could not initialize: %s", err.Error())
 	}
 
-	defer display.ClearProgress()
 	revs := make([]fossa.Revision, 0)
-	for _, module := range analyzed {
-		if ctx.Bool(Unknown) {
-			totalDeps := len(module.Deps)
-			i := 0
-			for _, dep := range module.Deps {
-				i++
-				display.InProgress(fmt.Sprintf("Fetching License Info (%d/%d): %s", i, totalDeps, dep.ID.Name))
-				locator := fossa.LocatorOf(dep.ID)
-				// Quirk of the licenses API: Go projects are stored under the git fetcher.
-				if locator.Fetcher == "go" {
-					locator.Fetcher = "git"
-				}
-				rev, err := fossa.GetRevision(fossa.LocatorOf(dep.ID))
-				if err != nil {
-					log.Warn(err.Error())
-					continue
-				}
-				revs = append(revs, rev)
-			}
-		} else {
-			display.InProgress("Fetching License Info")
-			var locators []fossa.Locator
-			for _, dep := range module.Deps {
-				locator := fossa.LocatorOf(dep.ID)
-				if locator.Fetcher == "go" {
-					locator.Fetcher = "git"
-				}
-				locators = append(locators, locator)
-			}
-			revs, err = fossa.GetRevisions(locators)
-			if err != nil {
-				log.Fatalf("Could not fetch revisions: %s", err.Error())
-			}
-		}
+
+	locator := fossa.Locator{
+		Fetcher:  config.Fetcher(),
+		Project:  config.Project(),
+		Revision: config.Revision(),
 	}
-	display.ClearProgress()
+	revs, err = fossa.GetRevisionDependencies(locator)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to find licenses for project %s:", locator)
+	}
 
 	if ctx.Bool(JSON) {
 		output, err := json.Marshal(revs)


### PR DESCRIPTION
Closes #389 

This PR addresses the errors seen when running `fossa report licenses` by changing the way we look for license information.

Changes:
1. Revision licenses are now found directly using the api route `/api/revisions/%s/dependencies` instead of first analyzing the project and querying licenses for each revision found.
2. `if` block inside of `licenses.go` has been removed because the logic is now simplified inside of the one API call. 

Concerns:
1. Should we rip out the now unused functions `GetRevision()` and `GetRevisions()` inside `revisions.go`? 
2. Should we remove the `Unknown` flag from `licenses.go`?
I believe both of these concerns are related to how the current userbase uses `report licenses` and I am in favor of removing both of these code paths for simplicity.