### PR TITLE
Remove spectrometer installation for v2 comparison

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -382,5 +382,3 @@ CHECKSUM=${PROJECT_NAME}_${VERSION}_checksums.txt
 CHECKSUM_URL=${GITHUB_DOWNLOAD}/${TAG}/${CHECKSUM}
 
 execute
-
-(curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash -s -- -b ${BINDIR} > /dev/null 2> /dev/null) || true


### PR DESCRIPTION
With the official release of fossa cli 2.0 we renamed the binary from `spectrometer` to `fossa`. This causes conflicts within the build system and causes the cli installation to fail. This PR removes the installation of spectrometer entirely.

The CLI v2 comparison logic is confirmed to not cause any errors if the binary is unable to be found. Decisions about whether or not to remove this logic or rename the binary on installation can be made at a later date.