### PR TITLE
Log message if on Windows or not using ANSI

### DIFF
--- a/cmd/fossa/display/progress.go
+++ b/cmd/fossa/display/progress.go
@@ -9,6 +9,8 @@ func InProgress(message string) {
 	if useANSI && level > log.DebugLevel {
 		s.Suffix = " " + message
 		s.Restart()
+	} else {
+		log.Infof(message)
 	}
 }
 

--- a/cmd/fossa/display/progress.go
+++ b/cmd/fossa/display/progress.go
@@ -10,7 +10,7 @@ func InProgress(message string) {
 		s.Suffix = " " + message
 		s.Restart()
 	} else {
-		log.Infof(message)
+		log.Info(message)
 	}
 }
 


### PR DESCRIPTION
On Windows there is no fancy progress spinner. But then nothing is displayed while scanning.
When one of the modules fail (x of 37) the user cannot see which one had trouble.

```
PS C:\Users\stefan\go\src\github.com\docker\xxxxxx> fossa analyze --config .\.fossa-win.yml
WARNING Could not determine whether module is built: could not run go list:  (exit status 1)
WARNING Module does not appear to be built
FATAL Could not analyze: could not run go list:  (exit status 1)
```

So as a simple progress just log the message and the user can see which one failed

```
PS C:\Users\stefan\go\src\github.com\docker\xxxxxx> C:\Users\stefan\Desktop\fossa.exe analyze --config .\.fossa-win.yml
INFO Analyzing module (1/37): github.com/docker/xxxxxx/foo
INFO Analyzing module (2/37): github.com/docker/xxxxxx/bar
INFO Analyzing module (3/37): github.com/docker/xxxxxx/baz
WARNING Could not determine whether module is built: could not run go list:  (exit status 1)
WARNING Module does not appear to be built
FATAL Could not analyze: could not run go list:  (exit status 1)
...
```
