### PR TITLE
feat (format fossa test) improve fossa test output for readability

### DIFF
--- a/api/fossa/issues.go
+++ b/api/fossa/issues.go
@@ -10,24 +10,6 @@ import (
 
 const IssuesAPI = "/api/cli/%s/issues"
 
-// An Issue holds the FOSSA API response for the issue API.
-type Issue struct {
-	ID             int    `json:"id"`
-	PriorityString string `json:"priorityString"`
-	Resolved       bool   `json:"resolved"`
-	RevisionID     string `json:"revisionId"`
-	Type           string `json:"type"`
-	Rule           Rule   `json:"rule`
-
-	Name     string
-	Revision string
-}
-
-// Rule holds the representation of an Issue Rule.
-type Rule struct {
-	License string `json:"licenseId"`
-}
-
 // A wrapped list of issues returned by the FOSSA CLI issues endpoint
 // If a push-only API key is used, then only the count is returned
 type Issues struct {
@@ -36,6 +18,24 @@ type Issues struct {
 	Status string
 
 	NormalizedByType map[string][]Issue
+}
+
+// An Issue holds the FOSSA API response for the issue API.
+type Issue struct {
+	ID             int    `json:"id"`
+	PriorityString string `json:"priorityString"`
+	Resolved       bool   `json:"resolved"`
+	RevisionID     string `json:"revisionId"`
+	Type           string `json:"type"`
+	Rule           Rule   `json:"rule"`
+
+	Name     string
+	Revision string
+}
+
+// Rule holds the representation of an Issue's Rule.
+type Rule struct {
+	License string `json:"licenseId"`
 }
 
 // GetIssues loads the issues for a project.
@@ -74,7 +74,7 @@ func formatType(issueType string) string {
 	case "outdated_dependency":
 		return "Outdated Dependency"
 	default:
-		return "Unrecognized Issue Type"
+		return issueType
 	}
 }
 

--- a/api/fossa/issues.go
+++ b/api/fossa/issues.go
@@ -79,7 +79,7 @@ func formatType(issueType string) string {
 }
 
 func (issue *Issue) extractLocator() {
-	locator := regexp.MustCompile("[\\+\\,\\$\\s]+").Split(issue.RevisionID, -1)
+	locator := regexp.MustCompile("[+$]").Split(issue.RevisionID, -1)
 	if len(locator) >= 2 {
 		issue.Name = locator[1]
 	}

--- a/cmd/fossa/cmd/report/dependencies.go
+++ b/cmd/fossa/cmd/report/dependencies.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"text/template"
 
 	"github.com/apex/log"
 	"github.com/urfave/cli"
@@ -83,12 +82,7 @@ func dependenciesRun(ctx *cli.Context) error {
 		revisionsByFetcher[fetcher] = depList
 	}
 
-	tmpl, err := template.New("base").Parse(defaultDependenciesReportTemplate)
-	if err != nil {
-		log.Fatalf("Could not parse template data: %s", err.Error())
-	}
-
-	output, err := display.Template(tmpl, revisionsByFetcher)
+	output, err := display.TemplateString(defaultDependenciesReportTemplate, revisionsByFetcher)
 	fmt.Println(output)
 	return err
 }

--- a/cmd/fossa/cmd/report/licenses.go
+++ b/cmd/fossa/cmd/report/licenses.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"text/template"
 
 	"github.com/apex/log"
 	"github.com/urfave/cli"
@@ -91,12 +90,7 @@ func licensesRun(ctx *cli.Context) (err error) {
 		revisionsByLicense[license] = depList
 	}
 
-	tmpl, err := template.New("base").Parse(defaultLicenseReportTemplate)
-	if err != nil {
-		log.Fatalf("Could not parse template data: %s", err.Error())
-	}
-
-	output, err := display.Template(tmpl, revisionsByLicense)
+	output, err := display.TemplateString(defaultLicenseReportTemplate, revisionsByLicense)
 	fmt.Println(output)
 	return nil
 }

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -3,19 +3,18 @@ package test
 import (
 	"fmt"
 	"os"
-	"text/tabwriter"
-	"text/template"
 	"time"
 
 	"github.com/apex/log"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+
 	"github.com/fossas/fossa-cli/api"
 	"github.com/fossas/fossa-cli/api/fossa"
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
 	"github.com/fossas/fossa-cli/config"
-	"github.com/pkg/errors"
-	"github.com/urfave/cli"
 )
 
 const defaultTestTemplate = `Test Failed. {{.Count}} {{if gt .Count 1 -}} issues {{- else -}} issue {{- end}} found:
@@ -62,18 +61,11 @@ func Run(ctx *cli.Context) error {
 		return nil
 	}
 
-	testTemplate, err := template.New("base").Parse(defaultTestTemplate)
+	output, err := display.TemplateFormatTabs(defaultTestTemplate, issues, 12, 10, 5)
 	if err != nil {
 		return err
 	}
-
-	w := tabwriter.NewWriter(os.Stderr, 10, 12, 5, ' ', 0)
-	err = testTemplate.Execute(w, issues)
-	if err != nil {
-		return err
-	}
-
-	w.Flush()
+	fmt.Println(output)
 
 	if !ctx.Bool(SuppressIssues) {
 		os.Exit(1)

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -7,23 +7,23 @@ import (
 	"time"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
-	"github.com/urfave/cli"
-
 	"github.com/fossas/fossa-cli/api"
 	"github.com/fossas/fossa-cli/api/fossa"
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
 	"github.com/fossas/fossa-cli/config"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
 )
 
 const defaultTestTemplate = `Test Failed! {{.Count}} {{if gt .Count 1 -}} issues {{- else -}} issue {{- end}} found:
 {{- range $type, $issues := .NormalizedByType}}
