### PR TITLE
feat (Policy flag) Allow users to set the policy of a project to upload.

### DIFF
--- a/api/fossa/upload.go
+++ b/api/fossa/upload.go
@@ -30,6 +30,7 @@ type UploadOptions struct {
 	JIRAProjectKey string
 	Link           string
 	Team           string
+	Policy         string
 }
 
 // Upload uploads a project's analysis.
@@ -76,6 +77,9 @@ func Upload(title string, locator Locator, options UploadOptions, data []SourceU
 	}
 	if options.Team != "" {
 		q.Add("team", options.Team)
+	}
+	if options.Policy != "" {
+		q.Add("policy", options.Policy)
 	}
 
 	endpoint, err := url.Parse("/api/builds/custom?" + q.Encode())

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -165,6 +165,7 @@ func uploadAnalysis(normalized []fossa.SourceUnit) error {
 			JIRAProjectKey: config.JIRAProjectKey(),
 			Link:           config.Link(),
 			Team:           config.Team(),
+			Policy:         config.Policy(),
 		},
 		normalized)
 	display.ClearProgress()

--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -45,7 +45,7 @@ func WithAPIFlags(f []cli.Flag) []cli.Flag {
 }
 
 var (
-	API             = []cli.Flag{EndpointF, TitleF, FetcherF, ProjectF, RevisionF, BranchF, ProjectURLF, JIRAProjectKeyF, LinkF, TeamF}
+	API             = []cli.Flag{EndpointF, TitleF, FetcherF, ProjectF, RevisionF, BranchF, ProjectURLF, JIRAProjectKeyF, LinkF, TeamF, PolicyF}
 	Endpoint        = "endpoint"
 	EndpointF       = cli.StringFlag{Name: Short(Endpoint), Usage: "the FOSSA server endpoint (default: 'https://app.fossa.com')"}
 	Title           = "title"
@@ -66,6 +66,8 @@ var (
 	LinkF           = cli.StringFlag{Name: ShortUpper(Link), Usage: "a link to attach to the current build"}
 	Team            = "team"
 	TeamF           = cli.StringFlag{Name: ShortUpper(Team), Usage: "this repository's team inside your organization"}
+	Policy          = "policy"
+	PolicyF         = cli.StringFlag{Name: Policy, Usage: "the policy to assign to this project in FOSSA"}
 )
 
 func WithGlobalFlags(f []cli.Flag) []cli.Flag {

--- a/config/file.go
+++ b/config/file.go
@@ -33,6 +33,7 @@ type File interface {
 	JIRAProjectKey() string
 	Link() string
 	Team() string
+	Policy() string
 
 	Modules() []module.Module
 }
@@ -80,6 +81,10 @@ func (_ NoFile) Link() string {
 }
 
 func (_ NoFile) Team() string {
+	return ""
+}
+
+func (_ NoFile) Policy() string {
 	return ""
 }
 

--- a/config/file.v1/file.go
+++ b/config/file.v1/file.go
@@ -32,6 +32,7 @@ type CLIProperties struct {
 	JIRAProjectKey string `yaml:"jira_project_key,omitempty"` // Only used with custom fetcher
 	Link           string `yaml:"link,omitempty"`
 	Team           string `yaml:"team,omitempty"`
+	Policy         string `yaml:"policy,omitempty"`
 }
 
 type AnalyzeProperties struct {
@@ -140,7 +141,11 @@ func (file File) Link() string {
 }
 
 func (file File) Team() string {
-	return file.CLI.Link
+	return file.CLI.Team
+}
+
+func (file File) Policy() string {
+	return file.CLI.Policy
 }
 
 func (file File) Revision() string {

--- a/config/keys.go
+++ b/config/keys.go
@@ -115,6 +115,10 @@ func Team() string {
 	return TryStrings(StringFlag(flags.Team), file.Team(), "")
 }
 
+func Policy() string {
+	return TryStrings(StringFlag(flags.Policy), file.Policy(), "")
+}
+
 /**** Analysis configuration keys ****/
 
 func Options() (map[string]interface{}, error) {


### PR DESCRIPTION
This PR adds the flag `--policy` to fossa analyze so that users can set the policy while uploading. We could not use `-p` or `-P` as these were already taken.