### PR TITLE
feat (buckw) discover buck command and prefer buckw

### DIFF
--- a/buildtools/buck/buck.go
+++ b/buildtools/buck/buck.go
@@ -31,10 +31,10 @@ type Setup struct {
 }
 
 // New creates a new Buck instance that calls the buck build tool directly.
-func New(target string) Buck {
+func New(target, binary string) Buck {
 	return Setup{
 		Target: target,
-		Cmd:    Cmd,
+		Cmd:    NewCmd(binary),
 	}
 }
 

--- a/buildtools/buck/cmd.go
+++ b/buildtools/buck/cmd.go
@@ -8,16 +8,19 @@ import (
 	"github.com/fossas/fossa-cli/exec"
 )
 
-func Cmd(cmd string, args ...string) (string, error) {
-	out, _, err := exec.Run(exec.Cmd{
-		Name: "buck",
-		Argv: append([]string{cmd}, args...),
-	})
+// NewCmd creates a function that executes the chosen buck executable.
+func NewCmd(name string) func(string, ...string) (string, error) {
+	return func(cmd string, args ...string) (string, error) {
+		out, _, err := exec.Run(exec.Cmd{
+			Name: name,
+			Argv: append([]string{cmd}, args...),
+		})
 
-	if err != nil {
-		return out, errors.Wrapf(err, "Could not run `buck %s %+v` within the current directory", cmd, args)
+		if err != nil {
+			return out, errors.Wrapf(err, "Could not run `%s %s %+v` within the current directory", name, cmd, args)
+		}
+		return out, nil
 	}
-	return out, nil
 }
 
 func cmdAudit(command func(string, ...string) (string, error), cmd string, argv ...string) (AuditOutput, error) {

--- a/docs/integrations/buck.md
+++ b/docs/integrations/buck.md
@@ -35,7 +35,8 @@ analyze:
 ## Analysis
 
 Buck projects are uploaded with all of their source code broken into dependencies for license analysis by FOSSA. This project involves a few steps:
+1. Determine the correct buck command to run by trying to execute `FOSSA_BUCK_CMD`, `./buckw`, and `buck`.
 1. Run `buck audit input <target> --json` to retrieve a list of all dependencies.
-2. Upload these dependencies and maintain references to their uploaded locator.
-3. Create a dependency graph by recursively running `buck audit dependencies <target>` on each dependency and add it to the graph.
-4. Upload the dependency graph to FOSSA which will match the dependency locators to the raw upload and analysis of each dependency.
+1. Upload these dependencies and maintain references to their uploaded locator.
+1. Create a dependency graph by recursively running `buck audit dependencies <target>` on each dependency and add it to the graph.
+1. Upload the dependency graph to FOSSA which will match the dependency locators to the raw upload and analysis of each dependency.


### PR DESCRIPTION
Some users of buck prefer to use a buck command wrapper `buckw` instead of the default `buck` command. This PR discovers which one the directory is using by preferring `buckw` and ensures this is used throughout the analyzer. The implementation is very similar to how python discovers the correct command. Once the correct command is discovered, it is used to create a `Cmd()` function which can be used to execute the command.

I validated this by working with okbuck and buck codebases to ensure that a `buckw` file would be located and executed. I see no way to test this without also implementing a full buck integration suite.