### PR TITLE
fix (support method) change support to email

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@
   <a href="https://golangci.com/r/github.com/fossas/fossa-cli">
     <img src="https://golangci.com/badges/github.com/fossas/fossa-cli.svg">
   </a>
-  <a href="http://slack.fossa.io/">
-    <img src="https://slack.fossa.io/badge.svg">
-  </a>
   <a href="https://codecov.io/gh/fossas/fossa-cli">
     <img src="https://codecov.io/gh/fossas/fossa-cli/branch/master/graph/badge.svg" />
   </a>
@@ -184,8 +181,6 @@ License data is provided by [https://fossa.com](https://fossa.com)'s 500GB open 
 ## Development
 
 View our [Contribution Guidelines](.github/CONTRIBUTING.md) to get started.
-
-Join our public [Slack Channel](https://slack.fossa.io).
 
 ## License
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -23,7 +23,8 @@ TROUBLESHOOTING:
 Please try troubleshooting before filing a bug. If none of the suggestions work,
 you can file a bug at <https://github.com/fossas/fossa-cli/issues/new>.
 
-For additional support send an email to support@fossa.com.
+For additional support send an email to support@fossa.com with as much information
+as possible, screenshots are greatly appreciated!
 
 CREATING AN ISSUE:
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -23,7 +23,7 @@ TROUBLESHOOTING:
 Please try troubleshooting before filing a bug. If none of the suggestions work,
 you can file a bug at <https://github.com/fossas/fossa-cli/issues/new>.
 
-For additional support, ask the #cli channel at <https://slack.fossa.io>.
+For additional support send an email to support@fossa.com.
 
 CREATING AN ISSUE:
 


### PR DESCRIPTION
Deprecate slack in favor of a better ticketing system to keep track of active issues.