### PR TITLE
feat (report license text) add full license and attribution text for fossa report

### DIFF
--- a/api/fossa/revisions.go
+++ b/api/fossa/revisions.go
@@ -16,7 +16,6 @@ type License struct {
 	Ignored        bool
 	Title          string
 	URL            string
-	FullText       string
 	Copyright      string
 	Text           string
 	Attribution    string

--- a/api/fossa/revisions.go
+++ b/api/fossa/revisions.go
@@ -18,6 +18,8 @@ type License struct {
 	URL            string
 	FullText       string
 	Copyright      string
+	Text           string
+	Attribution    string
 }
 
 // A Revision holds the FOSSA API response for the revision API.
@@ -49,9 +51,16 @@ const RevisionsAPI = "/api/revisions/%s"
 const RevisionsDependenciesAPI = "/api/revisions/%s/dependencies"
 
 // GetRevisionDependencies returns all transitive dependencies for a project revision.
-func GetRevisionDependencies(locator Locator) ([]Revision, error) {
+func GetRevisionDependencies(locator Locator, licenseText bool) ([]Revision, error) {
 	var revisions []Revision
-	_, err := GetJSON(fmt.Sprintf(RevisionsDependenciesAPI, url.PathEscape(locator.OrgString())), &revisions)
+	licenseParams := url.Values{}
+	if licenseText {
+		licenseParams.Add("include_license_text", "true")
+		licenseParams.Add("generate_attribution", "true")
+	}
+
+	url := fmt.Sprintf(RevisionsDependenciesAPI, url.PathEscape(locator.OrgString())) + "?" + licenseParams.Encode()
+	_, err := GetJSON(url, &revisions)
 	return revisions, err
 }
 

--- a/cmd/fossa/cmd/report/dependencies.go
+++ b/cmd/fossa/cmd/report/dependencies.go
@@ -54,7 +54,7 @@ func dependenciesRun(ctx *cli.Context) error {
 		Project:  config.Project(),
 		Revision: config.Revision(),
 	}
-	revs, err := fossa.GetRevisionDependencies(locator)
+	revs, err := fossa.GetRevisionDependencies(locator, true)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to find dependencies for project %s:", locator)
 	}

--- a/cmd/fossa/cmd/report/licenses.go
+++ b/cmd/fossa/cmd/report/licenses.go
@@ -54,7 +54,7 @@ func licensesRun(ctx *cli.Context) (err error) {
 		Project:  config.Project(),
 		Revision: config.Revision(),
 	}
-	revs, err := fossa.GetRevisionDependencies(locator)
+	revs, err := fossa.GetRevisionDependencies(locator, true)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to find licenses for project %s:", locator)
 	}


### PR DESCRIPTION
Add fields `Attribution` and `LicenseText` for licenses being returned from the command `fossa report dependencies --json` and the query parameters required to retrieve the data. This enables users to see full license information right from the command line.

Code changes:
- Query parameters added
- Fields added to exisiting structs