### PR TITLE
Update how Maven modules are described in .fossa.yml

### DIFF
--- a/analyzers/maven/maven.go
+++ b/analyzers/maven/maven.go
@@ -82,9 +82,9 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 				return nil
 			}
 
-			submodules, err := maven.Modules(path, dir, checked)
+			submodules, err := maven.Modules(filepath.Join(path, "pom.xml"), path, checked)
 			if err != nil {
-				log.WithError(err).Debug("could not get modules at path")
+				log.WithError(err).Debugf("could not get modules at path %s", path)
 				return err
 			}
 
@@ -93,7 +93,7 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 					Name:        m.Name,
 					Type:        pkg.Maven,
 					BuildTarget: m.Target,
-					Dir:         dir,
+					Dir:         m.Dir,
 				})
 			}
 			// Continue recursing because there may be modules that are not declared under the current module.

--- a/analyzers/maven/maven_test.go
+++ b/analyzers/maven/maven_test.go
@@ -16,13 +16,16 @@ func TestDiscover(t *testing.T) {
 
 	p1 := modules[0]
 	assert.Equal(t, "Project 1 Sample", p1.Name)
-	assert.Equal(t, "testdata/pom.xml", p1.BuildTarget)
+	assert.Equal(t, "pom.xml", p1.BuildTarget)
+	assert.Equal(t, "testdata", p1.Dir)
 
 	p2 := modules[1]
 	assert.Equal(t, "Project Sample", p2.Name)
-	assert.Equal(t, "testdata/nested/pom.xml", p2.BuildTarget)
+	assert.Equal(t, "pom.xml", p2.BuildTarget)
+	assert.Equal(t, "testdata/nested", p2.Dir)
 
 	p3 := modules[2]
 	assert.Equal(t, "Other Project", p3.Name)
-	assert.Equal(t, "testdata/nested/pom-other.xml", p3.BuildTarget)
+	assert.Equal(t, "pom-other.xml", p3.BuildTarget)
+	assert.Equal(t, "testdata/nested", p3.Dir)
 }

--- a/analyzers/maven/testdata/pom-minimal.xml
+++ b/analyzers/maven/testdata/pom-minimal.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+ <modelVersion>4.0.0</modelVersion>
+ <artifactId>minimal</artifactId>
+ <version>1.3</version>
+ <modules>
+  <module>nested</module>
+ </modules>
+</project>

--- a/analyzers/maven/testdata/pom.xml
+++ b/analyzers/maven/testdata/pom.xml
@@ -5,7 +5,6 @@
  <artifactId>stuff</artifactId>
  <packaging>jar</packaging>
  <version>1.0-SNAPSHOT</version>
- <inceptionYear>2019</inceptionYear>
  <name>Project 1 Sample</name>
  <description>A sample project</description>
  <properties>

--- a/analyzers/maven/testdata/pom.xml
+++ b/analyzers/maven/testdata/pom.xml
@@ -7,9 +7,6 @@
  <version>1.0-SNAPSHOT</version>
  <name>Project 1 Sample</name>
  <description>A sample project</description>
- <properties>
-  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
- </properties>
  <dependencies>
   <dependency>
    <groupId>com.google.code.g</groupId>

--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -52,9 +52,7 @@ type MvnModule struct {
 	Dir string
 }
 
