### PR TITLE
fix (log file sync) defer file syncing until after the command finishes

### DIFF
--- a/cmd/fossa/display/log.go
+++ b/cmd/fossa/display/log.go
@@ -53,6 +53,11 @@ func SetFile(filename string) error {
 	return nil
 }
 
+// SyncFile syncs the FOSSA log file and writes all progress to disk.
+func SyncFile() error {
+	return file.Sync()
+}
+
 // File returns the log file name.
 func File() string {
 	return file.Name()
@@ -133,10 +138,6 @@ func Handler(entry *log.Entry) error {
 	}
 	data = append(data, byte('\n'))
 	_, err = file.Write(data)
-	if err != nil {
-		return err
-	}
-	err = file.Sync()
 	if err != nil {
 		return err
 	}

--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/apex/log"
 	"github.com/urfave/cli"
 
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze"
@@ -13,6 +14,7 @@ import (
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/test"
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/update"
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/upload"
+	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
 	"github.com/fossas/fossa-cli/cmd/fossa/version"
@@ -42,6 +44,16 @@ var App = cli.App{
 }
 
 func main() {
+	// Write the temp log file to disk after the command finishes.
+	defer func() {
+		err := display.SyncFile()
+		if err != nil {
+			log.Warnf("error writing to the log file: %s", err.Error())
+		}
+	}()
+
+	defer display.SyncFile()
+
 	err := App.Run(os.Args)
 	if err != nil {
 		switch e := err.(type) {

--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -52,8 +52,6 @@ func main() {
 		}
 	}()
 
-	defer display.SyncFile()
-
 	err := App.Run(os.Args)
 	if err != nil {
 		switch e := err.(type) {


### PR DESCRIPTION
Currently, we are running `file.Sync()` after every log line. This PR ensures that `file.Sync()` is only called once when the program finishes. This speeds up all FOSSA CLI analysis, especially golang.