### PR TITLE
fix (api error) return api error messages with bad requests

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -62,9 +62,7 @@ func jsonAPIRequest(method string, endpoint *url.URL, APIKey string, body []byte
 	}
 	err = json.Unmarshal(res, v)
 	if err != nil {
-		apiError := errorResponse{}
-		json.Unmarshal(res, &apiError)
-		return code, errors.Wrap(err, apiError.Error)
+		return code, errors.Wrap(err, "could not unmarshal JSON API response")
 	}
 	return code, nil
 }
@@ -115,7 +113,13 @@ func MakeAPIRequest(method string, endpoint *url.URL, APIKey string, body []byte
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "could not read API HTTP response")
 	}
-
 	log.WithField("response", string(res)).Debug("got API response")
+
+	apiError := errorResponse{}
+	err = json.Unmarshal(res, &apiError)
+	if apiError.Error != "" && err == nil {
+		return res, response.StatusCode, errors.New(apiError.Error)
+	}
+
 	return res, response.StatusCode, nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -15,6 +15,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
 var defaultClient = http.Client{
 	Timeout: 60 * time.Second,
 	Transport: &http.Transport{
@@ -58,7 +62,9 @@ func jsonAPIRequest(method string, endpoint *url.URL, APIKey string, body []byte
 	}
 	err = json.Unmarshal(res, v)
 	if err != nil {
-		return code, errors.Wrap(err, "could not unmarshal JSON API response")
+		apiError := errorResponse{}
+		json.Unmarshal(res, &apiError)
+		return code, errors.Wrap(err, apiError.Error)
 	}
 	return code, nil
 }


### PR DESCRIPTION
Previously the error returned by the cli would be confusing and debug logs would be needed in order to determine what happened. This PR adds support for including actual API error messages.