-// Modules returns a list of all Maven modules at the directory of pomFilePath and below. The Target field of
-// each MvnModule is set to the manifest file describing the module. The checked map is used to keep track of
-// the modules that have already been checked.
+// Modules returns a list of all Maven modules at the directory of pomFilePath and below.
 func Modules(pomFilePath string, reactorDir string, checked map[string]bool) ([]MvnModule, error) {
 	absPath, err := filepath.Abs(pomFilePath)
 	if err != nil {

--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -52,10 +52,9 @@ type MvnModule struct {
 	Dir string
 }
 
-// Modules returns a list specifying the Maven module at path, which may name a file or directory, and all the
-// Maven modules nested below it. The Target field of each MvnModule is set to the manifest file describing
-// the module. The visited manifest files are listed in the checked map.
-// If fromParent is true, then this path was supplied as a module from a parent's POM file.??
+// Modules returns a list of all Maven modules at the directory of pomFilePath and below. The Target field of
+// each MvnModule is set to the manifest file describing the module. The checked map is used to keep track of
+// the modules that have already been checked.
 func Modules(pomFilePath string, reactorDir string, checked map[string]bool) ([]MvnModule, error) {
 	absPath, err := filepath.Abs(pomFilePath)
 	if err != nil {

--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -93,8 +93,7 @@ func Modules(pomFilePath string, reactorDir string, checked map[string]bool) ([]
 		childPath := filepath.Join(pomDir, module)
 		childStat, err := os.Stat(childPath)
 		if err != nil {
-			log.WithError(err).Warnf("Could not check type of %q", childPath)
-			continue
+			return nil, errors.Wrapf(err, "could not check type of %q", childPath)
 		}
 		if childStat.IsDir() {
 			// Assume the listed module uses the standard name for the manifest file.

--- a/buildtools/maven/maven_test.go
+++ b/buildtools/maven/maven_test.go
@@ -8,30 +8,60 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/fossas/fossa-cli/buildtools/maven"
+	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/pkg"
 )
 
 var testdataDir = filepath.Join("..", "..", "analyzers", "maven", "testdata")
 
 func TestModules(t *testing.T) {
-	fullPath := filepath.Join(testdataDir, "pom.xml")
+	// Here we mostly just test the discovery of POM files, and analyzers/maven tests that we get the correct
+	// list of MvnModules.
+
+	path1 := filepath.Join(testdataDir, "pom.xml")
 	checked := make(map[string]bool)
-	mods, err := maven.Modules(fullPath, testdataDir, checked)
+	mods, err := maven.Modules(path1, testdataDir, checked)
 	if assert.NoError(t, err) {
 		assert.Len(t, mods, 1)
+		for _, mod := range mods {
+			exists, err := files.Exists(mod.Dir, mod.Target)
+			assert.NoError(t, err)
+			assert.True(t, exists)
+		}
 	}
 
 	// After the pom.xml file in testdataDir has been checked, make sure we don't check it again.
-	modsAgain, err := maven.Modules(testdataDir, testdataDir, checked)
+	modsAgain, err := maven.Modules(path1, testdataDir, checked)
 	if assert.NoError(t, err) {
 		assert.Nil(t, modsAgain)
 	}
 
-	checked2 := make(map[string]bool)
-	dirOnlyPath := filepath.Join(testdataDir, "nested")
-	mods2, err := maven.Modules(dirOnlyPath, testdataDir, checked2)
+	// Make sure we follow references to other modules (module as path to a file) listed in the POM file.
+	path2 := filepath.Join(testdataDir, "nested", "pom.xml")
+	mods2, err := maven.Modules(path2, testdataDir, make(map[string]bool))
 	if assert.NoError(t, err) {
 		assert.Len(t, mods2, 2)
+		for _, mod := range mods2 {
+			exists, err := files.Exists(mod.Dir, mod.Target)
+			assert.NoError(t, err)
+			assert.True(t, exists)
+		}
+	}
+
+	// Make sure we follow references to other modules (module as path to a directory) listed in the POM file.
+	path3 := filepath.Join(testdataDir, "pom-minimal.xml")
+	mods3, err := maven.Modules(path3, testdataDir, make(map[string]bool))
+	if assert.NoError(t, err) {
+		assert.Len(t, mods3, 3)
+
+		// Test fallback to artifact ID if name is not given in the manifest.
+		assert.Contains(t, mods3, maven.MvnModule{Name: "minimal", Target: "pom-minimal.xml", Dir: testdataDir})
+
+		for _, mod := range mods3 {
+			exists, err := files.Exists(mod.Dir, mod.Target)
+			assert.NoError(t, err)
+			assert.True(t, exists)
+		}
 	}
 }
 


### PR DESCRIPTION
This changes the way we describe Maven modules in our `.fossa.yml` to make modules filterable based on their path relative to the root of the FOSSA project by providing more of the path to each module's POM file in the `path` property rather than in `target`. Only discovery of modules is changed here. Existing configurations should continue to work fine.