### PR TITLE
fix (rpm install) return stdout instead of zero value

### DIFF
--- a/buildtools/rpm/rpm_test.go
+++ b/buildtools/rpm/rpm_test.go
@@ -1,11 +1,11 @@
 package rpm_test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"testing"
 
 	"github.com/fossas/fossa-cli/buildtools/rpm"
+	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/testing/helpers"
 	"github.com/stretchr/testify/assert"
 )
@@ -100,8 +100,8 @@ func mockSingleRPM() rpm.Shell {
 				}
 				switch args[len(args)-1] {
 				case "dep-one":
-					stdout, stderr, _ := stringFile("testdata/licenses/dep-one-license")
-					return stdout, stderr, fmt.Errorf("error should not cause a failure")
+					stdout, stderr, err := stringFile("testdata/licenses/dep-one-license")
+					return stdout, stderr, errors.Wrap(err, "error should not cause a failure")
 				case "dep-two":
 					return stringFile("testdata/licenses/dep-two-license")
 				case "dep-three":
@@ -117,8 +117,8 @@ func mockSingleRPM() rpm.Shell {
 			case "-qR":
 				switch args[1] {
 				case "dep-one":
-					stdout, stderr, _ := stringFile("testdata/dep-one-transitive")
-					return stdout, stderr, fmt.Errorf("error should not cause a failure")
+					stdout, stderr, err := stringFile("testdata/dep-one-transitive")
+					return stdout, stderr, errors.Wrap(err, "error should not cause a failure")
 				case "dep-two":
 					return stringFile("testdata/dep-two-transitive")
 				case "dep-four":

--- a/buildtools/rpm/rpm_test.go
+++ b/buildtools/rpm/rpm_test.go
@@ -1,6 +1,7 @@
 package rpm_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -99,7 +100,8 @@ func mockSingleRPM() rpm.Shell {
 				}
 				switch args[len(args)-1] {
 				case "dep-one":
-					return stringFile("testdata/licenses/dep-one-license")
+					stdout, stderr, _ := stringFile("testdata/licenses/dep-one-license")
+					return stdout, stderr, fmt.Errorf("error should not cause a failure")
 				case "dep-two":
 					return stringFile("testdata/licenses/dep-two-license")
 				case "dep-three":
@@ -115,7 +117,8 @@ func mockSingleRPM() rpm.Shell {
 			case "-qR":
 				switch args[1] {
 				case "dep-one":
-					return stringFile("testdata/dep-one-transitive")
+					stdout, stderr, _ := stringFile("testdata/dep-one-transitive")
+					return stdout, stderr, fmt.Errorf("error should not cause a failure")
 				case "dep-two":
 					return stringFile("testdata/dep-two-transitive")
 				case "dep-four":


### PR DESCRIPTION
RPM commands often return `exit code 1` to signal an error even though nothing is output on `stderr` and the expected output is returned on `stdout`. Due to this, we must log that an error occurred but attempt to proceed with the information that we do have.