### PR TITLE
fix (walk error) handle a case where path.go returns a nil file

### DIFF
--- a/analyzers/bazel/bazel.go
+++ b/analyzers/bazel/bazel.go
@@ -50,6 +50,7 @@ func Discover(dir string, opts map[string]interface{}) ([]module.Module, error) 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.WithError(err).WithField("path", path).Debug("error while walking for discovery")
+			return err
 		}
 
 		if !info.IsDir() && (info.Name() == "BUILD" || info.Name() == "BUILD.bazel") {

--- a/analyzers/clojure/clojure.go
+++ b/analyzers/clojure/clojure.go
@@ -56,6 +56,7 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.WithError(err).WithField("path", path).Debug("error while walking for discovery")
+			return err
 		}
 
 		if !info.IsDir() && info.Name() == "project.clj" {

--- a/analyzers/cocoapods/cocoapods.go
+++ b/analyzers/cocoapods/cocoapods.go
@@ -75,6 +75,7 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.WithError(err).WithField("path", path).Debug("error while walking for discovery")
+			return err
 		}
 
 		if !info.IsDir() && info.Name() == "Podfile" {

--- a/analyzers/ruby/ruby.go
+++ b/analyzers/ruby/ruby.go
@@ -61,6 +61,7 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.WithError(err).WithField("path", path).Debug("error while walking for discovery")
+			return err
 		}
 
 		if !info.IsDir() && info.Name() == "Gemfile" {

--- a/analyzers/rust/rust.go
+++ b/analyzers/rust/rust.go
@@ -50,6 +50,7 @@ func Discover(dir string, options map[string]interface{}) ([]module.Module, erro
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.WithError(err).WithField("path", path).Debug("error while walking for discovery")
+			return err
 		}
 
 		if !info.IsDir() && info.Name() == "Cargo.lock" {


### PR DESCRIPTION
When path.go encounters an error it will pass that error into the user-provided walk function as well as a `nil` value for the file. In some areas of our codebase, we are returning this error and in others, we are simply logging it. In some scenarios, this can cause the FOSSA CLI to panic when it tries to read file information about a file that does not exist.