### PR TITLE
fix (update fail) don't fail when there are no updates available

### DIFF
--- a/cmd/fossa/cmd/update/update.go
+++ b/cmd/fossa/cmd/update/update.go
@@ -37,7 +37,7 @@ func Do(c *cli.Context) {
 		log.Fatalf("Unable to update: %s", err.Error())
 	}
 	if !ok {
-		log.Fatalf("No updates available")
+		log.Info("No updates available")
 	}
 
 	version, err := Update()


### PR DESCRIPTION
Closes #154 
When `fossa update` is run and the user is on the latest version the command used to fail. This changes that behavior.