### PR TITLE
fix (Gradle analyzer) Fix gradle discovery for root projects and add a flag to scan all submodules

### DIFF
--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -114,10 +114,10 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 			}
 			if len(projects) == 0 {
 				modules = append(modules, module.Module{
-					Name:        name,
+					Name:        filepath.Base(path),
 					Type:        pkg.Gradle,
 					BuildTarget: ":",
-					Dir:         dir,
+					Dir:         path,
 				})
 			}
 			// Don't continue recursing, because anything else is probably a

--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -31,10 +31,10 @@ type Analyzer struct {
 }
 
 type Options struct {
-	Cmd    string `mapstructure:"cmd"`
-	Task   string `mapstructure:"task"`
-	Online bool   `mapstructure:"online"`
-
+	Cmd           string `mapstructure:"cmd"`
+	Task          string `mapstructure:"task"`
+	Online        bool   `mapstructure:"online"`
+	AllSubmodules bool   `mapstructure:"allsubmodules"`
 	// TODO: These are temporary until v2 configuration files (with proper BuildTarget) are implemented.
 	Project       string `mapstructure:"project"`
 	Configuration string `mapstructure:"configuration"`
@@ -162,7 +162,16 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	var err error
 	targets := strings.Split(a.Module.BuildTarget, ":")
 
-	if a.Options.Task != "" {
+	if a.Options.AllSubmodules {
+		submodules, err := g.Projects()
+		if err != nil {
+			return graph.Deps{}, err
+		}
+		depsByConfig, err = g.ProjectListDependencies(submodules)
+		if err != nil {
+			return graph.Deps{}, err
+		}
+	} else if a.Options.Task != "" {
 		depsByConfig, err = g.DependenciesTask(strings.Split(a.Options.Task, " ")...)
 		if err != nil {
 			return graph.Deps{}, err

--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -167,7 +167,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		if err != nil {
 			return graph.Deps{}, err
 		}
-		depsByConfig, err = g.ProjectListDependencies(submodules)
+		depsByConfig, err = g.MergeProjectsDependencies(submodules)
 		if err != nil {
 			return graph.Deps{}, err
 		}

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -27,6 +27,37 @@ type Dependency struct {
 	IsProject bool
 }
 
+func (g *Gradle) ProjectListDependencies(projects []string) (map[string]graph.Deps, error) {
+	configurationMap := make(map[string]graph.Deps)
+	for _, project := range projects {
+		depGraph, err := g.Dependencies(project)
+		if err != nil {
+			return configurationMap, err
+		}
+		for configuration, configGraph := range depGraph {
+			if configurationMap[configuration].Direct == nil {
+				configurationMap[configuration] = configGraph
+			} else {
+				for id, transitivePackage := range configGraph.Transitive {
+					configurationMap[configuration].Transitive[id] = transitivePackage
+				}
+				tempDirect := configurationMap[configuration].Direct
+				for _, dep := range configGraph.Direct {
+					if !contains(tempDirect, dep) {
+						tempDirect = append(tempDirect, dep)
+					}
+				}
+				configurationMap[configuration] = graph.Deps{
+					Direct:     tempDirect,
+					Transitive: configurationMap[configuration].Transitive,
+				}
+			}
+		}
+	}
+
+	return configurationMap, nil
+}
+
 func (g *Gradle) Dependencies(project string) (map[string]graph.Deps, error) {
 	args := []string{
 		project + ":dependencies",
@@ -218,4 +249,13 @@ func NormalizeDependencies(imports []Dependency, deps map[Dependency][]Dependenc
 		Direct:     i,
 		Transitive: d,
 	}
+}
+
+func contains(array []pkg.Import, check pkg.Import) bool {
+	for _, val := range array {
+		if val == check {
+			return true
+		}
+	}
+	return false
 }

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -27,7 +27,9 @@ type Dependency struct {
 	IsProject bool
 }
 
-func (g *Gradle) ProjectListDependencies(projects []string) (map[string]graph.Deps, error) {
+// MergeProjectsDependecies creates a complete configuration to dep graph map by
+// looping through a given list of projects and merging their dependencies by configuration.
+func (g *Gradle) MergeProjectsDependencies(projects []string) (map[string]graph.Deps, error) {
 	configurationMap := make(map[string]graph.Deps)
 	for _, project := range projects {
 		depGraph, err := g.Dependencies(project)

--- a/config/keys_test.go
+++ b/config/keys_test.go
@@ -51,11 +51,12 @@ func TestModulesWithAnArgumentAndOptions(t *testing.T) {
 	flagSet := flag.NewFlagSet("test", 0)
 	flags.ConfigF.Apply(flagSet)
 	flags.OptionF.Apply(flagSet)
-	flagSet.Parse([]string{"gradle:argumentmodule"})
+	err := flagSet.Parse([]string{"gradle:argumentmodule"})
+	assert.NoError(t, err)
 
 	// Set the flag values.
 	ctx := cli.NewContext(cli.NewApp(), flagSet, nil)
-	err := ctx.Set(flags.Config, "testdata/test.yml")
+	err = ctx.Set(flags.Config, "testdata/test.yml")
 	assert.NoError(t, err)
 	err = ctx.Set(flags.Option, "allsubmodules:true")
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR fixes an issue with how a module is constructed when a `build.gradle` file is discovered but no subprojects are present. 

This PR also adds support for scanning all of a projects submodules using the flag `--option allsubmodules:true`. This is particularly useful when running `fossa analyze` with the argument `gradle::` to signify a gradle root project.

Steps for merging multiple projects dependency maps:
- Create one common `map[string]graph.Deps` object to hold all projects configuration mappings.
- Retrieve a projects dependency graph and start by looping through all configurations specified.
- Retrieve the associated `graph.Deps` from the specified configuration in the returnable map.
- First, merge Transitive dependencies into this configuration map.
- Second, merge Direct dependencies by looping through the exisiting list and appending only those that are not present.