### PR TITLE
errors (no API key) Common error when users forget to add an API key. 

### DIFF
--- a/api/fossa/fossa.go
+++ b/api/fossa/fossa.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/fossas/fossa-cli/api"
+	"github.com/fossas/fossa-cli/errors"
 )
 
 var (
@@ -22,8 +23,17 @@ func SetEndpoint(endpoint string) error {
 	return nil
 }
 
-func SetAPIKey(key string) {
+func SetAPIKey(key string) *errors.Error {
+	if key == "" {
+		return &errors.Error{
+			// Cause:           errors.New("temp"),
+			Type:            errors.User,
+			Troubleshooting: "A FOSSA API key is needed to run this command.",
+			Message:         errors.NoAPIKeyMessage,
+		}
+	}
 	apiKey = key
+	return nil
 }
 
 // Get makes an authenticated GET request to a FOSSA API endpoint.

--- a/api/fossa/fossa.go
+++ b/api/fossa/fossa.go
@@ -26,7 +26,6 @@ func SetEndpoint(endpoint string) error {
 func SetAPIKey(key string) *errors.Error {
 	if key == "" {
 		return &errors.Error{
-			// Cause:           errors.New("temp"),
 			Type:            errors.User,
 			Troubleshooting: "A FOSSA API key is needed to run this command.",
 			Message:         errors.NoAPIKeyMessage,

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -32,9 +32,9 @@ var Cmd = cli.Command{
 var _ cli.ActionFunc = Run
 
 func Run(ctx *cli.Context) error {
-	err := setup.SetContext(ctx)
+	err := setup.SetContext(ctx, true)
 	if err != nil {
-		log.Fatalf("Could not initialize: %s", err.Error())
+		log.Fatalf("Could not initialize module %s", err)
 	}
 
 	modules, err := config.Modules()

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -34,7 +34,7 @@ var _ cli.ActionFunc = Run
 func Run(ctx *cli.Context) error {
 	err := setup.SetContext(ctx, true)
 	if err != nil {
-		log.Fatalf("Could not initialize module %s", err)
+		log.Fatalf("Could not initialize %s", err)
 	}
 
 	modules, err := config.Modules()

--- a/cmd/fossa/cmd/build/build.go
+++ b/cmd/fossa/cmd/build/build.go
@@ -34,7 +34,7 @@ var Cmd = cli.Command{
 var _ cli.ActionFunc = Run
 
 func Run(ctx *cli.Context) error {
-	err := setup.SetContext(ctx)
+	err := setup.SetContext(ctx, false)
 	if err != nil {
 		log.Fatalf("Could not initialize: %s", err.Error())
 	}

--- a/cmd/fossa/cmd/init/init.go
+++ b/cmd/fossa/cmd/init/init.go
@@ -37,7 +37,7 @@ var Cmd = cli.Command{
 var _ cli.ActionFunc = Run
 
 func Run(ctx *cli.Context) error {
-	err := setup.SetContext(ctx)
+	err := setup.SetContext(ctx, false)
 	if err != nil {
 		log.Fatalf("Could not initialize: %s", err.Error())
 	}

--- a/cmd/fossa/cmd/report/dependencies.go
+++ b/cmd/fossa/cmd/report/dependencies.go
@@ -40,7 +40,7 @@ var dependenciesCmd = cli.Command{
 }
 
 func dependenciesRun(ctx *cli.Context) error {
-	err := setup.SetContext(ctx)
+	err := setup.SetContext(ctx, true)
 	if err != nil {
 		log.Fatalf("Could not initialize: %s", err.Error())
 	}

--- a/cmd/fossa/cmd/report/licenses.go
+++ b/cmd/fossa/cmd/report/licenses.go
@@ -40,7 +40,7 @@ var licensesCmd = cli.Command{
 }
 
 func licensesRun(ctx *cli.Context) (err error) {
-	err = setup.SetContext(ctx)
+	err = setup.SetContext(ctx, true)
 	if err != nil {
 		log.Fatalf("Could not initialize: %s", err.Error())
 	}

--- a/cmd/fossa/cmd/report/report.go
+++ b/cmd/fossa/cmd/report/report.go
@@ -1,13 +1,7 @@
 package report
 
 import (
-	"github.com/apex/log"
 	"github.com/urfave/cli"
-
-	"github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze"
-	"github.com/fossas/fossa-cli/cmd/fossa/setup"
-	"github.com/fossas/fossa-cli/config"
-	"github.com/fossas/fossa-cli/module"
 )
 
 const JSON = "json"
@@ -19,26 +13,4 @@ var Cmd = cli.Command{
 		dependenciesCmd,
 		licensesCmd,
 	},
-}
-
-func analyzeModules(ctx *cli.Context) ([]module.Module, error) {
-	err := setup.SetContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	modules, err := config.Modules()
-	if err != nil {
-		return nil, err
-	}
-	if len(modules) == 0 {
-		log.Fatal("No modules specified.")
-	}
-
-	analyzed, err := analyze.Do(modules, false)
-	if err != nil {
-		return nil, err
-	}
-
-	return analyzed, nil
 }

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -55,7 +55,7 @@ var Cmd = cli.Command{
 var _ cli.ActionFunc = Run
 
 func Run(ctx *cli.Context) error {
-	err := setup.SetContext(ctx)
+	err := setup.SetContext(ctx, true)
 	if err != nil {
 		log.Fatalf("Could not initialize: %s", err.Error())
 	}

--- a/cmd/fossa/cmd/upload/upload.go
+++ b/cmd/fossa/cmd/upload/upload.go
@@ -125,7 +125,7 @@ func getInput(ctx *cli.Context, usingLocators bool) ([]fossa.SourceUnit, error) 
 
 // Run executes the upload command.
 func Run(ctx *cli.Context) error {
-	err := setup.SetContext(ctx)
+	err := setup.SetContext(ctx, true)
 	if err != nil {
 		return errors.Wrap(err, "could not initialize")
 	}

--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/urfave/cli"
 
 	"github.com/apex/log"
-	"github.com/fossas/fossa-cli/config"
 
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"

--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -59,14 +59,9 @@ func main() {
 }
 
 func Run(ctx *cli.Context) error {
-	err := setup.SetContext(ctx)
+	err := setup.SetContext(ctx, true)
 	if err != nil {
 		return err
-	}
-
-	if config.APIKey() == "" && !ctx.Bool(analyze.ShowOutput) {
-		fmt.Printf("Incorrect Usage. FOSSA_API_KEY must be set as an environment variable or provided in .fossa.yml\n\n")
-		log.Fatalf("No API KEY provided")
 	}
 
 	err = initc.Run(ctx)

--- a/cmd/fossa/setup/setup.go
+++ b/cmd/fossa/setup/setup.go
@@ -2,15 +2,14 @@
 package setup
 
 import (
-	"github.com/urfave/cli"
-
 	"github.com/fossas/fossa-cli/api/fossa"
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/config"
+	"github.com/urfave/cli"
 )
 
 // SetContext initializes all application-level packages.
-func SetContext(ctx *cli.Context) error {
+func SetContext(ctx *cli.Context, setAPIKey bool) error {
 	// Set up configuration.
 	err := config.SetContext(ctx)
 	if err != nil {
@@ -26,7 +25,13 @@ func SetContext(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	fossa.SetAPIKey(config.APIKey())
+
+	if setAPIKey {
+		err = fossa.SetAPIKey(config.APIKey())
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/cmd/fossa/setup/setup.go
+++ b/cmd/fossa/setup/setup.go
@@ -27,9 +27,9 @@ func SetContext(ctx *cli.Context, setAPIKey bool) error {
 	}
 
 	if setAPIKey {
-		err = fossa.SetAPIKey(config.APIKey())
-		if err != nil {
-			return err
+		apiError := fossa.SetAPIKey(config.APIKey())
+		if apiError != nil {
+			return apiError
 		}
 	}
 

--- a/cmd/fossa/setup/setup.go
+++ b/cmd/fossa/setup/setup.go
@@ -2,10 +2,11 @@
 package setup
 
 import (
+	"github.com/urfave/cli"
+
 	"github.com/fossas/fossa-cli/api/fossa"
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/config"
-	"github.com/urfave/cli"
 )
 
 // SetContext initializes all application-level packages.

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -39,7 +39,11 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	var code, troubleshooting, link, message string
+	var err, code, troubleshooting, link, message string
+
+	if e.Cause != nil {
+		err = e.Cause.Error()
+	}
 
 	if e.ExitCode != 0 {
 		code = fmt.Sprintf("\n%s: %d", color.BlueString("EXIT CODE"), e.ExitCode)
@@ -66,7 +70,7 @@ func (e *Error) Error() string {
 		}
 	}
 
-	return e.Cause.Error() + code + troubleshooting + link + message
+	return err + code + troubleshooting + link + message
 }
 
 func Errorf(format string, args ...interface{}) error {


### PR DESCRIPTION
Add an error that looks like the following when users forget to add an API key:
<img width="571" alt="Screen Shot 2019-07-24 at 3 15 06 PM" src="https://user-images.githubusercontent.com/31230447/61832406-df023e80-ae25-11e9-9302-ca8550528681.png">

What is done here:
1. Rework `setContext` to take a boolean that sets the API key. This keeps code clean.
2. Change all instances of `setContext`.
3. Remove some unused mess inside of `report.go`.
