### PR TITLE
Handle the "Download" line in Maven

### DIFF
--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -168,6 +168,9 @@ func ParseDependencyTree(stdin string) (graph.Deps, error) {
 		if strings.HasPrefix(line, "[INFO] Downloading ") || strings.HasPrefix(line, "[WARNING]") {
 			continue
 		}
+		if strings.HasPrefix(line, "Download") {
+			continue
+		}
 		if started {
 			filteredLines = append(filteredLines, line)
 		}

--- a/buildtools/maven/testdata/dos.out
+++ b/buildtools/maven/testdata/dos.out
@@ -5,6 +5,7 @@
 [INFO] --------------------------------[ jar ]---------------------------------
 [INFO] 
 [INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ fossa ---
+Downloading: http://somewhere.com
 [INFO] fossa:test:jar:1-SNAPSHOT
 [INFO] +- dep:one:jar:1.0.0:compile
 [INFO] ------------------------------------------------------------------------


### PR DESCRIPTION
A panic was found in the Maven parser due to output formatted like the below text where `Downloading` or `Downloaded` appears after dependencies begin to appear. I looked into checking the array length, but this ended up messing with the parsing logic and resulted in incorrect graphs.
The solution was to filter lines that begin with `Download` from the output which we already do for other types of lines.
Tests are included.

```
[INFO] ---------------------< fossa:test >----------------------
[INFO] Maven dos formatted output with CRLR line endings.
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ fossa ---
Downloading: http://somewhere.com
[INFO] fossa:test:jar:1-SNAPSHOT
```