### PR TITLE
feat (gomodules vendor) support users who vendor custom deps and use gomodules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,7 @@ jobs:
       - run:
           name: Tag branch for release 
           command: |
+            [[ $CLI_RELEASE_TAG == v* ]]
             git tag $CLI_RELEASE_TAG
       - run:
           name: Install and run goreleaser
@@ -170,5 +171,3 @@ workflows:
           filters:
             branches:
               only: master
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,26 +139,19 @@ jobs:
           path: /tmp/artifacts
   release:
     <<: *defaults
+    working_directory: /go/src/github.com/fossas/fossa-cli
     docker:
       - image: circleci/golang:1
     steps:
+      - checkout
       - run:
-          name: Make folders
-          command: mkdir -p $ARTIFACTS
-      - run:
-          name: Install CLI
+          name: Tag branch for release 
           command: |
-            curl https://raw.githubusercontent.com/fossas/fossa-cli/$CIRCLE_SHA1/install.sh | bash
+            git tag $CLI_RELEASE_TAG
       - run:
-          name: Run FOSSA help
+          name: Install and run goreleaser
           command: |
-            fossa help > $ARTIFACTS/fossa-installer-help-stdout 2> $ARTIFACTS/fossa-installer-help-stderr
-      - run:
-          name: Save artifacts
-          command: |
-            cp $(which fossa) $ARTIFACTS
-      - store_artifacts:
-          path: /tmp/artifacts
+            curl -sL https://git.io/goreleaser | bash
 workflows:
   version: 2
   tests:
@@ -174,3 +167,8 @@ workflows:
             - integration-test
             - end-to-end-test
             - installer-test
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,28 @@ jobs:
             cp $(which fossa) $ARTIFACTS
       - store_artifacts:
           path: /tmp/artifacts
-  # TODO(leo): set up automated releases.
-  # release:
+  release:
+    <<: *defaults
+    docker:
+      - image: circleci/golang:1
+    steps:
+      - run:
+          name: Make folders
+          command: mkdir -p $ARTIFACTS
+      - run:
+          name: Install CLI
+          command: |
+            curl https://raw.githubusercontent.com/fossas/fossa-cli/$CIRCLE_SHA1/install.sh | bash
+      - run:
+          name: Run FOSSA help
+          command: |
+            fossa help > $ARTIFACTS/fossa-installer-help-stdout 2> $ARTIFACTS/fossa-installer-help-stderr
+      - run:
+          name: Save artifacts
+          command: |
+            cp $(which fossa) $ARTIFACTS
+      - store_artifacts:
+          path: /tmp/artifacts
 workflows:
   version: 2
   tests:
@@ -147,3 +167,10 @@ workflows:
       - integration-test
       - end-to-end-test
       - installer-test
+      - release:
+          type: approval
+          requires:
+            - unit-test
+            - integration-test
+            - end-to-end-test
+            - installer-test

