### PR TITLE
Fix parsing of gradle dependency tree

### DIFF
--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -160,7 +160,7 @@ func (s ShellCommand) DependencyTasks() ([]string, error) {
 //go:generate bash -c "genny -in=$GOPATH/src/github.com/fossas/fossa-cli/graph/readtree.go gen 'Generic=Dependency' | sed -e 's/package graph/package gradle/' > readtree_generated.go"
 
 func ParseDependencies(stdout string) ([]Dependency, map[Dependency][]Dependency, error) {
-	r := regexp.MustCompile("^([ `+\\\\|-]+)([^ `+\\\\|-].+)$")
+	r := regexp.MustCompile(`^((?:[ |\|]{1,1}    )*(?:[\\+|\\]{1,1}--- ))(.*)$`)
 	splitReg := regexp.MustCompile("\r?\n")
 	// Skip non-dependency lines.
 	var filteredLines []string

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -160,7 +160,7 @@ func (s ShellCommand) DependencyTasks() ([]string, error) {
 //go:generate bash -c "genny -in=$GOPATH/src/github.com/fossas/fossa-cli/graph/readtree.go gen 'Generic=Dependency' | sed -e 's/package graph/package gradle/' > readtree_generated.go"
 
 func ParseDependencies(stdout string) ([]Dependency, map[Dependency][]Dependency, error) {
-	r := regexp.MustCompile(`^((?:[ |\|]{1,1}    )*(?:[\\+|\\]{1,1}--- ))(.*)$`)
+	r := regexp.MustCompile(`^((?:[|+] +)*[\\+]--- )(.*)$`)
 	splitReg := regexp.MustCompile("\r?\n")
 	// Skip non-dependency lines.
 	var filteredLines []string

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -160,7 +160,7 @@ func (s ShellCommand) DependencyTasks() ([]string, error) {
 //go:generate bash -c "genny -in=$GOPATH/src/github.com/fossas/fossa-cli/graph/readtree.go gen 'Generic=Dependency' | sed -e 's/package graph/package gradle/' > readtree_generated.go"
 
 func ParseDependencies(stdout string) ([]Dependency, map[Dependency][]Dependency, error) {
-	r := regexp.MustCompile(`^((?:[|+] +)*[\\+]--- )(.*)$`)
+	r := regexp.MustCompile(`^((?:[|+]? +)*[\\+]--- )(.*)$`)
 	splitReg := regexp.MustCompile("\r?\n")
 	// Skip non-dependency lines.
 	var filteredLines []string

--- a/buildtools/gradle/testdata/complex.txt
+++ b/buildtools/gradle/testdata/complex.txt
@@ -9,6 +9,12 @@ Existing tags in registry: {"name":"somebody/something-something","tags":["lates
 Project :something-something
 ------------------------------------------------------------
 
+-api (n)
+No dependencies
+
+-runtime (n)
+\--- org.jetbrains.kotlin:kotlin-stdlib:1.3.30 (n)
+
 annotationProcessor - Annotation processors and their dependencies for source set 'main'.
 \--- org.projectlombok:lombok:1.16.16
 


### PR DESCRIPTION
In one of my projects I have a gradle dependency tree that looks like this:

```
-api (n)
No dependencies

-runtime (n)
\--- org.jetbrains.kotlin:kotlin-stdlib:1.3.30 (n)
[…]
```

This breaks the gradle analyzer. It bails out with the error message 

> FATAL Could not analyze: bad depth: 1 -api (n) []string{"-api (n)", "-", "api (n)"}


This PR improves the regex used to match gradle dependencies based on the possible output generated by gradle (see https://github.com/gradle/gradle/blob/e975872ae2cf1d521b73f1107cae772ca09c63cd/subprojects/core/src/main/java/org/gradle/internal/graph/GraphRenderer.java)