### PR TITLE
golang: fix support for go modules in subdirectories

### DIFF
--- a/analyzers/golang/golang.go
+++ b/analyzers/golang/golang.go
@@ -95,6 +95,7 @@ func New(m module.Module) (*Analyzer, error) {
 	return &Analyzer{
 		Go: gocmd.Go{
 			Cmd: cmd,
+			Dir: m.Dir,
 		},
 		GoVersion: version,
 


### PR DESCRIPTION
This commit fixes situations where a Go module is in a subdirectory of a
repository, as might often be the case in monorepos.

Previously, commands were attempted to be executed at the root of the
repo, which would fail because with Go modules, we can no longer rely on
a global GOPATH to tell us where the code lives, commands are only valid
when executed from within the Go module itself.

Resolves the issues in https://github.com/fossas/fossa-cli/issues/496