### PR TITLE
Add DownloadURL to Revision type

### DIFF
--- a/api/fossa/revisions.go
+++ b/api/fossa/revisions.go
@@ -31,6 +31,7 @@ type Revision struct {
 	Issues         []Issue
 	Version        string
 	Hash           string
+	DownloadURL    string
 }
 
 type DependencyLock struct {


### PR DESCRIPTION
This PR adds the DownloadURL field to the Revisions type, which allows the FOSSA service to report the URL from which a dependency is downloaded in the JSON report generated by the CLI.