### PR TITLE
fix (gradle sub projects) remove gradle sub projects for better graphs

### DIFF
--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -282,6 +282,10 @@ func NormalizeDependencies(imports []Dependency, deps map[Dependency][]Dependenc
 	// Set direct dependencies.
 	var i []pkg.Import
 	for _, dep := range imports {
+		if dep.IsProject {
+			continue
+		}
+
 		i = append(i, pkg.Import{
 			Target: dep.RequestedVersion,
 			Resolved: pkg.ID{
@@ -295,6 +299,10 @@ func NormalizeDependencies(imports []Dependency, deps map[Dependency][]Dependenc
 	// Set transitive dependencies.
 	d := make(map[pkg.ID]pkg.Package)
 	for parent, children := range deps {
+		if parent.IsProject {
+			continue
+		}
+
 		id := pkg.ID{
 			Type:     pkg.Gradle,
 			Name:     parent.Name,

--- a/buildtools/gradle/gradle_test.go
+++ b/buildtools/gradle/gradle_test.go
@@ -37,17 +37,12 @@ func TestAllDependencies(t *testing.T) {
 		assert.NoError(t, err)
 
 		direct := graph["test"].Direct
-		assert.Equal(t, 3, len(direct))
-		helpers.AssertPackageImport(t, direct, "core", "")
+		assert.Equal(t, 2, len(direct))
 		helpers.AssertPackageImport(t, direct, "dep:one", "1.0")
 		helpers.AssertPackageImport(t, direct, "dep:two", "2.0")
 
 		transitive := graph["test"].Transitive
-		assert.Equal(t, 6, len(transitive))
-
-		packageProject := helpers.PackageInTransitiveGraph(transitive, "core", "")
-		assert.NotEmpty(t, packageProject)
-		assert.Equal(t, 0, len(packageProject.Imports))
+		assert.Equal(t, 5, len(transitive))
 
 		packageOne := helpers.PackageInTransitiveGraph(transitive, "dep:one", "1.0")
 		assert.NotEmpty(t, packageOne)


### PR DESCRIPTION
Gradle subprojects appear in the Gradle dependency tree and we have always treated them equal to third party dependencies which results in them being uploaded to the FOSSA server and appearing in the dependency graph as unknown. There is an argument to be made that including them improves the accuracy of the cli dependency graph, although they also lead to unclear output for users in the form of unknown dependencies. Unfortunately in large Gradle projects, there are commonly over 100 unknown dependencies that cause many problems during integration. This PR removes Gradle projects from the uploaded dependency graph which results in projects not appearing as unknown dependencies and dependencies found in a subproject in the Gradle graph appearing as direct dependencies as opposed to deep dependencies. I believe that having subproject's dependencies appear as direct dependencies is more accurate as they are directly included by the user in code.

The following images will help to understand the motivation and results:
Simple Gradle output which is used to create the two following projects
```
compile - Dependencies for source set 'main'.
+--- project :grpc-core
|    +--- com.google.guava:guava:19.0
|    \--- com.google.code.findbugs:jsr305:3.0.0
\--- io.netty:netty-codec-http2:[4.1.0.CR7] -> 4.1.0.CR7
     +--- io.netty:netty-codec-http:4.1.0.CR7
     |    \--- io.netty:netty-codec:4.1.0.CR7
     |         \--- io.netty:netty-transport:4.1.0.CR7
     |              +--- io.netty:netty-buffer:4.1.0.CR7
     |              |    \--- io.netty:netty-common:4.1.0.CR7
     |              \--- io.netty:netty-resolver:4.1.0.CR7
     |                   \--- io.netty:netty-common:4.1.0.CR7
     \--- io.netty:netty-handler:4.1.0.CR7
          +--- io.netty:netty-buffer:4.1.0.CR7 (*)
          +--- io.netty:netty-transport:4.1.0.CR7 (*)
          \--- io.netty:netty-codec:4.1.0.CR7 (*)
```

UI without this PR's changes
<img width="965" alt="Screen Shot 2019-11-18 at 9 29 55 PM" src="https://user-images.githubusercontent.com/31230447/69120208-d32e2e00-0a4d-11ea-9317-7f647f0a3fd6.png">

UI with this PR's changes (notice that "FindBugs" & "Guava" are now direct dependencies and there are 0 unknown dependencies to cause confusion):
<img width="973" alt="Screen Shot 2019-11-18 at 9 29 31 PM" src="https://user-images.githubusercontent.com/31230447/69120215-d88b7880-0a4d-11ea-9a18-3bb5e753c725.png">
