### PR TITLE
Use runtimeClasspath configuration for resolution

### DIFF
--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -175,7 +175,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	return parseModuleV2(a)
 }
 
-var defaultConfigurations = []string{"compile", "api", "implementation", "compileDependenciesMetadata", "apiDependenciesMetadata", "implementationDependenciesMetadata"}
+var defaultConfigurations = []string{"runtimeClasspath", "compileDependenciesMetadata", "apiDependenciesMetadata", "implementationDependenciesMetadata"}
 
 func parseModuleV1(a *Analyzer) (graph.Deps, error) {
 	var configurations []string

--- a/analyzers/gradle/gradle.go
+++ b/analyzers/gradle/gradle.go
@@ -175,10 +175,16 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	return parseModuleV2(a)
 }
 
-var defaultConfigurations = []string{"runtimeClasspath", "compileDependenciesMetadata", "apiDependenciesMetadata", "implementationDependenciesMetadata"}
+// Groups of configurations to pull dependencies from. Later configuration
+// groups in this list are used as fallbacks when dependencies aren't found for
+// the current group.
+var defaultConfigurationGroups = [][]string{
+	{"compileClasspath", "runtimeClasspath"},
+	{"compile", "api", "implementation", "compileDependenciesMetadata", "apiDependenciesMetadata", "implementationDependenciesMetadata"},
+}
 
 func parseModuleV1(a *Analyzer) (graph.Deps, error) {
-	var configurations []string
+	var configurationGroups [][]string
 	var depsByConfig map[string]graph.Deps
 	var err error
 	targets := strings.Split(a.Module.BuildTarget, ":")
@@ -209,29 +215,38 @@ func parseModuleV1(a *Analyzer) (graph.Deps, error) {
 	}
 
 	if a.Options.Configuration != "" {
-		configurations = strings.Split(a.Options.Configuration, ",")
+		configurationGroups = [][]string{strings.Split(a.Options.Configuration, ",")}
 	} else if len(targets) > 1 && targets[1] != "" {
-		configurations = strings.Split(targets[1], ",")
+		configurationGroups = [][]string{strings.Split(targets[1], ",")}
 	} else if a.Options.AllConfigurations {
+		var configurations []string
 		for config := range depsByConfig {
 			configurations = append(configurations, config)
 		}
+		configurationGroups = [][]string{configurations}
 	} else {
-		configurations = defaultConfigurations
+		configurationGroups = defaultConfigurationGroups
 	}
 
 	merged := graph.Deps{
 		Direct:     nil,
 		Transitive: make(map[pkg.ID]pkg.Package),
 	}
-	for _, config := range configurations {
-		merged = mergeGraphs(merged, depsByConfig[config])
+
+	for _, group := range configurationGroups {
+		for _, config := range group {
+			merged = mergeGraphs(merged, depsByConfig[config])
+		}
+
+		if len(merged.Direct) > 0 {
+			break
+		}
 	}
 	return merged, nil
 }
 
 func parseModuleV2(a *Analyzer) (graph.Deps, error) {
-	var configurations []string
+	var configurationGroups [][]string
 	var depsByConfig map[string]graph.Deps
 	var err error
 
@@ -261,21 +276,29 @@ func parseModuleV2(a *Analyzer) (graph.Deps, error) {
 	}
 
 	if a.Options.Configuration != "" {
-		configurations = strings.Split(a.Options.Configuration, ",")
+		configurationGroups = [][]string{strings.Split(a.Options.Configuration, ",")}
 	} else if a.Options.AllConfigurations {
+		var configurations []string
 		for config := range depsByConfig {
 			configurations = append(configurations, config)
 		}
+		configurationGroups = [][]string{configurations}
 	} else {
-		configurations = defaultConfigurations
+		configurationGroups = defaultConfigurationGroups
 	}
 
 	merged := graph.Deps{
 		Direct:     nil,
 		Transitive: make(map[pkg.ID]pkg.Package),
 	}
-	for _, config := range configurations {
-		merged = mergeGraphs(merged, depsByConfig[config])
+	for _, group := range configurationGroups {
+		for _, config := range group {
+			merged = mergeGraphs(merged, depsByConfig[config])
+		}
+
+		if len(merged.Direct) > 0 {
+			break
+		}
 	}
 	return merged, nil
 }

--- a/analyzers/gradle/gradle_test.go
+++ b/analyzers/gradle/gradle_test.go
@@ -12,24 +12,16 @@ import (
 	"github.com/fossas/fossa-cli/pkg"
 )
 
-var DepAPIID = pkg.ID{Type: pkg.Maven, Name: "API", Revision: "1"}
-var DepImplmentationID = pkg.ID{Type: pkg.Maven, Name: "Implementation", Revision: "2"}
-var DepCompileID = pkg.ID{Type: pkg.Maven, Name: "Compile", Revision: "3"}
+var DepRuntimeClasspathID = pkg.ID{Type: pkg.Maven, Name: "Implementation", Revision: "2"}
 var DepCustomID = pkg.ID{Type: pkg.Maven, Name: "Custom", Revision: "4"}
-var ImportsAPI = []pkg.Import{pkg.Import{Resolved: DepAPIID}}
-var ImportsImplementation = []pkg.Import{pkg.Import{Resolved: DepImplmentationID}}
-var ImportsCompile = []pkg.Import{pkg.Import{Resolved: DepCompileID}}
+var ImportsRuntimeClasspath = []pkg.Import{pkg.Import{Resolved: DepRuntimeClasspathID}}
 var ImportsCustom = []pkg.Import{pkg.Import{Resolved: DepCustomID}}
-var DependenciesAPI = map[pkg.ID]pkg.Package{DepAPIID: pkg.Package{ID: DepAPIID}}
-var DependenciesImplementation = map[pkg.ID]pkg.Package{DepImplmentationID: pkg.Package{ID: DepImplmentationID}}
-var DependenciesCompile = map[pkg.ID]pkg.Package{DepCompileID: pkg.Package{ID: DepCompileID}}
+var DependenciesRuntimeClasspath = map[pkg.ID]pkg.Package{DepRuntimeClasspathID: pkg.Package{ID: DepRuntimeClasspathID}}
 var DependenciesCustom = map[pkg.ID]pkg.Package{DepCustomID: pkg.Package{ID: DepCustomID}}
 
 var testMap = map[string]graph.Deps{
-	"api":            graph.Deps{Direct: ImportsAPI, Transitive: DependenciesAPI},
-	"implementation": graph.Deps{Direct: ImportsImplementation, Transitive: DependenciesImplementation},
-	"compile":        graph.Deps{Direct: ImportsCompile, Transitive: DependenciesCompile},
-	"custom":         graph.Deps{Direct: ImportsCustom, Transitive: DependenciesCustom},
+	"runtimeClasspath": graph.Deps{Direct: ImportsRuntimeClasspath, Transitive: DependenciesRuntimeClasspath},
+	"custom":           graph.Deps{Direct: ImportsCustom, Transitive: DependenciesCustom},
 }
 
 func TestGradleDependencies(t *testing.T) {
@@ -37,10 +29,8 @@ func TestGradleDependencies(t *testing.T) {
 	a := gradle.Analyzer{Input: mock}
 	graph, err := a.Analyze()
 	assert.NoError(t, err)
-	assert.Equal(t, 3, len(graph.Transitive))
-	assert.Equal(t, graph.Transitive[DepAPIID].ID, DepAPIID)
-	assert.Equal(t, graph.Transitive[DepImplmentationID].ID, DepImplmentationID)
-	assert.Equal(t, graph.Transitive[DepCompileID].ID, DepCompileID)
+	assert.Equal(t, 1, len(graph.Transitive))
+	assert.Equal(t, graph.Transitive[DepRuntimeClasspathID].ID, DepRuntimeClasspathID)
 	assert.Empty(t, graph.Transitive[DepCustomID].ID)
 }
 
@@ -54,10 +44,8 @@ func TestGradleDependenciesAllConfigurations(t *testing.T) {
 	}
 	graph, err := a.Analyze()
 	assert.NoError(t, err)
-	assert.Equal(t, 4, len(graph.Transitive))
-	assert.Equal(t, graph.Transitive[DepAPIID].ID, DepAPIID)
-	assert.Equal(t, graph.Transitive[DepImplmentationID].ID, DepImplmentationID)
-	assert.Equal(t, graph.Transitive[DepCompileID].ID, DepCompileID)
+	assert.Equal(t, 2, len(graph.Transitive))
+	assert.Equal(t, graph.Transitive[DepRuntimeClasspathID].ID, DepRuntimeClasspathID)
 	assert.Equal(t, graph.Transitive[DepCustomID].ID, DepCustomID)
 }
 
@@ -71,10 +59,8 @@ func TestGradleDependenciesCustomConfigurations(t *testing.T) {
 	}
 	graph, err := a.Analyze()
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(graph.Transitive))
-	assert.Empty(t, graph.Transitive[DepAPIID].ID)
-	assert.Empty(t, graph.Transitive[DepImplmentationID].ID)
-	assert.Equal(t, graph.Transitive[DepCompileID].ID, DepCompileID)
+	assert.Equal(t, 1, len(graph.Transitive))
+	assert.Empty(t, graph.Transitive[DepRuntimeClasspathID].ID)
 	assert.Equal(t, graph.Transitive[DepCustomID].ID, DepCustomID)
 }
 

