### PR TITLE
Allow double-quoted strings

### DIFF
--- a/buildtools/pip/pip.go
+++ b/buildtools/pip/pip.go
@@ -156,13 +156,16 @@ func FromSetupPy(filename string) ([]Requirement, *errors.Error) {
 	var reqs []Requirement
 	for {
 		endBracket := strings.Index(contents, "]")
-		openQuote := strings.Index(contents, "'")
+		// python strings can be double-quoted, and often are
+		openQuote := strings.IndexAny(contents, "'\"")
 		if openQuote == -1 || openQuote > endBracket {
 			break
 		}
+		// Which quote are we matching, ' or "?
+		openQuoteChar := contents[openQuote]
 
 		contents = contents[openQuote+1:]
-		closeQuote := strings.Index(contents, "'")
+		closeQuote := strings.Index(contents, string(openQuoteChar))
 		if closeQuote == -1 {
 			// NB: silently failing here instead of throwing an error
 			break

--- a/buildtools/pip/pip_test.go
+++ b/buildtools/pip/pip_test.go
@@ -31,4 +31,5 @@ func TestFromSetupPy(t *testing.T) {
 	assert.Contains(t, reqs, pip.Requirement{Name: "gteq", Constraints: []pip.Constraint{{Revision: "2.0.0", Operator: ">="}}})
 	assert.Contains(t, reqs, pip.Requirement{Name: "sameline", Constraints: []pip.Constraint{{Revision: "1.0.0", Operator: "=="}}})
 	assert.Contains(t, reqs, pip.Requirement{Name: "latest", Constraints: nil})
+	assert.Contains(t, reqs, pip.Requirement{Name: "with-double-quotes", Constraints: nil})
 }

--- a/buildtools/pip/testdata/setup.py
+++ b/buildtools/pip/testdata/setup.py
@@ -6,6 +6,7 @@ setup(
     description='A sample Python project',
     install_requires=['simple==1.0.0',
                       'gteq>=2.0.0', 'sameline==1.0.0',
-                      'latest'
+                      'latest',
+                      "with-double-quotes"
                       ],
 )


### PR DESCRIPTION
`setuptools` strategy was not handling double quoted strings.

Note that the quote that opens the string must be the same quote to close the string.