### PR TITLE
feat (errors) better errors package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -168,6 +168,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:abf08734a6527df70ed361d7c369fb580e6840d8f7a6012e5f609fdfd93b4e48"
+  name = "github.com/mitchellh/go-wordwrap"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9e67c67572bc5dd02aef930e2b0ae3c02a4b5a5c"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:645110e089152bd0f4a011a2648fbb0e4df5977be73ca605781157ac297f50c4"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
@@ -479,6 +487,7 @@
     "github.com/fatih/color",
     "github.com/gnewton/jargo",
     "github.com/mattn/go-isatty",
+    "github.com/mitchellh/go-wordwrap",
     "github.com/mitchellh/mapstructure",
     "github.com/pkg/errors",
     "github.com/remeh/sizedwaitgroup",

--- a/analyzers/bower/bower.go
+++ b/analyzers/bower/bower.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/apex/log"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 
 	"github.com/fossas/fossa-cli/buildtools/bower"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"

--- a/analyzers/buck/buck.go
+++ b/analyzers/buck/buck.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 	"gopkg.in/go-ini/ini.v1"
 
 	"github.com/fossas/fossa-cli/buildtools/buck"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"

--- a/analyzers/buck/buck_test.go
+++ b/analyzers/buck/buck_test.go
@@ -3,10 +3,10 @@ package buck_test
 import (
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/fossas/fossa-cli/analyzers/buck"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/module"
 	"github.com/fossas/fossa-cli/pkg"
 )

--- a/analyzers/golang/discover.go
+++ b/analyzers/golang/discover.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/apex/log"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 
 	"github.com/fossas/fossa-cli/buildtools/gocmd"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/module"
 	"github.com/fossas/fossa-cli/pkg"

--- a/analyzers/golang/lockfile.go
+++ b/analyzers/golang/lockfile.go
@@ -4,9 +4,9 @@ import (
 	"path/filepath"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 
 	"github.com/fossas/fossa-cli/analyzers/golang/resolver"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/files"
 )
 

--- a/analyzers/golang/util.go
+++ b/analyzers/golang/util.go
@@ -5,9 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/fossas/fossa-cli/buildtools/gocmd"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/pkg"
 )
 

--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/apex/log"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 
 	"github.com/fossas/fossa-cli/buildtools/gradle"
 	"github.com/fossas/fossa-cli/config"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/graph"
 	"github.com/fossas/fossa-cli/module"
 	"github.com/fossas/fossa-cli/pkg"

--- a/analyzers/maven/maven.go
+++ b/analyzers/maven/maven.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/apex/log"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 
 	"github.com/fossas/fossa-cli/buildtools/maven"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"

--- a/analyzers/nodejs/nodejs.go
+++ b/analyzers/nodejs/nodejs.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/apex/log"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 
 	"github.com/fossas/fossa-cli/buildtools/npm"
 	"github.com/fossas/fossa-cli/buildtools/yarn"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"

--- a/analyzers/php/php.go
+++ b/analyzers/php/php.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/apex/log"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 
 	"github.com/fossas/fossa-cli/buildtools/composer"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"

--- a/analyzers/scala/scala.go
+++ b/analyzers/scala/scala.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/apex/log"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 
 	"github.com/fossas/fossa-cli/buildtools/sbt"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"

--- a/api/api.go
+++ b/api/api.go
@@ -12,7 +12,8 @@ import (
 	"time"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
+
+	"github.com/fossas/fossa-cli/errors"
 )
 
 type errorResponse struct {

--- a/api/fossa/builds.go
+++ b/api/fossa/builds.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pkg/errors"
+	"github.com/fossas/fossa-cli/errors"
 )
 
 const BuildsAPI = "/api/cli/%s/latest_build"

--- a/api/fossa/fossa.go
+++ b/api/fossa/fossa.go
@@ -23,26 +23,21 @@ var (
 func SetEndpoint(endpoint string) error {
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return errors.UnknownError(err)
+		return err
 	}
 	serverURL = u
 	return nil
 }
 
