### PR TITLE
feat (command timeout) add timeout for gradle analyzer

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -5,7 +5,7 @@ version: 2
 cli:
   server: https://app.fossa.com
   fetcher: custom
-  project: git@github.com:fossas/fossa-cli
+  project: https://github.com/fossas/fossa-cli
 analyze:
   modules:
   - name: github.com/fossas/fossa-cli/cmd/fossa

--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -35,6 +35,8 @@ type Options struct {
 	Online            bool   `mapstructure:"online"`
 	AllSubmodules     bool   `mapstructure:"all-submodules"`
 	AllConfigurations bool   `mapstructure:"all-configurations"`
+	Timeout           int    `mapstructure:"timeout"`
+	Retries           int    `mapstructure:"retries"`
 	// TODO: These are temporary until v2 configuration files (with proper BuildTarget) are implemented.
 	Project       string `mapstructure:"project"`
 	Configuration string `mapstructure:"configuration"`
@@ -55,8 +57,10 @@ func New(m module.Module) (*Analyzer, error) {
 			log.Warnf("A build.gradle file has been found at %s, but Gradle could not be found. Ensure that Fossa can access `gradle`, `gradlew`, `gradlew.bat`, or set the `FOSSA_GRADLE_CMD` environment variable. Error: %s", m.Dir, err.Error())
 		}
 	}
+	retries := options.Retries
+	timeout := options.Timeout
 
-	shellInput := gradle.NewShellInput(binary, m.Dir, options.Online)
+	shellInput := gradle.NewShellInput(binary, m.Dir, options.Online, timeout, retries)
 	analyzer := Analyzer{
 		Module:  m,
 		Options: options,
@@ -76,7 +80,7 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 	return DiscoverWithCommand(dir, options, gradle.Cmd)
 }
 
