### PR TITLE
fix (raw modules) prevent modules from appearing as projects

### DIFF
--- a/analyzers/gradle/integration_test.go
+++ b/analyzers/gradle/integration_test.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/apex/log"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/fossas/fossa-cli/testing/fixtures"
@@ -26,22 +25,17 @@ func TestGradleIntegration(t *testing.T) {
 	}
 
 	fixtures.Initialize(fixtureDir, []fixtures.Project{project}, func(p fixtures.Project, dir string) error {
-
-		_, stderr, err := runfossa.Init(dir)
-		if err != nil {
-			log.Error("failed to run fossa init on " + p.Name)
-			log.Error(stderr)
-			return err
-		}
-
 		return nil
 	})
+
+	dir := filepath.Join(fixtureDir, project.Name)
+	_, _, err := runfossa.Init(dir)
+	assert.NoError(t, err)
 
 	targets := []string{
 		"gradle:grpc-netty",
 	}
 
-	dir := filepath.Join(fixtureDir, project.Name)
 	for _, target := range targets {
 		output, err := runfossa.AnalyzeOutput(dir, []string{target})
 		assert.NoError(t, err)

--- a/analyzers/gradle/integration_test.go
+++ b/analyzers/gradle/integration_test.go
@@ -3,8 +3,8 @@ package gradle_test
 import (
 	"path/filepath"
 	"testing"
-	"time"
 
+	"github.com/apex/log"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/fossas/fossa-cli/testing/fixtures"
@@ -26,12 +26,16 @@ func TestGradleIntegration(t *testing.T) {
 	}
 
 	fixtures.Initialize(fixtureDir, []fixtures.Project{project}, func(p fixtures.Project, dir string) error {
+
+		_, stderr, err := runfossa.Init(dir)
+		if err != nil {
+			log.Error("failed to run fossa init on " + p.Name)
+			log.Error(stderr)
+			return err
+		}
+
 		return nil
 	})
-	time.Sleep(20000 * time.Millisecond)
-	dir := filepath.Join(fixtureDir, project.Name)
-	_, _, err := runfossa.Init(dir)
-	assert.NoError(t, err)
 
 	targets := []string{
 		"gradle:grpc-netty",

--- a/analyzers/gradle/integration_test.go
+++ b/analyzers/gradle/integration_test.go
@@ -41,6 +41,7 @@ func TestGradleIntegration(t *testing.T) {
 		"gradle:grpc-netty",
 	}
 
+	dir := filepath.Join(fixtureDir, project.Name)
 	for _, target := range targets {
 		output, err := runfossa.AnalyzeOutput(dir, []string{target})
 		assert.NoError(t, err)

--- a/analyzers/gradle/integration_test.go
+++ b/analyzers/gradle/integration_test.go
@@ -3,6 +3,7 @@ package gradle_test
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -27,7 +28,7 @@ func TestGradleIntegration(t *testing.T) {
 	fixtures.Initialize(fixtureDir, []fixtures.Project{project}, func(p fixtures.Project, dir string) error {
 		return nil
 	})
-
+	time.Sleep(20000 * time.Millisecond)
 	dir := filepath.Join(fixtureDir, project.Name)
 	_, _, err := runfossa.Init(dir)
 	assert.NoError(t, err)

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -45,7 +45,7 @@ func Run(ctx *cli.Context) error {
 		log.Fatal("No modules specified.")
 	}
 
-	analyzed, err := Do(modules)
+	analyzed, err := Do(modules, !ctx.Bool(ShowOutput))
 	if err != nil {
 		log.Fatalf("Could not analyze modules: %s", err.Error())
 		return err
@@ -78,7 +78,7 @@ func Run(ctx *cli.Context) error {
 	return uploadAnalysis(normalized)
 }
 
-func Do(modules []module.Module) (analyzed []module.Module, err error) {
+func Do(modules []module.Module, upload bool) (analyzed []module.Module, err error) {
 	defer display.ClearProgress()
 	for i, m := range modules {
 		display.InProgress(fmt.Sprintf("Analyzing module (%d/%d): %s", i+1, len(modules), m.Name))
@@ -88,7 +88,7 @@ func Do(modules []module.Module) (analyzed []module.Module, err error) {
 		// TODO: maybe this should target a third-party folder, rather than a single
 		// folder? Maybe "third-party folder" should be a separate module type?
 		if m.Type == pkg.Raw {
-			locator, err := fossa.UploadTarballProject(m.BuildTarget)
+			locator, err := fossa.UploadTarballDependency(m.BuildTarget, upload)
 			if err != nil {
 				log.Warnf("Could not upload raw module: %s", err.Error())
 			}

--- a/cmd/fossa/cmd/report/report.go
+++ b/cmd/fossa/cmd/report/report.go
@@ -1,9 +1,9 @@
 package report
 
 import (
+	"github.com/apex/log"
 	"github.com/urfave/cli"
 
-	"github.com/apex/log"
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
 	"github.com/fossas/fossa-cli/config"
@@ -33,7 +33,7 @@ func analyzeModules(ctx *cli.Context) ([]module.Module, error) {
 		log.Fatal("No modules specified.")
 	}
 
-	analyzed, err := analyze.Do(modules)
+	analyzed, err := analyze.Do(modules, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Treat raw modules as dependencies when being uploaded. This will enforce FOSSA core to ignore them on the projects page and only consider.

This is accomplished by leveraging functionality built for the Buck analyzer.