### PR TITLE
Replace .NET with nodejs on nodejs documentation

### DIFF
--- a/docs/integrations/nodejs.md
+++ b/docs/integrations/nodejs.md
@@ -30,7 +30,7 @@ analyze:
 
 #### `strategy: <string>`
 
-Manually specify the .NET analysis strategy to be used. Supported options are as follows and the individual behavior is listed in the Analysis section further down:
+Manually specify the nodejs analysis strategy to be used. Supported options are as follows and the individual behavior is listed in the Analysis section further down:
 - `npm-list`
 - `npm-lockfile`
 - `package.json`


### PR DESCRIPTION
This change fixes a typo in the nodejs documentation replacing  `.NET` with `nodejs`