### PR TITLE
fix (fossa upload) allow file argument

### DIFF
--- a/cmd/fossa/cmd/upload/upload.go
+++ b/cmd/fossa/cmd/upload/upload.go
@@ -115,8 +115,12 @@ func getInput(ctx *cli.Context, usingLocators bool) ([]fossa.SourceUnit, error) 
 		return []fossa.SourceUnit{sourceUnit}, nil
 	}
 
+	file, err := ioutil.ReadFile(raw)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not read file")
+	}
 	var out []fossa.SourceUnit
-	err := json.Unmarshal([]byte(raw), &out)
+	err = json.Unmarshal(file, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse build data")
 	}


### PR DESCRIPTION
This PR allows `fossa upload output.json` to upload the contents of `output.json` as a project.