### PR TITLE
Add CLI Flag to Skip TLS Verification

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -26,6 +27,14 @@ var defaultClient = http.Client{
 		DisableKeepAlives: true,
 		Proxy:             http.ProxyFromEnvironment,
 	},
+}
+
+var (
+	insecureTLS bool = false
+)
+
+func SetInsecureTLS(insecureTLSflag bool) {
+	insecureTLS = insecureTLSflag
 }
 
 // Get is a convenience method for MakeAPIRequest.
@@ -98,6 +107,15 @@ func MakeAPIRequest(method string, endpoint *url.URL, APIKey string, body []byte
 	req.Close = true
 	req.Header.Set("Authorization", "token "+APIKey)
 	req.Header.Set("Content-Type", "application/json")
+
+	// Set new TLS Config here
+	if insecureTLS {
+		defaultClient.Transport = &http.Transport{
+			DisableKeepAlives: true,
+			Proxy:             http.ProxyFromEnvironment,
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		}
+	}
 
 	// Send request.
 	response, err := defaultClient.Do(req)

--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -75,15 +75,17 @@ func WithGlobalFlags(f []cli.Flag) []cli.Flag {
 }
 
 var (
-	Global   = []cli.Flag{ConfigF, NoAnsiF, DebugF, VerboseF}
-	Config   = "config"
-	ConfigF  = cli.StringFlag{Name: Short(Config), Usage: "path to config file (default: '.fossa.{yml,yaml}')"}
-	NoAnsi   = "no-ansi"
-	NoAnsiF  = cli.BoolFlag{Name: NoAnsi, Usage: "do not use interactive mode (ANSI codes)"}
-	Debug    = "debug"
-	DebugF   = cli.BoolFlag{Name: Debug, Usage: "print debug information to stderr"}
-	Verbose  = "verbose"
-	VerboseF = cli.BoolFlag{Name: Verbose, Usage: "print limited debug information to stderr"}
+	Global    = []cli.Flag{ConfigF, InsecureF, NoAnsiF, DebugF, VerboseF}
+	Config    = "config"
+	ConfigF   = cli.StringFlag{Name: Short(Config), Usage: "path to config file (default: '.fossa.{yml,yaml}')"}
+	Insecure  = "insecure"
+	InsecureF = cli.BoolFlag{Name: Insecure, Usage: "do not verify TLS certificate authenticity"}
+	NoAnsi    = "no-ansi"
+	NoAnsiF   = cli.BoolFlag{Name: NoAnsi, Usage: "do not use interactive mode (ANSI codes)"}
+	Debug     = "debug"
+	DebugF    = cli.BoolFlag{Name: Debug, Usage: "print debug information to stderr"}
+	Verbose   = "verbose"
+	VerboseF  = cli.BoolFlag{Name: Verbose, Usage: "print limited debug information to stderr"}
 )
 
 func WithOptions(f []cli.Flag) []cli.Flag {

--- a/cmd/fossa/setup/setup.go
+++ b/cmd/fossa/setup/setup.go
@@ -4,6 +4,7 @@ package setup
 import (
 	"github.com/urfave/cli"
 
+	"github.com/fossas/fossa-cli/api"
 	"github.com/fossas/fossa-cli/api/fossa"
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/config"
@@ -33,6 +34,9 @@ func SetContext(ctx *cli.Context, requiresAPIKey bool) error {
 			return apiError
 		}
 	}
+
+	// Set up API HTTP Internals.
+	api.SetInsecureTLS(config.Insecure())
 
 	return nil
 }

--- a/config/keys.go
+++ b/config/keys.go
@@ -32,6 +32,11 @@ func Version() int {
 	return file.GetVersion()
 }
 
+// Insecure is true if the user wants to skip TLS Certificate authenticity checks
+func Insecure() bool {
+	return BoolFlag(flags.Insecure)
+}
+
 // Interactive is true if the user desires interactive output.
 func Interactive() bool {
 	return isatty.IsTerminal(os.Stderr.Fd()) && !BoolFlag(flags.NoAnsi)


### PR DESCRIPTION
This adds a simple '--insecure' flag that allows the cli to interact
with a Fossa server using self-signed certificate.