### PR TITLE
fix (improve failures) don't look for setup.py and don't fail on missing cocopods binary

### DIFF
--- a/analyzers/cocoapods/cocoapods.go
+++ b/analyzers/cocoapods/cocoapods.go
@@ -36,7 +36,7 @@ func New(m module.Module) (*Analyzer, error) {
 	// Set Cocoapods context variables
 	podCmd, podVersion, err := exec.Which("--version", os.Getenv("COCOAPODS_BINARY"), "pod")
 	if err != nil {
-		return nil, fmt.Errorf("could not find Cocoapods binary (try setting $COCOAPODS_BINARY): %s", err.Error())
+		log.Debugf("could not find Cocoapods binary (try setting $COCOAPODS_BINARY): %s", err.Error())
 	}
 
 	// Parse and validate options.

--- a/analyzers/python/python.go
+++ b/analyzers/python/python.go
@@ -84,7 +84,7 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 			return err
 		}
 
-		if !info.IsDir() && (info.Name() == "requirements.txt" || info.Name() == "setup.py") {
+		if !info.IsDir() && (info.Name() == "requirements.txt") {
 			moduleDir := filepath.Dir(filename)
 			_, ok := modules[moduleDir]
 			if ok {


### PR DESCRIPTION
Changes made:

1. We do not currently parse `setup.py` files and until then we should not be discovering python projects. We can add this method back once we improve python fallbacks.
1. Don't fail if we don't find the cocoapods binary because we do not actually need it for analysis.

These fixes drive the cli towards a future where we prefer to log warnings instead of failing.