### PR TITLE
fix (test flake) remove upper bound on test

### DIFF
--- a/exec/run_test.go
+++ b/exec/run_test.go
@@ -105,12 +105,12 @@ func TestRunRetry(t *testing.T) {
 	assert.Error(t, err)
 	assert.WithinDuration(t, start, time.Now(), 3*time.Second)
 
-	command.Retries = 4
+	command.Retries = 5
 	start = time.Now()
 	_, _, err = exec.Run(command)
 	end := time.Now()
 	assert.Error(t, err)
-	// 4 retries with a 1 second timeout means that the command should take 5 seconds to error.
-	assert.True(t, end.Sub(start) > 5*time.Second)
-	assert.True(t, end.Sub(start) < 6*time.Second)
+	// 5 retries with a 1 second timeout means the command should take more than 6 seconds,
+	// opposed to the 4 seconds it would take without the timeout.
+	assert.True(t, end.Sub(start) > 6*time.Second)
 }


### PR DESCRIPTION
The last test inside of `exec/run_test.go` was flaking when running inside of our CI and it is related to the fact that putting an upper bound on the `sleep 4` command is unreliable. This PR addresses this by increasing the number of timeouts to be larger than the initial sleep guaranteeing that a successful test ensures the command was not actually run.