### PR TITLE
feat (gradle project dir) enable the gradle analyzer to work with a monorepo like structure

### DIFF
--- a/analyzers/gradle/gradle_test.go
+++ b/analyzers/gradle/gradle_test.go
@@ -82,8 +82,8 @@ func TestGradleDiscovery(t *testing.T) {
 	modules, err := gradle.DiscoverWithCommand("testdata", make(map[string]interface{}), mockCommand("testdata/gradle-tasks-all"))
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(modules))
-	assert.True(t, moduleExists("grpc-netty", modules))
-	assert.True(t, moduleExists("grpc-xds", modules))
+	assert.True(t, moduleExists("testdata/grpc-netty", modules))
+	assert.True(t, moduleExists("testdata/grpc-xds", modules))
 }
 
 func mockCommand(mockOutput string) func(string, ...string) (string, error) {

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -7,12 +7,11 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
-
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"
 	"github.com/fossas/fossa-cli/pkg"
+	"github.com/pkg/errors"
 )
 
 // ShellCommand controls the information needed to run a gradle command.
@@ -93,7 +92,10 @@ func Dependencies(project string, i Input) (map[string]graph.Deps, error) {
 
 // ProjectDependencies returns the dependencies of a given gradle project
 func (s ShellCommand) ProjectDependencies(taskArgs ...string) (map[string]graph.Deps, error) {
-	arguments := append(taskArgs, "-p", s.Dir)
+	arguments := taskArgs
+	if s.Dir != "" {
+		arguments = append(arguments, "-p", s.Dir)
+	}
 	if !s.Online {
 		arguments = append(arguments, "--offline")
 	}
@@ -131,7 +133,11 @@ func (s ShellCommand) ProjectDependencies(taskArgs ...string) (map[string]graph.
 
 // DependencyTasks returns a list of gradle projects by analyzing a list of gradle tasks.
 func (s ShellCommand) DependencyTasks() ([]string, error) {
-	stdout, err := s.Cmd(s.Binary, "tasks", "--all", "--quiet", "-p", s.Dir)
+	arguments := []string{"tasks", "--all", "--quiet"}
+	if s.Dir != "" {
+		arguments = append(arguments, "-p", s.Dir)
+	}
+	stdout, err := s.Cmd(s.Binary, arguments...)
 	if err != nil {
 		return nil, err
 	}

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 
 	"github.com/apex/log"
+	"github.com/pkg/errors"
+
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"
 	"github.com/fossas/fossa-cli/pkg"
-	"github.com/pkg/errors"
 )
 
 // ShellCommand controls the information needed to run a gradle command.


### PR DESCRIPTION
Gradle analysis currently does not accurately gradle projects unless it is run at the root of the project. Gradle offers the ability to specify a project in a different directory and we are taking advantage of that here.

Changes made:
1. The module directory is now located where the module's root project is located.
1. The gradle command is found with respect to the directory where the module is located.