### PR TITLE
feat (gomodules scanning) scan go.mod and go.sum for dependencies.

### DIFF
--- a/analyzers/golang/analyze.go
+++ b/analyzers/golang/analyze.go
@@ -23,6 +23,11 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	m := a.Module
 	log.Debugf("%#v", m)
 
+	switch a.Options.Strategy {
+	case "lockfile:gomodules":
+		return gomodules.ModGraph("go.mod")
+	}
+
 	// Get Go project.
 	project, err := a.Project(m.BuildTarget)
 	if err != nil {

--- a/analyzers/golang/analyze.go
+++ b/analyzers/golang/analyze.go
@@ -25,7 +25,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 
 	switch a.Options.Strategy {
 	case "lockfile:gomodules":
-		return gomodules.ModGraph("go.mod")
+		return gomodules.ModGraph("")
 	}
 
 	// Get Go project.

--- a/analyzers/golang/analyze.go
+++ b/analyzers/golang/analyze.go
@@ -23,11 +23,6 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	m := a.Module
 	log.Debugf("%#v", m)
 
-	switch a.Options.Strategy {
-	case "lockfile:gomodules":
-		return gomodules.ModGraph("")
-	}
-
 	// Get Go project.
 	project, err := a.Project(m.BuildTarget)
 	if err != nil {

--- a/buildtools/gomodules/gomodules.go
+++ b/buildtools/gomodules/gomodules.go
@@ -60,6 +60,11 @@ func New(dir string) (Resolver, error) {
 // ModGraph returns the dependencies found in a `go.mod` file.
 // We cannot resolve a graph so we make all dependencies direct.
 func ModGraph(filename string) (graph.Deps, error) {
+	modFile := filename
+	if modFile == "" {
+		modFile = "go.mod"
+	}
+
 	mod, err := files.Read(filename)
 	if err != nil {
 		return graph.Deps{}, err
@@ -124,6 +129,11 @@ func ModGraph(filename string) (graph.Deps, error) {
 // includes dependencies which are not used and this may be inaccurate.
 // https://github.com/golang/go/wiki/Modules#is-gosum-a-lock-file-why-does-gosum-include-information-for-module-versions-i-am-no-longer-using
 func SumGraph(filename string) (graph.Deps, error) {
+	sumFile := filename
+	if sumFile == "" {
+		sumFile = "go.sum"
+	}
+
 	sum, err := files.Read(filename)
 	if err != nil {
 		return graph.Deps{}, nil

--- a/buildtools/gomodules/gomodules.go
+++ b/buildtools/gomodules/gomodules.go
@@ -65,7 +65,7 @@ func ModGraph(filename string) (graph.Deps, error) {
 		modFile = "go.mod"
 	}
 
-	mod, err := files.Read(filename)
+	mod, err := files.Read(modFile)
 	if err != nil {
 		return graph.Deps{}, err
 	}
@@ -134,7 +134,7 @@ func SumGraph(filename string) (graph.Deps, error) {
 		sumFile = "go.sum"
 	}
 
-	sum, err := files.Read(filename)
+	sum, err := files.Read(sumFile)
 	if err != nil {
 		return graph.Deps{}, nil
 	}

--- a/buildtools/gomodules/gomodules_test.go
+++ b/buildtools/gomodules/gomodules_test.go
@@ -86,3 +86,21 @@ func TestGoModGraph(t *testing.T) {
 	assert.NotEmpty(t, packageE)
 	assert.Empty(t, packageE.Imports)
 }
+
+func TestSumGraph(t *testing.T) {
+	depGraph, err := gomodules.SumGraph("testdata/go.sum")
+	assert.NoError(t, err)
+
+	assert.Len(t, depGraph.Direct, 2)
+	helpers.AssertPackageImport(t, depGraph.Direct, "repo/name/A", "v1.0.0")
+	helpers.AssertPackageImport(t, depGraph.Direct, "repo/name/B", "12345")
+
+	assert.Len(t, depGraph.Transitive, 2)
+	packageA := helpers.PackageInTransitiveGraph(depGraph.Transitive, "repo/name/A", "v1.0.0")
+	assert.NotEmpty(t, packageA)
+	assert.Empty(t, packageA.Imports)
+
+	packageD := helpers.PackageInTransitiveGraph(depGraph.Transitive, "repo/name/B", "12345")
+	assert.NotEmpty(t, packageD)
+	assert.Empty(t, packageD.Imports)
+}

--- a/buildtools/gomodules/testdata/go.mod
+++ b/buildtools/gomodules/testdata/go.mod
@@ -1,0 +1,22 @@
+// dummy comments
+// 
+// can vary in length which can break parsers.
+module test/package
+
+go 1.12
+
+require repo/name/A v1.0.0 // indirect
+
+require (
+	repo/B v0.0.5-0.20190714195934-000000000002
+	repo/C v1.1.0
+	repo/name/D v4.0.0 // indirect
+	repo/E v8.0.0+incompatible
+)
+
+replace repo/B => alias/repo/B v0.1.0
+
+replace (
+	repo/C => alias/repo/C v0.0.0-20180207000608-000000000003
+	repo/E => alias/repo/E v0.0.0-20170808103936-000000000005+incompatible
+)

--- a/buildtools/gomodules/testdata/go.sum
+++ b/buildtools/gomodules/testdata/go.sum
@@ -1,0 +1,5 @@
+repo/name/A v1.0.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+repo/name/A v1.0.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+repo/name/B v0.0.0-20160126235308-12345 h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
+repo/name/B v0.0.0-20160126235308-12345/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+WeirdLine


### PR DESCRIPTION
The precursor to the improved fallbacks PR. This is intended to only give users the strategy option for `go.mod` until we expand the fallback feature in an upcoming PR.

Features:
1. Scanning `go.mod` gives deps.
2. Scanning `go.sum` gives deps.

Tricky things:
- Parsing `go.mod`. Refer to the `testdata/go.mod` file to see all supported cases.
- Parsing `go.sum`. Every other line has a duplicate revision with `/go.mod` appended. This code skips these.