### PR TITLE
Fix gradle project name parsing for projects without group ID

### DIFF
--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -178,10 +178,11 @@ func ParseDependencies(stdout string) ([]Dependency, map[Dependency][]Dependency
 		dep := matches[2]
 		withoutAnnotations := strings.TrimSuffix(strings.TrimSuffix(strings.TrimSuffix(dep, " (*)"), " (n)"), " FAILED")
 		var parsed Dependency
-		if strings.HasPrefix(withoutAnnotations, "project :") {
+		if strings.HasPrefix(withoutAnnotations, "project ") {
 			// TODO: the desired method for handling this might be to recurse into the subproject.
 			parsed = Dependency{
-				Name:      strings.TrimPrefix(withoutAnnotations, "project :"),
+				// The project name may or may not have a leading colon.
+				Name:      strings.TrimPrefix(strings.TrimPrefix(withoutAnnotations, "project "), ":"),
 				IsProject: true,
 			}
 		} else {
@@ -196,9 +197,12 @@ func ParseDependencies(stdout string) ([]Dependency, map[Dependency][]Dependency
 			requestedIsNotResolved := len(sections) == 2
 
 			idSections := strings.Split(sections[0], ":")
-			name = idSections[0] + ":" + idSections[1]
-			if len(idSections) > 2 {
-				requestedVer = idSections[2]
+			name = idSections[0]
+			if len(idSections) > 1 {
+				name += ":" + idSections[1]
+				if len(idSections) > 2 {
+					requestedVer = idSections[2]
+				}
 			}
 
 			if requestedIsNotResolved {

--- a/buildtools/gradle/gradle_test.go
+++ b/buildtools/gradle/gradle_test.go
@@ -112,6 +112,24 @@ func TestParseDependencies(t *testing.T) {
 		ResolvedVersion:  "1.7.25",
 	}
 	assert.Contains(t, deps, expectDep2)
+
+	// A project.
+	expectProject1 := gradle.Dependency{
+		Name:             "typical-project-name",
+		RequestedVersion: "",
+		ResolvedVersion:  "",
+		IsProject:        true,
+	}
+	assert.Contains(t, deps, expectProject1)
+
+	// A project.
+	expectProject2 := gradle.Dependency{
+		Name:             "no-colons-in-project-name",
+		RequestedVersion: "",
+		ResolvedVersion:  "",
+		IsProject:        true,
+	}
+	assert.Contains(t, deps, expectProject2)
 }
 
 func TestShellCommand_DependencyTasks(t *testing.T) {

--- a/buildtools/gradle/testdata/complex.txt
+++ b/buildtools/gradle/testdata/complex.txt
@@ -193,13 +193,9 @@ compileClasspath - Compile classpath for source set 'main'.
 |    |    \--- io.swagger:swagger-annotations:1.5.20
 |    +--- io.springfox:springfox-spi:2.9.2
 |    |    \--- io.springfox:springfox-core:2.9.2
-|    |         +--- net.bytebuddy:byte-buddy:1.8.12 -> 1.9.3
-|    |         +--- com.google.guava:guava:20.0
-|    |         +--- com.fasterxml:classmate:1.4.0
 |    |         +--- org.slf4j:slf4j-api:1.7.25
 |    |         +--- org.springframework.plugin:spring-plugin-core:1.2.0.RELEASE
 |    |         |    +--- org.springframework:spring-beans:4.0.9.RELEASE -> 5.1.2.RELEASE (*)
-|    |         |    +--- org.springframework:spring-aop:4.0.9.RELEASE -> 5.1.2.RELEASE (*)
 |    |         |    \--- org.slf4j:slf4j-api:1.7.10 -> 1.7.25
 |    |         \--- org.springframework.plugin:spring-plugin-metadata:1.2.0.RELEASE
 |    |              +--- org.springframework.plugin:spring-plugin-core:1.2.0.RELEASE (*)
@@ -208,19 +204,18 @@ compileClasspath - Compile classpath for source set 'main'.
 |    |    +--- io.springfox:springfox-core:2.9.2 (*)
 |    |    \--- io.springfox:springfox-spi:2.9.2 (*)
 |    +--- io.springfox:springfox-swagger-common:2.9.2
-|    |    +--- io.springfox:springfox-spring-web:2.9.2
-|    |    |    +--- org.springframework.plugin:spring-plugin-metadata:1.2.0.RELEASE (*)
-|    |    |    \--- io.springfox:springfox-spi:2.9.2 (*)
-|    |    +--- com.google.guava:guava:20.0
-|    |    +--- com.fasterxml:classmate:1.4.0
 |    |    +--- org.slf4j:slf4j-api:1.7.25
 |    |    \--- org.springframework.plugin:spring-plugin-metadata:1.2.0.RELEASE (*)
 |    +--- io.springfox:springfox-spring-web:2.9.2 (*)
-|    +--- com.fasterxml:classmate:1.4.0
 |    \--- org.mapstruct:mapstruct:1.2.0.Final
 +--- io.springfox:springfox-swagger-ui:2.9.2
 |    \--- io.springfox:springfox-spring-web:2.9.2 (*)
-\--- project :simple-reference-service-api
+\--- project :typical-project-name
+
+implementation - Implementation only dependencies for source set 'main'. (n)
++--- io.something:swagger-ui:2.9.2 (n)
++--- something-no-colons (n)
+\--- project no-colons-in-project-name (n)
 
 (*) - dependencies omitted (listed previously)
 


### PR DESCRIPTION
In PR #454 we fixed a couple areas of parsing Gradle's output but overlooked the fact that a project name can sometimes appear on a line such as:
```
\--- project no-colons-in-project-name (n)
```
This PR handles such project names and proactively checks the lines of regular dependencies to handle correctly those that consist of just a dependency name, such as:
```
+--- something-no-colons (n)
```