### PR TITLE
feat (go dependency versions) Favor explicit versions instead of dependency hashes

### DIFF
--- a/analyzers/golang/analyze_test.go
+++ b/analyzers/golang/analyze_test.go
@@ -45,7 +45,7 @@ func TestPackageNoDeps(t *testing.T) {
 var customtag = pkg.ID{
 	Type:     pkg.Go,
 	Name:     "imports/customtag",
-	Revision: "54321",
+	Revision: "v3.0.0",
 }
 
 var combo = pkg.ID{

--- a/analyzers/golang/testdata/demotags/Gopkg.lock
+++ b/analyzers/golang/testdata/demotags/Gopkg.lock
@@ -6,14 +6,13 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "12345"
-  version = "v1.0.0"
 
 [[projects]]
   name = "imports/customtag"
   packages = ["."]
   pruneopts = "UT"
   revision = "54321"
-  version = "v2.0.0"
+  version = "v3.0.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/buildtools/dep/dep.go
+++ b/buildtools/dep/dep.go
@@ -5,10 +5,11 @@ import (
 	"path"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/fossas/fossa-cli/buildtools"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/pkg"
-	"github.com/pkg/errors"
 )
 
 // Resolver contains both the lockfile and manifest information. Resolver implements golang.Resolver.
@@ -100,13 +101,17 @@ func readLockfile(filepath string) (lockfile, error) {
 	normalized := make(map[string]pkg.Import)
 	for _, project := range lock.Projects {
 		for _, pk := range project.Packages {
+			revision := project.Version
+			if revision == "" {
+				revision = project.Revision
+			}
 			importpath := path.Join(project.Name, pk)
 			normalized[importpath] = pkg.Import{
 				Target: project.Version,
 				Resolved: pkg.ID{
 					Type:     pkg.Go,
 					Name:     importpath,
-					Revision: project.Revision,
+					Revision: revision,
 					Location: "",
 				},
 			}

--- a/buildtools/dep/dep_internal_test.go
+++ b/buildtools/dep/dep_internal_test.go
@@ -3,8 +3,9 @@ package dep
 import (
 	"testing"
 
-	"github.com/fossas/fossa-cli/pkg"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/fossas/fossa-cli/pkg"
 )
 
 func TestIsIgnored(t *testing.T) {
@@ -45,7 +46,7 @@ func TestReadLockfile(t *testing.T) {
 				Resolved: pkg.ID{
 					Type:     pkg.Go,
 					Name:     "cat/fossa",
-					Revision: "1",
+					Revision: "v0.3.0",
 					Location: "",
 				},
 			},


### PR DESCRIPTION
Gopkg.lock always shows a golang hash which we use as the dependency revision. This PR is a proposal to favor an explicit version and fallback to the revision hash only when necessary. This may require a PR on fossa core to allow versions to be displayed correctly.

Todo: Add tests. Work on core for display issues