### PR TITLE
[FC-1831] Use unix file separators in archive uploads

### DIFF
--- a/api/fossa/tar.go
+++ b/api/fossa/tar.go
@@ -201,10 +201,13 @@ func CreateTarball(dir string) (*os.File, []byte, error) {
 		if err != nil {
 			return err
 		}
-		header.Name, err = filepath.Rel(filepath.Dir(dir), filename)
+		relpath, err := filepath.Rel(filepath.Dir(dir), filename)
 		if err != nil {
 			return err
 		}
+		// golang's archive/tar package doesn't stop us from using the wrong file separators.
+		// we need to manually convert them.
+		header.Name = filepath.ToSlash(relpath)
 
 		err = t.WriteHeader(header)
 		if err != nil {


### PR DESCRIPTION
the ~~brutally pragmatic~~ archive/tar package doesn't prevent us from using invalid filepath separators. When doing an archive upload, we were uploading tarballs with `\`-separated file entries.

This has downstream effects that prevent license matches from being viewed.