### PR TITLE
Git contrib count

### DIFF
--- a/api/fossa/upload.go
+++ b/api/fossa/upload.go
@@ -116,3 +116,25 @@ func Upload(title string, locator Locator, options UploadOptions, data []SourceU
 
 	return ReadLocator(unmarshalled.Locator), nil
 }
+
+// UploadContributors posts contributor data to the project decribed by locator
+func UploadContributors(data map[string]string, locator Locator) {
+	payload, err := json.Marshal(data)
+	if err != nil {
+		log.Debugf("Failed to marshal contributor map: %s", err)
+	}
+	q := url.Values{}
+	q.Add("locator", locator.String())
+	endpoint, err := url.Parse("api/contributors?" + q.Encode())
+	if err != nil {
+		log.Debugf("Failed to generate contributor URL: %s", err)
+	}
+	body, statusCode, err := Post(endpoint.String(), payload)
+	if err != nil {
+		log.Debugf("Failed to POST contributor data: %s", err)
+	}
+	if statusCode != 200 {
+		log.Debugf("FOSSA reported an issue while uploading contributor data: %s", body)
+	}
+	return
+}

--- a/api/fossa/upload.go
+++ b/api/fossa/upload.go
@@ -122,18 +122,19 @@ func UploadContributors(data map[string]string, locator Locator) {
 	payload, err := json.Marshal(data)
 	if err != nil {
 		log.Debugf("Failed to marshal contributor map: %s", err)
+		return
 	}
 	q := url.Values{}
 	q.Add("locator", locator.String())
 	endpoint, err := url.Parse("api/contributors?" + q.Encode())
 	if err != nil {
 		log.Debugf("Failed to generate contributor URL: %s", err)
+		return
 	}
 	body, statusCode, err := Post(endpoint.String(), payload)
 	if err != nil {
 		log.Debugf("Failed to POST contributor data: %s", err)
-	}
-	if statusCode != 200 {
+	} else if statusCode != 200 {
 		log.Debugf("FOSSA reported an issue while uploading contributor data: %s", body)
 	}
 	return

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -387,10 +387,10 @@ func fetchGitContibutors() map[string]string {
 
 	// the format arg produces newline-separated lines of: <author-email> :: <commit date>
 	// We use commit date since some people backdate authorship
-	// dates are always YYYY-MM-DD format.
+	// dates are forced into YYYY-MM-DD format.
 	cmd := exec.Cmd{
 		Name:    "git",
-		Argv:    []string{"log", "--since", fmtSince, "--format=%ae :: %cd"},
+		Argv:    []string{"log", "--since", fmtSince, "--format=%ae :: %cd", "--date=short"},
 		Timeout: "10s",
 	}
 	output, _, err := exec.Run(cmd)

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -265,8 +265,12 @@ func Run(ctx *cli.Context) error {
 		return err
 	}
 
+	// At this point, we should allow failures to be logged, but not fail the process.
+	// Both of the functions below log failures and return safely.
 	contributors := fetchGitContibutors()
-	fossa.UploadContributors(contributors, locator)
+	if contributors != nil {
+		fossa.UploadContributors(contributors, locator)
+	}
 	return nil
 }
 

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -316,7 +316,7 @@ func Do(modules []module.Module, upload, rawModuleLicenseScan, devDeps bool) (an
 				Name:     locator.Project,
 				Revision: locator.Revision,
 			}
-			m.Imports = []pkg.Import{pkg.Import{Resolved: id}}
+			m.Imports = []pkg.Import{{Resolved: id}}
 			m.Deps = make(map[pkg.ID]pkg.Package)
 			m.Deps[id] = pkg.Package{
 				ID: id,

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -385,8 +384,12 @@ func fetchGitContibutors() map[string]string {
 	// the format arg produces newline-separated lines of: <author-email> :: <commit date>
 	// We use commit date since some people backdate authorship
 	// dates are always YYYY-MM-DD format.
-	cmd := exec.Command("git", "log", "--since", fmtSince, "--format=%ae :: %cd")
-	output, err := cmd.Output()
+	cmd := exec.Cmd{
+		Name:    "git",
+		Argv:    []string{"log", "--since", fmtSince, "--format=%ae :: %cd"},
+		Timeout: "10s",
+	}
+	output, _, err := exec.Run(cmd)
 	if err != nil {
 		log.Debugf("Failed to run 'git log': %s", err.Error())
 		return nil


### PR DESCRIPTION
A few assumptions are made here:

- We always shell out from the working directory.  As far as I can tell, this is required because of the config file.
- We only upload once per run, assuming that the git repository is in the current folder.  It would also find a higher-level git repo, but that seems unlikely to encounter normally.
- A failing contributor check is logged, but only at the debug level, and does not hurt the process.
- `git log ...` should not take longer than 10s.  In a stress test, 42,580 commits were processed in under 6 seconds, so 10 seconds seems reasonable even for extreme cases.