### PR TITLE
[FC-1059] Added consideration of lockfiles to nodejs IsBuilt()

### DIFF
--- a/analyzers/nodejs/nodejs.go
+++ b/analyzers/nodejs/nodejs.go
@@ -239,7 +239,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	// if npm as a tool does not exist, skip this
 	if a.NPM.Exists() {
 		pkgs, err := a.NPM.List(a.Module.BuildTarget)
-		if err != nil && len(pkgs.Dependencies) > 0 {
+		if err == nil && len(pkgs.Dependencies) > 0 {
 			// TODO: we should move this functionality in to the buildtool, and have it
 			// return `pkg.Package`s.
 			// Set direct dependencies.

--- a/analyzers/nodejs/nodejs_test.go
+++ b/analyzers/nodejs/nodejs_test.go
@@ -25,8 +25,9 @@ import (
 // in the transitive dependency list contains the correct dependency imports.
 func TestNDepsTransitiveImports(t *testing.T) {
 	m := module.Module{
-		Dir:  filepath.Join("testdata", "transitive-deps"),
-		Type: pkg.NodeJS,
+		Type:        pkg.NodeJS,
+		Dir:         filepath.Join("testdata", "transitive-deps"),
+		BuildTarget: filepath.Join("testdata", "transitive-deps"),
 	}
 
 	a, err := analyzers.New(m)
@@ -70,8 +71,9 @@ func TestNDepsTransitiveImports(t *testing.T) {
 // `dependencies`.
 func TestNoDependencies(t *testing.T) {
 	m := module.Module{
-		Dir:  filepath.Join("testdata", "empty"),
-		Type: pkg.NodeJS,
+		Type:        pkg.NodeJS,
+		Dir:         filepath.Join("testdata", "empty"),
+		BuildTarget: filepath.Join("testdata", "empty"),
 	}
 
 	a, err := analyzers.New(m)


### PR DESCRIPTION
Although we added support for package-lock.json parsing to npm analyzer, those files would never be parsed because the project needs to pass the "IsBuilt" check before getting analyzed. Also the first analysis strategy is `npm ls`, and for "unbuilt" projects `npm ls` just returns 0 and prints `{}` to stdout, so I also changed it so that fallback strategies are used if `npm ls` returns no deps.

Directory:
```
~/g/s/g/f/f/b/n/t/only_package_lock ❯❯❯ ls
package-lock.json
```
Before:
```
~/g/s/g/f/f/b/n/t/only_package_lock ❯❯❯ fossa analyze --output
⢿ Analyzing module (1/1): . WARNING Could not determine whether module is built: could not parse package manifest to check build: open package.json: no such file or directory
WARNING Module does not appear to be built
[{"Name":".","Type":"commonjspackage","Manifest":".","Build":{"Artifact":"default","Context":null,"Succeeded":true,"Imports":null,"Dependencies":null}}]
```
After:
```
~/g/s/g/f/f/b/n/t/only_package_lock ❯❯❯ fossa analyze --verbose --output
⣯ Analyzing module (1/1): . WARNING Could not determine deps from npm ls
WARNING Could not determine deps from node_modules
WARNING Could not determine deps from yarn lockfile
[{"Name":".","Type":"commonjspackage","Manifest":".","Build":{"Artifact":"default","Context":null,"Succeeded":true,"Imports":["npm+chai$4.1.2","npm+type-detect$3.0.0"],"Dependencies":[{"locator":"npm+deep-eql$3.0.1","imports":["npm+type-detect$4.0.8"]},{"locator":"npm+type-detect$4.0.8"},{"locator":"npm+get-func-name$2.0.0"},{"locator":"npm+pathval$1.1.0"},{"locator":"npm+type-detect$3.0.0"},{"locator":"npm+assertion-error$1.1.0"},{"locator":"npm+chai$4.1.2","imports":["npm+assertion-error$1.1.0","npm+check-error$1.0.2","npm+deep-eql$3.0.1","npm+get-func-name$2.0.0","npm+pathval$1.1.0","npm+type-detect$4.0.8"]},{"locator":"npm+check-error$1.0.2"}]}}]
```