### PR TITLE
[FC-977] Added strategy for parsing package-lock.json files

### DIFF
--- a/analyzers/nodejs/nodejs.go
+++ b/analyzers/nodejs/nodejs.go
@@ -121,7 +121,7 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 			return nil
 		}
 
-		filesToCheckFor := append([]string{"package.json"}, npm.PossibleLockfileFilenames...)
+		filesToCheckFor := append([]string{"package.json", "yarn.lock"}, npm.PossibleLockfileFilenames...)
 
 		for _, filename := range filesToCheckFor {
 			if info.Name() == filename {

--- a/analyzers/nodejs/nodejs.go
+++ b/analyzers/nodejs/nodejs.go
@@ -120,7 +120,8 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 		if !info.IsDir() && info.Name() == "package.json" {
 			name := filepath.Base(filepath.Dir(path))
 			// Parse from project name from `package.json` if possible
-			if manifest, err := npm.FromManifest(path, "package.json"); err == nil && manifest.Name != "" {
+			var manifest npm.Manifest
+			if manifest, err = npm.FromManifest(path, "package.json"); err == nil && manifest.Name != "" {
 				name = manifest.Name
 			}
 
@@ -140,7 +141,8 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 				if info.Name() == filename {
 					name := filepath.Base(filepath.Dir(path))
 					// Parse from project name from `package-lock.json` or `npm-shrinkwrap.json` if possible
-					if lockfile, err := npm.FindAndReadLockfile(path); err == nil && lockfile.Name != "" {
+					var lockfile npm.Lockfile
+					if lockfile, err = npm.FindAndReadLockfile(path); err == nil && lockfile.Name != "" {
 						name = lockfile.Name
 					}
 

--- a/analyzers/nodejs/nodejs2.go
+++ b/analyzers/nodejs/nodejs2.go
@@ -176,7 +176,7 @@ func AnalyzeNodeModules(dir module.Filepath, target module.Filepath) (graph.Deps
 	// TODO: this seems to introduce an infinite loop
 	return graph.Deps{}, errors.NotImplementedError()
 	/*dir := filepath.Dir(path) // TODO: pass in the module path as well?
-	deps, err := npm.FromNodeModules(dir, "package.json")
+	deps, err := npm.FromNodeModules(dir)
 	if err != nil {
 		return graph.Deps{}, errors.UnknownError(err, "Couldn't scan node_modules")
 	}

--- a/analyzers/nodejs/nodejs_discover_test.go
+++ b/analyzers/nodejs/nodejs_discover_test.go
@@ -13,8 +13,8 @@ import (
 /* Nested Module Order
     └─┬ nested-modules
       └─┬ module-1
-	  ├── module-2
-	  └── module-3
+        ├── module-2
+        └── module-3
 */
 func TestNestedModules(t *testing.T) {
 	modules, err := nodejs.Discover("testdata/nested-modules", make(map[string]interface{}))
@@ -27,15 +27,26 @@ func TestNestedModules(t *testing.T) {
 }
 
 /* Ignored Module Order
-	└─┬ ignored-modules
-  	  ├── node_modules
-  	  └── bower_components
+    └─┬ ignored-modules
+      ├── node_modules
+      └── bower_components
 */
 func TestNodeModulesAndBowerIgnored(t *testing.T) {
 	modules, err := nodejs.Discover("testdata/ignored-modules", make(map[string]interface{}))
 	assert.NoError(t, err)
 	assert.Equal(t, len(modules), 1)
 	assert.Contains(t, modules, newModule("ignored-modules", "."))
+}
+
+/* With Only a package-lock.json
+    └─┬ only-package-lock
+      └── package-lock.json
+*/
+func TestModuleWithOnlyLockfile(t *testing.T) {
+	modules, err := nodejs.Discover("testdata/only-package-lock", make(map[string]interface{}))
+	assert.NoError(t, err)
+	assert.Equal(t, len(modules), 1)
+	assert.Contains(t, modules, newModule("only-package-lock", "."))
 }
 
 func newModule(name, location string) module.Module {

--- a/analyzers/nodejs/nodejs_test.go
+++ b/analyzers/nodejs/nodejs_test.go
@@ -148,6 +148,8 @@ var chaiDirectDep = pkg.Import{
 var npmChaiFixtures = []string{
 	filepath.Join("testdata", "chai", "installed"),
 	filepath.Join("testdata", "chai", "installed-lockfile"),
+	filepath.Join("testdata", "chai", "installed-yarn-lockfile"),
+	filepath.Join("testdata", "chai", "installed-shrinkwrap"),
 	filepath.Join("testdata", "chai", "dev-deps"),
 }
 
@@ -212,6 +214,7 @@ func testUsingNodeModuleFallback(t *testing.T, buildTarget string) {
 
 	chaiProject := analysisResults.Transitive[chaiDirectDep.Resolved]
 	assert.NotNil(t, chaiProject)
+	assert.Equal(t, len(chaiProject.Imports), 6)
 	assertImport(t, chaiProject.Imports, "assertion-error", "1.1.0")
 	assertImport(t, chaiProject.Imports, "check-error", "1.0.2")
 	assertImport(t, chaiProject.Imports, "get-func-name", "2.0.0")

--- a/analyzers/nodejs/testdata/chai/installed-shrinkwrap/npm-shrinkwrap.json
+++ b/analyzers/nodejs/testdata/chai/installed-shrinkwrap/npm-shrinkwrap.json
@@ -1,0 +1,54 @@
+{
+  "name": "testdata",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    }
+  }
+}

--- a/analyzers/nodejs/testdata/only-package-lock/package-lock.json
+++ b/analyzers/nodejs/testdata/only-package-lock/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "a": {
+      "version": "1.0.0",
+      "requires": {
+        "b": "^2.0.0",
+        "c": "^3.0.0",
+        "d": "^4.0.0"
+      }
+    },
+    "b": {
+      "version": "2.0.0",
+      "requires": {
+        "c": "^3.0.0"
+      }
+    },
+    "c": {
+      "version": "3.0.0"
+    },
+    "d": {
+      "version": "4.0.0"
+    }
+  }
+}

--- a/buildtools/npm/lockfile.go
+++ b/buildtools/npm/lockfile.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fossas/fossa-cli/pkg"
 )
 
-var PossibleLockfileFilenames = [...]string{"package-lock.json", "npm-shrinkwrap.json"}
+var PossibleLockfileFilenames = [...]string{"npm-shrinkwrap.json", "package-lock.json"}
 
 type Lockfile struct {
 	Name         string

--- a/buildtools/npm/lockfile.go
+++ b/buildtools/npm/lockfile.go
@@ -59,7 +59,6 @@ func retrieveTransitiveInformation(deps Dependencies) (DependencyMap, DeepDepIds
 		}
 
 		// save IDs of dependencies that are required by this dependency
-		// NOTE: this implies that direct deps that are also deep deps aren't considered direct
 		depMap[id] = []pkg.ID{}
 		for depName, version := range info.Requires {
 			depId := pkg.ID{
@@ -98,6 +97,7 @@ func FromLockfile(path string) (graph.Deps, error) {
 
 	for id, depIds := range depMap {
 		// this ID is a direct dependency if it's not a deep dependency
+		// NOTE: this implies that direct deps that are also deep deps aren't considered direct
 		if _, ok := deepDepIds[id]; !ok {
 			directDeps = append(directDeps, pkg.Import{
 				Target:   id.Name,

--- a/buildtools/npm/lockfile.go
+++ b/buildtools/npm/lockfile.go
@@ -1,0 +1,125 @@
+package npm
+
+import (
+	"path/filepath"
+
+	"github.com/fossas/fossa-cli/errors"
+	"github.com/fossas/fossa-cli/files"
+	"github.com/fossas/fossa-cli/graph"
+	"github.com/fossas/fossa-cli/pkg"
+)
+
+var PossibleLockfileFilenames = [...]string{"package-lock.json", "npm-shrinkwrap.json"}
+
+type Lockfile struct {
+	Name         string
+	Version      string
+	Dependencies Dependencies
+}
+
+type DependencyLockEntry struct {
+	Version      string
+	Requires     map[string]string
+	Dependencies map[string]*DependencyLockEntry
+}
+
+type Dependencies map[string]*DependencyLockEntry
+type DependencyMap map[pkg.ID][]pkg.ID
+type DeepDepIdsSet map[pkg.ID]bool
+
+// FindAndReadLockfile checks the root of the node project at the given path for lockfiles, then returns the parsed
+// contents if one is found
+func FindAndReadLockfile(path string) (Lockfile, error) {
+	var lockfile Lockfile
+
+	for _, filename := range PossibleLockfileFilenames {
+		filePath := filepath.Join(path, filename)
+		exists, err := files.Exists(filePath)
+
+		if err == nil && exists {
+			err := files.ReadJSON(&lockfile, filePath)
+			return lockfile, err
+		}
+	}
+
+	return lockfile, errors.Newf("none of %v found at root of node project", PossibleLockfileFilenames)
+}
+
+// scanLockfileForDependencyInfo recursively scans a lockfile to construct a map of package IDs to their requirements
+// as well as a set of the package IDs that have been required by other dependencies somewhere else in the file
+func scanLockfileForDependencyInfo(deps Dependencies) (DependencyMap, DeepDepIdsSet) {
+	depMap := DependencyMap{}
+	deepDepIds := DeepDepIdsSet{}
+
+	for name, info := range deps {
+		id := pkg.ID{
+			Type:     pkg.NodeJS,
+			Name:     name,
+			Revision: info.Version,
+		}
+
+		// save IDs of dependencies that are required by this dependency
+		depMap[id] = []pkg.ID{}
+		for depName, version := range info.Requires {
+			depId := pkg.ID{
+				Type:     pkg.NodeJS,
+				Name:     depName,
+				Revision: version,
+			}
+			depMap[id] = append(depMap[id], depId)
+			deepDepIds[depId] = true
+		}
+
+		// recurse if this dependency has its own "dependencies" map
+		innerDepMap, moreDeepDepIds := scanLockfileForDependencyInfo(info.Dependencies)
+		for k, v := range innerDepMap {
+			depMap[k] = v
+		}
+		for k := range moreDeepDepIds {
+			deepDepIds[k] = true
+		}
+	}
+
+	return depMap, deepDepIds
+}
+
+// FromLockfile generates the dep graph based on the lockfile provided at the supplied path
+func FromLockfile(path string) (graph.Deps, error) {
+	lockfile, err := FindAndReadLockfile(path)
+	if err != nil {
+		return graph.Deps{}, err
+	}
+
+	depMap, deepDepIds := scanLockfileForDependencyInfo(lockfile.Dependencies)
+
+	directDeps := pkg.Imports{}
+	transitiveDeps := map[pkg.ID]pkg.Package{}
+
+	for id, depIds := range depMap {
+		// this ID is a direct dependency if it's not a deep dependency
+		if _, ok := deepDepIds[id]; !ok {
+			directDeps = append(directDeps, pkg.Import{
+				Target:   id.Name,
+				Resolved: id,
+			})
+		}
+
+		// gather transitive dependencies for ID
+		var imports pkg.Imports
+		for _, depId := range depIds {
+			imports = append(imports, pkg.Import{
+				Target:   depId.Name,
+				Resolved: depId,
+			})
+		}
+		transitiveDeps[id] = pkg.Package{
+			ID:      id,
+			Imports: imports,
+		}
+	}
+
+	return graph.Deps{
+		Direct:     directDeps,
+		Transitive: transitiveDeps,
+	}, nil
+}

--- a/buildtools/npm/manifest.go
+++ b/buildtools/npm/manifest.go
@@ -55,8 +55,8 @@ func PackageFromManifest(pathElems ...string) (pkg.Package, error) {
 }
 
 // FromNodeModules generates the dep graph based on the manifest provided at the supplied path
-func FromNodeModules(pathElems ...string) (graph.Deps, error) {
-	manifestPath := filepath.Join(pathElems...)
+func FromNodeModules(path string) (graph.Deps, error) {
+	manifestPath := filepath.Join(path, "package.json")
 	exists, err := files.Exists(manifestPath)
 	if err != nil {
 		return graph.Deps{}, err
@@ -84,17 +84,6 @@ func FromNodeModules(pathElems ...string) (graph.Deps, error) {
 		Direct:     rootPackage.Imports,
 		Transitive: transitiveDeps,
 	}, nil
-}
-
-type Lockfile struct {
-	Dependencies map[string]struct {
-		Version  string
-		Requires map[string]string
-	}
-}
-
-func FromLockfile(filename string) (Lockfile, error) {
-	return Lockfile{}, errors.NotImplementedError()
 }
 
 // TODO: add support for NODE_PATH and GLOBAL_FOLDERS.
@@ -129,7 +118,7 @@ func convertManifestToPkg(manifest Manifest) pkg.Package {
 
 	var imports pkg.Imports
 	for depName, version := range manifest.Dependencies {
-		id := pkg.ID{
+		depID := pkg.ID{
 			Type:     pkg.NodeJS,
 			Name:     depName,
 			Revision: version,
@@ -137,7 +126,7 @@ func convertManifestToPkg(manifest Manifest) pkg.Package {
 
 		depImport := pkg.Import{
 			Target:   depName,
-			Resolved: id,
+			Resolved: depID,
 		}
 		imports = append(imports, depImport)
 	}

--- a/buildtools/npm/testdata/only_package_lock/package-lock.json
+++ b/buildtools/npm/testdata/only_package_lock/package-lock.json
@@ -1,0 +1,68 @@
+{
+  "name": "testdata",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+        }
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+        }
+      }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+    },
+    "type-detect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
+      "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U="
+    }
+  }
+}

--- a/docs/integrations/nodejs.md
+++ b/docs/integrations/nodejs.md
@@ -27,7 +27,9 @@ analyze:
 Analysis for nodejs projects is executed a number of ways starting with the most accurate method and falling back to the least likely method to succeed as ordered:
 1. Parse output from `npm ls --json --production` - Runs if `npm` exists on the system and provides an accurate list of all dependencies needed to build the production project.
 2. Parse `package.json` - Runs if `package.json` can be successfully parsed into a dependency graph.
-3. Parse `yarn.lock` - Final strategy which detects dependencies based on the yarn lockfile.
+3. Parse `yarn.lock` - Detects dependencies based on the yarn lockfile.
+4. Parse `npm-shrinkwrap.json` - Detects dependencies based on the lockfile.
+5. Parse `package-lock.json` - Detects dependencies based on the lockfile.
 
 ## Known limitations
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -107,3 +107,7 @@ func (err *Error) WrapCause(msg string) *Error {
 func New(msg string) error {
 	return errors.New(msg)
 }
+
+func Newf(msg string, args ...interface{}) error {
+	return errors.New(fmt.Sprintf(msg, args...))
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -107,7 +107,3 @@ func (err *Error) WrapCause(msg string) *Error {
 func New(msg string) error {
 	return errors.New(msg)
 }
-
-func Newf(msg string, args ...interface{}) error {
-	return errors.New(fmt.Sprintf(msg, args...))
-}


### PR DESCRIPTION
Now the last fallback strategy for npm.Analyze will look for and parse package-lock.json files. It also works for npm-shrinkwrap.json files, that follow the same format. I also changed the discovery method for nodejs to check for package-lock.json files.