### PR TITLE
Added arm64 support to .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,12 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: darwin
+        goarch: arm64
     ldflags: -extldflags "-static" -s -w
       -X github.com/fossas/fossa-cli/cmd/fossa/version.version={{.Version}}
       -X github.com/fossas/fossa-cli/cmd/fossa/version.commit={{.Commit}}


### PR DESCRIPTION
Updated the .goreleaser.yml file to generate linux/arm64 release for fossa.

Resolves #625.

Signed-off-by: odidev odidev@puresoftware.com