### PR TITLE
feat (archive server analysis) add the --server-scan flag

### DIFF
--- a/docs/integrations/archive.md
+++ b/docs/integrations/archive.md
@@ -17,7 +17,6 @@ analyze:
   modules:
     - name: your-custom-project
       type: raw
-      path: .
       target: ./<directory-or-file>
 ```
 
@@ -27,3 +26,7 @@ Archive analysis is done entirely by the FOSSA backend and the FOSSA-CLI's only 
 1. A tarball is created from all files located in the `target`.
 2. FOSSA-CLI asks FOSSA for a secure S3 endpoint to upload the created tarball.
 3. The tarball is uploaded and FOSSA begins analyzing each file individually.
+
+### Notes
+
+FOSSA treats raw modules by default as folders without dependencies and runs a license scan on each file. If you would like to run full server side FOSSA analysis you can run `fossa analyze --server-scan` which will treat the uploaded folder as its own independent project which may contain dependencies.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -214,15 +214,16 @@ Analyzes the project for a list of its dependencies, optionally uploading the re
 FOSSA_API_KEY=YOUR_API_KEY fossa analyze
 ```
 
-| Flag         | Short | Description                                                                  |
-| ------------ | ----- | ---------------------------------------------------------------------------- |
-| `--config`   | `-c`  | Path to a [configuration file](/docs/config-file.md) including filename.     |
-| `--project`  | `-p`  | Configuration value for [project](/docs/config-file.md/#project-optional).   |
-| `--revision` | `-r`  | Configuration value for [revision](/docs/config-file.md/#revision-optional). |
-| `--endpoint` | `-e`  | Configuration value for [endpoint](/docs/config-file.md/#endpoint-optional). |
-| `--output`   | `-o`  | Output `fossa analyze` results to stdout.                                    |
-| `--debug`    |       | Print debugging information to stderr.                                       |
-| `--help`     | `-h`  | Print a help message.                                                        |
+| Flag            | Short | Description                                                                  |
+| --------------- | ----- | ---------------------------------------------------------------------------- |
+| `--config`      | `-c`  | Path to a [configuration file](/docs/config-file.md) including filename.     |
+| `--project`     | `-p`  | Configuration value for [project](/docs/config-file.md/#project-optional).   |
+| `--revision`    | `-r`  | Configuration value for [revision](/docs/config-file.md/#revision-optional). |
+| `--endpoint`    | `-e`  | Configuration value for [endpoint](/docs/config-file.md/#endpoint-optional). |
+| `--output`      | `-o`  | Output `fossa analyze` results to stdout.                                    |
+| `--server-scan` |       | Run a server side dependency scan on raw modules.                            |
+| `--debug`       |       | Print debugging information to stderr.                                       |
+| `--help`        | `-h`  | Print a help message.                                                        |
 
 ### `fossa test`
 Checks whether the project has licensing issues, as configured by its policy within FOSSA. If there are issues, it prints them on `stdout` and exits with code 1. If there are not issues, it exits with code 0. Fossa test can be used to fail a CI pipeline job.


### PR DESCRIPTION
This PR adds a `--server-scan` flag to signal that all raw modules should be analyzed using the fossa server-side dependency analysis. This allows users to leverage the UI based archive upload feature from the cli. By default the cli archive uploader will only run a license scan on fossa core.