### PR TITLE
Improve docs on `--suppress-issues` flag

### DIFF
--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -45,7 +45,7 @@ var Cmd = cli.Command{
 	Action: Run,
 	Flags: flags.WithGlobalFlags(flags.WithAPIFlags([]cli.Flag{
 		cli.IntFlag{Name: Timeout, Value: 10 * 60, Usage: "duration to wait for build completion (in seconds)"},
-		cli.BoolFlag{Name: SuppressIssues, Usage: "don't exit on stderr if issues are found"},
+		cli.BoolFlag{Name: SuppressIssues, Usage: "don't exit with code 1 if issues are found"},
 		cli.BoolFlag{Name: JSON, Usage: "format failed issues as JSON"},
 	})),
 }
@@ -178,7 +178,7 @@ func CheckIssues(locator fossa.Locator, stop <-chan time.Time) (fossa.Issues, *e
 			if err != nil {
 				return fossa.Issues{}, err
 			}
-      
+
 			switch issues.Status {
 			case "WAITING":
 				time.Sleep(PollRequestDelay)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -227,7 +227,7 @@ FOSSA_API_KEY=YOUR_API_KEY fossa analyze
 | `--help`        | `-h`  | Print a help message.                                                        |
 
 ### `fossa test`
-Checks whether the project has licensing issues, as configured by its policy within FOSSA. If there are issues, it prints them on `stdout` and exits with code 1. If there are not issues, it exits with code 0. Fossa test can be used to fail a CI pipeline job.
+Checks whether the project has licensing issues, as configured by its policy within FOSSA. If there are issues, it prints them on `stdout` and, unless the `--suppress-issues` flag is given, exits with code 1. If there are not issues, it exits with code 0. Fossa test can be used to fail a CI pipeline job.
 
 > Note: Report always requires an API Key to be set. A push-only API key can be used for `fossa test`, but issues will not be displayed if the test results in a failure.
 
@@ -243,10 +243,10 @@ FOSSA_API_KEY=YOUR_API_KEY_HERE fossa test --timeout 600
 | `--project`         | `-p`  | Configuration value for [project](/docs/config-file.md/#project-optional).        |
 | `--revision`        | `-r`  | Configuration value for [revision](/docs/config-file.md/#revision-optional).      |
 | `--endpoint`        | `-e`  | Configuration value for [endpoint](/docs/config-file.md/#endpoint-optional).      |
-| `--timeout`         |       | The amount of seconds to wait for an issue scan to complete. Default: 10 minutes. |
+| `--timeout`         |       | The number of seconds to wait for an issue scan to complete. Default: 10 minutes. |
 | `--debug`           |       | Print debugging information to stderr.                                            |
 | `--help`            | `-h`  | Print a help message.                                                             |
-| `--suppress-issues` |       | Don't exit on stderr if issues are found.                                         |
+| `--suppress-issues` |       | Don't exit with code 1 if issues are found.                                       |
 
 ### `fossa upload`
 


### PR DESCRIPTION
## Description

The documentation on the `--suppress-issues` flag was a bit misleading: it controls, not what's written to stderr, but whether the CLI exits with exit code 1.

## Acceptance Criteria
- The docs and usage message for this flag are improved.