### PR TITLE
feat (okbuck classpath) add a flag to buck analysis for specific types of dependencies.

### DIFF
--- a/analyzers/okbuck/okbuck.go
+++ b/analyzers/okbuck/okbuck.go
@@ -1,10 +1,10 @@
-// Package buck implements the analyzer for Buck. https://buckbuild.com
+// Package okbuck implements the analyzer for OkBuck. https://github.com/uber/okbuck.
 //
-// A `BuildTarget` in Buck is defined as a Build Target by Buck which is in
-// in the format of `//src/build:target`. Buck defines this as a string used to
+// A `BuildTarget` in OkBuck is defined as a Build Target by OkBuck which is in
+// in the format of `//src/build:target`. OkBuck defines this as a string used to
 // identify a Build Rule.
 //
-// This package is implemented by externally calling the `buck` build tool.
+// This package is implemented by externally calling the `okbuck` build tool.
 //
 // FAQ
 //
@@ -21,25 +21,42 @@ import (
 	"path/filepath"
 
 	"github.com/apex/log"
-
 	"github.com/fossas/fossa-cli/buildtools/okbuck"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"
 	"github.com/fossas/fossa-cli/module"
 	"github.com/fossas/fossa-cli/pkg"
+	"github.com/mitchellh/mapstructure"
 )
 
 // Analyzer defines a OkBuck analyzer.
 type Analyzer struct {
-	Module module.Module
-	Setup  okbuck.OkBuck
+	Module  module.Module
+	Setup   okbuck.OkBuck
+	Options Options
+}
+
+// Options sets analyzer options for Go modules.
+type Options struct {
+	ClassPath string `mapstructure:"classpath"` // Specify the classpath to target for a specific configurations dependencies.
 }
 
 // New constructs a new OkBuck analyzer from a module.
 func New(module module.Module) (*Analyzer, error) {
+	log.Debugf("%#v", module)
+
+	// Parse and validate options.
+	var options Options
+	err := mapstructure.Decode(module.Options, &options)
+	if err != nil {
+		return nil, err
+	}
+	log.WithField("options", options).Debug("parsed analyzer options")
+
 	analyzer := Analyzer{
-		Module: module,
-		Setup:  okbuck.New(module.BuildTarget),
+		Module:  module,
+		Setup:   okbuck.New(module.BuildTarget),
+		Options: options,
 	}
 	return &analyzer, nil
 }
@@ -59,9 +76,9 @@ func (a *Analyzer) IsBuilt() (bool, error) {
 	return true, nil
 }
 
-// Analyze analyzes an okbuck build target and its dependencies.
+// Analyze analyzes an OkBuck build target and its dependencies.
 func (a *Analyzer) Analyze() (graph.Deps, error) {
-	return a.Setup.Deps()
+	return a.Setup.Deps(a.Options.ClassPath)
 }
 
 // Discover searches for `buckw` executables in the present directory.

--- a/analyzers/okbuck/okbuck.go
+++ b/analyzers/okbuck/okbuck.go
@@ -21,12 +21,13 @@ import (
 	"path/filepath"
 
 	"github.com/apex/log"
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/fossas/fossa-cli/buildtools/okbuck"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"
 	"github.com/fossas/fossa-cli/module"
 	"github.com/fossas/fossa-cli/pkg"
-	"github.com/mitchellh/mapstructure"
 )
 
 // Analyzer defines a OkBuck analyzer.

--- a/buildtools/okbuck/cmd.go
+++ b/buildtools/okbuck/cmd.go
@@ -5,14 +5,14 @@ import (
 	"github.com/fossas/fossa-cli/exec"
 )
 
