### PR TITLE
fix (gradle configurations) add default configurations and change how targets are handled

### DIFF
--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/fossas/fossa-cli/buildtools/gradle"
+	"github.com/fossas/fossa-cli/config"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"
@@ -161,6 +162,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	var configurations []string
 	var depsByConfig map[string]graph.Deps
 	var err error
+	targets := strings.Split(a.Module.BuildTarget, ":")
 
 	if a.Options.AllSubmodules {
 		submodules, err := g.Projects()
@@ -179,6 +181,8 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	} else {
 		if a.Options.Project != "" {
 			project = a.Options.Project
+		} else if config.Version() < 2 {
+			project = targets[0]
 		} else {
 			project = a.Module.BuildTarget
 		}
@@ -191,6 +195,8 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	defaultConfigurations := []string{"compile", "api", "implementation", "compileDependenciesMetadata", "apiDependenciesMetadata", "implementationDependenciesMetadata"}
 	if a.Options.Configuration != "" {
 		configurations = strings.Split(a.Options.Configuration, ",")
+	} else if config.Version() < 2 && len(targets) > 1 && targets[1] != "" {
+		configurations = strings.Split(targets[1], ",")
 	} else if a.Options.AllConfigurations {
 		for config := range depsByConfig {
 			configurations = append(configurations, config)

--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -188,7 +188,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		}
 	}
 
-	defaultConfigurations := []string{"compile", "api", "implementation"}
+	defaultConfigurations := []string{"compile", "api", "implementation", "compileDependenciesMetadata", "apiDependenciesMetadata", "implementationDependenciesMetadata"}
 	if a.Options.Configuration != "" {
 		configurations = strings.Split(a.Options.Configuration, ",")
 	} else if len(targets) > 1 && targets[1] != "" {

--- a/analyzers/gradle/integration_test.go
+++ b/analyzers/gradle/integration_test.go
@@ -34,7 +34,6 @@ func TestGradleIntegration(t *testing.T) {
 
 	targets := []string{
 		"gradle:grpc-netty",
-		"gradle:grpc-netty:compile",
 	}
 
 	for _, target := range targets {

--- a/config/file.go
+++ b/config/file.go
@@ -19,6 +19,8 @@ import (
 // an interface here in anticipation of new versions of configuration files,
 // which will likely be implemented as different structs.
 type File interface {
+	GetVersion() int
+
 	APIKey() string
 	Server() string
 
@@ -36,6 +38,10 @@ type File interface {
 }
 
 type NoFile struct{}
+
+func (_ NoFile) GetVersion() int {
+	return 0
+}
 
 func (_ NoFile) APIKey() string {
 	return ""
@@ -103,7 +109,7 @@ func InitFile(modules []module.Module) File {
 
 	// Construct configuration file.
 	return v1.File{
-		Version: 1,
+		Version: 2,
 		CLI: v1.CLIProperties{
 			Server:  Endpoint(),
 			Fetcher: Fetcher(),

--- a/config/file.v1/file.go
+++ b/config/file.v1/file.go
@@ -9,10 +9,6 @@ import (
 	"github.com/fossas/fossa-cli/pkg"
 )
 
-var (
-	ErrWrongVersion = errors.New("config file version is not 1")
-)
-
 type File struct {
 	Version int `yaml:"version"`
 
@@ -60,9 +56,6 @@ func New(data []byte) (File, error) {
 	if err != nil {
 		return File{}, err
 	}
-	if v, ok := contents["version"].(int); !ok || v != 1 {
-		return File{}, ErrWrongVersion
-	}
 
 	// Unmarshal file.
 	var file File
@@ -104,6 +97,10 @@ func New(data []byte) (File, error) {
 	}
 
 	return file, nil
+}
+
+func (file File) GetVersion() int {
+	return file.Version
 }
 
 func (file File) APIKey() string {

--- a/config/keys.go
+++ b/config/keys.go
@@ -26,6 +26,10 @@ var (
 	filename string
 )
 
+func Version() int {
+	return file.GetVersion()
+}
+
 // Interactive is true if the user desires interactive output.
 func Interactive() bool {
 	return isatty.IsTerminal(os.Stderr.Fd()) && !BoolFlag(flags.NoAnsi)


### PR DESCRIPTION
1. Add `implementationDependenciesMetadata` after this configuration was seen in multiple customer's ouput. Documentation on this configuration is hard to find on this feature on Gradle's end.
2. Allow buildtargets formatted like `<project>:<subproject>` to be handled correctly. Currently `<subproject>` is turned into the configuration.
3. Add an option `all-configurations` to allow users to catch all configurations by default.
4. Add backward compatibility to support older users' config files.