### PR TITLE
feat (dependency paths) unmarshal additional information

### DIFF
--- a/api/fossa/revisions.go
+++ b/api/fossa/revisions.go
@@ -23,13 +23,22 @@ type License struct {
 
 // A Revision holds the FOSSA API response for the revision API.
 type Revision struct {
-	Locator  *Locator `json:"loc"`
-	Licenses []License
-	Project  *Project
-	Meta     []RevisionMeta
-	Issues   []Issue
-	Version  string
-	Hash     string
+	Locator        *Locator `json:"loc"`
+	Licenses       []License
+	Project        *Project
+	DependencyLock DependencyLock `json:"DependencyLock"`
+	Meta           []RevisionMeta
+	Issues         []Issue
+	Version        string
+	Hash           string
+}
+
+type DependencyLock struct {
+	PathsTo PathsTo `json:"paths_to"`
+}
+
+type PathsTo struct {
+	Paths [][]string `json:"paths"`
 }
 
 // A RevisionMeta holds metadata about a FOSSA API revision.


### PR DESCRIPTION
This PR unmarshals further information from the revision API that is queried to retrieve dependency information. The result is that additional fields are populated in the JSON output which include dependency path information accessed under DependencyLock -> paths_to -> paths. The resulting 2D paths array outputs information such that the last dependency in the individual arrays directly includes the dependency which contains the path information. 
Example:
```JSON
        "DependencyLock": {
            "paths_to": {
                "paths": [
                    [
                        "go+github.com/fossas/fossa-cli/cmd/fossa/cmd/init$",
                        "go+github.com/fossas/fossa-cli/analyzers$",
                        "go+github.com/fossas/fossa-cli/analyzers/carthage$",
                        "go+github.com/fossas/fossa-cli/buildtools/carthage$",
                        "go+github.com/rveen/ogdl$v1.1",
                        "go+bytes$"
                    ],
                    [
```