### PR TITLE
fix (fossa test) Poll the fossa issues endpoint until a scan is complete.

### DIFF
--- a/api/fossa/issues.go
+++ b/api/fossa/issues.go
@@ -23,6 +23,7 @@ type Issue struct {
 type Issues struct {
 	Count  int
 	Issues []Issue
+	Status string
 }
 
 // GetIssues loads the issues for a project.

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -124,6 +124,7 @@ func CheckBuild(locator fossa.Locator, stop <-chan time.Time) (fossa.Build, erro
 	}
 }
 
+// CheckIssues polls the issues endpoint until an issue scan has been run on the latest project revision.
 func CheckIssues(locator fossa.Locator, stop <-chan time.Time) (fossa.Issues, error) {
 	for {
 		select {
@@ -138,8 +139,14 @@ func CheckIssues(locator fossa.Locator, stop <-chan time.Time) (fossa.Issues, er
 			if err != nil {
 				return fossa.Issues{}, errors.Wrap(err, "error while loading issues")
 			}
-			log.Debugf("Got issues: %#v", issues)
-			return issues, nil
+			switch issues.Status {
+			case "WAITING":
+				log.Debugf("Got issues: %#v", issues)
+			case "SCANNED":
+				return issues, nil
+			default:
+				return issues, fmt.Errorf("unknown task status: %s", issues.Status)
+			}
 		}
 	}
 }

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -141,7 +141,7 @@ func CheckIssues(locator fossa.Locator, stop <-chan time.Time) (fossa.Issues, er
 			}
 			switch issues.Status {
 			case "WAITING":
-				log.Debugf("Got issues: %#v", issues)
+				time.Sleep(pollRequestDelay)
 			case "SCANNED":
 				return issues, nil
 			default:


### PR DESCRIPTION
This PR prevents `fossa test` from reporting an incomplete issues scan to a user.