### PR TITLE
feat (gradle V2) improve gradle analyzer

### DIFF
--- a/analyzers/gradle/gradle2.go
+++ b/analyzers/gradle/gradle2.go
@@ -51,9 +51,13 @@ func NewDiscover(dir module.Filepath) (map[module.Filepath]module.DiscoveredStra
 		}
 
 		if info.IsDir() {
-			buildScripts, err := filepath.Glob(filepath.Join(dir, "build.gradle*"))
-			if err != nil || len(buildScripts) == 0 {
+			buildScripts, err := filepath.Glob(filepath.Join(path, "build.gradle*"))
+			if err != nil {
 				return err
+			}
+
+			if len(buildScripts) == 0 {
+				return nil
 			}
 
 			modules.AddStrategy(info, path, DependenciesCmd)

--- a/analyzers/gradle/gradle2.go
+++ b/analyzers/gradle/gradle2.go
@@ -1,0 +1,144 @@
+// Package gradle implements analyzers for Gradle.
+//
+// A `BuildTarget` in Gradle is `$PROJECT:$CONFIGURATION`, where the Gradle
+// module would list its dependencies by running `gradle $PROJECT:dependencies
+// --configuration=$CONFIGURATION`. The directory of the `build.gradle` file is
+// specified by `Dir`.
+package gradle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/apex/log"
+
+	"github.com/fossas/fossa-cli/buildtools/gradle"
+	"github.com/fossas/fossa-cli/errors"
+	"github.com/fossas/fossa-cli/graph"
+	"github.com/fossas/fossa-cli/module"
+	"github.com/fossas/fossa-cli/pkg"
+)
+
+const (
+	AnalyzerName = "gradle"
+
+	DependenciesCmd = "dependencies"
+)
+
+var GradleAnalyzer = module.AnalyzerV2{
+	Name:         AnalyzerName,
+	DiscoverFunc: NewDiscover,
+	Strategies: module.Strategies{
+		Named: map[module.StrategyName]module.Strategy{
+			// DependenciesCmd: AnalyzeYarnCmd,
+		},
+		Optimal: []module.StrategyName{DependenciesCmd},
+		SortedNames: []module.StrategyName{
+			DependenciesCmd,
+		},
+	},
+}
+
+// type Options struct {
+// 	Online            bool   `mapstructure:"online"`
+// }
+
+func NewDiscover(dir module.Filepath) (map[module.Filepath]module.DiscoveredStrategies, *errors.Error) {
+	log.WithField("dir", dir).Debug("discovering gradle modules")
+	modules := module.FilepathStrategies{}
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.WithError(err).WithField("path", path).Debug("error while walking for discovery")
+			return err
+		}
+
+		if !info.IsDir() && info.Name() == "build.gradle" {
+			modules.AddStrategy(info, path, DependenciesCmd)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, errors.UnknownError(err, "could not find Gradle projects")
+	}
+
+	return modules, nil
+}
+
+func (a *Analyzer) Analyze() (graph.Deps, error) {
+	return parseModuleV2(a)
+}
+
+// Groups of configurations to pull dependencies from. Later configuration
+// groups in this list are used as fallbacks when dependencies aren't found for
+// the current group.
+var defaultConfigurationGroups = [][]string{
+	{"compileClasspath", "runtimeClasspath"},
+	{"compile", "api", "implementation", "compileDependenciesMetadata", "apiDependenciesMetadata", "implementationDependenciesMetadata"},
+}
+
+func parseModuleV2(a *Analyzer) (graph.Deps, error) {
+	var configurationGroups [][]string
+	var depsByConfig map[string]graph.Deps
+	var err error
+
+	submodules, err := a.Input.DependencyTasks()
+	if err != nil {
+		return graph.Deps{}, err
+	}
+	depsByConfig, err = gradle.MergeProjectsDependencies(a.Input, submodules)
+	if err != nil {
+		return graph.Deps{}, err
+	}
+
+	if a.Options.Configuration != "" {
+		configurationGroups = [][]string{strings.Split(a.Options.Configuration, ",")}
+	} else if a.Options.AllConfigurations {
+		var configurations []string
+		for config := range depsByConfig {
+			configurations = append(configurations, config)
+		}
+		configurationGroups = [][]string{configurations}
+	} else {
+		configurationGroups = defaultConfigurationGroups
+	}
+
+	merged := graph.Deps{
+		Direct:     nil,
+		Transitive: make(map[pkg.ID]pkg.Package),
+	}
+	for _, group := range configurationGroups {
+		for _, config := range group {
+			merged = mergeGraphs(merged, depsByConfig[config])
+		}
+
+		if len(merged.Direct) > 0 {
+			break
+		}
+	}
+	return merged, nil
+}
+
+func mergeGraphs(gs ...graph.Deps) graph.Deps {
+	merged := graph.Deps{
+		Direct:     nil,
+		Transitive: make(map[pkg.ID]pkg.Package),
+	}
+
+	importSet := make(map[pkg.Import]bool)
+	for _, g := range gs {
+		for _, i := range g.Direct {
+			importSet[i] = true
+		}
+		for id, dep := range g.Transitive {
+			merged.Transitive[id] = dep
+		}
+	}
+	for i := range importSet {
+		merged.Direct = append(merged.Direct, i)
+	}
+
+	return merged
+}

