### PR TITLE
fix (ruby errors) change is built check and fix errors

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ archive:
     - goos: windows
       format: zip
 release:
-  prerelease: true
+  prerelease: false
 brews:
   -
     name: fossa

--- a/buildtools/bundler/bundler.go
+++ b/buildtools/bundler/bundler.go
@@ -19,7 +19,7 @@ type Gem struct {
 	Revision string
 }
 
-func (b *Bundler) List() ([]Gem, *errors.Error) {
+func (b *Bundler) List() ([]Gem, error) {
 	stdout, stderr, err := exec.Run(exec.Cmd{
 		Name: b.Cmd,
 		Argv: []string{"list"},
@@ -47,7 +47,7 @@ func (b *Bundler) List() ([]Gem, *errors.Error) {
 	return gems, nil
 }
 
-func (b *Bundler) Install(flags ...string) *errors.Error {
+func (b *Bundler) Install(flags ...string) error {
 	if flags == nil {
 		flags = []string{"--frozen", "--deployment"}
 	}

--- a/buildtools/bundler/lockfile.go
+++ b/buildtools/bundler/lockfile.go
@@ -58,7 +58,7 @@ var requirementsRegex = regexp.MustCompile(`^( *?)(\S+?)(?:\!?|( \((.*?)\)\!?)?)
 // implementing parsing logic.
 type VersionSpecifier string
 
-func FromLockfile(filename string) (Lockfile, *errors.Error) {
+func FromLockfile(filename string) (Lockfile, error) {
 	contents, err := files.Read(filename)
 	if err != nil {
 		return Lockfile{}, &errors.Error{


### PR DESCRIPTION
This is a similar nil typed error issue that we saw with buck. We should use this as a warning sign that  we need to start checking for errors in tests instead of only checking for nil errors.