-func SetAPIKey(key string) error {
-	if key == "" {
-		return errors.UnknownError(errors.New("Deepest error"))
-		// return missingAPIKeyError
-	}
+func SetAPIKey(key string) {
 	apiKey = key
-	return nil
 }
 
 // Get makes an authenticated GET request to a FOSSA API endpoint.
 func Get(endpoint string) (res string, statusCode int, err error) {
 	u, err := serverURL.Parse(endpoint)
 	if err != nil {
-		return "", 0, errors.UnknownError(err)
+		return "", 0, err
 	}
 	return api.Get(u, apiKey, nil)
 }

--- a/api/fossa/fossa.go
+++ b/api/fossa/fossa.go
@@ -10,15 +10,20 @@ import (
 )
 
 var (
-	ErrMissingAPIKey = errors.New("missing FOSSA API key")
-	serverURL        *url.URL
-	apiKey           string
+	serverURL          *url.URL
+	apiKey             string
+	missingAPIKeyError = &errors.Error{
+		Cause:           errors.New("missing API Key"),
+		Type:            "user",
+		Troubleshooting: "follow the link for instructions to add an API KEY",
+		Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/user-guide.md/#3-analyzing-a-project",
+	}
 )
 
 func SetEndpoint(endpoint string) error {
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return err
+		return errors.UnknownError(err)
 	}
 	serverURL = u
 	return nil
@@ -26,7 +31,8 @@ func SetEndpoint(endpoint string) error {
 
 func SetAPIKey(key string) error {
 	if key == "" {
-		return ErrMissingAPIKey
+		return errors.UnknownError(errors.New("Deepest error"))
+		// return missingAPIKeyError
 	}
 	apiKey = key
 	return nil
@@ -36,7 +42,7 @@ func SetAPIKey(key string) error {
 func Get(endpoint string) (res string, statusCode int, err error) {
 	u, err := serverURL.Parse(endpoint)
 	if err != nil {
-		return "", 0, err
+		return "", 0, errors.UnknownError(err)
 	}
 	return api.Get(u, apiKey, nil)
 }

--- a/api/fossa/fossa.go
+++ b/api/fossa/fossa.go
@@ -6,11 +6,13 @@ import (
 	"net/url"
 
 	"github.com/fossas/fossa-cli/api"
+	"github.com/fossas/fossa-cli/errors"
 )
 
 var (
-	serverURL *url.URL
-	apiKey    string
+	ErrMissingAPIKey = errors.New("missing FOSSA API key")
+	serverURL        *url.URL
+	apiKey           string
 )
 
 func SetEndpoint(endpoint string) error {
@@ -22,8 +24,12 @@ func SetEndpoint(endpoint string) error {
 	return nil
 }
 
-func SetAPIKey(key string) {
+func SetAPIKey(key string) error {
+	if key == "" {
+		return ErrMissingAPIKey
+	}
 	apiKey = key
+	return nil
 }
 
 // Get makes an authenticated GET request to a FOSSA API endpoint.

--- a/api/fossa/fossa.go
+++ b/api/fossa/fossa.go
@@ -6,18 +6,11 @@ import (
 	"net/url"
 
 	"github.com/fossas/fossa-cli/api"
-	"github.com/fossas/fossa-cli/errors"
 )
 
 var (
-	serverURL          *url.URL
-	apiKey             string
-	missingAPIKeyError = &errors.Error{
-		Cause:           errors.New("missing API Key"),
-		Type:            "user",
-		Troubleshooting: "follow the link for instructions to add an API KEY",
-		Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/user-guide.md/#3-analyzing-a-project",
-	}
+	serverURL *url.URL
+	apiKey    string
 )
 
 func SetEndpoint(endpoint string) error {

--- a/api/fossa/issues.go
+++ b/api/fossa/issues.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"regexp"
 
-	"github.com/pkg/errors"
+	"github.com/fossas/fossa-cli/errors"
 )
 
 const IssuesAPI = "/api/cli/%s/issues"

--- a/api/fossa/normalize.go
+++ b/api/fossa/normalize.go
@@ -3,8 +3,7 @@ package fossa
 import (
 	"encoding/json"
 
-	"github.com/pkg/errors"
-
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/module"
 	"github.com/fossas/fossa-cli/pkg"
 )

--- a/api/fossa/tar.go
+++ b/api/fossa/tar.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/files"
 )
 

--- a/api/fossa/upload.go
+++ b/api/fossa/upload.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/pkg/errors"
-
 	"github.com/apex/log"
+
 	"github.com/fossas/fossa-cli/cmd/fossa/version"
+	"github.com/fossas/fossa-cli/errors"
 )
 
 // Errors related to preconditions.

--- a/buildtools/bundler/lockfile.go
+++ b/buildtools/bundler/lockfile.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/files"
 )
 

--- a/buildtools/composer/composer.go
+++ b/buildtools/composer/composer.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 )
 

--- a/buildtools/dep/dep.go
+++ b/buildtools/dep/dep.go
@@ -5,9 +5,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/fossas/fossa-cli/buildtools"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/pkg"
 )

--- a/buildtools/gocmd/go.go
+++ b/buildtools/gocmd/go.go
@@ -6,8 +6,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/pkg/errors"
-
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 )
 

