### PR TITLE
fix (nested poms) fix a bug where nested pom files could not be found 

### DIFF
--- a/analyzers/maven/maven.go
+++ b/analyzers/maven/maven.go
@@ -134,7 +134,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 
 	switch a.Options.Strategy {
 	case "pom-file":
-		return maven.GraphFromTarget(a.Module.BuildTarget)
+		return maven.PomFileGraph(a.Module.BuildTarget, a.Module.Dir)
 	case "maven-tree":
 		return a.Maven.DependencyTree(a.Module.Dir, a.Module.BuildTarget)
 	default:
@@ -163,6 +163,6 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 			return deps, nil
 		}
 
-		return maven.GraphFromTarget(a.Module.BuildTarget)
+		return maven.PomFileGraph(a.Module.BuildTarget, a.Module.Dir)
 	}
 }

--- a/analyzers/maven/maven_test.go
+++ b/analyzers/maven/maven_test.go
@@ -12,7 +12,7 @@ func TestDiscover(t *testing.T) {
 	modules, err := maven.Discover("testdata", nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, 3, len(modules))
+	assert.Equal(t, 4, len(modules))
 
 	p1 := modules[0]
 	assert.Equal(t, "Project 1 Sample", p1.Name)
@@ -28,4 +28,9 @@ func TestDiscover(t *testing.T) {
 	assert.Equal(t, "Other Project", p3.Name)
 	assert.Equal(t, "pom-other.xml", p3.BuildTarget)
 	assert.Equal(t, "testdata/nested", p3.Dir)
+
+	p4 := modules[3]
+	assert.Equal(t, "Deep Nested Project", p4.Name)
+	assert.Equal(t, "deep-nested/pom.xml", p4.BuildTarget)
+	assert.Equal(t, "testdata/nested", p4.Dir)
 }

--- a/analyzers/maven/testdata/nested/deep-nested/pom.xml
+++ b/analyzers/maven/testdata/nested/deep-nested/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+ <modelVersion>4.0.0</modelVersion>
+ <groupId>com.someone.code.gson</groupId>
+ <artifactId>gson-extras</artifactId>
+ <packaging>jar</packaging>
+ <version>1.0-SNAPSHOT</version>
+ <inceptionYear>2019</inceptionYear>
+ <name>Deep Nested Project</name>
+ <dependencies>
+  <dependency>
+   <groupId>com.google.code.g</groupId>
+   <artifactId>g</artifactId>
+   <version>2.7</version>
+   <scope>compile</scope>
+  </dependency>
+  <dependency>
+   <groupId>javax.annotation</groupId>
+   <artifactId>jsr250-api</artifactId>
+   <version>1.0.2</version>
+  </dependency>
+  <dependency>
+   <groupId>junit</groupId>
+   <artifactId>junit</artifactId>
+   <version>3.8.2</version>
+   <scope>test</scope>
+  </dependency>
+ </dependencies>
+</project>

--- a/analyzers/maven/testdata/nested/pom.xml
+++ b/analyzers/maven/testdata/nested/pom.xml
@@ -14,6 +14,7 @@
  </parent>
  <modules>
   <module>pom-other.xml</module>
+  <module>deep-nested</module>
  </modules>
  <description>Other project</description>
  <properties>

--- a/analyzers/maven/testdata/pom.xml
+++ b/analyzers/maven/testdata/pom.xml
@@ -7,23 +7,4 @@
  <version>1.0-SNAPSHOT</version>
  <name>Project 1 Sample</name>
  <description>A sample project</description>
- <dependencies>
-  <dependency>
-   <groupId>com.google.code.g</groupId>
-   <artifactId>g</artifactId>
-   <version>2.7</version>
-   <scope>compile</scope>
-  </dependency>
-  <dependency>
-   <groupId>javax.annotation</groupId>
-   <artifactId>jsr250-api</artifactId>
-   <version>1.0.2</version>
-  </dependency>
-  <dependency>
-   <groupId>junit</groupId>
-   <artifactId>junit</artifactId>
-   <version>3.8.2</version>
-   <scope>test</scope>
-  </dependency>
- </dependencies>
 </project>

--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -131,7 +131,7 @@ func (m *Maven) tryDependencyCommands(subGoal, dir, buildTarget string) (stdout 
 	if err != nil {
 		// Now we try to identify the groupId:artifactId identifier for the module and specify the path to
 		// the manifest file directly.
-		pom, err2 := ResolveManifestFromBuildTarget(buildTarget)
+		pom, err2 := ResolveManifestFromTarget(buildTarget, dir)
 		if err2 != nil {
 			// Using buildTarget as a module ID or as a path to a manifest did not work.
 			// Return just the error from running the mvn goal the first time.

--- a/buildtools/maven/maven_test.go
+++ b/buildtools/maven/maven_test.go
@@ -36,7 +36,7 @@ func TestModules(t *testing.T) {
 	pomWithModules := filepath.Join(testdataDir, "nested", "pom.xml")
 	mods2, err := maven.Modules(pomWithModules, testdataDir, make(map[string]bool))
 	assert.NoError(t, err)
-	assert.Len(t, mods2, 2)
+	assert.Len(t, mods2, 3)
 	for _, mod := range mods2 {
 		exists, err := files.Exists(mod.Dir, mod.Target)
 		assert.NoError(t, err)
@@ -47,7 +47,7 @@ func TestModules(t *testing.T) {
 	pomWithModules2 := filepath.Join(testdataDir, "pom-minimal.xml")
 	mods3, err := maven.Modules(pomWithModules2, testdataDir, make(map[string]bool))
 	assert.NoError(t, err)
-	assert.Len(t, mods3, 3)
+	assert.Len(t, mods3, 4)
 	for _, mod := range mods3 {
 		exists, err := files.Exists(mod.Dir, mod.Target)
 		assert.NoError(t, err)

--- a/buildtools/maven/pom_test.go
+++ b/buildtools/maven/pom_test.go
@@ -10,9 +10,10 @@ import (
 	"github.com/fossas/fossa-cli/pkg"
 )
 
-func TestGraphFromTarget(t *testing.T) {
+func TestPomFileGraph(t *testing.T) {
 	// This test needs just the Dependencies field of a Manifest to be translated to a graph.Deps.
-	projectDir := testdataDir
+	projectDir := testdataDir + "/nested"
+	projectTarget := "deep-nested/pom.xml"
 
 	id1 := pkg.ID{Type: pkg.Maven, Name: "com.google.code.g:g", Revision: "2.7"}
 	id2 := pkg.ID{Type: pkg.Maven, Name: "javax.annotation:jsr250-api", Revision: "1.0.2"}
@@ -29,26 +30,26 @@ func TestGraphFromTarget(t *testing.T) {
 		id3: {ID: id3},
 	}
 
-	got, err := maven.GraphFromTarget(projectDir)
+	got, err := maven.PomFileGraph(projectTarget, projectDir)
 	assert.NoError(t, err)
 	assert.Equal(t, wantDirect, got.Direct)
 	assert.Equal(t, wantTransitive, got.Transitive)
 }
 
-func TestResolveManifestFromBuildTarget(t *testing.T) {
+func TestResolveManifestFromTarget(t *testing.T) {
 	// A directory path.
-	pom, err := maven.ResolveManifestFromBuildTarget(testdataDir)
+	pom, err := maven.ResolveManifestFromTarget(testdataDir, ".")
 	if assert.NoError(t, err) {
 		assert.Equal(t, "com.domain.name:stuff", pom.GroupID+":"+pom.ArtifactID)
 	}
 
 	// A POM file path.
-	pom2, err := maven.ResolveManifestFromBuildTarget(filepath.Join(testdataDir, "nested", "pom.xml"))
+	pom2, err := maven.ResolveManifestFromTarget(filepath.Join(testdataDir, "nested", "pom.xml"), ".")
 	if assert.NoError(t, err) {
 		assert.Equal(t, "com.someone.code.a:gson-extras", pom2.GroupID+":"+pom2.ArtifactID)
 	}
 
 	// A project identifier.
-	_, err3 := maven.ResolveManifestFromBuildTarget("something:else")
+	_, err3 := maven.ResolveManifestFromTarget("something:else", ".")
 	assert.Error(t, err3)
 }


### PR DESCRIPTION
The following target is what we discover when a maven project has a nested pom file:
```
  - name: Keycloak BOM for adapters
    type: mvn
    target: adapter/pom.xml
    path: boms
```

The function `ResolveManifestFromBuildTarget` fails when passed `adapter/pom.xml` as the target because it is unable to be found.

This PR:
1. Passes directory through so that it can be used to read the pom file.
2. Adds supporting tests for discovery and pom file analysis.

The logic change is really only at `buildtools/maven/pom.go:82` The rest is supporting function changes and some name changes now that we are not only passing in a buildtarget.