### PR TITLE
Update docs and help output for flags that only effective on project creation.

### DIFF
--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -24,7 +24,7 @@ Detailed issue data cannot be read. This could be related to using a push-only A
 ========================================================================
 {{$type}}
 ========================================================================
-Dependency	Revision	{{if or (eq $type "Flagged by Policy") (eq $type "Denied by Policy") -}} License {{- end}}
+Dependency	Revision	{{if or (eq $type "Flagged by Policy") (eq $type "Denied by Policy") -}} {{- end}}
 {{- range $i, $issue := $issues}}
 {{$issue.Name}}	{{$issue.Revision}}
 {{- end}}

--- a/cmd/fossa/cmd/test/test.go
+++ b/cmd/fossa/cmd/test/test.go
@@ -26,7 +26,7 @@ Detailed issue data cannot be read. This could be related to using a push-only A
 ========================================================================
 Dependency	Revision	{{if or (eq $type "Flagged by Policy") (eq $type "Denied by Policy") -}} License {{- end}}
 {{- range $i, $issue := $issues}}
-{{$issue.Name}}	{{$issue.Revision}}	{{$issue.Rule.License }}
+{{$issue.Name}}	{{$issue.Revision}}
 {{- end}}
 {{end}}
 `

--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -49,7 +49,7 @@ var (
 	Endpoint        = "endpoint"
 	EndpointF       = cli.StringFlag{Name: Short(Endpoint), Usage: "the FOSSA server endpoint (default: 'https://app.fossa.com')"}
 	Title           = "title"
-	TitleF          = cli.StringFlag{Name: Short(Title), Usage: "the title of the FOSSA project. (default: the project name)"}
+	TitleF          = cli.StringFlag{Name: Short(Title), Usage: "the title of the FOSSA project, valid ONLY on project creation (default: the project name)"}
 	Fetcher         = "fetcher"
 	FetcherF        = cli.StringFlag{Name: Short(Fetcher), Usage: "type of fetcher to use for fossa. (default: 'custom')"}
 	Project         = "project"
@@ -65,9 +65,9 @@ var (
 	Link            = "link"
 	LinkF           = cli.StringFlag{Name: ShortUpper(Link), Usage: "a link to attach to the current build"}
 	Team            = "team"
-	TeamF           = cli.StringFlag{Name: ShortUpper(Team), Usage: "this repository's team inside your organization"}
+	TeamF           = cli.StringFlag{Name: ShortUpper(Team), Usage: "this repository's team inside your organization, valid ONLY on project creation"}
 	Policy          = "policy"
-	PolicyF         = cli.StringFlag{Name: Policy, Usage: "the policy to assign to this project in FOSSA"}
+	PolicyF         = cli.StringFlag{Name: Policy, Usage: "the policy to assign to this project in FOSSA, valid ONLY on project creation"}
 )
 
 func WithGlobalFlags(f []cli.Flag) []cli.Flag {

--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -49,7 +49,7 @@ var (
 	Endpoint        = "endpoint"
 	EndpointF       = cli.StringFlag{Name: Short(Endpoint), Usage: "the FOSSA server endpoint (default: 'https://app.fossa.com')"}
 	Title           = "title"
-	TitleF          = cli.StringFlag{Name: Short(Title), Usage: "the title of the FOSSA project, valid ONLY on project creation (default: the project name)"}
+	TitleF          = cli.StringFlag{Name: Short(Title), Usage: "the title of the FOSSA project (applies ONLY to new projects) (default: the project name)"}
 	Fetcher         = "fetcher"
 	FetcherF        = cli.StringFlag{Name: Short(Fetcher), Usage: "type of fetcher to use for fossa. (default: 'custom')"}
 	Project         = "project"
@@ -65,9 +65,9 @@ var (
 	Link            = "link"
 	LinkF           = cli.StringFlag{Name: ShortUpper(Link), Usage: "a link to attach to the current build"}
 	Team            = "team"
-	TeamF           = cli.StringFlag{Name: ShortUpper(Team), Usage: "this repository's team inside your organization, valid ONLY on project creation"}
+	TeamF           = cli.StringFlag{Name: ShortUpper(Team), Usage: "this repository's team inside your organization (applies ONLY to new projects)"}
 	Policy          = "policy"
-	PolicyF         = cli.StringFlag{Name: Policy, Usage: "the policy to assign to this project in FOSSA, valid ONLY on project creation"}
+	PolicyF         = cli.StringFlag{Name: Policy, Usage: "the policy to assign to this project in FOSSA, (applies ONLY to new projects)"}
 )
 
 func WithGlobalFlags(f []cli.Flag) []cli.Flag {

--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -49,7 +49,7 @@ var (
 	Endpoint        = "endpoint"
 	EndpointF       = cli.StringFlag{Name: Short(Endpoint), Usage: "the FOSSA server endpoint (default: 'https://app.fossa.com')"}
 	Title           = "title"
-	TitleF          = cli.StringFlag{Name: Short(Title), Usage: "the title of the FOSSA project (applies ONLY to new projects) (default: the project name)"}
+	TitleF          = cli.StringFlag{Name: Short(Title), Usage: "the title of the FOSSA project (applies only to new projects) (default: the project name)"}
 	Fetcher         = "fetcher"
 	FetcherF        = cli.StringFlag{Name: Short(Fetcher), Usage: "type of fetcher to use for fossa. (default: 'custom')"}
 	Project         = "project"
@@ -65,9 +65,9 @@ var (
 	Link            = "link"
 	LinkF           = cli.StringFlag{Name: ShortUpper(Link), Usage: "a link to attach to the current build"}
 	Team            = "team"
-	TeamF           = cli.StringFlag{Name: ShortUpper(Team), Usage: "this repository's team inside your organization (applies ONLY to new projects)"}
+	TeamF           = cli.StringFlag{Name: ShortUpper(Team), Usage: "this repository's team inside your organization (applies only to new projects)"}
 	Policy          = "policy"
-	PolicyF         = cli.StringFlag{Name: Policy, Usage: "the policy to assign to this project in FOSSA, (applies ONLY to new projects)"}
+	PolicyF         = cli.StringFlag{Name: Policy, Usage: "the policy to assign to this project in FOSSA, (applies only to new projects)"}
 )
 
 func WithGlobalFlags(f []cli.Flag) []cli.Flag {

--- a/docs/integrations/gradle.md
+++ b/docs/integrations/gradle.md
@@ -31,9 +31,11 @@ analyze:
       path: path-to-build.gradle
       target: subproject
       type: gradle
+      options:
+        online: true
 ```
 
