### PR TITLE
Add "team" parameter to requests for archive dependency uploads

### DIFF
--- a/api/fossa/tar.go
+++ b/api/fossa/tar.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/apex/log"
 
+	"github.com/fossas/fossa-cli/config"
 	"github.com/fossas/fossa-cli/errors"
 	"github.com/fossas/fossa-cli/files"
 )
@@ -454,6 +455,10 @@ func tarballUpload(name string, dependency, rawLicenseScan, upload bool, tarball
 
 	if rawLicenseScan {
 		parameters.Add("rawLicenseScan", "true")
+	}
+
+	if team := config.Team(); team != "" {
+		parameters.Add("team", team)
 	}
 
 	_, _, err = Post(ComponentsBuildAPI+"?"+parameters.Encode(), data)


### PR DESCRIPTION
## Description
[FC-2759](https://fossa.atlassian.net/browse/FC-2759)

We haven't been specifying to which team to add new dependencies that are uploaded as archives. This is needed now with the new, consistent permissions checks in Core.

There's a corresponding PR in the Core repo.

## Acceptance Criteria
A user who doesn't have an organization-wide role to view all projects can still submit raw archive uploads using the CLI.

## Testing plan
- Get an API key of a user who has the None role in the organization (i.e., no role) and a Team Admin role in a team.
- Submit a build with a `type: raw` module using that API key.
- Ensure that the upload succeeded and that you can view the project and dependency in the UI.

## Risks
This is a fairly small, self-contained change that shouldn't adversely affect any other functionality.