### PR TITLE
fix (zero deps error) log a better message when a project has no dependencies

### DIFF
--- a/cmd/fossa/cmd/report/dependencies.go
+++ b/cmd/fossa/cmd/report/dependencies.go
@@ -74,6 +74,11 @@ func dependenciesRun(ctx *cli.Context) error {
 		}
 	}
 
+	if len(revisionsByFetcher) == 0 {
+		fmt.Printf("\nNo dependencies were found for project %s", locator)
+		return nil
+	}
+
 	// Sort the dependency lists alphabetically by Project Title.
 	for fetcher, depList := range revisionsByFetcher {
 		sort.Slice(depList[:], func(i, j int) bool {

--- a/cmd/fossa/cmd/report/licenses.go
+++ b/cmd/fossa/cmd/report/licenses.go
@@ -82,6 +82,11 @@ func licensesRun(ctx *cli.Context) (err error) {
 		}
 	}
 
+	if len(revisionsByLicense) == 0 {
+		fmt.Printf("\nNo licenses were found for project %s", locator)
+		return nil
+	}
+
 	// Sort the dependency lists alphabetically by Project Title.
 	for license, depList := range revisionsByLicense {
 		sort.Slice(depList[:], func(i, j int) bool {


### PR DESCRIPTION
When a project has 0 dependencies we should log a nice message.
Previously the error looked like this:
```bash
$ fossa report dependencies
⣯ Fetching Dependency Information # 3rd-Party Software Dependency List
Generated by fossa-cli (https://github.com/fossas/fossa-cli).
This project includes the following dependencies sorted by corresponding location:


```
With the small update, it looks like this:
```bash
$ fossa report licenses
⣟ Fetching License Information
No licenses were found for project custom+ludwig-zero$395ddcd50
```

I did not change the error message when a user passes the `--json` flag as that would introduce unexpected behavior for any user attempting to parse the response. The default return in json is `[]` which can be interpreted as 0 dependencies by the client.