### PR TITLE
improve error messages when running commands

### DIFF
--- a/exec/run.go
+++ b/exec/run.go
@@ -131,10 +131,10 @@ func toEnv(env map[string]string) []string {
 
 // BuildExec translates FOSSA exec structures into standard library exec
 // commands.
-func BuildExec(cmd Cmd) (*exec.Cmd, bytes.Buffer) {
-	var stderr bytes.Buffer
+func BuildExec(cmd Cmd) (*exec.Cmd, *bytes.Buffer) {
+	stderr := new(bytes.Buffer)
 	xc := exec.Command(cmd.Name, cmd.Argv...)
-	xc.Stderr = &stderr
+	xc.Stderr = stderr
 
 	if cmd.Dir != "" {
 		xc.Dir = cmd.Dir

--- a/exec/run_test.go
+++ b/exec/run_test.go
@@ -114,3 +114,14 @@ func TestRunRetry(t *testing.T) {
 	// opposed to the 4 seconds it would take without the timeout.
 	assert.True(t, end.Sub(start) > 6*time.Second)
 }
+
+func TestRunCaptureStderr(t *testing.T) {
+	command := exec.Cmd{
+		Name: "pwd",
+		Argv: []string{"--invalid-flag"},
+	}
+	stdout, stderr, err := exec.Run(command)
+	assert.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.NotEmpty(t, stderr)
+}


### PR DESCRIPTION
This PR attempts to make some failure modes in `fossa` a bit better. Specifically, we were running into an issue where `fossa` would report  only this error:

```
FATAL Could not analyze: could not run go list:  (exit status 1)
```

It wasn't quite clear, as a user, how to go about resolving this. This PR reflects the patch I added to `fossa` in order to diagnose the error. (In my case, it turned out to be a repository that had been removed, and `go list -json a/b/c` was failing because an underlying `git fetch` command was failing.) Specifically, this adds the command that was run to the error message, and also fixes a bug that was preventing `fossa`'s internal command helpers from correctly capturing stderr. The latter comes with a regression test.