### PR TITLE
Request download url when rendering reports

### DIFF
--- a/api/fossa/revisions.go
+++ b/api/fossa/revisions.go
@@ -65,10 +65,11 @@ const RevisionsDependenciesAPI = "/api/revisions/%s/dependencies"
 func GetRevisionDependencies(locator Locator, licenseText bool) ([]Revision, error) {
 	var revisions []Revision
 	licenseParams := url.Values{}
+	licenseParams.Add("includeDownloadUrl", "true")
+
 	if licenseText {
 		licenseParams.Add("include_license_text", "true")
 		licenseParams.Add("generate_attribution", "true")
-		licenseParams.Add("includeDownloadUrl", "true")
 	}
 
 	url := fmt.Sprintf(RevisionsDependenciesAPI, url.PathEscape(locator.OrgString())) + "?" + licenseParams.Encode()

--- a/api/fossa/revisions.go
+++ b/api/fossa/revisions.go
@@ -68,6 +68,7 @@ func GetRevisionDependencies(locator Locator, licenseText bool) ([]Revision, err
 	if licenseText {
 		licenseParams.Add("include_license_text", "true")
 		licenseParams.Add("generate_attribution", "true")
+		licenseParams.Add("includeDownloadUrl", "true")
 	}
 
 	url := fmt.Sprintf(RevisionsDependenciesAPI, url.PathEscape(locator.OrgString())) + "?" + licenseParams.Encode()


### PR DESCRIPTION
FOSSA onprem 2.1.10 requires clients specify an `includeDownloadUrl` query parameter when requesting dependencies if the client wishes to view the download url for the dependencies.

This PR adds that functionality to the FOSSA CLI for the `dependencies` and `licenses` reports.