### PR TITLE
test (analyzer strategies) test the order that strategies are selected

### DIFF
--- a/module/module_test.go
+++ b/module/module_test.go
@@ -1,0 +1,66 @@
+package module_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/fossas/fossa-cli/cmd/fossa/display"
+	"github.com/fossas/fossa-cli/errors"
+	"github.com/fossas/fossa-cli/graph"
+	"github.com/fossas/fossa-cli/module"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/semaphore"
+)
+
+func TestOptimalAndSortedStrategies(t *testing.T) {
+	test := module.AnalyzerV2{
+		Name: "testing",
+		Strategies: module.Strategies{
+			Named: map[module.StrategyName]module.Strategy{
+				"one": func(module.Filepath, module.Filepath) (graph.Deps, *errors.Error) {
+					return graph.Deps{}, &errors.Error{Cause: fmt.Errorf("one failed")}
+				},
+				"two": func(module.Filepath, module.Filepath) (graph.Deps, *errors.Error) {
+					return graph.Deps{}, nil
+				},
+				"three": func(module.Filepath, module.Filepath) (graph.Deps, *errors.Error) {
+					return graph.Deps{}, nil
+				},
+				"four": func(module.Filepath, module.Filepath) (graph.Deps, *errors.Error) {
+					return graph.Deps{}, &errors.Error{Cause: fmt.Errorf("four failed")}
+				},
+				"five": func(module.Filepath, module.Filepath) (graph.Deps, *errors.Error) {
+					return graph.Deps{}, nil
+				},
+			},
+			SortedNames: []module.StrategyName{"one", "two", "three", "four", "five"},
+			Optimal:     []module.StrategyName{"one", "two"},
+		},
+	}
+
+	disp := display.StartDisplay()
+	defer disp.Stop()
+	ctx := context.Background()
+	sem := semaphore.NewWeighted(int64(1))
+	startJob := func() error {
+		return sem.Acquire(ctx, 1)
+	}
+	endJob := func() {
+		sem.Release(1)
+	}
+	progress := disp.StartProcess(test.Name)
+
+	strategiesToScan := map[string]string{
+		"one":     "file-one",
+		"two":     "file-two",
+		"three":   "file-three",
+		"four":    "file-four",
+		"unknown": "unknown",
+	}
+
+	graphs, err := test.ScanModule(startJob, endJob, progress, ".", strategiesToScan)
+	assert.Nil(t, err)
+	expectedGraphOrder := []module.TaggedGraph{module.TaggedGraph{Strategy: "two", File: "file-two"}, module.TaggedGraph{Strategy: "three", File: "file-three"}}
+	assert.Equal(t, expectedGraphOrder, graphs)
+}

--- a/module/module_test.go
+++ b/module/module_test.go
@@ -52,10 +52,10 @@ func TestOptimalAndSortedStrategies(t *testing.T) {
 	progress := disp.StartProcess(test.Name)
 
 	strategiesToScan := map[string]string{
-		"one":     "file-one",
+		"four":    "file-four",
 		"two":     "file-two",
 		"three":   "file-three",
-		"four":    "file-four",
+		"one":     "file-one",
 		"unknown": "unknown",
 	}
 


### PR DESCRIPTION
This PR introduces testing for the `module.Analyzer` file that handles scanning modules. This test ensures that the proper strategies are tested and that they are ordered correctly, even though they may not be scanned in the same order. This PR also prevents unrecognized strategies from crashing the scanner.