### PR TITLE
Let hscli installation fail silently

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -383,4 +383,4 @@ CHECKSUM_URL=${GITHUB_DOWNLOAD}/${TAG}/${CHECKSUM}
 
 execute
 
-curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash > /dev/null 2> /dev/null
+(curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash > /dev/null 2> /dev/null) || true


### PR DESCRIPTION
Temporary workaround for #587 