-========================================================================
+------------------------------------------------------------------------
 {{$type}}
-========================================================================
-{{range $i, $issue := $issues}}
+------------------------------------------------------------------------
+Dependency	Revision	{{if or (eq $type "Flagged by Policy") (eq $type "Denied by Policy") -}} License {{- end}}
+{{- range $i, $issue := $issues}}
 {{$issue.Name}}	{{$issue.Revision}}	{{$issue.Rule.License}}
 {{- end}}
 {{end}}

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -19,9 +19,9 @@ import (
 
 const defaultTestTemplate = `Test Failed! {{.Count}} {{if gt .Count 1 -}} issues {{- else -}} issue {{- end}} found:
 {{- range $type, $issues := .NormalizedByType}}
-------------------------------------------------------------------------
+========================================================================
 {{$type}}
-------------------------------------------------------------------------
+========================================================================
 Dependency	Revision	{{if or (eq $type "Flagged by Policy") (eq $type "Denied by Policy") -}} License {{- end}}
 {{- range $i, $issue := $issues}}
 {{$issue.Name}}	{{$issue.Revision}}	{{$issue.Rule.License}}

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -7,24 +7,28 @@ import (
 	"time"
 
 	"github.com/apex/log"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+
 	"github.com/fossas/fossa-cli/api"
 	"github.com/fossas/fossa-cli/api/fossa"
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
 	"github.com/fossas/fossa-cli/config"
-	"github.com/pkg/errors"
-	"github.com/urfave/cli"
 )
 
-const defaultTestTemplate = `Test Failed! {{.Count}} {{if gt .Count 1 -}} issues {{- else -}} issue {{- end}} found:
+const defaultTestTemplate = `Test Failed! {{.Count}} {{if gt .Count 1 -}} issues {{- else -}} issue {{- end}} found.
+{{- $length := len .NormalizedByType -}} {{ if eq $length 0 }}
+Detailed issue data cannot be read. This could be related to using a push-only API token.
+{{- end}}
 {{- range $type, $issues := .NormalizedByType}}
 ========================================================================
 {{$type}}
 ========================================================================
 Dependency	Revision	{{if or (eq $type "Flagged by Policy") (eq $type "Denied by Policy") -}} License {{- end}}
 {{- range $i, $issue := $issues}}
-{{$issue.Name}}	{{$issue.Revision}}	{{$issue.Rule.License}}
+{{$issue.Name}}	{{$issue.Revision}}	{{$issue.Rule.License }}
 {{- end}}
 {{end}}
 `

--- a/cmd/fossa/display/template.go
+++ b/cmd/fossa/display/template.go
@@ -1,7 +1,7 @@
 package display
 
 import (
-	"bytes"
+	"strings"
 	"text/tabwriter"
 	"text/template"
 
@@ -29,13 +29,13 @@ func TemplateString(templateString string, data interface{}) (string, error) {
 
 // Template renders a template and its context to a string.
 func Template(tmpl *template.Template, data interface{}) (string, error) {
-	var buf bytes.Buffer
-	err := tmpl.Execute(&buf, data)
+	var builder strings.Builder
+	err := tmpl.Execute(&builder, data)
 	if err != nil {
 		return "", err
 	}
 
-	return buf.String(), nil
+	return builder.String(), nil
 }
 
 // TemplateFormatTabs renders a template with the desired tab format.
@@ -45,12 +45,12 @@ func TemplateFormatTabs(tmpl string, data interface{}, minWidth, tabWidth, paddi
 		return "", errors.Wrap(err, "Could not parse template data")
 	}
 
-	var buf bytes.Buffer
-	w := tabwriter.NewWriter(&buf, minWidth, tabWidth, padding, ' ', 0)
+	var builder strings.Builder
+	w := tabwriter.NewWriter(&builder, minWidth, tabWidth, padding, ' ', 0)
 	err = testTemplate.Execute(w, data)
 	if err != nil {
 		return "", err
 	}
 
-	return buf.String(), nil
+	return builder.String(), nil
 }

--- a/cmd/fossa/display/template.go
+++ b/cmd/fossa/display/template.go
@@ -2,6 +2,8 @@ package display
 
 import (
 	"bytes"
+	"log"
+	"text/tabwriter"
 	"text/template"
 )
 
@@ -15,10 +17,36 @@ func TemplateFile(filename string, data interface{}) (string, error) {
 	return Template(tmpl, data)
 }
 
+// TemplateString renders a template from a string template.
+func TemplateString(templateString string, data interface{}) (string, error) {
+	tmpl, err := template.New("base").Parse(templateString)
+	if err != nil {
+		log.Fatalf("Could not parse template data: %s", err.Error())
+	}
+	return Template(tmpl, data)
+}
+
 // Template renders a template and its context to a string.
 func Template(tmpl *template.Template, data interface{}) (string, error) {
 	var buf bytes.Buffer
 	err := tmpl.Execute(&buf, data)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// TemplateFormatTabs renders a template with the desired tab format.
+func TemplateFormatTabs(tmpl string, data interface{}, minWidth, tabWidth, padding int) (string, error) {
+	testTemplate, err := template.New("base").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, minWidth, tabWidth, padding, ' ', 0)
+	err = testTemplate.Execute(w, data)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/fossa/display/template.go
+++ b/cmd/fossa/display/template.go
@@ -2,16 +2,17 @@ package display
 
 import (
 	"bytes"
-	"log"
 	"text/tabwriter"
 	"text/template"
+
+	"github.com/fossas/fossa-cli/errors"
 )
 
 // TemplateFile renders a template file and its context to string.
 func TemplateFile(filename string, data interface{}) (string, error) {
 	tmpl, err := template.ParseFiles(filename)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "Could not parse template data")
 	}
 
 	return Template(tmpl, data)
@@ -21,7 +22,7 @@ func TemplateFile(filename string, data interface{}) (string, error) {
 func TemplateString(templateString string, data interface{}) (string, error) {
 	tmpl, err := template.New("base").Parse(templateString)
 	if err != nil {
-		log.Fatalf("Could not parse template data: %s", err.Error())
+		return "", errors.Wrap(err, "Could not parse template data")
 	}
 	return Template(tmpl, data)
 }
@@ -41,7 +42,7 @@ func Template(tmpl *template.Template, data interface{}) (string, error) {
 func TemplateFormatTabs(tmpl string, data interface{}, minWidth, tabWidth, padding int) (string, error) {
 	testTemplate, err := template.New("base").Parse(tmpl)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "Could not parse template data")
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
This PR closes #216 

Improve `fossa test` output so that instead of outputting:
```
Test failed! 4 issues found
{"Count":4,"Issues":[{"ID":137012,"PriorityString":"low","Resolved":false,"Revision":{"loc":null,"Licenses":null,"Project":null,"Meta":null,"Issues":null},"Type":"policy_flag"},{"ID":170908,"PriorityString":"low","Resolved":false,"Revision":{"loc":null,"Licenses":null,"Project":null,"Meta":null,"Issues":null},"Type":"unlicensed_dependency"},{"ID":171495,"PriorityString":"low","Resolved":false,"Revision":{"loc":null,"Licenses":null,"Project":null,"Meta":null,"Issues":null},"Type":"policy_flag"},{"ID":175711,"PriorityString":"low","Resolved":false,"Revision":{"loc":null,"Licenses":null,"Project":null,"Meta":null,"Issues":null},"Type":"policy_flag"}],"Status":"SCANNED"}
```
We will output a formatted message:
```
Test Failed. 4 issues found:
========================================================================
Flagged by Policy
========================================================================

JSV              4.0.2      Artistic-1.0
ua-parser-js     0.7.18     GPL-2.0-only
mapbox-gl        0.44.2     GPL-3.0-only

========================================================================
Unlicensed Dependency
========================================================================

curry     1.2.0
```

Changes made:
- Improve `fossa.Issues` so that it normalizes issues after they are received by an api request.
- Add the option to output information in JSON.

Expected Future Issues:
- New issue types will need to be manually added so that are printed in a nice format.
- Dependencies with multiple issues will output unnecessary noise. I have determined this is out of scope for this PR.

Tests will be added once the fossa test server PR is completed.