-## Options
+## Configuration Options
 
   | Option               |  Type  | Name                                           | Common Use Case                                                            |
   | -------------------- | :----: | ---------------------------------------------- | -------------------------------------------------------------------------- |
@@ -45,7 +47,6 @@ analyze:
   | `all-submodules`     |  bool  | [All Submodules](#all-submodules-bool)         | Running `fossa analyze gradle:.` and you want to analyze all sub-projects. |
   | `configuration`      | string | [Configuration](#configuration-string)         | Comma separated list of configurations to analyze.                         |
   | `all-configurations` |  bool  | [All Configurations](#all-configurations-bool) | Analyze all configurations for the gradle project.                         |
-
 
 
 #### `cmd: <string>` 
@@ -67,7 +68,7 @@ Specify the amount of times to retry running the gradle command after it fails t
 
 #### `online: <bool>`
 
-When set to true, this option will remove the `--offline` flag from the command `gradle <project>:dependencies --quiet --offline` used to find the dependencies of the specified project.
+When set to true, this option will remove the `--offline` flag from the command `gradle <project>:dependencies --quiet --offline` used to find the dependencies of the specified project. Specify this in the .fossa.yml file under options. See above for example.
 
 #### `all-submodules: <bool>`
 

--- a/docs/integrations/maven.md
+++ b/docs/integrations/maven.md
@@ -26,6 +26,8 @@ analyze:
       type: mvn
       path: .
       target: pom.xml
+      options:
+        cmd: "mvn dependency:tree"
 ```
 
 ## Options

--- a/docs/integrations/sbt.md
+++ b/docs/integrations/sbt.md
@@ -14,14 +14,14 @@ In addition, SBT requires the following plugin to be installed:
 
 Automatic: Run `fossa init` to detect all directories with a `build.sbt` file at their root. fossa runs `sbt projects` at these directories roots and creates a module for each sbt project with configuration set to `compile` by default.
 
-Manual: Add an `sbt` module with the path to the `build.sbt` file in your project. Set target to `<project>:<configuration>` where project is the desired sbt project and configuration is the configuration analysis is desired for.
+Manual: Add an `sbt` module with the path to the directory where a `build.sbt` file is located in your project. Set target to `<project>:<configuration>` where project is the desired sbt project and configuration is the configuration analysis is desired for.
 
 ```yaml
 analyze:
   modules:
     - name: your-sbt-project
       type: sbt
-      path: build.sbt
+      path: .
       target: <project>:<configuration>
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -204,20 +204,20 @@ Analyzes the project for a list of its dependencies, optionally uploading the re
 FOSSA_API_KEY=YOUR_API_KEY fossa analyze
 ```
 
-| Flag            | Short | Description                                                                             |
-| --------------- | ----- | --------------------------------------------------------------------------------------- |
-| `--config`      | `-c`  | Path to a [configuration file](/docs/config-file.md) including filename.                |
-| `--project`     | `-p`  | Configuration value for [project](/docs/config-file.md/#project-optional).              |
-| `--revision`    | `-r`  | Configuration value for [revision](/docs/config-file.md/#revision-optional).            |
-| `--endpoint`    | `-e`  | Configuration value for [endpoint](/docs/config-file.md/#endpoint-optional).            |
-| `--output`      | `-o`  | Output `fossa analyze` results to stdout.                                               |
-| `--server-scan` |       | Run a server side dependency scan on raw modules.                                       |
-| `--dev`         |       | Include development dependencies. CAUTION: valid only for nodejs projects.              |
-| `--debug`       |       | Print debugging information to stderr.                                                  |
-| `--help`        | `-h`  | Print a help message.                                                                   |
-| `--team`        | `-T`  | Connect the project with the specified team in FOSSA. Valid only on project creation.   |
-| `--policy`      |       | Connect the project with the specified policy in FOSSA. Valid only on project creation. |
-| `--title`       | `-t`  | Set the title that appears in the FOSSA UI. Valid only on project creation              |
+| Flag            | Short | Description                                                                           |
+| --------------- | ----- | ------------------------------------------------------------------------------------- |
+| `--config`      | `-c`  | Path to a [configuration file](/docs/config-file.md) including filename.              |
+| `--project`     | `-p`  | Configuration value for [project](/docs/config-file.md/#project-optional).            |
+| `--revision`    | `-r`  | Configuration value for [revision](/docs/config-file.md/#revision-optional).          |
+| `--endpoint`    | `-e`  | Configuration value for [endpoint](/docs/config-file.md/#endpoint-optional).          |
+| `--output`      | `-o`  | Output `fossa analyze` results to stdout.                                             |
+| `--server-scan` |       | Run a server side dependency scan on raw modules.                                     |
+| `--dev`         |       | Include development dependencies. CAUTION: valid only for nodejs projects.            |
+| `--debug`       |       | Print debugging information to stderr.                                                |
+| `--help`        | `-h`  | Print a help message.                                                                 |
+| `--team`        | `-T`  | Connect the project with the specified team in FOSSA. Applies only to new projects.   |
+| `--policy`      |       | Connect the project with the specified policy in FOSSA. Applies only to new projects. |
+| `--title`       | `-t`  | Set the title that appears in the FOSSA UI. Applies only to new projects.             |
 
 > NOTE: The title, policy, and team flags only affect a project the first time it is uploaded. Any subsequent times that `fossa analyze` is run the flags will be ignored. This feature was created to allow users to associate a project with their team on first upload, but prevents the CLI from modifying changes made in the UI.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -168,17 +168,8 @@ Combination of [`fossa init`](#fossa-init) and [`fossa analyze`](#fossa-analyze)
 # Creates a config file, runs an analysis, and uploads the results.
 FOSSA_API_KEY=YOUR_API_KEY fossa
 ```
-  
-| Flag         | Short | Description                                                                  |
-| ------------ | ----- | ---------------------------------------------------------------------------- |
-| `--config`   | `-c`  | Path to a [configuration file](/docs/config-file.md) including filename.     |
-| `--project`  | `-p`  | Configuration value for [project](/docs/config-file.md/#project-optional).   |
-| `--revision` | `-r`  | Configuration value for [revision](/docs/config-file.md/#revision-optional). |
-| `--endpoint` | `-e`  | Configuration value for [endpoint](/docs/config-file.md/#endpoint-optional). |
-| `--output`   | `-o`  | Output `fossa analyze` results to stdout.                                    |
-| `--debug`    |       | Print debugging information to stderr.                                       |
-| `--version ` | `-v`  | Print the currently installed FOSSA CLI version.                             |
-| `--help`     | `-h`  | Print a help message.                                                        |
+
+All flags for `fossa init` and `fossa analyze` are valid for `fossa`.
 
 ### `fossa init`
 
@@ -213,18 +204,22 @@ Analyzes the project for a list of its dependencies, optionally uploading the re
 FOSSA_API_KEY=YOUR_API_KEY fossa analyze
 ```
 
-| Flag            | Short | Description                                                                  |
-| --------------- | ----- | ---------------------------------------------------------------------------- |
-| `--config`      | `-c`  | Path to a [configuration file](/docs/config-file.md) including filename.     |
-| `--project`     | `-p`  | Configuration value for [project](/docs/config-file.md/#project-optional).   |
-| `--revision`    | `-r`  | Configuration value for [revision](/docs/config-file.md/#revision-optional). |
-| `--endpoint`    | `-e`  | Configuration value for [endpoint](/docs/config-file.md/#endpoint-optional). |
-| `--output`      | `-o`  | Output `fossa analyze` results to stdout.                                    |
-| `--team`        | `-T`  | Connect this project with the specified existing team in FOSSA.              |
-| `--server-scan` |       | Run a server side dependency scan on raw modules.                            |
-| `--dev`         |       | Include development dependencies. CAUTION: valid only for nodejs projects.   |
-| `--debug`       |       | Print debugging information to stderr.                                       |
-| `--help`        | `-h`  | Print a help message.                                                        |
+| Flag            | Short | Description                                                                             |
+| --------------- | ----- | --------------------------------------------------------------------------------------- |
+| `--config`      | `-c`  | Path to a [configuration file](/docs/config-file.md) including filename.                |
+| `--project`     | `-p`  | Configuration value for [project](/docs/config-file.md/#project-optional).              |
+| `--revision`    | `-r`  | Configuration value for [revision](/docs/config-file.md/#revision-optional).            |
+| `--endpoint`    | `-e`  | Configuration value for [endpoint](/docs/config-file.md/#endpoint-optional).            |
+| `--output`      | `-o`  | Output `fossa analyze` results to stdout.                                               |
+| `--server-scan` |       | Run a server side dependency scan on raw modules.                                       |
+| `--dev`         |       | Include development dependencies. CAUTION: valid only for nodejs projects.              |
+| `--debug`       |       | Print debugging information to stderr.                                                  |
+| `--help`        | `-h`  | Print a help message.                                                                   |
+| `--team`        | `-T`  | Connect the project with the specified team in FOSSA. Valid only on project creation.   |
+| `--policy`      |       | Connect the project with the specified policy in FOSSA. Valid only on project creation. |
+| `--title`       | `-t`  | Set the title that appears in the FOSSA UI. Valid only on project creation              |
+
+> NOTE: The title, policy, and team flags only affect a project the first time it is uploaded. Any subsequent times that `fossa analyze` is run the flags will be ignored. This feature was created to allow users to associate a project with their team on first upload, but prevents the CLI from modifying changes made in the UI.
 
 ### `fossa test`
 Checks whether the project has licensing issues, as configured by its policy within FOSSA. If there are issues, it prints them on `stdout` and, unless the `--suppress-issues` flag is given, exits with code 1. If there are not issues, it exits with code 0. Fossa test can be used to fail a CI pipeline job.


### PR DESCRIPTION
## Description
This PR clarifies the `team`, `title`, and `policy` flags which only have affect a project when it is created.

Other changes have been made as well:
- Fix to the sbt documentation that incorrectly told users to specify the `buildt.sbt` file as their path.
- Update to the maven docs to include an example of using the `cmd` option.
- Remove the `License` field from the `fossa test` output. A breaking change in the FOSSA API was made that prevents us from getting the data. In the future, we can work with a new endpoint but for now, I believe it is best to remove the confusing text.