### PR TITLE
feat(dep reports) add hash and version field to dep reports [FC-701]

### DIFF
--- a/api/fossa/revisions.go
+++ b/api/fossa/revisions.go
@@ -28,6 +28,8 @@ type Revision struct {
 	Project  *Project
 	Meta     []RevisionMeta
 	Issues   []Issue
+	Version  string
+	Hash     string
 }
 
 // A RevisionMeta holds metadata about a FOSSA API revision.


### PR DESCRIPTION
Adds `Hash` and `Version` fields to revisions returned from core so golang deps can have their commit hashes and dep versions explicitly defined in cli reports