### PR TITLE
fix (gradle parser) bug related to windows line endings

### DIFF
--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -58,7 +58,7 @@ func New(m module.Module) (*Analyzer, error) {
 	}
 
 	if analyzer.GradleCmd == "" {
-		gradle, _, err := exec.Which("-v", os.Getenv("FOSSA_GRADLE_CMD"), "./gradlew", "gradle")
+		gradle, _, err := exec.Which("-v", os.Getenv("FOSSA_GRADLE_CMD"), "./gradlew", "./gradlew.bat" "gradle")
 		if err != nil {
 			log.Warnf("Could not find Gradle: %s", err.Error())
 		}

--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -58,7 +58,7 @@ func New(m module.Module) (*Analyzer, error) {
 	}
 
 	if analyzer.GradleCmd == "" {
-		gradle, _, err := exec.Which("-v", os.Getenv("FOSSA_GRADLE_CMD"), "./gradlew", "./gradlew.bat" "gradle")
+		gradle, _, err := exec.Which("-v", os.Getenv("FOSSA_GRADLE_CMD"), "./gradlew", "./gradlew.bat", "gradle")
 		if err != nil {
 			log.Warnf("Could not find Gradle: %s", err.Error())
 		}

--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -58,7 +58,7 @@ func New(m module.Module) (*Analyzer, error) {
 	}
 
 	if analyzer.GradleCmd == "" {
-		gradle, _, err := exec.Which("-v", os.Getenv("FOSSA_GRADLE_CMD"), "./gradlew", "./gradlew.bat", "gradle")
+		gradle, _, err := exec.Which("-v", os.Getenv("FOSSA_GRADLE_CMD"), "./gradlew", ".\\gradlew.bat", "gradle")
 		if err != nil {
 			log.Warnf("Could not find Gradle: %s", err.Error())
 		}

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -83,7 +83,8 @@ func (g *Gradle) DependenciesTask(taskArgs ...string) (map[string]graph.Deps, er
 	// Divide output into configurations. Each configuration is separated by an
 	// empty line, started with a configuration name (and optional description),
 	// and has a dependency as its second line.
-	sections := strings.Split(stdout, "\n\n")
+	splitReg := regexp.MustCompile("\r?\n\r?\n")
+	sections := splitReg.Split(stdout, -1)
 	for _, section := range sections {
 		lines := strings.Split(section, "\n")
 		if len(lines) < 2 {

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -137,10 +137,10 @@ func (g *Gradle) Run(taskArgs ...string) (string, error) {
 
 func ParseDependencies(stdout string) ([]Dependency, map[Dependency][]Dependency, error) {
 	r := regexp.MustCompile("^([ `+\\\\|-]+)([^ `+\\\\|-].+)$")
-
+	splitReg := regexp.MustCompile("\r?\n")
 	// Skip non-dependency lines.
 	var filteredLines []string
-	for _, line := range strings.Split(stdout, "\n") {
+	for _, line := range splitReg.Split(stdout, -1) {
 		if r.MatchString(line) {
 			filteredLines = append(filteredLines, line)
 		}

--- a/buildtools/gradle/gradle_test.go
+++ b/buildtools/gradle/gradle_test.go
@@ -1,7 +1,6 @@
 package gradle_test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -26,26 +25,27 @@ var depFour = gradle.Dependency{Name: "dep:four", Resolved: "4.0", Target: "4.0"
 var depFive = gradle.Dependency{Name: "dep:five", Resolved: "5.0", Target: "5.0", IsProject: false}
 
 func TestParseDependencyTree(t *testing.T) {
-	dat, err := ioutil.ReadFile("testdata/gradleDependencies")
-	assert.NoError(t, err)
-	direct, transitive, err := gradle.ParseDependencies(string(dat))
-	fmt.Println(direct)
-	fmt.Println(transitive)
-	assert.NoError(t, err)
+	files := []string{"testdata/unix", "testdata/dos"}
+	for _, file := range files {
+		dat, err := ioutil.ReadFile(file)
+		assert.NoError(t, err)
+		direct, transitive, err := gradle.ParseDependencies(string(dat))
+		assert.NoError(t, err)
 
-	assert.Equal(t, 3, len(direct))
-	assert.Contains(t, direct, depProject)
-	assert.Contains(t, direct, depOne)
-	assert.Contains(t, direct, depTwo)
+		assert.Equal(t, 3, len(direct))
+		assert.Contains(t, direct, depProject)
+		assert.Contains(t, direct, depOne)
+		assert.Contains(t, direct, depTwo)
 
-	assert.Equal(t, 6, len(transitive))
-	assert.Contains(t, transitive, depProject)
-	assert.Contains(t, transitive, depOne)
-	assert.Contains(t, transitive, depTwo)
-	assert.Contains(t, transitive[depTwo], depThree)
-	assert.Contains(t, transitive[depTwo], depFive)
-	assert.Contains(t, transitive, depThree)
-	assert.Contains(t, transitive[depThree], depFour)
-	assert.Contains(t, transitive, depFour)
-	assert.Contains(t, transitive, depFive)
+		assert.Equal(t, 6, len(transitive))
+		assert.Contains(t, transitive, depProject)
+		assert.Contains(t, transitive, depOne)
+		assert.Contains(t, transitive, depTwo)
+		assert.Contains(t, transitive[depTwo], depThree)
+		assert.Contains(t, transitive[depTwo], depFive)
+		assert.Contains(t, transitive, depThree)
+		assert.Contains(t, transitive[depThree], depFour)
+		assert.Contains(t, transitive, depFour)
+		assert.Contains(t, transitive, depFive)
+	}
 }

--- a/buildtools/gradle/gradle_test.go
+++ b/buildtools/gradle/gradle_test.go
@@ -25,11 +25,16 @@ var depFour = gradle.Dependency{Name: "dep:four", Resolved: "4.0", Target: "4.0"
 var depFive = gradle.Dependency{Name: "dep:five", Resolved: "5.0", Target: "5.0", IsProject: false}
 
 func TestParseDependencyTree(t *testing.T) {
-	files := []string{"testdata/unix", "testdata/dos"}
-	for _, file := range files {
-		dat, err := ioutil.ReadFile(file)
+	dos := "testdata/dos"
+	unix := "testdata/unix"
+	for _, file := range []string{unix, dos} {
+		data, err := ioutil.ReadFile(file)
 		assert.NoError(t, err)
-		direct, transitive, err := gradle.ParseDependencies(string(dat))
+		if file == dos {
+			assertDosFile(t, data)
+		}
+
+		direct, transitive, err := gradle.ParseDependencies(string(data))
 		assert.NoError(t, err)
 
 		assert.Equal(t, 3, len(direct))
@@ -47,5 +52,17 @@ func TestParseDependencyTree(t *testing.T) {
 		assert.Contains(t, transitive[depThree], depFour)
 		assert.Contains(t, transitive, depFour)
 		assert.Contains(t, transitive, depFive)
+	}
+}
+
+func assertDosFile(t *testing.T, file []byte) {
+	fixture := string(file)
+	for i := range fixture {
+		if i == 0 {
+			continue
+		}
+		if fixture[i] == '\n' {
+			assert.Equal(t, uint8('\r'), fixture[i-1])
+		}
 	}
 }

--- a/buildtools/gradle/testdata/dos
+++ b/buildtools/gradle/testdata/dos
@@ -1,0 +1,9 @@
+compile - Dependencies for source set 'main' (deprecated, use 'implementation ' instead).
++--- project :core
++--- dep:one:1.0
+|    \--- dep:three:3.0
+|         \--- dep:four:4.0
+\--- dep:two:2.0
+     +--- dep:three:3.0
+     |    \--- dep:four:4.0
+     \--- dep:five:5.0

--- a/buildtools/gradle/testdata/unix
+++ b/buildtools/gradle/testdata/unix
@@ -1,7 +1,8 @@
 compile - Dependencies for source set 'main' (deprecated, use 'implementation ' instead).
 +--- project :core
 +--- dep:one:1.0
-     \--- dep:three:3.0
+|    \--- dep:three:3.0
+|         \--- dep:four:4.0
 \--- dep:two:2.0
      +--- dep:three:3.0
      |    \--- dep:four:4.0

--- a/docs/integrations/gradle.md
+++ b/docs/integrations/gradle.md
@@ -4,7 +4,7 @@
 
 Gradle support in FOSSA CLI depends on the following tools existing in your environment:
 
-- Gradle (defaults to `gradle` or local `gradlew`, configure with `$GRADLE_BINARY`)
+- Gradle (defaults to the first successful command to run from the following list: `$FOSSA_GRADLE_CMD`, `gradlew`, `gradlew.bat`, `gradle`)
 
 ## Configuration
 
@@ -15,10 +15,10 @@ Gradle support in FOSSA CLI depends on the following tools existing in your envi
  1. Look for a root Gradle build (`build.gradle`).
  2. Run `gradle tasks --all` to find all available sub-modules that support a `:dependencies` command.
  3. If no valid tasks are found, list the root project, `:`, as a Build Target.
- 3. Filter out any suspicious-looking tasks (i.e. labeled `test` or `testCompile`).
- 4. Write tasks to configuration (`fossa.yml`).
+ 4. Filter out any suspicious-looking tasks (i.e. labeled `test` or `testCompile`).
+ 5. Write tasks to configuration (`fossa.yml`).
 
-If a gradle wrapper was provided in the same directory (`./gradlew`), `fossa` will use that over the local `gradle` binary.
+If a gradle wrapper was provided in the same directory (`./gradlew`, `./gradlew.bat`), `fossa` will use that over the local `gradle` binary.
 
 ### Manual
 


### PR DESCRIPTION
Gradle previously didn't correctly parse output with CRLF line endings. This PR also adds support for the `gradlew.bat` file which is used on windows machines in place of the `gradlew` command.