### PR TITLE
feat (clean debug logs) add --verbose flag to allow cleaner logs

### DIFF
--- a/cmd/fossa/display/display.go
+++ b/cmd/fossa/display/display.go
@@ -15,7 +15,7 @@ var (
 	s       *spinner.Spinner
 	useANSI bool
 	level   log.Level
-	limited bool
+	verbose bool
 )
 
 func init() {

--- a/cmd/fossa/display/display.go
+++ b/cmd/fossa/display/display.go
@@ -15,7 +15,7 @@ var (
 	s       *spinner.Spinner
 	useANSI bool
 	level   log.Level
-	callers bool
+	limited bool
 )
 
 func init() {

--- a/cmd/fossa/display/display.go
+++ b/cmd/fossa/display/display.go
@@ -15,6 +15,7 @@ var (
 	s       *spinner.Spinner
 	useANSI bool
 	level   log.Level
+	callers bool
 )
 
 func init() {

--- a/cmd/fossa/display/log.go
+++ b/cmd/fossa/display/log.go
@@ -24,23 +24,22 @@ func SetInteractive(interactive bool) {
 	color.NoColor = !useANSI
 }
 
-// SetLimited ensures that limited caller logs are added when requested.
-func SetLimited(limit bool) {
-	limited = limit
-}
-
 // SetDebug turns debug logging to STDERR on or off.
 //
 // The log file always writes debug-level entries.
-func SetDebug(debug bool) {
+func SetDebug(debug bool, setVerbose bool) {
 	// This sets the `level` variable rather than calling `log.SetLevel`, because
 	// calling `log.SetLevel` filters entries by level _before_ they reach the
 	// handler. This is not desirable, because we always want our handler to see
 	// debug entries so they can be written to the log file.
+	level = log.InfoLevel
 	if debug {
 		level = log.DebugLevel
-	} else {
-		level = log.InfoLevel
+	}
+
+	verbose = false
+	if setVerbose {
+		verbose = true
 	}
 }
 
@@ -67,9 +66,9 @@ func Handler(entry *log.Entry) error {
 	// If in debug mode, add caller.
 	if level == log.DebugLevel {
 		entry.Fields["callers"] = []string{}
-		callerDepth := 20
-		if limited {
-			callerDepth = 6
+		callerDepth := 6
+		if verbose {
+			callerDepth = 20
 		}
 
 		// See https://golang.org/pkg/runtime/#Frames

--- a/cmd/fossa/display/log.go
+++ b/cmd/fossa/display/log.go
@@ -24,9 +24,9 @@ func SetInteractive(interactive bool) {
 	color.NoColor = !useANSI
 }
 
-// SetDebugCallers ensures that the caller logs are included in debug output.
-func SetDebugCallers(setCallers bool) {
-	callers = setCallers
+// SetLimited ensures that limited caller logs are added when requested.
+func SetLimited(limit bool) {
+	limited = limit
 }
 
 // SetDebug turns debug logging to STDERR on or off.
@@ -64,11 +64,16 @@ func File() string {
 //
 // TODO: does this need to be synchronised?
 func Handler(entry *log.Entry) error {
-	// If in debug caller mode is set, add caller.
-	if level == log.DebugLevel && callers {
+	// If in debug mode is set, add caller.
+	if level == log.DebugLevel {
 		entry.Fields["callers"] = []string{}
+		callerDepth := 20
+		if limited {
+			callerDepth = 6
+		}
+
 		// See https://golang.org/pkg/runtime/#Frames
-		pcs := make([]uintptr, 20)
+		pcs := make([]uintptr, callerDepth)
 		n := runtime.Callers(0, pcs)
 		pcs = pcs[:n]
 		frames := runtime.CallersFrames(pcs)

--- a/cmd/fossa/display/log.go
+++ b/cmd/fossa/display/log.go
@@ -24,6 +24,11 @@ func SetInteractive(interactive bool) {
 	color.NoColor = !useANSI
 }
 
+// SetDebugCallers ensures that the caller logs are included in debug output.
+func SetDebugCallers(setCallers bool) {
+	callers = setCallers
+}
+
 // SetDebug turns debug logging to STDERR on or off.
 //
 // The log file always writes debug-level entries.
@@ -59,8 +64,8 @@ func File() string {
 //
 // TODO: does this need to be synchronised?
 func Handler(entry *log.Entry) error {
-	// If in debug mode, add caller.
-	if level == log.DebugLevel {
+	// If in debug caller mode is set, add caller.
+	if level == log.DebugLevel && callers {
 		entry.Fields["callers"] = []string{}
 		// See https://golang.org/pkg/runtime/#Frames
 		pcs := make([]uintptr, 20)

--- a/cmd/fossa/display/log.go
+++ b/cmd/fossa/display/log.go
@@ -64,7 +64,7 @@ func File() string {
 //
 // TODO: does this need to be synchronised?
 func Handler(entry *log.Entry) error {
-	// If in debug mode is set, add caller.
+	// If in debug mode, add caller.
 	if level == log.DebugLevel {
 		entry.Fields["callers"] = []string{}
 		callerDepth := 20

--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -73,15 +73,15 @@ func WithGlobalFlags(f []cli.Flag) []cli.Flag {
 }
 
 var (
-	Global        = []cli.Flag{ConfigF, NoAnsiF, DebugF, DebugCallersF}
+	Global        = []cli.Flag{ConfigF, NoAnsiF, DebugF, DebugLimitedF}
 	Config        = "config"
 	ConfigF       = cli.StringFlag{Name: Short(Config), Usage: "path to config file (default: '.fossa.{yml,yaml}')"}
 	NoAnsi        = "no-ansi"
 	NoAnsiF       = cli.BoolFlag{Name: NoAnsi, Usage: "do not use interactive mode (ANSI codes)"}
 	Debug         = "debug"
 	DebugF        = cli.BoolFlag{Name: Debug, Usage: "print debug information to stderr"}
-	DebugCallers  = "debug-callers"
-	DebugCallersF = cli.BoolFlag{Name: DebugCallers, Usage: "print debug information with full call stack to stderr"}
+	DebugLimited  = "debug-limited"
+	DebugLimitedF = cli.BoolFlag{Name: DebugLimited, Usage: "print limited debug information to stderr"}
 )
 
 func WithOptions(f []cli.Flag) []cli.Flag {

--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -73,13 +73,15 @@ func WithGlobalFlags(f []cli.Flag) []cli.Flag {
 }
 
 var (
-	Global  = []cli.Flag{ConfigF, NoAnsiF, DebugF}
-	Config  = "config"
-	ConfigF = cli.StringFlag{Name: Short(Config), Usage: "path to config file (default: '.fossa.{yml,yaml}')"}
-	NoAnsi  = "no-ansi"
-	NoAnsiF = cli.BoolFlag{Name: NoAnsi, Usage: "do not use interactive mode (ANSI codes)"}
-	Debug   = "debug"
-	DebugF  = cli.BoolFlag{Name: Debug, Usage: "print debug information to stderr"}
+	Global        = []cli.Flag{ConfigF, NoAnsiF, DebugF, DebugCallersF}
+	Config        = "config"
+	ConfigF       = cli.StringFlag{Name: Short(Config), Usage: "path to config file (default: '.fossa.{yml,yaml}')"}
+	NoAnsi        = "no-ansi"
+	NoAnsiF       = cli.BoolFlag{Name: NoAnsi, Usage: "do not use interactive mode (ANSI codes)"}
+	Debug         = "debug"
+	DebugF        = cli.BoolFlag{Name: Debug, Usage: "print debug information to stderr"}
+	DebugCallers  = "debug-callers"
+	DebugCallersF = cli.BoolFlag{Name: DebugCallers, Usage: "print debug information with full call stack to stderr"}
 )
 
 func WithOptions(f []cli.Flag) []cli.Flag {

--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -73,15 +73,15 @@ func WithGlobalFlags(f []cli.Flag) []cli.Flag {
 }
 
 var (
-	Global        = []cli.Flag{ConfigF, NoAnsiF, DebugF, DebugLimitedF}
-	Config        = "config"
-	ConfigF       = cli.StringFlag{Name: Short(Config), Usage: "path to config file (default: '.fossa.{yml,yaml}')"}
-	NoAnsi        = "no-ansi"
-	NoAnsiF       = cli.BoolFlag{Name: NoAnsi, Usage: "do not use interactive mode (ANSI codes)"}
-	Debug         = "debug"
-	DebugF        = cli.BoolFlag{Name: Debug, Usage: "print debug information to stderr"}
-	DebugLimited  = "debug-limited"
-	DebugLimitedF = cli.BoolFlag{Name: DebugLimited, Usage: "print limited debug information to stderr"}
+	Global   = []cli.Flag{ConfigF, NoAnsiF, DebugF, VerboseF}
+	Config   = "config"
+	ConfigF  = cli.StringFlag{Name: Short(Config), Usage: "path to config file (default: '.fossa.{yml,yaml}')"}
+	NoAnsi   = "no-ansi"
+	NoAnsiF  = cli.BoolFlag{Name: NoAnsi, Usage: "do not use interactive mode (ANSI codes)"}
+	Debug    = "debug"
+	DebugF   = cli.BoolFlag{Name: Debug, Usage: "print debug information to stderr"}
+	Verbose  = "verbose"
+	VerboseF = cli.BoolFlag{Name: Verbose, Usage: "print limited debug information to stderr"}
 )
 
 func WithOptions(f []cli.Flag) []cli.Flag {

--- a/cmd/fossa/setup/setup.go
+++ b/cmd/fossa/setup/setup.go
@@ -19,8 +19,7 @@ func SetContext(ctx *cli.Context) error {
 
 	// Set up logging.
 	display.SetInteractive(config.Interactive())
-	display.SetDebug(config.Debug())
-	display.SetLimited(config.DebugLimited())
+	display.SetDebug(config.Debug(), config.Verbose())
 
 	// Set up API.
 	err = fossa.SetEndpoint(config.Endpoint())

--- a/cmd/fossa/setup/setup.go
+++ b/cmd/fossa/setup/setup.go
@@ -20,6 +20,7 @@ func SetContext(ctx *cli.Context) error {
 	// Set up logging.
 	display.SetInteractive(config.Interactive())
 	display.SetDebug(config.Debug())
+	display.SetDebugCallers(config.DebugCallers())
 
 	// Set up API.
 	err = fossa.SetEndpoint(config.Endpoint())

--- a/cmd/fossa/setup/setup.go
+++ b/cmd/fossa/setup/setup.go
@@ -20,7 +20,7 @@ func SetContext(ctx *cli.Context) error {
 	// Set up logging.
 	display.SetInteractive(config.Interactive())
 	display.SetDebug(config.Debug())
-	display.SetDebugCallers(config.DebugCallers())
+	display.SetLimited(config.DebugLimited())
 
 	// Set up API.
 	err = fossa.SetEndpoint(config.Endpoint())

--- a/config/keys.go
+++ b/config/keys.go
@@ -37,7 +37,12 @@ func Interactive() bool {
 
 // Debug is true if the user has requested debug-level logging.
 func Debug() bool {
-	return BoolFlag(flags.Debug)
+	return BoolFlag(flags.Debug) || BoolFlag(flags.DebugCallers)
+}
+
+// DebugCallers is true if the user has requested debug-level logging with full caller output.
+func DebugCallers() bool {
+	return BoolFlag(flags.DebugCallers)
 }
 
 // Filepath is the configuration file path.

--- a/config/keys.go
+++ b/config/keys.go
@@ -26,6 +26,7 @@ var (
 	filename string
 )
 
+// Version outputs the installed FOSSA CLI version.
 func Version() int {
 	return file.GetVersion()
 }
@@ -37,12 +38,12 @@ func Interactive() bool {
 
 // Debug is true if the user has requested debug-level logging.
 func Debug() bool {
-	return BoolFlag(flags.Debug) || BoolFlag(flags.DebugLimited)
+	return BoolFlag(flags.Debug)
 }
 
-// DebugLimited is true if the user has requested debug-level logging with less output.
-func DebugLimited() bool {
-	return BoolFlag(flags.DebugLimited)
+// Verbose is true if the user has requested verbose output.
+func Verbose() bool {
+	return BoolFlag(flags.Verbose)
 }
 
 // Filepath is the configuration file path.

--- a/config/keys.go
+++ b/config/keys.go
@@ -37,12 +37,12 @@ func Interactive() bool {
 
 // Debug is true if the user has requested debug-level logging.
 func Debug() bool {
-	return BoolFlag(flags.Debug) || BoolFlag(flags.DebugCallers)
+	return BoolFlag(flags.Debug) || BoolFlag(flags.DebugLimited)
 }
 
-// DebugCallers is true if the user has requested debug-level logging with full caller output.
-func DebugCallers() bool {
-	return BoolFlag(flags.DebugCallers)
+// DebugLimited is true if the user has requested debug-level logging with less output.
+func DebugLimited() bool {
+	return BoolFlag(flags.DebugLimited)
 }
 
 // Filepath is the configuration file path.


### PR DESCRIPTION
The problem we have today is that debug logs output a massive amount of information that can be difficult for users to parse. This change is intended to split the debug command into two paths. One command will output abridged debug information and the other will output complete logs. I believe we should not change the expected behavior of the `--debug` command as it stands.

This PR adds the `--verbose` flag which can be added to the debug command to output more detailed logs. Omitting this flag currently only reduces the number of callers included.

Changes output from 
```Shell
DEBUG got API response callers=[/Users/zachlavallee/go/src/github.com/fossas/fossa-cli/api/api.go:github.com/fossas/fossa-cli/api.MakeAPIRequest:116
 /Users/zachlavallee/go/src/github.com/fossas/fossa-cli/api/api.go:github.com/fossas/fossa-cli/api.stringAPIRequest:51
 /Users/zachlavallee/go/src/github.com/fossas/fossa-cli/api/api.go:github.com/fossas/fossa-cli/api.Post:37
 /Users/zachlavallee/go/src/github.com/fossas/fossa-cli/api/fossa/fossa.go:github.com/fossas/fossa-cli/api/fossa.Post:54
 /Users/zachlavallee/go/src/github.com/fossas/fossa-cli/api/fossa/upload.go:github.com/fossas/fossa-cli/api/fossa.Upload:87
 /Users/zachlavallee/go/src/github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze/analyze.go:github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze.uploadAnalysis:137
 /Users/zachlavallee/go/src/github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze/analyze.go:github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze.Run:78
 /Users/zachlavallee/go/src/github.com/fossas/fossa-cli/vendor/github.com/urfave/cli/app.go:github.com/fossas/fossa-cli/vendor/github.com/urfave/cli.HandleAction:490
 /Users/zachlavallee/go/src/github.com/fossas/fossa-cli/vendor/github.com/urfave/cli/command.go:github.com/fossas/fossa-cli/vendor/github.com/urfave/cli.Command.Run:210
 /Users/zachlavallee/go/src/github.com/fossas/fossa-cli/vendor/github.com/urfave/cli/app.go:github.com/fossas/fossa-cli/vendor/github.com/urfave/cli.(*App).Run:255
 /Users/zachlavallee/go/src/github.com/fossas/fossa-cli/cmd/fossa/main.go:main.main:48] response={"error":"Invalid API Token"}
```

To:
```Shell
DEBUG got API response callers=[/Users/zachlavallee/go/src/github.com/fossas/fossa-cli/api/api.go:github.com/fossas/fossa-cli/api.MakeAPIRequest:116] response={"error":"Invalid API Token"}
```

