### PR TITLE
Check each Maven POM manifest only once when discovering modules

### DIFF
--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -69,16 +69,16 @@ func Modules(path string, baseDir string, checked map[string]bool) ([]MvnModule,
 		dir = filepath.Dir(path)
 	}
 
-	absPath, err := filepath.Abs(path)
+	absPath, err := filepath.Abs(pomFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not get absolute path of %q", absPath)
+		return nil, errors.Wrapf(err, "could not get absolute path of %q", pomFile)
 	}
 
 	if checked[absPath] {
 		return nil, nil
 	}
 
-	checked[pomFile] = true
+	checked[absPath] = true
 
 	var pom Manifest
 	if err := files.ReadXML(&pom, pomFile); err != nil {

--- a/buildtools/maven/maven_test.go
+++ b/buildtools/maven/maven_test.go
@@ -21,6 +21,12 @@ func TestModules(t *testing.T) {
 		assert.Len(t, mods, 1)
 	}
 
+	// After the pom.xml file in testdataDir has been checked, make sure we don't check it again.
+	modsAgain, err := maven.Modules(testdataDir, testdataDir, checked)
+	if assert.NoError(t, err) {
+		assert.Nil(t, modsAgain)
+	}
+
 	checked2 := make(map[string]bool)
 	dirOnlyPath := filepath.Join(testdataDir, "nested")
 	mods2, err := maven.Modules(dirOnlyPath, testdataDir, checked2)


### PR DESCRIPTION
This should've been part of the previous commit (89eb004f5617fe2c46cca5c167ce6a8f117bc4c7). Without this fix, a repository with a few Maven modules can have some modules listed more than once in `.fossa.yml` from running `fossa init`.