### PR TITLE
fix (gradle error) error on exit code and stderr

### DIFF
--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -1,6 +1,7 @@
 package gradle
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -237,11 +238,16 @@ func Cmd(command string, timeout string, retries int, taskArgs ...string) (strin
 	}
 
 	stdout, stderr, err := exec.Run(tempcmd)
-	if stderr != "" {
-		return stdout, errors.Errorf("%s", stderr)
+	if err != nil {
+		return stdout, &errors.Error{
+			Cause:           err,
+			Type:            errors.Exec,
+			Troubleshooting: fmt.Sprintf("Fossa could not run `%s %s` within the current directory. Try running this command and ensure that gradle is installed in your environment.\nstdout: %s\nstderr: %s", command, taskArgs, stdout, stderr),
+			Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/integrations/gradle.md#gradle",
+		}
 	}
 
-	return stdout, err
+	return stdout, nil
 }
 
 // ValidBinary finds the best possible gradle command to run for

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -238,7 +238,7 @@ func Cmd(command string, timeout string, retries int, taskArgs ...string) (strin
 	}
 
 	stdout, stderr, err := exec.Run(tempcmd)
-	if err != nil {
+	if err != nil && stderr != "" {
 		return stdout, &errors.Error{
 			Cause:           err,
 			Type:            errors.Exec,


### PR DESCRIPTION
This fix ensures that the FOSSA CLI will error out only when gradle exits with an exit code and with output on stderr. The reasoning for this is that we have seen scenarios where gradle will output on stderr but successfully run the gradle task and output success on stdout. We have also seen scenarios where gradle will exit with a failure code but successfully run and ouput on stdout. The variations here are unpredictable due to different plugins and different setups and often are impossible for their users to debug. This update ensures that we will only fail when see both failure signals.