### PR TITLE
Use -mod=readonly flag for go list

### DIFF
--- a/buildtools/gocmd/go.go
+++ b/buildtools/gocmd/go.go
@@ -75,6 +75,8 @@ func (g *Go) List(pkgs, flags []string, vendor bool) ([]Package, error) {
 	argv := append(flags, pkgs...)
 	if vendor {
 		argv = append([]string{"-mod=vendor"}, argv...)
+	} else {
+		argv = append([]string{"-mod=readonly"}, argv...)
 	}
 	cmd := exec.Cmd{
 		Name: g.Cmd,

--- a/buildtools/gocmd/go.go
+++ b/buildtools/gocmd/go.go
@@ -5,6 +5,8 @@ package gocmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/fossas/fossa-cli/errors"
@@ -75,7 +77,7 @@ func (g *Go) List(pkgs, flags []string, vendor bool) ([]Package, error) {
 	argv := append(flags, pkgs...)
 	if vendor {
 		argv = append([]string{"-mod=vendor"}, argv...)
-	} else {
+	} else if _, err := os.Stat(filepath.Join(g.Dir, "go.mod")); err == nil {
 		argv = append([]string{"-mod=readonly"}, argv...)
 	}
 	cmd := exec.Cmd{


### PR DESCRIPTION
This is a backward-compatible workaround for the issues seen with the new `-mod` flag defaults in golang 1.14