### PR TITLE
fix (missing remote error) set project name to directory if git cannot be read.

### DIFF
--- a/vcs/git.go
+++ b/vcs/git.go
@@ -1,8 +1,10 @@
 package vcs
 
 import (
+	"path/filepath"
 	"strings"
 
+	"github.com/apex/log"
 	"gopkg.in/src-d/go-git.v4"
 
 	"github.com/fossas/fossa-cli/errors"
@@ -43,5 +45,6 @@ func (gr *GitRepository) Project() string {
 	if err == nil && origin != nil {
 		return origin.Config().URLs[0]
 	}
-	return ""
+	log.Warnf("Git was found but the remote could not be found. Using directory name instead: %s", err.Error())
+	return filepath.Base(gr.dir)
 }

--- a/vcs/git.go
+++ b/vcs/git.go
@@ -45,6 +45,6 @@ func (gr *GitRepository) Project() string {
 	if err == nil && origin != nil {
 		return origin.Config().URLs[0]
 	}
-	log.Warnf("Git was found but the remote could not be found. Using directory name instead: %s", err.Error())
+	log.Warnf("Git was found but the remote could not be found, using directory name instead. error: %s", err.Error())
 	return filepath.Base(gr.dir)
 }


### PR DESCRIPTION
We try to set project name to the git remote. A problem arises if we find a git project but are unable to determine any project information. This PR logs the following message and sets project to the base filepath:
`WARNING Git was found but the remote could not be found, using directory name instead. error: remote not found`