--- a/analyzers/golang/analyze.go
+++ b/analyzers/golang/analyze.go
@@ -179,7 +179,7 @@ func ListLockfileResolution(a *Analyzer) (graph.Deps, error) {
 	for _, buildTag := range a.BuildTags {
 		// Use `go list` to get imports and deps of module.
 		flags := []string{"-tags", buildTag}
-		main, err := a.Go.ListOne(m.BuildTarget, flags)
+		main, err := a.Go.ListOne(m.BuildTarget, flags, a.Options.ModulesVendor)
 		if err != nil {
 			return graph.Deps{}, err
 		}
@@ -190,7 +190,7 @@ func ListLockfileResolution(a *Analyzer) (graph.Deps, error) {
 		}
 
 		log.Debugf("Go main package: %#v", main)
-		deps, err := a.Go.List(main.Deps, flags)
+		deps, err := a.Go.List(main.Deps, flags, a.Options.ModulesVendor)
 		if err != nil {
 			return graph.Deps{}, err
 		}

--- a/analyzers/golang/analyze_test.go
+++ b/analyzers/golang/analyze_test.go
@@ -19,7 +19,7 @@ func TestProjectNotInDeps(t *testing.T) {
 	analyzer, err := golang.New(module.Module{Name: "test", Type: pkg.Go, BuildTarget: buildTarget})
 	assert.NoError(t, err)
 
-	main, err := analyzer.Go.ListOne(buildTarget, nil)
+	main, err := analyzer.Go.ListOne(buildTarget, nil, false)
 	assert.NoError(t, err)
 
 	deps, err := analyzer.Analyze()

--- a/analyzers/golang/discover.go
+++ b/analyzers/golang/discover.go
@@ -43,7 +43,7 @@ func Discover(dir string, opts map[string]interface{}) ([]module.Module, error) 
 		Cmd: cmd,
 		Dir: dir,
 	}
-	found, err := g.List([]string{"./..."}, nil)
+	found, err := g.List([]string{"./..."}, nil, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not find Go projects")
 	}

--- a/analyzers/golang/golang.go
+++ b/analyzers/golang/golang.go
@@ -58,6 +58,7 @@ type Options struct {
 	AllowDeepVendor           bool     `mapstructure:"allow-deep-vendor"`            // Allows nested vendored dependencies to be resolved using ancestor lockfiles farther than their direct parent.
 	AllowExternalVendor       bool     `mapstructure:"allow-external-vendor"`        // Allows reading vendor lockfiles of other projects.
 	AllowExternalVendorPrefix string   `mapstructure:"allow-external-vendor-prefix"` // If set, allow reading vendor lockfiles of projects whose import path's prefix matches. Multiple space-delimited prefixes can be specified.
+	ModulesVendor             bool     `mapstructure:"modules-vendor"`               // Allows gomodules projects that rely on vendor directories to work.
 	SkipImportTracing         bool     `mapstructure:"skip-tracing"`                 // Skips dependency tracing.
 	SkipProject               bool     `mapstructure:"skip-project"`                 // Skips project detection.
 }
@@ -125,7 +126,7 @@ func (a *Analyzer) Build() error {
 func (a *Analyzer) IsBuilt() (bool, error) {
 	m := a.Module
 	log.Debugf("%#v", m)
-	pkg, err := a.Go.ListOne(m.BuildTarget, nil)
+	pkg, err := a.Go.ListOne(m.BuildTarget, nil, a.Options.ModulesVendor)
 	if err != nil {
 		return false, err
 	}

--- a/analyzers/golang/util.go
+++ b/analyzers/golang/util.go
@@ -17,7 +17,7 @@ var (
 
 // Dir returns the absolute path to a Go package.
 func (a *Analyzer) Dir(importpath string) (string, error) {
-	pkg, err := a.Go.ListOne(importpath, nil)
+	pkg, err := a.Go.ListOne(importpath, nil, a.Options.ModulesVendor)
 	if err != nil {
 		return "", err
 	}

--- a/buildtools/gocmd/go.go
+++ b/buildtools/gocmd/go.go
@@ -56,8 +56,8 @@ type GoListPackageError struct {
 }
 
 // ListOne runs List for a single package.
-func (g *Go) ListOne(pkg string, flags []string) (Package, error) {
-	pkgs, err := g.List([]string{pkg}, flags)
+func (g *Go) ListOne(pkg string, flags []string, vendor bool) (Package, error) {
+	pkgs, err := g.List([]string{pkg}, flags, vendor)
 	if err != nil {
 		return Package{}, err
 	}
@@ -68,10 +68,13 @@ func (g *Go) ListOne(pkg string, flags []string) (Package, error) {
 }
 
 // List runs `go list` to return information about packages.
-func (g *Go) List(pkgs, flags []string) ([]Package, error) {
+func (g *Go) List(pkgs, flags []string, vendor bool) ([]Package, error) {
 	// Run `go list -json $PKG` and unmarshal output.
 	var output []GoListOutput
 	argv := append(flags, pkgs...)
+	if vendor {
+		argv = append([]string{"-mod=vendor"}, argv...)
+	}
 	stdout, stderr, err := exec.Run(exec.Cmd{
 		Name: g.Cmd,
 		Argv: append([]string{"list", "-json"}, argv...),

--- a/docs/integrations/golang.md
+++ b/docs/integrations/golang.md
@@ -39,13 +39,14 @@ analyze:
 
 ## Options
 
-| Option                         |   Type   | Name                                                                    | Common Use Case                              |
-| ------------------------------ | :------: | ----------------------------------------------------------------------- | -------------------------------------------- |
-| `tags`                         | []string | [Tags](#tags-string)                                               | Project utilizes go build tags.              |
+| Option                         |   Type   | Name                                                                 | Common Use Case                              |
+| ------------------------------ | :------: | -------------------------------------------------------------------- | -------------------------------------------- |
+| `tags`                         | []string | [Tags](#tags-string)                                                 | Project utilizes go build tags.              |
 | `all-tags`                     |   bool   | [All Tags](#all-tags-bool)                                           | Make sure all OS and Arch tags are caught.   |
 | `strategy`                     |  string  | [Strategy](#strategy-string)                                         | Specify a go package manager.                |
 | `lockfile`                     |  string  | [Lockfile Path](#lockfilepath-string)                                | Specify a custom lockfile.                   |
 | `manifest`                     |  string  | [Manifest Path](#manifestpath-string)                                | Specify a custom manifest file.              |
+| `modules-vendor`               |   bool   | [Modules Vendor](#modules-vendor-bool)                               | Set if you using gomodules and vendoring.    |
 | `allow-unresolved`             |   bool   | [Allow Unresolved](#allow-unresolved-bool)                           | Dependency revision is not in lockfile.      |
 | `allow-unresolved-prefix`      |  string  | [Allow Unresolved Prefix](#allow-unresolved-prefix-string)           | Allow a specific unresolved package.         |
 | `allow-nested-vendor`          |   bool   | [Allow Nested Vendor](#allow-nested-vendor-bool)                     | Project's parent holds the desired lockfile. |
@@ -104,7 +105,11 @@ Example:
 ```yaml
     manifest: config/customManifest.toml
 ```
-#### `allow-unresolved: <bool>`            
+#### `modules-vendor: <bool>`
+
+If your project is using gomodules and relying on a vendor directory you can set this flag to ensure that go can find your dependencies. Relevant information here: https://github.com/golang/go/wiki/Modules#how-do-i-use-vendoring-with-modules-is-vendoring-going-away.
+
+#### `allow-unresolved: <bool>`
 
 If analysis finds any dependencies from `go list` that do not have a revision specified in a lockfile, analysis will fail by default. If it is acceptable to skip these packages during analysis and upload an incomplete dependency graph set `allow-unresolved: true`. This problem is usually a result of the underlying project having build issues. 
 


### PR DESCRIPTION
This PR is necessary because Golang cannot find vendored dependencies if a user is using custom vendored dependencies along with gomodules. This adds the `-mod=vendor` flag when running `go list` in certain scenarios.

Relevant information on why these changes are necessary: https://github.com/golang/go/wiki/Modules#how-do-i-use-vendoring-with-modules-is-vendoring-going-away