### PR TITLE
fix (static compile) turn off cgo when compiling

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 builds:
   - main: ./cmd/fossa/
+    env:
+      - CGO_ENABLED=0
     binary: fossa
     goos:
       - windows


### PR DESCRIPTION
Closes #417 and closes #527 

This PR sets `CGO_ENABLED=0` to ensure that fossa-cli can run on all environments.

In finding the solution my investigation turned up the fact that if I compiled the fossa-cli using the command `GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static"` on my mac it created a binary that would work in Alpine, however if I ran the same command in a container that used `glibc` (compared to `musl` which Alpine uses) it would not work in Alpine, unless I set `CGO_ENABLED=0` which turns off cgo. I suspect this is due to golang's default cross-compilation behavior for mac -> linux builds.

Relevant information:
- https://stackoverflow.com/questions/34729748/installed-go-binary-not-found-in-path-on-alpine-linux-docker
- https://www.osso.nl/blog/golang-statically-linked/
