### PR TITLE
errors (wrong arguments) better errors when users manually specify modules.

### DIFF
--- a/config/keys.go
+++ b/config/keys.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -11,6 +11,7 @@ import (
 	"github.com/mattn/go-isatty"
 
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/module"
 	"github.com/fossas/fossa-cli/pkg"
 )
@@ -159,7 +160,11 @@ func Modules() ([]module.Module, error) {
 	if args.Present() {
 		// Validate arguments.
 		if ctx.NArg() != 1 {
-			return nil, errors.New("must specify exactly 1 module")
+			return nil, &errors.Error{
+				Cause:           errors.New("must specify exactly 1 module in arguments"),
+				Troubleshooting: fmt.Sprintf("Confirm that you are running the correct command and are attempting to manually specify modules in arguments. If you are, ensure that you are correctly specifying one module in the format of <package_type>:<target>. Arguments currently specified `%s`", args),
+				Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/user-guide.md/#argument-configuration",
+			}
 		}
 
 		// Parse module.
@@ -169,7 +174,11 @@ func Modules() ([]module.Module, error) {
 		name := strings.Join(sections[1:], ":")
 		mtype, err := pkg.ParseType(typename)
 		if err != nil {
-			return nil, err
+			return nil, &errors.Error{
+				Cause:           err,
+				Troubleshooting: fmt.Sprintf("Confirm that you are running the correct command and are attempting to manually specify modules in arguments. If you are, ensure that you are correctly specifying one module in the format of <package_type>:<target>. Arguments currently specified `%s`", args),
+				Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/user-guide.md/#argument-configuration",
+			}
 		}
 
 		// Note that these parsed modules do not have any options set yet.

--- a/config/keys.go
+++ b/config/keys.go
@@ -162,8 +162,9 @@ func Modules() ([]module.Module, error) {
 		if ctx.NArg() != 1 {
 			return nil, &errors.Error{
 				Cause:           errors.New(fmt.Sprintf("must specify exactly 1 module in arguments: %s", args)),
-				Troubleshooting: fmt.Sprintf("Confirm that you are running the correct command and are attempting to manually specify modules in arguments. If you are, ensure that you are correctly specifying one module in the format of <package_type>:<target>. Arguments currently specified `%s`", args),
+				Troubleshooting: fmt.Sprintf("Ensure that you are specifying only one module in the arguments, currently specified `%s`", args),
 				Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/user-guide.md/#argument-configuration",
+				Message:         errors.ArgumentModuleMessage,
 			}
 		}
 
@@ -176,8 +177,9 @@ func Modules() ([]module.Module, error) {
 		if err != nil {
 			return nil, &errors.Error{
 				Cause:           err,
-				Troubleshooting: fmt.Sprintf("Confirm that you are running the correct command and are attempting to manually specify modules in arguments. If you are, ensure that you are correctly specifying one module in the format of <package_type>:<target>. Arguments currently specified `%s`", args),
+				Troubleshooting: fmt.Sprintf("Ensure that you are specifying a valid package type. Arguments supplied `%s`", args),
 				Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/user-guide.md/#argument-configuration",
+				Message:         errors.ArgumentModuleMessage,
 			}
 		}
 

--- a/config/keys.go
+++ b/config/keys.go
@@ -161,7 +161,7 @@ func Modules() ([]module.Module, error) {
 		// Validate arguments.
 		if ctx.NArg() != 1 {
 			return nil, &errors.Error{
-				Cause:           errors.New("must specify exactly 1 module in arguments"),
+				Cause:           errors.New(fmt.Sprintf("must specify exactly 1 module in arguments: %s", args)),
 				Troubleshooting: fmt.Sprintf("Confirm that you are running the correct command and are attempting to manually specify modules in arguments. If you are, ensure that you are correctly specifying one module in the format of <package_type>:<target>. Arguments currently specified `%s`", args),
 				Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/user-guide.md/#argument-configuration",
 			}

--- a/docs/integrations/debian.md
+++ b/docs/integrations/debian.md
@@ -21,7 +21,6 @@ analyze:
   - name: fossa
     type: debian
     target: apt
-*   path: .
 ```
 
 ## Analysis

--- a/errors/messages.go
+++ b/errors/messages.go
@@ -12,26 +12,34 @@ var ReportBugMessage = `
 ` + color.HiYellowString("REPORTING A BUG:") + `
 ` + wordwrap.WrapString("Please try troubleshooting before filing a bug. If the suggestions do not help you can file a bug at "+color.HiBlueString("https://github.com/fossas/fossa-cli/issues/new")+".", width) + `
 ` + wordwrap.WrapString("Please attach the debug logs from:", width) + `
-  
+
   ` + color.HiGreenString("fossa <cmd> --debug") + `
-  
+
 ` + wordwrap.WrapString("For additional support, contact "+color.MagentaString("support@fossa.com")+".", width)
 
 var NoAPIKeyMessage = `
 
 ` + wordwrap.WrapString("Running `fossa analyze` performs a dependency analysis and uploads the result to FOSSA. To run an analysis without uploading results, run:", width) + `
-    
+
     ` + color.HiGreenString("fossa analyze --output") + `
 
 ` + wordwrap.WrapString("You can provide your API key by setting the $FOSSA_API_KEY environment variable. For example, try running:", width) + `
-    
+
     ` + color.HiGreenString("FOSSA_API_KEY=<YOUR_API_KEY_HERE> $command") + `
 
 ` + wordwrap.WrapString("You can create an API key for your FOSSA account at:", width) + `
-    
+
     ` + color.HiBlueString("$endpoint/account/settings/integrations/api_tokens") + `
 `
 
 var NotImplementedMessage = `This code path has not yet been implemented.`
 
 var typeNilError = `fossa had difficulty reading this error message. Please report this as a bug.` + ReportBugMessage
+
+var ArgumentModuleMessage = `
+
+` + wordwrap.WrapString("Did you misspell the command? Run "+color.HiGreenString("fossa -h")+" to view supported commands", width) + `
+
+Are you trying to scan a single module? Try:
+fossa [global options] <package_type>:<target>
+For example: ` + color.GreenString("fossa --show-output golang:modulename")


### PR DESCRIPTION
Example error when a user accidentally runs `fossa analyse`.
<img width="707" alt="Screen Shot 2019-09-09 at 3 15 21 PM" src="https://user-images.githubusercontent.com/31230447/64570233-d8b41d00-d314-11e9-8dbc-8d5110f07cb4.png">

Ideally this command will be deprecated in the future, but at the moment this is a good fix until we overhaul the commands.
