### PR TITLE
fix (fossa report urls) Modify fossa report to give the full dependency url.

### DIFF
--- a/cmd/fossa/cmd/report/dependencies.go
+++ b/cmd/fossa/cmd/report/dependencies.go
@@ -26,7 +26,7 @@ This project includes the following dependencies sorted by corresponding locatio
 ========================================================================
 The following software has been found at this location:
 {{range $i, $dep := $deps}}
-- {{$dep.Project.Title}} - {{$dep.Locator.Revision}} - (from {{$dep.Locator.Project}})
+- {{$dep.Project.Title}} - {{$dep.Locator.Revision}} - (from {{$dep.Project.URL}})
 {{- end}}
 {{end}}
 `

--- a/cmd/fossa/cmd/report/licenses.go
+++ b/cmd/fossa/cmd/report/licenses.go
@@ -26,7 +26,7 @@ This software includes the following software and licenses:
 ========================================================================
 The following software have components provided under the terms of this license:
 {{range $i, $dep := $deps}}
-- {{$dep.Project.Title}} (from {{$dep.Locator.Project}})
+- {{$dep.Project.Title}} (from {{$dep.Project.URL}})
 {{- end}}
 {{end}}
 `


### PR DESCRIPTION
Ensure that the full dependency url is listed when running `fossa report licenses`.