--- a/analyzers/gradle/gradle_test.go
+++ b/analyzers/gradle/gradle_test.go
@@ -83,7 +83,7 @@ func TestGradleDiscoverKotlin(t *testing.T) {
 func TestGradleNewDiscovery(t *testing.T) {
 	modules, err := gradle.NewDiscover("testdata")
 	assert.Nil(t, err)
-	assert.Len(t, modules, 2)
+	assert.Len(t, modules, 3)
 	assert.Equal(t, modules, map[string]map[string]string{
 		"testdata/discover-groovy": map[string]string{
 			"dependencies": "discover-groovy",
@@ -91,7 +91,11 @@ func TestGradleNewDiscovery(t *testing.T) {
 		"testdata/discover-kotlin": map[string]string{
 			"dependencies": "discover-kotlin",
 		},
+		"testdata/discover-nested/nested": map[string]string{
+			"dependencies": "nested",
+		},
 	})
+}
 
 func TestGradleDiscoverNested(t *testing.T) {
 	modules, err := gradle.DiscoverWithCommand("testdata/discover-nested", make(map[string]interface{}), mockCommand("testdata/discover-nested/nested/gradle-tasks-all"))

--- a/analyzers/gradle/gradle_test.go
+++ b/analyzers/gradle/gradle_test.go
@@ -80,6 +80,20 @@ func TestGradleKotlinDiscovery(t *testing.T) {
 	assert.True(t, moduleExists("discover-kotlin/grpc-xds", modules))
 }
 
+func TestGradleNewDiscovery(t *testing.T) {
+	modules, err := gradle.NewDiscover("testdata")
+	assert.Nil(t, err)
+	assert.Len(t, modules, 2)
+	assert.Equal(t, modules, map[string]map[string]string{
+		"testdata/discover-groovy": map[string]string{
+			"dependencies": "discover-groovy",
+		},
+		"testdata/discover-kotlin": map[string]string{
+			"dependencies": "discover-kotlin",
+		},
+	})
+}
+
 func mockCommand(mockOutput string) func(string, string, int, ...string) (string, error) {
 	return func(string, string, int, ...string) (string, error) {
 		output, err := ioutil.ReadFile(mockOutput)

--- a/buildtools/gradle/gradle2.go
+++ b/buildtools/gradle/gradle2.go
@@ -12,9 +12,10 @@ import (
 	"github.com/fossas/fossa-cli/pkg"
 )
 
+// Deps finds the correct gradle command to use and pieces together
+// an accurate dependency graoh of the entire gradle project.
 func Deps(dir, target module.Filepath) (graph.Deps, *errors.Error) {
-	// Get the correct gradle command to run from the directory
-	cmd, err := GradleCmd(dir)
+	cmd, err := bestCmd(dir)
 	if err != nil {
 		return graph.Deps{}, err
 	}
@@ -23,45 +24,60 @@ func Deps(dir, target module.Filepath) (graph.Deps, *errors.Error) {
 	return DepsWithCommand(input, dir, target)
 }
 
+// DepsWithCommand uses the supplied command to find an accurate
+// dependency graph.
 func DepsWithCommand(input Input, dir, target string) (graph.Deps, *errors.Error) {
-	// Run gradle tasks on the target to get all dependency tasks
 	projects, err := input.DependencyTasks()
 	if err != nil {
-		return graph.Deps{}, errors.UnknownError(err, "")
+		return graph.Deps{}, &errors.Error{
+			Cause:           err,
+			Type:            errors.Exec,
+			Troubleshooting: "`gradle tasks --all` was unable to be run. This likely represents an issue with your gradle configuration and should be diagnosed by attempting to the run the command and fix any associated errors. FOSSA will be unable to accurately determine your dependency graph until this issue is fixed.",
+		}
 	}
 
 	depMap := map[pkg.ID]pkg.Package{}
 	directSet := map[pkg.Import]bool{}
 	for _, project := range projects {
-		fmt.Println(project)
 		depGraph, err := Dependencies(project, input)
 		if err != nil {
-			return graph.Deps{}, errors.UnknownError(err, "")
+			return graph.Deps{}, &errors.Error{
+				Cause:           err,
+				Type:            errors.Exec,
+				Troubleshooting: fmt.Sprintf("`gradle %s:dependencies` was unable to be run. This likely signifies an issue with your gradle build and should be diagnosed by attempting to the run the command and fixing any associated errors. FOSSA will be unable to accurately determine your dependency graph until this issue is fixed.", project),
+			}
 		}
 
 		projectDirectSet := map[pkg.Import]bool{}
 		for configuration, configGraph := range depGraph {
+			// Collect each sub-project's direct dependencies and
+			// combine to create the whole project's direct dependencies.
 			for _, dep := range configGraph.Direct {
 				projectDirectSet[dep] = true
 				directSet[dep] = true
 			}
 
-			// Look through each dep, set imports if it is larger and add the current usage.
-			for dep, pack := range configGraph.Transitive {
-				currDep := depMap[dep]
+			// Look through each dep and set id, usage, and imports.
+			for depID, depPackage := range configGraph.Transitive {
+				currentDep := depMap[depID]
+				currentDep.ID = depID
 
-				currDep.ID = dep
-				if currDep.Usage == nil {
-					currDep.Usage = map[string]bool{}
+				if currentDep.Usage == nil {
+					currentDep.Usage = map[string]bool{}
 				}
-				currDep.Usage[configuration] = true
+				currentDep.Usage[configuration] = true
 
-				// Hack
-				if len(pack.Imports) > len(currDep.Imports) {
-					currDep.Imports = pack.Imports
+				// We prefer the larger list for two reasons:
+				// 1. With sub-projects, the direct dependencies are
+				// 	determined on a project level and not here.
+				// 2. With packages, the list of dependencies will be
+				// 	identical across sub-projects, unless repeated within
+				// 	a single sub-project, in which case there will be 0 deps.
+				if len(depPackage.Imports) > len(currentDep.Imports) {
+					currentDep.Imports = depPackage.Imports
 				}
 
-				depMap[dep] = currDep
+				depMap[depID] = currentDep
 			}
 		}
 
@@ -89,9 +105,8 @@ func DepsWithCommand(input Input, dir, target string) (graph.Deps, *errors.Error
 	}, nil
 }
 
-// GradleCmd finds the best possible gradle command to run for
-// shell commands.
-func GradleCmd(dir string) (string, *errors.Error) {
+// bestCmd finds the best possible gradle command to run for shell commands.
+func bestCmd(dir string) (string, *errors.Error) {
 	cmd, _, err := exec.Which("--version", os.Getenv("FOSSA_GRADLE_CMD"), filepath.Join(dir, "gradlew"), filepath.Join(dir, "gradlew.bat"), "gradle")
 	if err != nil {
 		return "", &errors.Error{

--- a/buildtools/gradle/gradle2.go
+++ b/buildtools/gradle/gradle2.go
@@ -1,0 +1,105 @@
+package gradle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/fossas/fossa-cli/errors"
+	"github.com/fossas/fossa-cli/exec"
+	"github.com/fossas/fossa-cli/graph"
+	"github.com/fossas/fossa-cli/module"
+	"github.com/fossas/fossa-cli/pkg"
+)
+
+func Deps(dir, target module.Filepath) (graph.Deps, *errors.Error) {
+	// Get the correct gradle command to run from the directory
+	cmd, err := GradleCmd(dir)
+	if err != nil {
+		return graph.Deps{}, err
+	}
+
+	input := NewShellInput(cmd, dir, true, "", 0)
+	return DepsWithCommand(input, dir, target)
+}
+
+func DepsWithCommand(input Input, dir, target string) (graph.Deps, *errors.Error) {
+	// Run gradle tasks on the target to get all dependency tasks
+	projects, err := input.DependencyTasks()
+	if err != nil {
+		return graph.Deps{}, errors.UnknownError(err, "")
+	}
+
+	depMap := map[pkg.ID]pkg.Package{}
+	directSet := map[pkg.Import]bool{}
+	for _, project := range projects {
+		fmt.Println(project)
+		depGraph, err := Dependencies(project, input)
+		if err != nil {
+			return graph.Deps{}, errors.UnknownError(err, "")
+		}
+
+		projectDirectSet := map[pkg.Import]bool{}
+		for configuration, configGraph := range depGraph {
+			for _, dep := range configGraph.Direct {
+				projectDirectSet[dep] = true
+				directSet[dep] = true
+			}
+
+			// Look through each dep, set imports if it is larger and add the current usage.
+			for dep, pack := range configGraph.Transitive {
+				currDep := depMap[dep]
+
+				currDep.ID = dep
+				if currDep.Usage == nil {
+					currDep.Usage = map[string]bool{}
+				}
+				currDep.Usage[configuration] = true
+
+				// Hack
+				if len(pack.Imports) > len(currDep.Imports) {
+					currDep.Imports = pack.Imports
+				}
+
+				depMap[dep] = currDep
+			}
+		}
+
+		projectDirectList := []pkg.Import{}
+		for projectDep := range projectDirectSet {
+			projectDirectList = append(projectDirectList, projectDep)
+		}
+
+		projectID := pkg.ID{Type: pkg.Gradle, Name: project}
+		depMap[projectID] = pkg.Package{
+			ID:      projectID,
+			Imports: projectDirectList,
+			Usage:   depMap[projectID].Usage,
+		}
+	}
+
+	directList := []pkg.Import{}
+	for dep := range directSet {
+		directList = append(directList, dep)
+	}
+
+	return graph.Deps{
+		Direct:     directList,
+		Transitive: depMap,
+	}, nil
+}
+
+// GradleCmd finds the best possible gradle command to run for
+// shell commands.
+func GradleCmd(dir string) (string, *errors.Error) {
+	cmd, _, err := exec.Which("--version", os.Getenv("FOSSA_GRADLE_CMD"), filepath.Join(dir, "gradlew"), filepath.Join(dir, "gradlew.bat"), "gradle")
+	if err != nil {
+		return "", &errors.Error{
+			Cause:           err,
+			Type:            errors.Exec,
+			Troubleshooting: "FOSSA could not find a valid gradle binary to run. This will prevent your gradle projects from being accurately analyzed",
+		}
+	}
+
+	return cmd, nil
+}

--- a/buildtools/gradle/testdata/project-one
+++ b/buildtools/gradle/testdata/project-one
@@ -1,0 +1,28 @@
+*** Skipping the build of codegen and compilation of proto files because skipCodegen=true
+:project-one:dependencies
+
+------------------------------------------------------------
+Project :project-one - gRPC: Nett
+------------------------------------------------------------
+
+one - Configuration for archive artifacts.
+\--- dep:one:1.0.0
+
+two - The Checkstyle libraries to be used for this project.
+\--- dep:two:2.0.0
+     +--- dep:three:3.0.0
+
+three - Configuration for default artifacts.
++--- project :project-two
+|    +--- dep:one:1.0.0
+|    \--- dep:five:5.0.0
+|         \--- dep:one:1.0.0
+\--- dep:four:4.0.0
+
+(*) - dependencies omitted (listed previously)
+
+BUILD SUCCESSFUL
+
+Total time: 4.394 secs
+
+This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.13/userguide/gradle_daemon.html

--- a/buildtools/gradle/testdata/project-two
+++ b/buildtools/gradle/testdata/project-two
@@ -1,0 +1,30 @@
+*** Skipping the build of codegen and compilation of proto files because skipCodegen=true
+:project-two:dependencies
+
+------------------------------------------------------------
+Project :project-two - gRPC: Nett
+------------------------------------------------------------
+
+unknown-configuration
+No dependencies
+
+three - Configuration for default artifacts.
+\--- project :project-one
+     +--- dep:two:2.0.0
+     |    +--- dep:three:3.0.0
+     \--- dep:one:1.0.0
+
+four - Dependencies for source set 'main'.
+\--- dep:five:5.0.0
+     \--- dep:one:1.0.0
+
+five - The Jacoco agent to use to get coverage data.
+\--- dep:one:1.0.0
+
+(*) - dependencies omitted (listed previously)
+
+BUILD SUCCESSFUL
+
+Total time: 4.394 secs
+
+This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.13/userguide/gradle_daemon.html

--- a/buildtools/gradle/testdata/tasks-output.txt
+++ b/buildtools/gradle/testdata/tasks-output.txt
@@ -4,10 +4,10 @@ All tasks runnable from root project
 
 Build tasks
 -----------
-dependencies-proj:assemble - Assembles the outputs of this project.
-dependencies-proj:build - Assembles and tests this project.
-dependencies-proj:buildNeeded - Assembles and tests this project and all projects it depends on.
-dependencies-proj:classes - Assembles main classes.
+project-one:assemble - Assembles the outputs of this project.
+project-one:build - Assembles and tests this project.
+project-one:buildNeeded - Assembles and tests this project and all projects it depends on.
+project-one:classes - Assembles main classes.
 
 Build Setup tasks
 -----------------
@@ -16,30 +16,31 @@ wrapper - Generates Gradle wrapper files. [incubating]
 
 Help tasks
 ----------
-buildEnvironment - Displays all buildscript dependencies declared in root project 'dependencies-proj'.
-dependencies-proj:buildEnvironment - Displays all buildscript dependencies declared in project ':dependencies-proj'.
-components - Displays the components produced by root project 'dependencies-proj'. [incubating]
-dependencies-proj:components - Displays the components produced by project ':dependencies-proj'. [incubating]
-dependencies - Displays all dependencies declared in root project 'dependencies-proj'.
-dependencies-proj:dependencies - Displays all dependencies declared in project ':dependencies-proj'.
-dependencyInsight - Displays the insight into a specific dependency in root project 'dependencies-proj'.
-dependencies-proj:dependencyInsight - Displays the insight into a specific dependency in project ':dependencies-proj'.
-dependentComponents - Displays the dependent components of components in root project 'dependencies-proj'. [incubating]
-dependencies-proj:dependentComponents - Displays the dependent components of components in project ':dependencies-proj'. [incubating]
+buildEnvironment - Displays all buildscript dependencies declared in root project 'project-one'.
+project-one:buildEnvironment - Displays all buildscript dependencies declared in project ':dependencies-proj'.
+components - Displays the components produced by root project 'project-one'. [incubating]
+project-one:components - Displays the components produced by project ':dependencies-proj'. [incubating]
+dependencies - Displays all dependencies declared in root project 'project-one'.
+project-one:dependencies - Displays all dependencies declared in project ':dependencies-proj'.
+project-two:dependencies - Displays all dependencies declared in project ':dependencies-proj'.
+dependencyInsight - Displays the insight into a specific dependency in root project 'project-one'.
+project-one:dependencyInsight - Displays the insight into a specific dependency in project ':dependencies-proj'.
+dependentComponents - Displays the dependent components of components in root project 'project-one'. [incubating]
+project-one:dependentComponents - Displays the dependent components of components in project ':dependencies-proj'. [incubating]
 help - Displays a help message.
-dependencies-proj:help - Displays a help message.
-model - Displays the configuration model of root project 'dependencies-proj'. [incubating]
-dependencies-proj:model - Displays the configuration model of project ':dependencies-proj'. [incubating]
-projects - Displays the sub-projects of root project 'dependencies-proj'.
-dependencies-proj:projects - Displays the sub-projects of project ':dependencies-proj'.
-properties - Displays the properties of root project 'dependencies-proj'.
-dependencies-proj:properties - Displays the properties of project ':dependencies-proj'.
-tasks - Displays the tasks runnable from root project 'dependencies-proj' (some of the displayed tasks may belong to subprojects).
-dependencies-proj:tasks - Displays the tasks runnable from project ':dependencies-proj'.
+project-one:help - Displays a help message.
+model - Displays the configuration model of root project 'project-one'. [incubating]
+project-one:model - Displays the configuration model of project ':dependencies-proj'. [incubating]
+projects - Displays the sub-projects of root project 'project-one'.
+project-one:projects - Displays the sub-projects of project ':dependencies-proj'.
+properties - Displays the properties of root project 'project-one'.
+project-one:properties - Displays the properties of project ':dependencies-proj'.
+tasks - Displays the tasks runnable from root project 'project-one' (some of the displayed tasks may belong to subprojects).
+project-one:tasks - Displays the tasks runnable from project ':dependencies-proj'.
 
 Verification tasks
 ------------------
-dependencies-proj:check - Runs all checks.
-dependencies-proj:ktlint - Check Kotlin code style.
-dependencies-proj:test - Runs the unit tests.
+project-one:check - Runs all checks.
+project-one:ktlint - Check Kotlin code style.
+project-one:test - Runs the unit tests.
 

--- a/cmd/fossa/cmd/analyze/analyze2.go
+++ b/cmd/fossa/cmd/analyze/analyze2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fossas/fossa-cli/analyzers/python"
 	"github.com/fossas/fossa-cli/analyzers/gradle"
 	"github.com/fossas/fossa-cli/analyzers/ruby"
+	"github.com/fossas/fossa-cli/analyzers/nodejs"
 	"github.com/fossas/fossa-cli/api/fossa"
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"

--- a/cmd/fossa/cmd/analyze/analyze2.go
+++ b/cmd/fossa/cmd/analyze/analyze2.go
@@ -11,8 +11,8 @@ import (
 	"github.com/urfave/cli"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/fossas/fossa-cli/analyzers/nodejs"
 	"github.com/fossas/fossa-cli/analyzers/python"
+	"github.com/fossas/fossa-cli/analyzers/gradle"
 	"github.com/fossas/fossa-cli/analyzers/ruby"
 	"github.com/fossas/fossa-cli/api/fossa"
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
@@ -42,6 +42,7 @@ var Analyzers = []module.AnalyzerV2{
 	nodejs.NodeAnalyzer,
 	python.PythonAnalyzer,
 	ruby.RubyAnalyzer,
+	gradle.GradleAnalyzer,
 }
 
 // TODO: progress indicators, ...

--- a/module/analyzer2.go
+++ b/module/analyzer2.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -57,6 +58,20 @@ type Strategies struct {
 	SortedNames []StrategyName
 	// The set of optimal strategies. This will be used for warnings
 	Optimal []StrategyName
+}
+
+// FilepathStrategies maps strategies to the filepath they were found in.
+type FilepathStrategies map[Filepath]DiscoveredStrategies
+
+// AddStrategy adds a strategy with filepath to the FilepathStrategies.
+func (fileStrategies FilepathStrategies) AddStrategy(info os.FileInfo, path string, name StrategyName) {
+	moduleDir := filepath.Dir(path)
+	current, ok := fileStrategies[moduleDir]
+	if !ok {
+		current = make(DiscoveredStrategies)
+	}
+	current[name] = info.Name()
+	fileStrategies[moduleDir] = current
 }
 
 // The filepath is the relative filepath from the root of the module

--- a/module/analyzer2.go
+++ b/module/analyzer2.go
@@ -65,13 +65,12 @@ type FilepathStrategies map[Filepath]DiscoveredStrategies
 
 // AddStrategy adds a strategy with filepath to the FilepathStrategies.
 func (fileStrategies FilepathStrategies) AddStrategy(info os.FileInfo, path string, name StrategyName) {
-	moduleDir := filepath.Dir(path)
-	current, ok := fileStrategies[moduleDir]
+	current, ok := fileStrategies[path]
 	if !ok {
 		current = make(DiscoveredStrategies)
 	}
 	current[name] = info.Name()
-	fileStrategies[moduleDir] = current
+	fileStrategies[path] = current
 }
 
 // The filepath is the relative filepath from the root of the module

--- a/pkg/package.go
+++ b/pkg/package.go
@@ -41,6 +41,8 @@ type Deps map[ID]Package
 type Package struct {
 	ID ID
 
+	Usage map[string]bool
+
 	Imports []Import
 }
 


### PR DESCRIPTION
This PR adds better support for parsing Gradle projects and updates the analyzer to handle the V2 format. This update primarily focuses on the changes discussed in the gradle RFC and implements a better way to understand gradle projects and the relationship between dependencies, sub-projects, and configurations.

Two things to note:
1. Package tags are implemented using an additional field in the package object. This may change but for now it will be left as we improve upon out package tagging setup.
2. Gradle projects will fail when analyzed using the new analyzer due to a bug within the normalization code that cannot handle circular dependencies. Gradle does not allow circular dependencies, but due to the way projects are configured it is possible for them to appear that way to the CLI. I believe that this fix is related to the normalization logic and should be handled at a later date.