### PR TITLE
Fall back to parent's version in ant analyzer

### DIFF
--- a/buildtools/ant/ant.go
+++ b/buildtools/ant/ant.go
@@ -72,10 +72,14 @@ func locatorFromJar(path string) (pkg.ID, *errors.Error) {
 			if groupID == "" {
 				groupID = pomFile.Parent.GroupID
 			}
+			version := pomFile.Version
+			if version == "" {
+				version = pomFile.Parent.Version
+			}
 			return pkg.ID{
 				Type:     pkg.Maven,
 				Name:     groupID + ":" + pomFile.ArtifactID,
-				Revision: pomFile.Version,
+				Revision: version,
 			}, nil
 		} else {
 			log.Debugf("%s", err)


### PR DESCRIPTION
We were already doing the fallback for `groupId`, and this adds an additional fallback for `version`