-func DiscoverWithCommand(dir string, options map[string]interface{}, command func(string, ...string) (string, error)) ([]module.Module, error) {
+func DiscoverWithCommand(dir string, options map[string]interface{}, command func(string, int, int, ...string) (string, error)) ([]module.Module, error) {
 	log.WithField("dir", dir).Debug("discovering gradle modules")
 	var modules []module.Module
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -35,7 +35,7 @@ type Options struct {
 	Online            bool   `mapstructure:"online"`
 	AllSubmodules     bool   `mapstructure:"all-submodules"`
 	AllConfigurations bool   `mapstructure:"all-configurations"`
-	Timeout           int    `mapstructure:"timeout"`
+	Timeout           string `mapstructure:"timeout"`
 	Retries           int    `mapstructure:"retries"`
 	// TODO: These are temporary until v2 configuration files (with proper BuildTarget) are implemented.
 	Project       string `mapstructure:"project"`
@@ -78,7 +78,7 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 	return DiscoverWithCommand(dir, options, gradle.Cmd)
 }
 
-func DiscoverWithCommand(dir string, userOptions map[string]interface{}, command func(string, int, int, ...string) (string, error)) ([]module.Module, error) {
+func DiscoverWithCommand(dir string, userOptions map[string]interface{}, command func(string, string, int, ...string) (string, error)) ([]module.Module, error) {
 	var options Options
 	err := mapstructure.Decode(userOptions, &options)
 	if err != nil {

--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -57,10 +57,8 @@ func New(m module.Module) (*Analyzer, error) {
 			log.Warnf("A build.gradle file has been found at %s, but Gradle could not be found. Ensure that Fossa can access `gradle`, `gradlew`, `gradlew.bat`, or set the `FOSSA_GRADLE_CMD` environment variable. Error: %s", m.Dir, err.Error())
 		}
 	}
-	retries := options.Retries
-	timeout := options.Timeout
 
-	shellInput := gradle.NewShellInput(binary, m.Dir, options.Online, timeout, retries)
+	shellInput := gradle.NewShellInput(binary, m.Dir, options.Online, options.Timeout, options.Retries)
 	analyzer := Analyzer{
 		Module:  m,
 		Options: options,

--- a/analyzers/gradle/gradle_test.go
+++ b/analyzers/gradle/gradle_test.go
@@ -86,8 +86,8 @@ func TestGradleDiscovery(t *testing.T) {
 	assert.True(t, moduleExists("testdata/grpc-xds", modules))
 }
 
-func mockCommand(mockOutput string) func(string, ...string) (string, error) {
-	return func(string, ...string) (string, error) {
+func mockCommand(mockOutput string) func(string, int, int, ...string) (string, error) {
+	return func(string, int, int, ...string) (string, error) {
 		output, err := ioutil.ReadFile(mockOutput)
 		return string(output), err
 	}

--- a/analyzers/gradle/gradle_test.go
+++ b/analyzers/gradle/gradle_test.go
@@ -86,8 +86,8 @@ func TestGradleDiscovery(t *testing.T) {
 	assert.True(t, moduleExists("testdata/grpc-xds", modules))
 }
 
-func mockCommand(mockOutput string) func(string, int, int, ...string) (string, error) {
-	return func(string, int, int, ...string) (string, error) {
+func mockCommand(mockOutput string) func(string, string, int, ...string) (string, error) {
+	return func(string, string, int, ...string) (string, error) {
 		output, err := ioutil.ReadFile(mockOutput)
 		return string(output), err
 	}

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -230,13 +230,15 @@ func ParseDependencies(stdout string) ([]Dependency, map[Dependency][]Dependency
 // Cmd executes the gradle shell command.
 func Cmd(command string, timeout, retries int, taskArgs ...string) (string, error) {
 	tempcmd := exec.Cmd{
-		Name: "sleep",
-		Argv: []string{"5"},
+		Name:    command,
+		Argv:    taskArgs,
+		Timeout: time.Duration(timeout) * time.Second,
+		Retries: retries,
 	}
 
-	stdout, stderr, err := exec.RunTimeoutRetry(tempcmd, time.Duration(timeout), retries)
+	stdout, stderr, err := exec.Run(tempcmd)
 	if stderr != "" {
-		return stdout, errors.Errorf("", stderr)
+		return stdout, errors.Errorf("%s", stderr)
 	}
 
 	return stdout, err

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/apex/log"
 	"github.com/pkg/errors"
@@ -21,9 +20,9 @@ type ShellCommand struct {
 	Binary  string
 	Dir     string
 	Online  bool
-	Timeout int
+	Timeout string
 	Retries int
-	Cmd     func(command string, timeout int, retries int, arguments ...string) (string, error)
+	Cmd     func(command string, timeout string, retries int, arguments ...string) (string, error)
 }
 
 // Dependency models a gradle dependency.
@@ -42,7 +41,7 @@ type Input interface {
 }
 
 // NewShellInput creates a new ShellCommand and returns it as an Input.
-func NewShellInput(binary, dir string, online bool, timeout, retries int) Input {
+func NewShellInput(binary, dir string, online bool, timeout string, retries int) Input {
 	return ShellCommand{
 		Binary:  binary,
 		Dir:     dir,
@@ -229,11 +228,11 @@ func ParseDependencies(stdout string) ([]Dependency, map[Dependency][]Dependency
 }
 
 // Cmd executes the gradle shell command.
-func Cmd(command string, timeout, retries int, taskArgs ...string) (string, error) {
+func Cmd(command string, timeout string, retries int, taskArgs ...string) (string, error) {
 	tempcmd := exec.Cmd{
 		Name:    command,
 		Argv:    taskArgs,
-		Timeout: time.Duration(timeout) * time.Second,
+		Timeout: timeout,
 		Retries: retries,
 	}
 

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -145,6 +145,7 @@ func (s ShellCommand) DependencyTasks() ([]string, error) {
 	}
 	stdout, err := s.Cmd(s.Binary, s.Timeout, s.Retries, arguments...)
 	if err != nil {
+		log.Warnf("Error found running `%s %s`: %s", s.Binary, arguments, err)
 		return nil, err
 	}
 	var projects []string

--- a/buildtools/gradle/gradle_test.go
+++ b/buildtools/gradle/gradle_test.go
@@ -145,7 +145,7 @@ func MockGradle(t *testing.T, file string) gradle.ShellCommand {
 	fileContents, err := ioutil.ReadFile(file)
 	assert.NoError(t, err)
 	return gradle.ShellCommand{
-		Cmd: func(tmp string, args ...string) (string, error) {
+		Cmd: func(string, int, int, ...string) (string, error) {
 			return string(fileContents), nil
 		},
 	}

--- a/buildtools/gradle/gradle_test.go
+++ b/buildtools/gradle/gradle_test.go
@@ -145,7 +145,7 @@ func MockGradle(t *testing.T, file string) gradle.ShellCommand {
 	fileContents, err := ioutil.ReadFile(file)
 	assert.NoError(t, err)
 	return gradle.ShellCommand{
-		Cmd: func(string, int, int, ...string) (string, error) {
+		Cmd: func(string, string, int, ...string) (string, error) {
 			return string(fileContents), nil
 		},
 	}

--- a/docs/integrations/gradle.md
+++ b/docs/integrations/gradle.md
@@ -35,16 +35,16 @@ analyze:
 
 ## Options
 
-  | Option               |  Type  | Name                                           | Common Use Case                                                             |
-  | -------------------- | :----: | ---------------------------------------------- | --------------------------------------------------------------------------- |
-  | `cmd`                | string | [Cmd](#cmd-string)                             | Specify the gradle command to use.                                          |
-  | `task`               | string | [Task](#task-string)                           | Specify the gradle task to run.                                             |
-  | `timeout`            |  int   | [Timeout](#timeout-int)                        | Specify the length of time in seconds a `gradle` command is allowed to run. |
-  | `retries`            |  int   | [Retries](#retries-int)                        | Specify the number of times to retry a `gradle` command when it fails.      |
-  | `online`             |  bool  | [Online](#online-bool)                         | Remove `--offline` from the `gradle <project>:dependencies` command.        |
-  | `all-submodules`     |  bool  | [All Submodules](#all-submodules-bool)         | Running `fossa analyze gradle:.` and you want to analyze all sub-projects.  |
-  | `configuration`      | string | [Configuration](#configuration-string)         | Comma separated list of configurations to analyze.                          |
-  | `all-configurations` |  bool  | [All Configurations](#all-configurations-bool) | Analyze all configurations for the gradle project.                          |
+  | Option               |  Type  | Name                                           | Common Use Case                                                            |
+  | -------------------- | :----: | ---------------------------------------------- | -------------------------------------------------------------------------- |
+  | `cmd`                | string | [Cmd](#cmd-string)                             | Specify the gradle command to use.                                         |
+  | `task`               | string | [Task](#task-string)                           | Specify the gradle task to run.                                            |
+  | `timeout`            | string | [Timeout](#timeout-string)                     | Specify the length of time a `gradle` command is allowed to run.           |
+  | `retries`            |  int   | [Retries](#retries-int)                        | Specify the number of times to retry a `gradle` command when it fails.     |
+  | `online`             |  bool  | [Online](#online-bool)                         | Remove `--offline` from the `gradle <project>:dependencies` command.       |
+  | `all-submodules`     |  bool  | [All Submodules](#all-submodules-bool)         | Running `fossa analyze gradle:.` and you want to analyze all sub-projects. |
+  | `configuration`      | string | [Configuration](#configuration-string)         | Comma separated list of configurations to analyze.                         |
+  | `all-configurations` |  bool  | [All Configurations](#all-configurations-bool) | Analyze all configurations for the gradle project.                         |
 
 
 
@@ -56,9 +56,10 @@ Specify the command for fossa to use when it runs gradle commands. By default, t
 
 Specify the exact arguments to be run by the gradle command before analyzing output for dependencies. By default this is `<project>:dependencies --quiet --offline` but this can be changed to anything using this option.
 
-#### `timeout: <int>`
+#### `timeout: <string>`
 
-Specify the amount of time in seconds that a gradle command is allowed to run before timing out. When fossa shells out to run `gradle` or `gradlew` the command can hang and consume extra resources. This option allows a user to kill the command and continue analyzing a project.
+Specify the amount of time in that a gradle command is allowed to run before timing out. When fossa shells out to run `gradle` or `gradlew` the command can hang and consume extra resources. This option allows a user to kill the command and continue analyzing a project.
+> A duration string is a sequence of numbers, each with a unit suffix, such as "500ms", "1.5m", or "2h45m". Valid time units are "ms", "s", "m", "h".
 
 #### `retries: <int>`
 

--- a/docs/integrations/gradle.md
+++ b/docs/integrations/gradle.md
@@ -35,14 +35,17 @@ analyze:
 
 ## Options
 
-  | Option               |  Type  | Name                                              | Common Use Case                                                            |
-  | -------------------- | :----: | ------------------------------------------------- | -------------------------------------------------------------------------- |
-  | `cmd`                | string | [Cmd](#cmd-string)                              | Specify the gradle command to use.                                         |
-  | `task`               | string | [Task](#task-string)                           | Specify the gradle task to run.                                            |
-  | `online`             |  bool  | [Online](#online-bool)                         | Remove `--offline` from the `gradle <project>:dependencies` command.       |
-  | `all-submodules`     |  bool  | [All Submodules](#all-submodules-bool)         | Running `fossa analyze gradle:.` and you want to analyze all sub-projects. |
-  | `configuration`      | string | [Configuration](#configuration-string)         | Comma separated list of configurations to analyze.                         |
-  | `all-configurations` |  bool  | [All Configurations](#all-configurations-bool) | Analyze all configurations for the gradle project.                         |
+  | Option               |  Type  | Name                                           | Common Use Case                                                             |
+  | -------------------- | :----: | ---------------------------------------------- | --------------------------------------------------------------------------- |
+  | `cmd`                | string | [Cmd](#cmd-string)                             | Specify the gradle command to use.                                          |
+  | `task`               | string | [Task](#task-string)                           | Specify the gradle task to run.                                             |
+  | `timeout`            |  int   | [Timeout](#timeout-int)                        | Specify the length of time in seconds a `gradle` command is allowed to run. |
+  | `retries`            |  int   | [Retries](#retries-int)                        | Specify the number of times to retry a `gradle` command when it fails.      |
+  | `online`             |  bool  | [Online](#online-bool)                         | Remove `--offline` from the `gradle <project>:dependencies` command.        |
+  | `all-submodules`     |  bool  | [All Submodules](#all-submodules-bool)         | Running `fossa analyze gradle:.` and you want to analyze all sub-projects.  |
+  | `configuration`      | string | [Configuration](#configuration-string)         | Comma separated list of configurations to analyze.                          |
+  | `all-configurations` |  bool  | [All Configurations](#all-configurations-bool) | Analyze all configurations for the gradle project.                          |
+
 
 
 #### `cmd: <string>` 
@@ -52,6 +55,14 @@ Specify the command for fossa to use when it runs gradle commands. By default, t
 #### `task: <string>`
 
 Specify the exact arguments to be run by the gradle command before analyzing output for dependencies. By default this is `<project>:dependencies --quiet --offline` but this can be changed to anything using this option.
+
+#### `timeout: <int>` 
+
+Specify the amount of time in seconds that a gradle command is allowed to run before timing out. When fossa shells out to run `gradle` or `gradlew` the command can hang and consume extra resources. This option allows a user to kill the command and continue analyzing a project.
+
+#### `retries: <int>`
+
+Specify the amount of times to retry running the gradle command after it fails to complete. This command works best in conjunction with the `timeout` option in order to allow a command to be killed and retried.
 
 #### `online: <bool>`
 

--- a/docs/integrations/gradle.md
+++ b/docs/integrations/gradle.md
@@ -56,7 +56,7 @@ Specify the command for fossa to use when it runs gradle commands. By default, t
 
 Specify the exact arguments to be run by the gradle command before analyzing output for dependencies. By default this is `<project>:dependencies --quiet --offline` but this can be changed to anything using this option.
 
-#### `timeout: <int>` 
+#### `timeout: <int>`
 
 Specify the amount of time in seconds that a gradle command is allowed to run before timing out. When fossa shells out to run `gradle` or `gradlew` the command can hang and consume extra resources. This option allows a user to kill the command and continue analyzing a project.
 

--- a/exec/run_test.go
+++ b/exec/run_test.go
@@ -3,6 +3,7 @@ package exec_test
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -40,4 +41,49 @@ func TestDefaultEnv(t *testing.T) {
 		Name: "example",
 	})
 	assert.Contains(t, c.Env, "alice=bob")
+}
+
+func TestRun(t *testing.T) {
+	command := exec.Cmd{
+		Name: "pwd",
+	}
+	stdout, _, err := exec.Run(command)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, stdout)
+}
+
+func TestRunTimeout(t *testing.T) {
+	command := exec.Cmd{
+		Name:    "sleep",
+		Argv:    []string{"2"},
+		Timeout: 3 * time.Second,
+	}
+	_, _, err := exec.Run(command)
+	assert.NoError(t, err)
+
+	command.Timeout = 1 * time.Second
+	_, _, err = exec.Run(command)
+	assert.Contains(t, err.Error(), "timed out")
+}
+
+func TestRunRetry(t *testing.T) {
+	command := exec.Cmd{
+		Name:    "sleep",
+		Argv:    []string{"3"},
+		Timeout: 1 * time.Second,
+		Retries: 1,
+	}
+
+	start := time.Now()
+	_, _, err := exec.Run(command)
+	assert.Error(t, err)
+	assert.WithinDuration(t, start, time.Now(), 3*time.Second)
+
+	command.Retries = 4
+	start = time.Now()
+	_, _, err = exec.Run(command)
+	assert.Error(t, err)
+	// 4 retries with a 1 second timeout means that the command should take 5 seconds to error.
+	assert.True(t, time.Since(start) > 5*time.Second)
+	assert.True(t, time.Since(start) < 6*time.Second)
 }

--- a/exec/run_test.go
+++ b/exec/run_test.go
@@ -40,6 +40,7 @@ func TestDefaultEnv(t *testing.T) {
 	c, _ := exec.BuildExec(exec.Cmd{
 		Name: "example",
 	})
+
 	assert.Contains(t, c.Env, "alice=bob")
 }
 
@@ -47,12 +48,37 @@ func TestRun(t *testing.T) {
 	command := exec.Cmd{
 		Name: "pwd",
 	}
-	stdout, _, err := exec.Run(command)
+
+	stdout, stderr, err := exec.Run(command)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, stdout)
+	assert.Empty(t, stderr)
 }
 
-func TestRunTimeout(t *testing.T) {
+func TestRunFails(t *testing.T) {
+	command := exec.Cmd{
+		Name: "FakeCommand",
+	}
+
+	stdout, stderr, err := exec.Run(command)
+	assert.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestRunTimeoutSucceeds(t *testing.T) {
+	command := exec.Cmd{
+		Name:    "pwd",
+		Timeout: 3 * time.Second,
+	}
+
+	stdout, stderr, err := exec.Run(command)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestRunTimeoutTimesOut(t *testing.T) {
 	command := exec.Cmd{
 		Name:    "sleep",
 		Argv:    []string{"2"},

--- a/exec/run_test.go
+++ b/exec/run_test.go
@@ -69,7 +69,7 @@ func TestRunFails(t *testing.T) {
 func TestRunTimeoutSucceeds(t *testing.T) {
 	command := exec.Cmd{
 		Name:    "pwd",
-		Timeout: 3 * time.Second,
+		Timeout: "3s",
 	}
 
 	stdout, stderr, err := exec.Run(command)
@@ -82,12 +82,12 @@ func TestRunTimeoutTimesOut(t *testing.T) {
 	command := exec.Cmd{
 		Name:    "sleep",
 		Argv:    []string{"2"},
-		Timeout: 3 * time.Second,
+		Timeout: "3s",
 	}
 	_, _, err := exec.Run(command)
 	assert.NoError(t, err)
 
-	command.Timeout = 1 * time.Second
+	command.Timeout = "1s"
 	_, _, err = exec.Run(command)
 	assert.Contains(t, err.Error(), "timed out")
 }
@@ -96,7 +96,7 @@ func TestRunRetry(t *testing.T) {
 	command := exec.Cmd{
 		Name:    "sleep",
 		Argv:    []string{"4"},
-		Timeout: 1 * time.Second,
+		Timeout: "1s",
 		Retries: 1,
 	}
 

--- a/exec/run_test.go
+++ b/exec/run_test.go
@@ -95,7 +95,7 @@ func TestRunTimeoutTimesOut(t *testing.T) {
 func TestRunRetry(t *testing.T) {
 	command := exec.Cmd{
 		Name:    "sleep",
-		Argv:    []string{"3"},
+		Argv:    []string{"4"},
 		Timeout: 1 * time.Second,
 		Retries: 1,
 	}
@@ -108,8 +108,9 @@ func TestRunRetry(t *testing.T) {
 	command.Retries = 4
 	start = time.Now()
 	_, _, err = exec.Run(command)
+	end := time.Now()
 	assert.Error(t, err)
 	// 4 retries with a 1 second timeout means that the command should take 5 seconds to error.
-	assert.True(t, time.Since(start) > 5*time.Second)
-	assert.True(t, time.Since(start) < 6*time.Second)
+	assert.True(t, end.Sub(start) > 5*time.Second)
+	assert.True(t, end.Sub(start) < 6*time.Second)
 }


### PR DESCRIPTION
Currently a WIP

When the FOSSA CLI shells out to external commands it is put at the mercy of those commands to succeed. If one of those commands consumes excess resources on the host machine and prevents analysis from succeeding, we should have the ability to timeout, kill the command, and move on. 

The worst behaving command is `gradle` which has shown that unpredictably it can cause analysis to take hours. 

This PR accomplishes the following:
- Rework `fossa/exec` to include optional timeout and retry logic.
- Implement this logic in gradle.
- Add options to gradle to allow users to configure these values on their own.