--- a/docs/integrations/gradle.md
+++ b/docs/integrations/gradle.md
@@ -77,11 +77,11 @@ This options tells Fossa to scan for all sub projects of the specified module. T
 
 This option takes a comma delimited list of configurations to include in the dependency scan. Fossa includes a few configurations by default but allows the user to specify any specific configurations they are interested in.
 
-The default list of configurations is: `compile, api, implementation, compileDependenciesMetadata, apiDependenciesMetadata, implementationDependenciesMetadata`
+The default list of configurations is: `runtimeClasspath, compileDependenciesMetadata, apiDependenciesMetadata, implementationDependenciesMetadata`
 
 Example:
 ```yaml
-    configuration: implementation,implementationTest,customConfiguration
+    configuration: runtimeClasspath,testRuntimeClasspath,customConfiguration
 ```
 
 #### `all-configurations: <bool>`

--- a/docs/integrations/gradle.md
+++ b/docs/integrations/gradle.md
@@ -77,7 +77,7 @@ This options tells Fossa to scan for all sub projects of the specified module. T
 
 This option takes a comma delimited list of configurations to include in the dependency scan. Fossa includes a few configurations by default but allows the user to specify any specific configurations they are interested in.
 
-The default list of configurations is: `runtimeClasspath, compileDependenciesMetadata, apiDependenciesMetadata, implementationDependenciesMetadata`
+The default list of configurations is: `compileClasspath, runtimeClasspath` with a fallback to `compile, api, implementation, compileDependenciesMetadata, apiDependenciesMetadata, implementationDependenciesMetadata` for older versions of gradle.
 
 Example:
 ```yaml


### PR DESCRIPTION
When using version wildcards (e.g. `+`), the output of `gradle dependencies` doesn't capture the resolved version in the configurations we look for: `api`, `implementation`, ... .

The Java plugin for gradle internally generates a `runtimeClasspath` configuration, which _does_ include the resolved versions: ![](https://docs.gradle.org/current/userguide/img/java-library-ignore-deprecated-main.png)

This PR changes the set of default configurations to include `runtimeClasspath` instead of `compile`, `api`, and `implementation`.