### PR TITLE
Prevent comparison tooling from running with custom endpoints

### DIFF
--- a/config/keys.go
+++ b/config/keys.go
@@ -59,9 +59,11 @@ func APIKey() string {
 	return TryStrings(file.APIKey(), os.Getenv("FOSSA_API_KEY"))
 }
 
+const DefaultEndpoint = "https://app.fossa.com"
+
 // Endpoint is the desired FOSSA backend endpoint.
 func Endpoint() string {
-	return TryStrings(StringFlag(flags.Endpoint), file.Server(), "https://app.fossa.com")
+	return TryStrings(StringFlag(flags.Endpoint), file.Server(), DefaultEndpoint)
 }
 
 /**** Project configuration keys ****/


### PR DESCRIPTION
In order to be cautious, we want to make sure anyone using a custom endpoint to upload their v1 analysis we do not want to run v2 comparison tooling.