### PR TITLE
Allow Leiningen to output on stderr without failing

### DIFF
--- a/analyzers/clojure/clojure.go
+++ b/analyzers/clojure/clojure.go
@@ -113,7 +113,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	if err == nil && len(dependencies.Direct) > 0 {
 		return dependencies, nil
 	}
-	log.Warnf("FALLING BACK to parse clojure project file.\nLeiningen analysis could not be run, address the following error for more accurate results:\n%s", err.Troubleshooting)
+	log.Warnf("FALLING BACK to parse clojure project files which will result in less accurate results.\nAddress the following error from Leiningen to improve the analysis results:\n%s", err.Troubleshooting)
 	log.Debug(err.Error())
 
 	// 3. Parse `project.clj` as best as we can.

--- a/buildtools/leiningen/leiningen.go
+++ b/buildtools/leiningen/leiningen.go
@@ -53,7 +53,7 @@ func ShellOutput(binary, dir string) Output {
 				return stdout, &errors.Error{
 					Cause:           err,
 					Type:            errors.Exec,
-					Troubleshooting: fmt.Sprintf("Ensure that %s is installed correctly and that `%s %s` can be run in the directory `%s`.\nstdout: %s\nstderr: %", binary, binary, strings.Join(args, " "), dir, stdout, stderr),
+					Troubleshooting: fmt.Sprintf("Ensure that %s is installed correctly and that `%s %s` can be run in the directory `%s`.\nstdout: %s\nstderr: %s", binary, binary, strings.Join(args, " "), dir, stdout, stderr),
 				}
 			}
 

--- a/buildtools/leiningen/leiningen.go
+++ b/buildtools/leiningen/leiningen.go
@@ -49,11 +49,11 @@ func ShellOutput(binary, dir string) Output {
 			}
 
 			stdout, stderr, err := exec.Run(cmd)
-			if stderr != "" || err != nil {
+			if err != nil {
 				return stdout, &errors.Error{
 					Cause:           err,
 					Type:            errors.Exec,
-					Troubleshooting: fmt.Sprintf("Ensure that %s is installed correctly and that `%s %s` can be run in the directory `%s`", binary, binary, strings.Join(args, " "), dir),
+					Troubleshooting: fmt.Sprintf("Ensure that %s is installed correctly and that `%s %s` can be run in the directory `%s`.\nstdout: %s\nstderr: %", binary, binary, strings.Join(args, " "), dir, stdout, stderr),
 				}
 			}
 


### PR DESCRIPTION
Closes #569 
When Leiningen is run for the first time in a project it outputs information about downloading dependencies onto stderr. Previously we were treating this as a failure but this PR corrects that. We will also now output the stderr information when the command exits with an error code.

I also modified the fallback error message to clarify that we are warning the user that a nonbreaking error occurred during Leiningen analysis which will not prevent analysis from succeeding but could prevent the results from being as accurate.