### PR TITLE
fix (ruby tests) fix flaky ruby integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
             mkdir -p $ARTIFACTS
       - restore_cache:
           keys:
-            - v4-integration-test-fixtures
+            - ${CACHE_VERSION}-integration-test-fixtures
       - run:
           name: Run integration tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
             make -s ci-integration-test > $TEST_RESULTS/go-test-report.xml
       # cache the fixtures generated from cloning, installation, and building so we can save time on runs
       - save_cache:
-          key: v4-integration-test-fixtures
+          key: ${CACHE_VERSION}-integration-test-fixtures
           paths:
             - /tmp/fossa-cli-fixtures
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,20 +79,12 @@ jobs:
           command: |
             mkdir -p $TEST_RESULTS
             mkdir -p $ARTIFACTS
-      - restore_cache:
-          keys:
-            - ${CACHE_VERSION}-integration-test-fixtures
       - run:
           name: Run integration tests
           command: |
             # Load shell helpers (e.g. sdkman)
             source /home/fossa/.bashrc
             make -s ci-integration-test > $TEST_RESULTS/go-test-report.xml
-      # cache the fixtures generated from cloning, installation, and building so we can save time on runs
-      - save_cache:
-          key: ${CACHE_VERSION}-integration-test-fixtures
-          paths:
-            - /tmp/fossa-cli-fixtures
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/analyzers/gradle/integration_test.go
+++ b/analyzers/gradle/integration_test.go
@@ -14,11 +14,12 @@ import (
 
 var (
 	fixtureDir = filepath.Join(fixtures.Directory(), "gradle", "analyzer")
-	project    = fixtures.Project{
+	grpc       = fixtures.Project{
 		Name:   "grpc-java",
 		URL:    "https://github.com/grpc/grpc-java",
 		Commit: "cf083239e7cbbde7e8ed7d3f038202735f84c2d3",
 	}
+	projects = []fixtures.Project{grpc}
 )
 
 func TestGradleIntegration(t *testing.T) {
@@ -26,32 +27,30 @@ func TestGradleIntegration(t *testing.T) {
 		t.Skip("Skip integration test")
 	}
 
-	fixtures.Initialize(fixtureDir, []fixtures.Project{project}, func(p fixtures.Project, dir string) error {
-
-		args := []string{"build"}
+	fixtures.Initialize(fixtureDir, projects, func(p fixtures.Project, dir string) error {
+		args := []string{"build", "-p", dir}
+		command := filepath.Join(dir, "gradlew")
 		_, stderr, err := exec.Run(exec.Cmd{
-			Command: "./gradlew",
-			Name:    "./gradlew",
-			Argv:    args,
-			Dir:     dir,
+			Name: command,
+			Argv: args,
 		})
 		if err != nil {
 			log.Error("Error running ./gradlew")
 			log.Error(stderr)
 		}
+
+		_, _, err = runfossa.Init(dir)
+		assert.NoError(t, err)
+
 		return nil
 	})
 
-	dir := filepath.Join(fixtureDir, project.Name)
-	_, _, err := runfossa.Init(dir)
-	assert.NoError(t, err)
-
-	targets := []string{
-		"gradle:grpc-netty",
+	targets := map[string]string{
+		grpc.Name: "gradle:grpc-netty",
 	}
 
-	for _, target := range targets {
-		output, err := runfossa.AnalyzeOutput(dir, []string{target})
+	for project, target := range targets {
+		output, err := runfossa.AnalyzeOutput(filepath.Join(fixtureDir, project), []string{target})
 		assert.NoError(t, err)
 		assert.NotEmpty(t, output)
 		assert.NotEmpty(t, output[0].Build.Dependencies)

--- a/analyzers/nodejs/integration_test.go
+++ b/analyzers/nodejs/integration_test.go
@@ -102,32 +102,14 @@ func projectInitializer(proj fixtures.Project, projectDir string) error {
 
 var projects = []fixtures.Project{
 	fixtures.Project{
-		Name:   "puppeteer",
-		URL:    "https://github.com/GoogleChrome/puppeteer",
-		Commit: "b97bddf8e5750d20c6ba82392eebe2a3fd2dd218",
-		Env: map[string]string{
-			"PUPPETEER_SKIP_CHROMIUM_DOWNLOAD": "1",
-		},
-	},
-	fixtures.Project{
 		Name:   "fakerjs",
 		URL:    "https://github.com/Marak/faker.js",
 		Commit: "3a4bb358614c1e1f5d73f4df45c13a1a7aa013d7",
 	},
 	fixtures.Project{
-		Name:   "fastify",
-		URL:    "https://github.com/fastify/fastify",
-		Commit: "1b16a4c5e381f9292d3ac2c327c3bda4bd277408",
-	},
-	fixtures.Project{
 		Name:   "nest",
 		URL:    "https://github.com/nestjs/nest",
 		Commit: "ce498e86150f7de4a260f0c393d47ec4cc920ea1",
-	},
-	fixtures.Project{
-		Name:   "ohm",
-		URL:    "https://github.com/harc/ohm",
-		Commit: "8202eff3723cfa26522134e7b003cf31ab5de445",
 	},
 	fixtures.Project{
 
@@ -140,16 +122,6 @@ var projects = []fixtures.Project{
 		URL:           "https://github.com/standard/standard",
 		Commit:        "bc02256fa2c03632e657248483c55a752e63e724",
 		ModuleOptions: map[string]interface{}{"allow-npm-err": true},
-	},
-	fixtures.Project{
-		Name:   "sodium-encryption",
-		URL:    "https://github.com/mafintosh/sodium-encryption",
-		Commit: "42a7cba0f97718157e8c7a386ef94ba31e16837a",
-	},
-	fixtures.Project{
-		Name:   "request",
-		URL:    "https://github.com/request/request",
-		Commit: "8162961dfdb73dc35a5a4bfeefb858c2ed2ccbb7",
 	},
 }
 

--- a/analyzers/ruby/integration_test.go
+++ b/analyzers/ruby/integration_test.go
@@ -22,13 +22,11 @@ func TestRubyIntegration(t *testing.T) {
 	if testing.Short() {
 		return
 	}
-	t.Parallel()
 
 	fixtures.Initialize(rubyAnalyzerFixtureDir, projects, projectInitializer)
 	for _, project := range projects {
 		proj := project
 		t.Run("Analysis:\t"+proj.Name, func(t *testing.T) {
-			t.Parallel()
 
 			module := module.Module{
 				Dir:         filepath.Join(rubyAnalyzerFixtureDir, proj.Name),

--- a/analyzers/ruby/integration_test.go
+++ b/analyzers/ruby/integration_test.go
@@ -73,7 +73,7 @@ func projectInitializer(proj fixtures.Project, projectDir string) error {
 		Dir:     projectDir,
 	})
 	if err != nil {
-		log.Error("failed to run fossa init on " + proj.Name)
+		log.Error("failed to run bundle on " + proj.Name)
 		log.Error(stderr)
 		return err
 	}
@@ -91,9 +91,9 @@ func projectInitializer(proj fixtures.Project, projectDir string) error {
 
 var projects = []fixtures.Project{
 	fixtures.Project{
-		Name:   "rails",
-		URL:    "https://github.com/rails/rails",
-		Commit: "f4a30d2a0706f278a20c63a3d99288de79b52e5f",
+		Name:   "fluentd",
+		URL:    "https://github.com/fluent/fluentd.git",
+		Commit: "3566901ab4a00e0168b4a6078153dde85601fc53",
 	},
 	fixtures.Project{
 		Name:   "vagrant",


### PR DESCRIPTION
Get the ruby tests back into a reliable state. The suspected issue is that the rails repo is too large (179mb) and breaking on circleci after attempting to clone and run bundle.