### PR TITLE
Check for nil graph from empty Cartfile.resolved

### DIFF
--- a/buildtools/carthage/cartfile.go
+++ b/buildtools/carthage/cartfile.go
@@ -92,6 +92,11 @@ func FromResolvedCartfile(projectName string, dir string) (Package, error) {
 	var cartfile Package
 	cartfileGraph := ogdl.FromFile(cartfilePath)
 
+	if cartfileGraph == nil {
+		log.Debugf("Done parsing empty Cartfile.resolved")
+		return cartfile, nil
+	}
+
 	var allDependencies []Requirement
 
 	// Parse the OGDL


### PR DESCRIPTION
A follow-up for the panic in #430 

If the `Cartfile.resolved` is empty then `cartfileGraph` is `nil`.

Without that check fossa-cli runs into

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x15af891]

goroutine 1 [running]:
github.com/fossas/fossa-cli/buildtools/carthage.FromResolvedCartfile(0xc00002cd0b, 0xd, 0xc00002d320, 0x28, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/stefanscherer/.gvm/pkgsets/go1.12/global/src/github.com/fossas/fossa-cli/buildtools/carthage/cartfile.go:98 +0x2f1
github.com/fossas/fossa-cli/buildtools/carthage.Requirement.Package(0xc0000278e0, 0x6, 0xc00002ccf0, 0x28, 0xc0000278e6, 0x7, 0xc00002cd0b, 0xd, 0xc000152c38, 0x7, ...)
	/Users/stefanscherer/.gvm/pkgsets/go1.12/global/src/github.com/fossas/fossa-cli/buildtools/carthage/cartfile.go:50 +0x39e
github.com/fossas/fossa-cli/buildtools/carthage.RecurseDeps(0xc000246090, 0x185e583, 0x4, 0x0, 0x0, 0xc000148400, 0x8, 0x8, 0xc000152c38, 0x7)
	/Users/stefanscherer/.gvm/pkgsets/go1.12/global/src/github.com/fossas/fossa-cli/buildtools/carthage/cartfile.go:167 +0x2f2
github.com/fossas/fossa-cli/analyzers/carthage.(*Analyzer).Analyze(0xc0000c79a0, 0x1, 0x0, 0x0, 0xc000152c20, 0x7, 0xc000152c38)
	/Users/stefanscherer/.gvm/pkgsets/go1.12/global/src/github.com/fossas/fossa-cli/analyzers/carthage/carthage.go:166 +0x726
github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze.Do(0xc000202000, 0x22, 0x27, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/stefanscherer/.gvm/pkgsets/go1.12/global/src/github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze/analyze.go:122 +0x9a8
github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze.Run(0xc0000b69a0, 0x0, 0xc0000b69a0)
	/Users/stefanscherer/.gvm/pkgsets/go1.12/global/src/github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze/analyze.go:48 +0xf6
github.com/fossas/fossa-cli/vendor/github.com/urfave/cli.HandleAction(0x173e4a0, 0x188aa60, 0xc0000b69a0, 0xc000036700, 0x0)
	/Users/stefanscherer/.gvm/pkgsets/go1.12/global/src/github.com/fossas/fossa-cli/vendor/github.com/urfave/cli/app.go:490 +0xc8
github.com/fossas/fossa-cli/vendor/github.com/urfave/cli.Command.Run(0x185fa06, 0x7, 0x0, 0x0, 0x0, 0x0, 0x0, 0x186c149, 0x1a, 0x0, ...)
	/Users/stefanscherer/.gvm/pkgsets/go1.12/global/src/github.com/fossas/fossa-cli/vendor/github.com/urfave/cli/command.go:210 +0x92f
github.com/fossas/fossa-cli/vendor/github.com/urfave/cli.(*App).Run(0x1f29ca0, 0xc000020140, 0x4, 0x4, 0x0, 0x0)
	/Users/stefanscherer/.gvm/pkgsets/go1.12/global/src/github.com/fossas/fossa-cli/vendor/github.com/urfave/cli/app.go:255 +0x69b
main.main()
	/Users/stefanscherer/.gvm/pkgsets/go1.12/global/src/github.com/fossas/fossa-cli/cmd/fossa/main.go:48 +0x55
~/.
```