-func Cmd(cmd string, args ...string) (string, error) {
+func Cmd(args ...string) (string, error) {
 	out, _, err := exec.Run(exec.Cmd{
 		Name: "./buckw",
-		Argv: append([]string{cmd}, args...),
+		Argv: args,
 	})
 
 	if err != nil {
-		return out, errors.Wrapf(err, "Could not run `buckw %s %+v` within the current directory", cmd, args)
+		return out, errors.Wrapf(err, "Could not run `buckw %+v` within the current directory", args)
 	}
 	return out, nil
 }

--- a/buildtools/okbuck/okbuck_test.go
+++ b/buildtools/okbuck/okbuck_test.go
@@ -18,9 +18,9 @@ func TestOkBuck(t *testing.T) {
 	assertImport(t, testGraph.Direct, "dep:one")
 	assertImport(t, testGraph.Direct, "dep:two")
 
-	dep1, err := findPackage(testGraph.Transitive, "dep:two")
+	dep2, err := findPackage(testGraph.Transitive, "dep:two")
 	assert.NoError(t, err)
-	assert.Empty(t, dep1.Imports)
+	assert.Empty(t, dep2.Imports)
 }
 
 func TestOkBuckClassPath(t *testing.T) {
@@ -30,16 +30,16 @@ func TestOkBuckClassPath(t *testing.T) {
 	assertImport(t, testGraph.Direct, "dep:one")
 	assertImport(t, testGraph.Direct, "dep:three")
 
-	dep1, err := findPackage(testGraph.Transitive, "dep:three")
+	dep3, err := findPackage(testGraph.Transitive, "dep:three")
 	assert.NoError(t, err)
-	assert.Empty(t, dep1.Imports)
+	assert.Empty(t, dep3.Imports)
 }
 
 func MockOkBuck(file string, classpath string) okbuck.OkBuck {
 	return okbuck.Setup{
 		Target: "test",
-		Cmd: func(command string, temp ...string) (string, error) {
-			switch command {
+		Cmd: func(args ...string) (string, error) {
+			switch args[0] {
 			case "targets":
 				return testFile(file)
 			case "audit":

--- a/buildtools/okbuck/okbuck_test.go
+++ b/buildtools/okbuck/okbuck_test.go
@@ -5,9 +5,10 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/fossas/fossa-cli/buildtools/okbuck"
 	"github.com/fossas/fossa-cli/pkg"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestOkBuck(t *testing.T) {

--- a/buildtools/okbuck/testdata/buckw-classpath
+++ b/buildtools/okbuck/testdata/buckw-classpath
@@ -1,0 +1,2 @@
+.okbuck/android/constraint/__package.aar#aar_prebuilt_jar__/classes.jar
+.okbuck/android/constraint/__package.jar__/package.jar

--- a/buildtools/okbuck/testdata/buckw-targets
+++ b/buildtools/okbuck/testdata/buckw-targets
@@ -1,10 +1,16 @@
 [
 {
+  "aar" : ":package.aar__downloaded",
   "buck.base_path" : "dependency1",
   "mavenCoords" : "dep:one:jar:1.0.0"
 },
 {
   "buck.base_path" : "dep2",
   "mavenCoords" : "dep:two:jar:2.0.0"
+},
+{
+  "binaryJar" : ":package.jar__downloaded",
+  "buck.base_path" : "dep3",
+  "mavenCoords" : "dep:three:jar:3.0.0"
 }
 ]


### PR DESCRIPTION
This commit adds the functionality to get only dependencies listed from the command `buckw audit classpath <target>`. This allows runtime dependencies to be separated from test and development dependencies.

In order to use this feature add `--option classpath:<target>` to the `fossa analyze` command. Alternatively it can be added inside of a fossa configuration file as follows:
```
version: 1
cli:
  server: https://app.fossa.io
  fetcher: custom
  project: okbuck
analyze:
  modules:
  - name: okbuck
    type: okbuck
    target: //...
    path: .
    options:
      classpath: //app:bin_prodRelease
```

The changes made to achieve this:
1. Run `./buckw audit classpath <target>` and separate the unique jars.
1. Map the aar or jar identifiers from the `./buckw targets //...` command to their dependency informtation.
1. Associate the utilized jars with the dependency information and return.