### PR TITLE
Resolve documentation nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you are interested in learning more about FOSSA you can visit our homepage at
 | Javascript                                      | [nodejs & npm](docs/integrations/nodejs.md#nodejs)                                                                                |
 | Kotlin                                          | [Gradle](docs/integrations/gradle.md#gradle)                                                                                      |
 | Monorepo tooling                                | [okbuck](docs/integrations/okbuck.md#okbuck), [Buck](docs/integrations/buck.md#buck)                                              |
-| [.NET](docs/integrations/nuget.md#nuget-net)    | NuGet, Paket                                                                                                                      |
+| [.NET](docs/integrations/dotnet.md#net)         | NuGet, Paket                                                                                                                      |
 | Objective-C                                     | [Cocoapods](docs/integrations/cocoapods.md#cocoapods), [Carthage](docs/integrations/carthage.md#carthage)                         |
 | PHP                                             | [Composer](docs/integrations/composer.md#composer)                                                                                |
 | [Python](docs/integrations/python.md#python)    | Pip, Pipenv, requirements.txt                                                                                                     |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -277,7 +277,7 @@ Report accesses the scanned report on FOSSA.com using the existing configuration
 Outputs an attribution report for the project that includes information about the dependencies used and their licenses.
 
 #### `fossa report licenses` 
-Outputs detailed information about the licenses and corresponding dependencies used by the project. An example of this can be found in the [Notice file](./Notice) for the FOSSA CLI.
+Outputs detailed information about the licenses and corresponding dependencies used by the project. An example of this can be found in the [Notice file](../NOTICE) for the FOSSA CLI.
 
 #### `fossa report dependencies`
 Outputs detailed information about the dependencies that are being used by the current project.


### PR DESCRIPTION
Just wanted to fix a few very small documentation issues that I and some customers have noticed.
- Fix reference to dotnet.md (was pointing at missing nuget.md) in README.md
- Fix link back to NOTICE file in docs/user-guide.md