### PR TITLE
fix (module filter) consider windows file paths when filtering modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ bin/
 .vscode/
 coverage.txt
 cmd/fossa/fossa
+analyzers/gradle/testdata/.gradle
+analyzers/gradle/testdata/.project
+analyzers/gradle/testdata/.settings

--- a/cmd/fossa/cmd/init/init.go
+++ b/cmd/fossa/cmd/init/init.go
@@ -88,7 +88,7 @@ func Do(includeAll bool, options map[string]interface{}) ([]module.Module, error
 }
 
 // FilterSuspiciousModules removes modules from known paths to prevent vendored third-party,
-// test, or other modules that do not likely belong to the first party project from being analyzed.
+// test, or other modules that likely do not belong to the first party project being analyzed.
 func FilterSuspiciousModules(modules []module.Module) []module.Module {
 	var filtered []module.Module
 	suspicious := regexp.MustCompile(`(docs?[/\\]|[Tt]est|examples?|vendor[/\\]|node_modules[/\\]|.srclib-cache[/\\]|spec[/\\]|Godeps[/\\]|.git[/\\]|bower_components[/\\]|third[_-]party[/\\]|tmp[/\\]|Carthage[/\\]Checkouts[/\\])`)

--- a/cmd/fossa/cmd/init/init.go
+++ b/cmd/fossa/cmd/init/init.go
@@ -91,7 +91,7 @@ func Do(includeAll bool, options map[string]interface{}) ([]module.Module, error
 // test, or other modules that likely do not belong to the first party project being analyzed.
 func FilterSuspiciousModules(modules []module.Module) []module.Module {
 	var filtered []module.Module
-	suspicious := regexp.MustCompile(`(docs?[/\\]|[Tt]est|examples?|vendor[/\\]|node_modules[/\\]|.srclib-cache[/\\]|spec[/\\]|Godeps[/\\]|.git[/\\]|bower_components[/\\]|third[_-]party[/\\]|tmp[/\\]|Carthage[/\\]Checkouts[/\\])`)
+	suspicious := regexp.MustCompile(`docs?[/\\]|[Tt]est|examples?|vendor[/\\]|node_modules[/\\]|.srclib-cache[/\\]|spec[/\\]|Godeps[/\\]|.git[/\\]|bower_components[/\\]|third[_-]party[/\\]|tmp[/\\]|Carthage[/\\]Checkouts[/\\]`)
 	for _, d := range modules {
 		log.Debugf("Discovered: %#v", d)
 

--- a/cmd/fossa/cmd/init/init.go
+++ b/cmd/fossa/cmd/init/init.go
@@ -83,9 +83,16 @@ func Do(includeAll bool, options map[string]interface{}) ([]module.Module, error
 	if includeAll {
 		return discovered, nil
 	}
+
+	return FilterSuspiciousModules(discovered), nil
+}
+
+// FilterSuspiciousModules removes modules from known paths to prevent vendored third-party,
+// test, or other modules that do not likely belong to the first party project from being analyzed.
+func FilterSuspiciousModules(modules []module.Module) []module.Module {
 	var filtered []module.Module
-	suspicious := regexp.MustCompile("(docs?/|[Tt]est|examples?|vendor/|node_modules/|.srclib-cache/|spec/|Godeps/|.git/|bower_components/|third[_-]party/|tmp/|Carthage/Checkouts/)")
-	for _, d := range discovered {
+	suspicious := regexp.MustCompile(`(docs?[/\\]|[Tt]est|examples?|vendor[/\\]|node_modules[/\\]|.srclib-cache[/\\]|spec[/\\]|Godeps[/\\]|.git[/\\]|bower_components[/\\]|third[_-]party[/\\]|tmp[/\\]|Carthage[/\\]Checkouts[/\\])`)
+	for _, d := range modules {
 		log.Debugf("Discovered: %#v", d)
 
 		// Match name regexp.
@@ -103,5 +110,5 @@ func Do(includeAll bool, options map[string]interface{}) ([]module.Module, error
 
 		filtered = append(filtered, d)
 	}
-	return filtered, nil
+	return filtered
 }

--- a/cmd/fossa/cmd/init/init.go
+++ b/cmd/fossa/cmd/init/init.go
@@ -79,11 +79,11 @@ func Do(includeAll bool, options map[string]interface{}) ([]module.Module, error
 
 	// TODO: Check whether modules were previously ignored.
 
-	// Filter noisy modules (docs, examples, etc.).
 	if includeAll {
 		return discovered, nil
 	}
 
+	// Filter noisy modules (docs, examples, etc.).
 	return FilterSuspiciousModules(discovered), nil
 }
 

--- a/cmd/fossa/cmd/init/init_test.go
+++ b/cmd/fossa/cmd/init/init_test.go
@@ -16,6 +16,7 @@ func TestModuleFiltering(t *testing.T) {
 	goNotExecutable := module.Module{IsExecutable: false, Type: pkg.Go}
 	goExecutable := module.Module{IsExecutable: true, Type: pkg.Go}
 	unfiltered := []module.Module{node, nodeWindows, temp, goNotExecutable, goExecutable}
+
 	filtered := initc.FilterSuspiciousModules(unfiltered)
 	assert.NotContains(t, filtered, node)
 	assert.NotContains(t, filtered, nodeWindows)

--- a/cmd/fossa/cmd/init/init_test.go
+++ b/cmd/fossa/cmd/init/init_test.go
@@ -1,0 +1,25 @@
+package init_test
+
+import (
+	"testing"
+
+	initc "github.com/fossas/fossa-cli/cmd/fossa/cmd/init"
+	"github.com/fossas/fossa-cli/module"
+	"github.com/fossas/fossa-cli/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModuleFiltering(t *testing.T) {
+	node := module.Module{Dir: "temp/node_modules/subdir"}
+	nodeWindows := module.Module{Dir: "temp\\node_modules\\subdir"}
+	temp := module.Module{Dir: "tmp/subdir"}
+	goNotExecutable := module.Module{IsExecutable: false, Type: pkg.Go}
+	goExecutable := module.Module{IsExecutable: true, Type: pkg.Go}
+	unfiltered := []module.Module{node, nodeWindows, temp, goNotExecutable, goExecutable}
+	filtered := initc.FilterSuspiciousModules(unfiltered)
+	assert.NotContains(t, filtered, node)
+	assert.NotContains(t, filtered, nodeWindows)
+	assert.NotContains(t, filtered, goNotExecutable)
+	assert.NotContains(t, filtered, temp)
+	assert.Contains(t, filtered, goExecutable)
+}


### PR DESCRIPTION
This PR implements module filtering for windows file paths and breaks the functionality out into a testable unit of code. This is accomplished by changing `node_modules/` to `node_modules[/\\]` in the filtering regex.

I also added a few lines to the `.gitignore` file to ignore files created by our test suite.