### PR TITLE
Added more description error messages for fossa test failures

### DIFF
--- a/api/fossa/builds.go
+++ b/api/fossa/builds.go
@@ -20,12 +20,12 @@ type Build struct {
 
 // GetLatestBuild loads the most recent build for a revision
 // or returns an error if the revision does not exist, or the revision has no builds.
-func GetLatestBuild(locator Locator) (Build, error) {
+func GetLatestBuild(locator Locator) (Build, int, error) {
 	var build Build
-	_, err := GetJSON(fmt.Sprintf(BuildsAPI, url.PathEscape(locator.OrgString())), &build)
+	status_code, err := GetJSON(fmt.Sprintf(BuildsAPI, url.PathEscape(locator.OrgString())), &build)
 	if err != nil {
-		return Build{}, errors.Wrap(err, "could not get Build from API")
+		return Build{}, status_code, errors.Wrap(err, "could not get Build from API")
 	}
 
-	return build, nil
+	return build, status_code, nil
 }


### PR DESCRIPTION
I was running into this issue and getting this error message.  Apologies for not waiting for it to be assigned to me beforehand as indicated in the contributions guide, but I wanted to hopefully help out by adding an error message for users.

The other thing was I noticed it returned a `500` error code. Tho I am looking for this status code, I am wondering if there would be a way to instead return a 400 level error?

Address #413 

Signed-off-by: Zuhayr Elahi <elahi.zuhayr@gmail.com>