### PR TITLE
fix (wrong config file path field)

### DIFF
--- a/docs/integrations/bazel.md
+++ b/docs/integrations/bazel.md
@@ -26,7 +26,7 @@ analyze:
     - name:   WORKSPACE
       type:   bazel
       target: vendor/...
-      dir:    project-dir
+      path:    project-dir
 ```
 
 ## Options
@@ -44,7 +44,7 @@ analyze:
     - name:   go-bazel-file
       type:   bazel
       target: repos.bzl
-      dir:   project-dir
+      path:   project-dir
       options:
         strategy: go-bazel
 ```

--- a/docs/integrations/buck.md
+++ b/docs/integrations/buck.md
@@ -29,7 +29,7 @@ analyze:
     - name:   buckproject
       type:   buck
       target: //programs:buck
-      dir:   .
+      path:   .
 ```
 
 ## Analysis

--- a/docs/integrations/carthage.md
+++ b/docs/integrations/carthage.md
@@ -23,7 +23,7 @@ analyze:
     - name: carthage-project
       type: cart
       target: python/project
-      dir:  python/project
+      path:  python/project
 ```
 
 ## Analysis

--- a/docs/integrations/clojure.md
+++ b/docs/integrations/clojure.md
@@ -25,7 +25,7 @@ analyze:
     - name: test/clojure
       type: clojure
       target: project.clj
-      dir:  clojure/project
+      path:  clojure/project
       options:
         strategy: lein
 ```

--- a/docs/integrations/cocoapods.md
+++ b/docs/integrations/cocoapods.md
@@ -22,7 +22,7 @@ analyze:
     - name: cocoa-repo
       type: pod
       target: .
-      dir:  .
+      path:  .
 ```
 
 ## Analysis

--- a/docs/integrations/composer.md
+++ b/docs/integrations/composer.md
@@ -22,7 +22,7 @@ analyze:
   modules:
     - name: your-composer-project
       type: composer
-      dir: composer.json
+      path: composer.json
       target: directory/composer.json
 ```
 

--- a/docs/integrations/dotnet.md
+++ b/docs/integrations/dotnet.md
@@ -16,7 +16,7 @@ analyze:
     - name: NugetModule
       type: nuget
       target: MyProject/Manifest.csproj
-      dir: MyProject
+      path: MyProject
       options:
         strategy: package-reference
 ```

--- a/docs/integrations/okbuck.md
+++ b/docs/integrations/okbuck.md
@@ -20,7 +20,7 @@ analyze:
     - name: okbuck
       type: okbuck
       target: //...
-      dir:   .
+      path:   .
       options:
             classpath: //app:bin_prodRelease
 ```

--- a/docs/integrations/python.md
+++ b/docs/integrations/python.md
@@ -27,7 +27,7 @@ analyze:
     - name: github.com/fossas/fossa-cli/cmd/fossa
       type: pip
       target: python/project
-      dir:  python/project
+      path:  python/project
       options:
         strategy: pipenv
 ```

--- a/docs/integrations/rust.md
+++ b/docs/integrations/rust.md
@@ -20,7 +20,7 @@ analyze:
     - name: cargo-project
       type: cargo
       target: rust/root
-      dir:  rust/root
+      path:  rust/root
 ```
 
 ## Analysis


### PR DESCRIPTION
## Description
Some of the language docs reccomend using a `dir` field instead of a `path` field 

I'm not entirely sure how this happened but I suspect it was a combination of:
- `dir` being used in the code to describe this field
- `path` rarely being used in a critical way so users' projects would not break if they did use `dir`.