--- a/buildtools/gomodules/gomodules.go
+++ b/buildtools/gomodules/gomodules.go
@@ -6,9 +6,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/fossas/fossa-cli/buildtools"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/pkg"
 )

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"

--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"

--- a/buildtools/maven/pom.go
+++ b/buildtools/maven/pom.go
@@ -6,8 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/graph"
 	"github.com/fossas/fossa-cli/pkg"

--- a/buildtools/pip/pip.go
+++ b/buildtools/pip/pip.go
@@ -45,7 +45,7 @@ func (p *Pip) List() ([]Requirement, *errors.Error) {
 	if err != nil {
 		return nil, &errors.Error{
 			Cause:           err,
-			Type:            "shell",
+			Type:            errors.Exec,
 			Troubleshooting: fmt.Sprintf("Ensure that %s is installed, if it is then try to run %s list --format=json", p.Cmd, p.Cmd),
 			Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/integrations/python.md#strategy-string",
 		}
@@ -55,8 +55,8 @@ func (p *Pip) List() ([]Requirement, *errors.Error) {
 	if err != nil {
 		return nil, &errors.Error{
 			Cause:           err,
-			Type:            "shell",
-			Troubleshooting: fmt.Sprintf("the following output from the command %s list --format=json could not be un-marshalled:\n%s\ntry running the command on your own and checking for any errors", p.Cmd, string(stdout)),
+			Type:            errors.Unknown,
+			Troubleshooting: fmt.Sprintf("The following output from the command %s list --format=json could not be un-marshalled:\n%s\ntry running the command on your own and checking for any errors", p.Cmd, string(stdout)),
 			Link:            "https://pip.pypa.io/en/stable/reference/pip_list",
 		}
 	}
@@ -69,8 +69,8 @@ func FromFile(filename string) ([]Requirement, *errors.Error) {
 	if err != nil {
 		return nil, &errors.Error{
 			Cause:           err,
-			Type:            "unknown",
-			Troubleshooting: fmt.Sprintf("Ensure that `%s` exists", filename),
+			Type:            errors.User,
+			Troubleshooting: fmt.Sprintf("Ensure that `%s` exists.", filename),
 			Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/integrations/python.md#analysis",
 		}
 	}

--- a/buildtools/pip/pip.go
+++ b/buildtools/pip/pip.go
@@ -69,7 +69,7 @@ func FromFile(filename string) ([]Requirement, *errors.Error) {
 	if err != nil {
 		return nil, &errors.Error{
 			Cause:           err,
-			Type:            "user",
+			Type:            "unknown",
 			Troubleshooting: fmt.Sprintf("Ensure that `%s` exists", filename),
 			Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/integrations/python.md#analysis",
 		}

--- a/buildtools/pip/pip.go
+++ b/buildtools/pip/pip.go
@@ -37,29 +37,39 @@ func (p *Pip) Install(requirementsFilename string) error {
 	return err
 }
 
-func (p *Pip) List() ([]Requirement, error) {
+func (p *Pip) List() ([]Requirement, *errors.Error) {
 	stdout, _, err := exec.Run(exec.Cmd{
 		Name: p.Cmd,
 		Argv: []string{"list", "--format=json"},
 	})
 	if err != nil {
-		return nil, err
+		return nil, &errors.Error{
+			Cause:           err,
+			Type:            "shell",
+			Troubleshooting: fmt.Sprintf("Ensure that %s is installed, if it is then try to run %s list --format=json", p.Cmd, p.Cmd),
+			Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/integrations/python.md#strategy-string",
+		}
 	}
 	var reqs []Requirement
 	err = json.Unmarshal([]byte(stdout), &reqs)
 	if err != nil {
-		return nil, err
+		return nil, &errors.Error{
+			Cause:           err,
+			Type:            "shell",
+			Troubleshooting: fmt.Sprintf("the following output from the command %s list --format=json could not be un-marshalled:\n%s\ntry running the command on your own and checking for any errors", p.Cmd, string(stdout)),
+			Link:            "https://pip.pypa.io/en/stable/reference/pip_list",
+		}
 	}
 	return reqs, nil
 }
 
-func FromFile(filename string) ([]Requirement, error) {
+// FromFile reads a list of dependencies from the supplied `requirements.txt` formatted file.
+func FromFile(filename string) ([]Requirement, *errors.Error) {
 	contents, err := files.Read(filename)
 	if err != nil {
 		return nil, &errors.Error{
 			Cause:           err,
 			Type:            "user",
-			Message:         "Get the file?",
 			Troubleshooting: fmt.Sprintf("Ensure that `%s` exists", filename),
 			Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/integrations/python.md#analysis",
 		}

--- a/buildtools/pip/pip.go
+++ b/buildtools/pip/pip.go
@@ -2,10 +2,12 @@ package pip
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/apex/log"
 
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 )
@@ -54,7 +56,13 @@ func (p *Pip) List() ([]Requirement, error) {
 func FromFile(filename string) ([]Requirement, error) {
 	contents, err := files.Read(filename)
 	if err != nil {
-		return nil, err
+		return nil, &errors.Error{
+			Cause:           err,
+			Type:            "user",
+			Message:         "Get the file?",
+			Troubleshooting: fmt.Sprintf("Ensure that `%s` exists", filename),
+			Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/integrations/python.md#analysis",
+		}
 	}
 
 	var reqs []Requirement

--- a/buildtools/pip/pip_test.go
+++ b/buildtools/pip/pip_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestFromFile(t *testing.T) {
 	reqs, err := pip.FromFile("testdata/requirements.txt")
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, 8, len(reqs))
 	assert.Contains(t, reqs, pip.Requirement{Name: "simple", Revision: "1.0.0", Operator: "=="})
 	assert.Contains(t, reqs, pip.Requirement{Name: "extra", Revision: "2.0.0", Operator: "=="})

--- a/buildtools/pip/pipdeptree.go
+++ b/buildtools/pip/pipdeptree.go
@@ -5,9 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/pkg/errors"
-
 	"github.com/fossas/fossa-cli/buildtools/pip/bindata"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 )
 

--- a/buildtools/pipenv/pipenv_test.go
+++ b/buildtools/pipenv/pipenv_test.go
@@ -1,13 +1,13 @@
 package pipenv_test
 
 import (
-	"errors"
 	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/fossas/fossa-cli/buildtools/pipenv"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/pkg"
 )
 
@@ -20,11 +20,11 @@ import (
 */
 func TestDirectDeps(t *testing.T) {
 	file, err := ioutil.ReadFile("testdata/get-deps/pipenv-graph-json-tree.json")
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 	testEnv := Mock(file, nil)
 
 	deps, error := testEnv.Deps()
-	assert.NoError(t, error)
+	assert.Nil(t, error)
 
 	imports := deps.Direct
 	assert.NotZero(t, imports)
@@ -35,11 +35,11 @@ func TestDirectDeps(t *testing.T) {
 
 func TestTransitiveDeps(t *testing.T) {
 	file, err := ioutil.ReadFile("testdata/get-deps/pipenv-graph-json-tree.json")
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 	testEnv := Mock(file, nil)
 
-	deps, error := testEnv.Deps()
-	assert.NoError(t, error)
+	deps, err := testEnv.Deps()
+	assert.Nil(t, err)
 
 	graph := deps.Transitive
 	assert.NotZero(t, graph)
@@ -69,19 +69,11 @@ func TestTransitiveDeps(t *testing.T) {
 	assert.Equal(t, 0, len(packageE.Imports))
 }
 
-func TestNoFile(t *testing.T) {
-	testEnv := Mock([]byte{}, errors.New("test error"))
-
-	deps, err := testEnv.Deps()
-	assert.Zero(t, deps)
-	assert.EqualError(t, err, "test error")
-}
-
 // Mock constructs a pipenv.Cmd using mock build tool output.
 func Mock(file []byte, err error) pipenv.Cmd {
 	return pipenv.Cmd{
-		Graph: func(string) (string, error) {
-			return string(file), err
+		Graph: func(string) (string, *errors.Error) {
+			return string(file), nil
 		},
 	}
 }

--- a/buildtools/sbt/sbt.go
+++ b/buildtools/sbt/sbt.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/exec"
 	"github.com/fossas/fossa-cli/files"
 	"github.com/fossas/fossa-cli/pkg"

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -127,7 +127,7 @@ func Do(modules []module.Module, upload bool) (analyzed []module.Module, err err
 		}
 		deps, err := analyzer.Analyze()
 		if err != nil {
-			log.Fatalf("Could not analyze: %s", err.Error())
+			return analyzed, errors.Wrapf(err, "error analyzing module `%s` in directory `%s`", m.Name, m.Dir)
 		}
 		m.Imports = deps.Direct
 		m.Deps = deps.Transitive

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -38,10 +38,7 @@ func Run(ctx *cli.Context) error {
 		log.Fatalf("Could not initialize: %s", err.Error())
 	}
 
-	err = fossa.SetAPIKey(config.APIKey())
-	if err != nil {
-		return errors.UnknownError(err)
-	}
+	fossa.SetAPIKey(config.APIKey())
 
 	modules, err := config.Modules()
 	if err != nil {

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -39,18 +39,8 @@ func Run(ctx *cli.Context) error {
 	}
 
 	err = fossa.SetAPIKey(config.APIKey())
-	if err != nil && !ctx.Bool(ShowOutput) {
-		switch err {
-		case fossa.ErrMissingAPIKey:
-			return &errors.Error{
-				Cause:           err,
-				Type:            "user",
-				Message:         "add a FOSSA API KEY",
-				Troubleshooting: "go to fossa.com",
-			}
-		default:
-			return err
-		}
+	if err != nil {
+		return errors.UnknownError(err)
 	}
 
 	modules, err := config.Modules()

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
 	"github.com/fossas/fossa-cli/config"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/module"
 	"github.com/fossas/fossa-cli/pkg"
 )
@@ -35,6 +36,21 @@ func Run(ctx *cli.Context) error {
 	err := setup.SetContext(ctx)
 	if err != nil {
 		log.Fatalf("Could not initialize: %s", err.Error())
+	}
+
+	err = fossa.SetAPIKey(config.APIKey())
+	if err != nil && !ctx.Bool(ShowOutput) {
+		switch err {
+		case fossa.ErrMissingAPIKey:
+			return &errors.Error{
+				Cause:           err,
+				Type:            "user",
+				Message:         "add a FOSSA API KEY",
+				Troubleshooting: "go to fossa.com",
+			}
+		default:
+			return err
+		}
 	}
 
 	modules, err := config.Modules()

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -12,7 +12,6 @@ import (
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
 	"github.com/fossas/fossa-cli/config"
-	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/module"
 	"github.com/fossas/fossa-cli/pkg"
 )
@@ -37,8 +36,6 @@ func Run(ctx *cli.Context) error {
 	if err != nil {
 		log.Fatalf("Could not initialize: %s", err.Error())
 	}
-
-	fossa.SetAPIKey(config.APIKey())
 
 	modules, err := config.Modules()
 	if err != nil {
@@ -124,7 +121,7 @@ func Do(modules []module.Module, upload bool) (analyzed []module.Module, err err
 		}
 		deps, err := analyzer.Analyze()
 		if err != nil {
-			return analyzed, errors.Wrapf(err, "error analyzing module `%s` in directory `%s`", m.Name, m.Dir)
+			log.Fatalf("Could not analyze: %s", err.Error())
 		}
 		m.Imports = deps.Direct
 		m.Deps = deps.Transitive

--- a/cmd/fossa/cmd/build/build.go
+++ b/cmd/fossa/cmd/build/build.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 
 	"github.com/fossas/fossa-cli/analyzers"
@@ -12,6 +11,7 @@ import (
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
 	"github.com/fossas/fossa-cli/config"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/module"
 )
 

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 
 	"github.com/fossas/fossa-cli/api"
@@ -16,6 +15,7 @@ import (
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
 	"github.com/fossas/fossa-cli/config"
+	"github.com/fossas/fossa-cli/errors"
 )
 
 const defaultTestTemplate = `Test Failed! {{.Count}} {{if gt .Count 1 -}} issues {{- else -}} issue {{- end}} found.

--- a/cmd/fossa/cmd/update/update.go
+++ b/cmd/fossa/cmd/update/update.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/apex/log"
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
 	"github.com/rhysd/go-github-selfupdate/selfupdate"
 	"github.com/urfave/cli"
 
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/version"
+	"github.com/fossas/fossa-cli/errors"
 )
 
 const updateEndpoint = "fossas/fossa-cli"

--- a/cmd/fossa/cmd/upload/upload.go
+++ b/cmd/fossa/cmd/upload/upload.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 
 	"github.com/fossas/fossa-cli/api/fossa"
@@ -35,6 +34,7 @@ import (
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
 	"github.com/fossas/fossa-cli/config"
+	"github.com/fossas/fossa-cli/errors"
 )
 
 // Command-specific flags for `fossa upload`.

--- a/cmd/fossa/setup/setup.go
+++ b/cmd/fossa/setup/setup.go
@@ -26,6 +26,7 @@ func SetContext(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	fossa.SetAPIKey(config.APIKey())
 
 	return nil
 }

--- a/cmd/fossa/setup/setup.go
+++ b/cmd/fossa/setup/setup.go
@@ -26,7 +26,6 @@ func SetContext(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	fossa.SetAPIKey(config.APIKey())
 
 	return nil
 }

--- a/config/file.v1/file.go
+++ b/config/file.v1/file.go
@@ -2,9 +2,9 @@ package v1
 
 import (
 	"github.com/apex/log"
-	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/module"
 	"github.com/fossas/fossa-cli/pkg"
 )

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -23,8 +23,8 @@ type Error struct {
 	ExitCode        int
 	Cause           error  // Base error.
 	Type            string // Type helps us tell the user to log an issue, go to docs, etc.
-	Message         string
-	Troubleshooting string
+	Message         string // Help message for the user, creating a ticket, opening an issue, etc.
+	Troubleshooting string // Simple solution or debugging instructions.
 	Link            string // Link to documentation or reference information.
 }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -35,6 +35,10 @@ creating the issue, please attach the debug log located at:
 `
 }
 
+func Errorf(format string, args ...interface{}) error {
+	return errors.Errorf(format, args...)
+}
+
 func Wrap(cause error, msg string) error {
 	return errors.Wrap(cause, msg)
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -11,10 +11,12 @@ var (
 	ErrNotImplemented = errors.New("not yet implemented")
 )
 
-func UnknownError(err error) error {
+// UnknownError creates a simple fossa error using an existing error and additional context.
+func UnknownError(err error, message string) *Error {
 	return &Error{
-		Cause: err,
-		Type:  "unknown",
+		Cause:   err,
+		Type:    "unknown",
+		Message: message,
 	}
 }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -12,11 +12,19 @@ var (
 	ErrNotImplemented = errors.New("not yet implemented")
 )
 
+type Type = int
+
+const (
+	User Type = iota
+	Exec
+	Unknown
+)
+
 // UnknownError creates a simple fossa error using an existing error and additional context.
 func UnknownError(err error, message string) *Error {
 	return &Error{
 		Cause: err,
-		Type:  "unknown",
+		Type:  Unknown,
 	}
 }
 
@@ -24,7 +32,7 @@ func UnknownError(err error, message string) *Error {
 type Error struct {
 	ExitCode        int
 	Cause           error  // Base error.
-	Type            string // Type helps us tell the user to log an issue, go to docs, etc.
+	Type            Type   // Type helps us tell the user to log an issue, go to docs, etc.
 	Message         string // Help message for the user, contact support, opening an issue, etc.
 	Troubleshooting string // Simple solution or debugging instructions.
 	Link            string // Link to documentation or reference information.
@@ -45,12 +53,13 @@ func (e *Error) Error() string {
 		link = fmt.Sprintf("\n%s: %s", color.GreenString("LINK"), e.Link)
 	}
 
+	message = e.Message
 	if message == "" {
 		switch e.Type {
-		case "user":
-		case "shell":
+		case User:
+		case Exec:
 			fallthrough
-		case "unknown":
+		case Unknown:
 			fallthrough
 		default:
 			message = ReportBugMessage

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -7,15 +7,17 @@ var (
 	ErrNotImplemented = errors.New("not yet implemented")
 )
 
+// Error is the fossa implementation of errors for providing user-friendly information.
 type Error struct {
+	ExitCode        int
 	Cause           error
-	Common          bool
+	Type            string
 	Message         string
 	Troubleshooting string
 }
 
 func (e *Error) Error() string {
-	return `Error: ` + e.Message + `
+	return `Error: ` + e.Cause.Error() + `
 TROUBLESHOOTING:
 
 ` + e.Troubleshooting + `
@@ -52,7 +54,6 @@ func WrapError(cause error, err Error) Error {
 	case *Error:
 		return Error{
 			Cause:           e,
-			Common:          err.Common,
 			Message:         err.Message,
 			Troubleshooting: err.Troubleshooting,
 		}

--- a/errors/messages.go
+++ b/errors/messages.go
@@ -1,13 +1,30 @@
 package errors
 
-const defaultMessage = `
+import "github.com/fatih/color"
+import "github.com/mitchellh/go-wordwrap"
 
-Please try troubleshooting before filing a bug. If none of the suggestions work,
-you can file a bug at <https://github.com/fossas/fossa-cli/issues/new>.
+var ReportBugMessage = `
 
-CREATING AN ISSUE:
+` + color.HiYellowString("REPORTING A BUG:") + `
+Please try troubleshooting before filing a bug. If none of the suggestions
+work, you can file a bug at ` + color.HiBlueString("https://github.com/fossas/fossa-cli/issues/new") + `.
+Please attach the debug logs from:
 
-Before creating an issue, please search GitHub issues for similar problems. When
-creating the issue, please attach the debug log located at:
+    ` + color.HiGreenString("fossa <cmd> --debug") + `
 
-  /tmp/fossa-cli-debug-log`
+For additional support, contact ` + color.MagentaString("support@fossa.com")
+
+var NoAPIKeyMessage = `
+
+` + wordwrap.WrapString("Running `fossa analyze` performs a dependency analysis and uploads the result to FOSSA. To run an analysis without uploading results, run:", 78) + `
+    
+    ` + color.HiGreenString("fossa analyze --output") + `
+
+` + wordwrap.WrapString("You can provide your API key by setting the $FOSSA_API_KEY environment variable. For example, try running:", 78) + `
+    
+    ` + color.HiGreenString("FOSSA_API_KEY=<YOUR_API_KEY_HERE> $command") + `
+
+` + wordwrap.WrapString("You can create an API key for your FOSSA account at:", 78) + `
+    
+    ` + color.HiBlueString("$endpoint/account/settings/integrations/api_tokens") + `
+`

--- a/errors/messages.go
+++ b/errors/messages.go
@@ -1,0 +1,13 @@
+package errors
+
+const defaultMessage = `
+
+Please try troubleshooting before filing a bug. If none of the suggestions work,
+you can file a bug at <https://github.com/fossas/fossa-cli/issues/new>.
+
+CREATING AN ISSUE:
+
+Before creating an issue, please search GitHub issues for similar problems. When
+creating the issue, please attach the debug log located at:
+
+  /tmp/fossa-cli-debug-log`

--- a/errors/messages.go
+++ b/errors/messages.go
@@ -3,28 +3,29 @@ package errors
 import "github.com/fatih/color"
 import "github.com/mitchellh/go-wordwrap"
 
+const width = 78
+
 var ReportBugMessage = `
 
 ` + color.HiYellowString("REPORTING A BUG:") + `
-Please try troubleshooting before filing a bug. If none of the suggestions
-work, you can file a bug at ` + color.HiBlueString("https://github.com/fossas/fossa-cli/issues/new") + `.
-Please attach the debug logs from:
-
-    ` + color.HiGreenString("fossa <cmd> --debug") + `
-
-For additional support, contact ` + color.MagentaString("support@fossa.com")
+` + wordwrap.WrapString("Please try troubleshooting before filing a bug. If the suggestions do not help you can file a bug at "+color.HiBlueString("https://github.com/fossas/fossa-cli/issues/new")+".", width) + `
+` + wordwrap.WrapString("Please attach the debug logs from:", width) + `
+  
+  ` + color.HiGreenString("fossa <cmd> --debug") + `
+  
+` + wordwrap.WrapString("For additional support, contact "+color.MagentaString("support@fossa.com")+".", width)
 
 var NoAPIKeyMessage = `
 
-` + wordwrap.WrapString("Running `fossa analyze` performs a dependency analysis and uploads the result to FOSSA. To run an analysis without uploading results, run:", 78) + `
+` + wordwrap.WrapString("Running `fossa analyze` performs a dependency analysis and uploads the result to FOSSA. To run an analysis without uploading results, run:", width) + `
     
     ` + color.HiGreenString("fossa analyze --output") + `
 
-` + wordwrap.WrapString("You can provide your API key by setting the $FOSSA_API_KEY environment variable. For example, try running:", 78) + `
+` + wordwrap.WrapString("You can provide your API key by setting the $FOSSA_API_KEY environment variable. For example, try running:", width) + `
     
     ` + color.HiGreenString("FOSSA_API_KEY=<YOUR_API_KEY_HERE> $command") + `
 
-` + wordwrap.WrapString("You can create an API key for your FOSSA account at:", 78) + `
+` + wordwrap.WrapString("You can create an API key for your FOSSA account at:", width) + `
     
     ` + color.HiBlueString("$endpoint/account/settings/integrations/api_tokens") + `
 `

--- a/exec/run.go
+++ b/exec/run.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/apex/log"
-	"github.com/pkg/errors"
+	"github.com/fossas/fossa-cli/errors"
 )
 
 // Cmd represents a single command. If Name and Argv are set, this is treated as

--- a/vendor/github.com/mitchellh/go-wordwrap/LICENSE.md
+++ b/vendor/github.com/mitchellh/go-wordwrap/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/go-wordwrap/README.md
+++ b/vendor/github.com/mitchellh/go-wordwrap/README.md
@@ -1,0 +1,39 @@
+# go-wordwrap
+
+`go-wordwrap` (Golang package: `wordwrap`) is a package for Go that
+automatically wraps words into multiple lines. The primary use case for this
+is in formatting CLI output, but of course word wrapping is a generally useful
+thing to do.
+
+## Installation and Usage
+
+Install using `go get github.com/mitchellh/go-wordwrap`.
+
+Full documentation is available at
+http://godoc.org/github.com/mitchellh/go-wordwrap
+
+Below is an example of its usage ignoring errors:
+
+```go
+wrapped := wordwrap.WrapString("foo bar baz", 3)
+fmt.Println(wrapped)
+```
+
+Would output:
+
+```
+foo
+bar
+baz
+```
+
+## Word Wrap Algorithm
+
+This library doesn't use any clever algorithm for word wrapping. The wrapping
+is actually very naive: whenever there is whitespace or an explicit linebreak.
+The goal of this library is for word wrapping CLI output, so the input is
+typically pretty well controlled human language. Because of this, the naive
+approach typically works just fine.
+
+In the future, we'd like to make the algorithm more advanced. We would do
+so without breaking the API.

--- a/vendor/github.com/mitchellh/go-wordwrap/go.mod
+++ b/vendor/github.com/mitchellh/go-wordwrap/go.mod
@@ -1,0 +1,1 @@
+module github.com/mitchellh/go-wordwrap

--- a/vendor/github.com/mitchellh/go-wordwrap/wordwrap.go
+++ b/vendor/github.com/mitchellh/go-wordwrap/wordwrap.go
@@ -1,0 +1,73 @@
+package wordwrap
+
+import (
+	"bytes"
+	"unicode"
+)
+
+// WrapString wraps the given string within lim width in characters.
+//
+// Wrapping is currently naive and only happens at white-space. A future
+// version of the library will implement smarter wrapping. This means that
+// pathological cases can dramatically reach past the limit, such as a very
+// long word.
+func WrapString(s string, lim uint) string {
+	// Initialize a buffer with a slightly larger size to account for breaks
+	init := make([]byte, 0, len(s))
+	buf := bytes.NewBuffer(init)
+
+	var current uint
+	var wordBuf, spaceBuf bytes.Buffer
+
+	for _, char := range s {
+		if char == '\n' {
+			if wordBuf.Len() == 0 {
+				if current+uint(spaceBuf.Len()) > lim {
+					current = 0
+				} else {
+					current += uint(spaceBuf.Len())
+					spaceBuf.WriteTo(buf)
+				}
+				spaceBuf.Reset()
+			} else {
+				current += uint(spaceBuf.Len() + wordBuf.Len())
+				spaceBuf.WriteTo(buf)
+				spaceBuf.Reset()
+				wordBuf.WriteTo(buf)
+				wordBuf.Reset()
+			}
+			buf.WriteRune(char)
+			current = 0
+		} else if unicode.IsSpace(char) {
+			if spaceBuf.Len() == 0 || wordBuf.Len() > 0 {
+				current += uint(spaceBuf.Len() + wordBuf.Len())
+				spaceBuf.WriteTo(buf)
+				spaceBuf.Reset()
+				wordBuf.WriteTo(buf)
+				wordBuf.Reset()
+			}
+
+			spaceBuf.WriteRune(char)
+		} else {
+
+			wordBuf.WriteRune(char)
+
+			if current+uint(spaceBuf.Len()+wordBuf.Len()) > lim && uint(wordBuf.Len()) < lim {
+				buf.WriteRune('\n')
+				current = 0
+				spaceBuf.Reset()
+			}
+		}
+	}
+
+	if wordBuf.Len() == 0 {
+		if current+uint(spaceBuf.Len()) <= lim {
+			spaceBuf.WriteTo(buf)
+		}
+	} else {
+		spaceBuf.WriteTo(buf)
+		wordBuf.WriteTo(buf)
+	}
+
+	return buf.String()
+}


### PR DESCRIPTION
Addresses some of the concerns in Issue #344. This PR is aimed at standardizing the way the FOSSA CLI handles errors and making it easier to provide users with actionable information when an error is encountered.

The stages of this PR are as follows:
1. Standardize the FOSSA CLI into one single errors package: `github.com/fossas/fossa-cli/errors`
2. Improve the errors package to pretty print error with actionable information.

In follow-up PRs 
- identify all of the points where the cli is erroring in the unpredictable ways mentioned in #344. 
- Standardize the errors package across the cli.
- Create more commonly seen errors.

Formatted errors look like:
<img width="719" alt="Screen Shot 2019-07-17 at 7 59 19 PM" src="https://user-images.githubusercontent.com/31230447/61425930-694e1e00-a8cd-11e9-93c8-468c6472cd7a.png">
