### PR TITLE
fix (maven parser) filter warnings prefix

### DIFF
--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -165,7 +165,7 @@ func ParseDependencyTree(stdin string) (graph.Deps, error) {
 		if line == "[INFO] " || line == "[INFO] ------------------------------------------------------------------------" {
 			started = false
 		}
-		if strings.HasPrefix(line, "[INFO] Downloading ") {
+		if strings.HasPrefix(line, "[INFO] Downloading ") || strings.HasPrefix(line, "[WARNING]") {
 			continue
 		}
 		if started {

--- a/buildtools/maven/testdata/unix.out
+++ b/buildtools/maven/testdata/unix.out
@@ -5,6 +5,7 @@
 [INFO] --------------------------------[ jar ]---------------------------------
 [INFO] 
 [INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ jmh-introduction ---
+[WARNING] The artifact org.mapstruct:mapstruct-jdk8:jar:1.3.0.Final has been relocated to org.mapstruct:mapstruct:jar:1.3.0.Final
 [INFO] de.frank:jmh-introduction:jar:1-SNAPSHOT
 [INFO] +- dep:one:jar:1.0.0:provided
 [INFO] \- dep:two:jar:2.0.0:compile


### PR DESCRIPTION
We are currently not ignoring maven output `WARNING`s which are meaningless output to creating a dependency graph, but currently, result in us not correctly parsing maven output.

This fix adds the line to our test file and filters it out in our parser.