### PR TITLE
fix (hanging commands) refactor sbt and timeout hanging commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ cmd/fossa/fossa
 analyzers/gradle/testdata/discover-groovy/.gradle
 analyzers/gradle/testdata/discover-groovy/.project
 analyzers/gradle/testdata/discover-groovy/.settings
+analyzers/gradle/testdata/discover-kotlin/.gradle
+analyzers/gradle/testdata/discover-nested/nested/.gradle

--- a/analyzers/golang/discover.go
+++ b/analyzers/golang/discover.go
@@ -36,7 +36,8 @@ func Discover(dir string, opts map[string]interface{}) ([]module.Module, error) 
 
 	cmd, _, err := exec.Which("version", options.Cmd, "go")
 	if err != nil {
-		return nil, errors.New("`go` not found, skipping searching for Go projects")
+		log.Debug("`go` not found, skipping searching for Go projects")
+		return nil, nil
 	}
 
 	g := gocmd.Go{

--- a/analyzers/scala/scala.go
+++ b/analyzers/scala/scala.go
@@ -79,17 +79,8 @@ func New(m module.Module) (*Analyzer, error) {
 func Discover(dir string, options map[string]interface{}) ([]module.Module, error) {
 	log.WithField("dir", dir).Debug("discovering modules")
 
-	// Construct SBT instance (for listing projects).
-	sbtCmd, _, err := exec.WhichArgs([]string{"-no-colors", "about"}, os.Getenv("SBT_BINARY"), "sbt")
-	if err != nil {
-		return nil, nil
-	}
-	sbt := sbt.SBT{
-		Bin: sbtCmd,
-	}
-
 	var modules []module.Module
-	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		log.WithField("path", path).Debug("discovering modules")
 
 		if err != nil {
@@ -107,6 +98,16 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 				return nil
 			}
 			log.Debug("Path has build.sbt")
+
+			// Construct SBT instance (for listing projects).
+			sbtCmd, _, err := exec.WhichArgs([]string{"-no-colors", "about"}, os.Getenv("SBT_BINARY"), "sbt")
+			if err != nil {
+				return nil
+			}
+
+			sbt := sbt.SBT{
+				Bin: sbtCmd,
+			}
 
 			dir := filepath.Dir(path)
 			projects, err := sbt.Projects(dir)

--- a/buildtools/sbt/sbt.go
+++ b/buildtools/sbt/sbt.go
@@ -133,6 +133,12 @@ func FilterLine(line string) bool {
 		strings.HasPrefix(infoMsg, "Updating ") ||
 		strings.HasPrefix(infoMsg, "Done ") ||
 		strings.HasPrefix(infoMsg, "downloading ") ||
+		strings.HasPrefix(infoMsg, `Welcome to the build`) ||
+		infoMsg == `           __    __` ||
+		infoMsg == `     _____/ /_  / /_` ||
+		infoMsg == `    / ___/ __ \/ __/` ||
+		infoMsg == `   (__  ) /_/ / /_` ||
+		infoMsg == `  /____/_.___/\__/` ||
 		strings.HasPrefix(strings.TrimSpace(infoMsg), "[SUCCESSFUL ]"))
 }
 

--- a/exec/which.go
+++ b/exec/which.go
@@ -12,11 +12,13 @@ func Which(arg string, cmds ...string) (cmd string, output string, err error) {
 }
 
 // WhichArgs is `Which` but passes multiple arguments to each candidate.
+// The default timeout is set to 5 minutes to kill hanging commands.
 func WhichArgs(argv []string, cmds ...string) (cmd string, output string, err error) {
 	return WhichWithResolver(cmds, func(cmd string) (string, bool, error) {
 		stdout, stderr, err := Run(Cmd{
-			Name: cmd,
-			Argv: argv,
+			Name:    cmd,
+			Argv:    argv,
+			Timeout: "5m",
 		})
 		if err != nil {
 			return "", false, err


### PR DESCRIPTION
This PR does four things.

1. Refactor the SBT discover function to first detect the presence of build.sbt before trying to run sbt about. The command is only ever used once as filepath.SkipDir is called once sbt projects is run so this does not increase complexity.
2. Make 5 minutes the default timeout when running which to determine the best command. This prevents hanging commands from ruining the pipeline but is long enough to kill any existing commands.
3. Fixes an error with parsing newer sbt output. Refer to code changes to see the new lines that are also skipped.
4. Turn the go not found warning into a debug message. This has led to a lot of confusing behavior and debug should provide the same amount of information for those missing the command.