### PR TITLE
Replace "Python" with "Ruby" in Ruby documentation

### DIFF
--- a/docs/integrations/ruby.md
+++ b/docs/integrations/ruby.md
@@ -16,7 +16,7 @@ Run `fossa init` to walk the file tree and detect all directories which contain 
 
 ### Manual
 
-Add a module with `type: gem`, and `target` and `path` set to the root of the Python project.
+Add a module with `type: gem`, and `target` and `path` set to the root of the Ruby project.
 
 ```yaml
 analyze:


### PR DESCRIPTION
curl https://api.github.com/users/technoweenie -I
HTTP/1.1 200 OK
X-GitHub-Media-Type: github.v3
curl https://api.github.com/users/technoweenie -I \
 -H "Accept: application/vnd.github.full+json"
HTTP/1.1 200 OK
X-GitHub-Media-Type: github.v3; param=full; format=json
curl https://api.github.com/users/technoweenie -I \
 -H "Accept: application/vnd.github.v3.full+json"
HTTP/1.1 200 OK
X-GitHub-Media-Type: github.v3; param=full