### PR TITLE
fossa upload-project command

### DIFF
--- a/api/fossa/locator.go
+++ b/api/fossa/locator.go
@@ -61,9 +61,20 @@ func (l Locator) URL() string {
 	if branch == "" {
 		branch = "master"
 	}
+
+	project := l.Project
+
+	if l.Fetcher == "archive" {
+		orgID, err := GetOrganizationID()
+		if err != nil {
+			log.Warnf("Could not get OrganizationID while constructing locator")
+		}
+		project = orgID + "/" + project
+	}
+
 	url, err := url.Parse(
 		"/projects/" +
-			url.PathEscape(l.Fetcher+"+"+l.Project) +
+			url.PathEscape(l.Fetcher+"+"+project) +
 			"/refs/branch/" +
 			url.PathEscape(branch) +
 			"/" +

--- a/api/fossa/tar.go
+++ b/api/fossa/tar.go
@@ -468,10 +468,10 @@ func tarballUpload(name, revision string, dependency, rawLicenseScan, upload boo
 		parameters.Add("policy", uploadOptions.Policy)
 	}
 	if uploadOptions.ReleaseGroup != "" {
-		q.Add("releaseGroup", uploadOptions.ReleaseGroup)
+		parameters.Add("releaseGroup", uploadOptions.ReleaseGroup)
 	}
 	if uploadOptions.ReleaseGroupVersion != "" {
-		q.Add("releaseGroupVersion", uploadOptions.ReleaseGroupVersion)
+		parameters.Add("releaseGroupVersion", uploadOptions.ReleaseGroupVersion)
 	}
 
 	_, _, err = Post(ComponentsBuildAPI+"?"+parameters.Encode(), data)

--- a/api/fossa/tar.go
+++ b/api/fossa/tar.go
@@ -467,6 +467,12 @@ func tarballUpload(name, revision string, dependency, rawLicenseScan, upload boo
 	if uploadOptions.Policy != "" {
 		parameters.Add("policy", uploadOptions.Policy)
 	}
+	if uploadOptions.ReleaseGroup != "" {
+		q.Add("releaseGroup", uploadOptions.ReleaseGroup)
+	}
+	if uploadOptions.ReleaseGroupVersion != "" {
+		q.Add("releaseGroupVersion", uploadOptions.ReleaseGroupVersion)
+	}
 
 	_, _, err = Post(ComponentsBuildAPI+"?"+parameters.Encode(), data)
 	if err != nil {

--- a/api/fossa/tar.go
+++ b/api/fossa/tar.go
@@ -471,7 +471,7 @@ func tarballUpload(name, revision string, dependency, rawLicenseScan, upload boo
 		parameters.Add("releaseGroup", uploadOptions.ReleaseGroup)
 	}
 	if uploadOptions.ReleaseGroupVersion != "" {
-		parameters.Add("releaseGroupVersion", uploadOptions.ReleaseGroupVersion)
+		parameters.Add("releaseGroupRelease", uploadOptions.ReleaseGroupVersion)
 	}
 
 	_, _, err = Post(ComponentsBuildAPI+"?"+parameters.Encode(), data)

--- a/api/fossa/upload.go
+++ b/api/fossa/upload.go
@@ -25,12 +25,14 @@ var (
 
 // UploadOptions are optional keys that provide extra metadata for an upload.
 type UploadOptions struct {
-	Branch         string
-	ProjectURL     string
-	JIRAProjectKey string
-	Link           string
-	Team           string
-	Policy         string
+	Branch              string
+	ProjectURL          string
+	JIRAProjectKey      string
+	Link                string
+	Team                string
+	Policy              string
+	ReleaseGroup        string
+	ReleaseGroupVersion string
 }
 
 // Upload uploads a project's analysis.
@@ -80,6 +82,12 @@ func Upload(title string, locator Locator, options UploadOptions, data []SourceU
 	}
 	if options.Policy != "" {
 		q.Add("policy", options.Policy)
+	}
+	if options.ReleaseGroup != "" {
+		q.Add("releaseGroup", options.ReleaseGroup)
+	}
+	if options.ReleaseGroupVersion != "" {
+		q.Add("releaseGroupVersion", options.ReleaseGroupVersion)
 	}
 
 	endpoint, err := url.Parse("/api/builds/custom?" + q.Encode())

--- a/api/fossa/upload.go
+++ b/api/fossa/upload.go
@@ -87,7 +87,7 @@ func Upload(title string, locator Locator, options UploadOptions, data []SourceU
 		q.Add("releaseGroup", options.ReleaseGroup)
 	}
 	if options.ReleaseGroupVersion != "" {
-		q.Add("releaseGroupVersion", options.ReleaseGroupVersion)
+		q.Add("releaseGroupRelease", options.ReleaseGroupVersion)
 	}
 
 	endpoint, err := url.Parse("/api/builds/custom?" + q.Encode())

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -365,12 +365,14 @@ func uploadAnalysis(normalized []fossa.SourceUnit) (fossa.Locator, error) {
 			Revision: config.Revision(),
 		},
 		fossa.UploadOptions{
-			Branch:         config.Branch(),
-			ProjectURL:     config.ProjectURL(),
-			JIRAProjectKey: config.JIRAProjectKey(),
-			Link:           config.Link(),
-			Team:           config.Team(),
-			Policy:         config.Policy(),
+			Branch:              config.Branch(),
+			ProjectURL:          config.ProjectURL(),
+			JIRAProjectKey:      config.JIRAProjectKey(),
+			Link:                config.Link(),
+			Team:                config.Team(),
+			Policy:              config.Policy(),
+			ReleaseGroup:        config.ReleaseGroup(),
+			ReleaseGroupVersion: config.ReleaseGroupVersion(),
 		},
 		normalized)
 	display.ClearProgress()

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -304,7 +304,15 @@ func Do(modules []module.Module, upload, rawModuleLicenseScan, devDeps bool) (an
 		// TODO: maybe this should target a third-party folder, rather than a single
 		// folder? Maybe "third-party folder" should be a separate module type?
 		if m.Type == pkg.Raw {
-			locator, err := fossa.UploadTarball(m.Name, "", m.BuildTarget, rawModuleLicenseScan, rawModuleLicenseScan, upload, fossa.UploadOptions{})
+			locator, err := fossa.UploadTarball(fossa.UploadTarballOptions{
+				Name:           m.Name,
+				Revision:       "",
+				Directory:      m.BuildTarget,
+				IsDependency:   rawModuleLicenseScan,
+				RawLicenseScan: rawModuleLicenseScan,
+				Upload:         upload,
+				UploadOptions:  fossa.UploadOptions{},
+			})
 			if err != nil {
 				log.Warnf("Could not upload raw module: %s", err.Error())
 			}

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -304,7 +304,7 @@ func Do(modules []module.Module, upload, rawModuleLicenseScan, devDeps bool) (an
 		// TODO: maybe this should target a third-party folder, rather than a single
 		// folder? Maybe "third-party folder" should be a separate module type?
 		if m.Type == pkg.Raw {
-			locator, err := fossa.UploadTarball(m.Name, m.BuildTarget, rawModuleLicenseScan, rawModuleLicenseScan, upload)
+			locator, err := fossa.UploadTarball(m.Name, "", m.BuildTarget, rawModuleLicenseScan, rawModuleLicenseScan, upload, fossa.UploadOptions{})
 			if err != nil {
 				log.Warnf("Could not upload raw module: %s", err.Error())
 			}

--- a/cmd/fossa/cmd/archive/archive.go
+++ b/cmd/fossa/cmd/archive/archive.go
@@ -1,0 +1,71 @@
+package archive
+
+import (
+	"fmt"
+
+	"github.com/apex/log"
+	"github.com/urfave/cli"
+
+	"github.com/fossas/fossa-cli/api/fossa"
+	"github.com/fossas/fossa-cli/cmd/fossa/display"
+	"github.com/fossas/fossa-cli/cmd/fossa/flags"
+	"github.com/fossas/fossa-cli/cmd/fossa/setup"
+)
+
+var Cmd = cli.Command{
+	Name:      "archive",
+	Usage:     "Archive Upload",
+	Action:    Run,
+	ArgsUsage: "MODULE",
+	Flags: flags.WithGlobalFlags(flags.WithAPIFlags(flags.WithOptions([]cli.Flag{
+		flags.TemplateF,
+	}))),
+}
+
+var _ cli.ActionFunc = Run
+
+func Run(ctx *cli.Context) error {
+	err := setup.SetContext(ctx, true)
+	if err != nil {
+		log.Fatalf("Could not initialize %s", err)
+	}
+
+	dirs := ctx.Args()
+	if len(dirs) == 0 {
+		log.Fatal("no directories specified")
+	}
+
+	defer display.ClearProgress()
+	archiveLocators := []fossa.Locator{}
+
+	for i := 0; i < len(dirs); i++ {
+		dir := dirs.Get(i)
+		display.InProgress(fmt.Sprintf("Archive uploading directory (%d/%d): %s", i+1, len(dirs), dir))
+
+		locator, err := fossa.UploadTarball(dir, dir, false, true, true)
+		if err != nil {
+			log.Warnf("Could not archive upload `%s` with error: %s", dir, err.Error())
+		} else {
+			archiveLocators = append(archiveLocators, locator)
+		}
+	}
+
+	fmt.Println(archiveReports(archiveLocators))
+	return err
+}
+
+func archiveReports(locators []fossa.Locator) string {
+	formattedURLs := `
+============================================================
+
+    FOSSA Reports:
+`
+	for _, loc := range locators {
+		formattedURLs = formattedURLs + fmt.Sprintf("    %s  %s\n", loc.Project, loc.URL())
+	}
+	formattedURLs = formattedURLs + `
+============================================================
+`
+
+	return formattedURLs
+}

--- a/cmd/fossa/cmd/archive/archive.go
+++ b/cmd/fossa/cmd/archive/archive.go
@@ -18,9 +18,7 @@ var Cmd = cli.Command{
 	Usage:     "Archive Upload",
 	Action:    Run,
 	ArgsUsage: "MODULE",
-	Flags: flags.WithGlobalFlags(flags.WithAPIFlags(flags.WithOptions([]cli.Flag{
-		flags.TemplateF,
-	}))),
+	Flags:     flags.WithGlobalFlags(flags.WithAPIFlags([]cli.Flag{})),
 }
 
 var _ cli.ActionFunc = Run

--- a/cmd/fossa/cmd/archive/archive.go
+++ b/cmd/fossa/cmd/archive/archive.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
+	"github.com/fossas/fossa-cli/config"
 )
 
 var Cmd = cli.Command{
@@ -36,36 +37,22 @@ func Run(ctx *cli.Context) error {
 	}
 
 	defer display.ClearProgress()
-	archiveLocators := []fossa.Locator{}
 
-	for i := 0; i < len(dirs); i++ {
-		dir := dirs.Get(i)
-		display.InProgress(fmt.Sprintf("Archive uploading directory (%d/%d): %s", i+1, len(dirs), dir))
+	dir := dirs.Get(0)
+	display.InProgress(fmt.Sprintf("Archive uploading directory: %s", dir))
 
-		locator, err := fossa.UploadTarball(dir, dir, false, true, true)
-		if err != nil {
-			log.Warnf("Could not archive upload `%s` with error: %s", dir, err.Error())
-		} else {
-			archiveLocators = append(archiveLocators, locator)
-		}
+	locator, err := fossa.UploadTarballProject(config.Project(), config.Revision(), dir, true, fossa.UploadOptions{
+		Branch:         config.Branch(),
+		JIRAProjectKey: config.JIRAProjectKey(),
+		Team:           config.Team(),
+		Policy:         config.Policy(),
+	})
+
+	if err != nil {
+		log.Warnf("Could not archive upload `%s` with error: %s", dir, err.Error())
+		return err
 	}
 
-	fmt.Println(archiveReports(archiveLocators))
-	return err
-}
-
-func archiveReports(locators []fossa.Locator) string {
-	formattedURLs := `
-============================================================
-
-    FOSSA Reports:
-`
-	for _, loc := range locators {
-		formattedURLs = formattedURLs + fmt.Sprintf("    %s  %s\n", loc.Project, loc.URL())
-	}
-	formattedURLs = formattedURLs + `
-============================================================
-`
-
-	return formattedURLs
+	fmt.Println(locator.ReportURL())
+	return nil
 }

--- a/cmd/fossa/cmd/upload_project/upload_project.go
+++ b/cmd/fossa/cmd/upload_project/upload_project.go
@@ -15,7 +15,7 @@ import (
 
 var Cmd = cli.Command{
 	Name:      "upload-project",
-	Usage:     "Uploads source code to fossa for server side scanning",
+	Usage:     "Uploads source code to FOSSA that will be treated as a single project",
 	Action:    Run,
 	ArgsUsage: "MODULE",
 	Flags:     flags.WithGlobalFlags(flags.WithAPIFlags([]cli.Flag{})),
@@ -39,13 +39,21 @@ func Run(ctx *cli.Context) error {
 	dir := dirs.Get(0)
 	display.InProgress(fmt.Sprintf("Uploading directory: %s", dir))
 
-	locator, err := fossa.UploadTarballProject(config.Project(), config.Revision(), dir, true, fossa.UploadOptions{
-		Branch:              config.Branch(),
-		JIRAProjectKey:      config.JIRAProjectKey(),
-		Team:                config.Team(),
-		Policy:              config.Policy(),
-		ReleaseGroup:        config.ReleaseGroup(),
-		ReleaseGroupVersion: config.ReleaseGroupVersion(),
+	locator, err := fossa.UploadTarball(fossa.UploadTarballOptions{
+		Name:           config.Project(),
+		Revision:       config.Revision(),
+		Directory:      dir,
+		RawLicenseScan: true,
+		IsDependency:   false,
+		Upload:         true,
+		UploadOptions: fossa.UploadOptions{
+			Branch:              config.Branch(),
+			JIRAProjectKey:      config.JIRAProjectKey(),
+			Team:                config.Team(),
+			Policy:              config.Policy(),
+			ReleaseGroup:        config.ReleaseGroup(),
+			ReleaseGroupVersion: config.ReleaseGroupVersion(),
+		},
 	})
 
 	if err != nil {

--- a/cmd/fossa/cmd/upload_project/upload_project.go
+++ b/cmd/fossa/cmd/upload_project/upload_project.go
@@ -1,4 +1,4 @@
-package archive
+package upload_project
 
 import (
 	"fmt"
@@ -14,8 +14,8 @@ import (
 )
 
 var Cmd = cli.Command{
-	Name:      "archive",
-	Usage:     "Archive Upload",
+	Name:      "upload-project",
+	Usage:     "Uploads source code to fossa for server side scanning",
 	Action:    Run,
 	ArgsUsage: "MODULE",
 	Flags:     flags.WithGlobalFlags(flags.WithAPIFlags([]cli.Flag{})),
@@ -37,17 +37,19 @@ func Run(ctx *cli.Context) error {
 	defer display.ClearProgress()
 
 	dir := dirs.Get(0)
-	display.InProgress(fmt.Sprintf("Archive uploading directory: %s", dir))
+	display.InProgress(fmt.Sprintf("Uploading directory: %s", dir))
 
 	locator, err := fossa.UploadTarballProject(config.Project(), config.Revision(), dir, true, fossa.UploadOptions{
-		Branch:         config.Branch(),
-		JIRAProjectKey: config.JIRAProjectKey(),
-		Team:           config.Team(),
-		Policy:         config.Policy(),
+		Branch:              config.Branch(),
+		JIRAProjectKey:      config.JIRAProjectKey(),
+		Team:                config.Team(),
+		Policy:              config.Policy(),
+		ReleaseGroup:        config.ReleaseGroup(),
+		ReleaseGroupVersion: config.ReleaseGroupVersion(),
 	})
 
 	if err != nil {
-		log.Warnf("Could not archive upload `%s` with error: %s", dir, err.Error())
+		log.Warnf("Could not upload project `%s` with error: %s", dir, err.Error())
 		return err
 	}
 

--- a/cmd/fossa/flags/flags.go
+++ b/cmd/fossa/flags/flags.go
@@ -45,29 +45,33 @@ func WithAPIFlags(f []cli.Flag) []cli.Flag {
 }
 
 var (
-	API             = []cli.Flag{EndpointF, TitleF, FetcherF, ProjectF, RevisionF, BranchF, ProjectURLF, JIRAProjectKeyF, LinkF, TeamF, PolicyF}
-	Endpoint        = "endpoint"
-	EndpointF       = cli.StringFlag{Name: Short(Endpoint), Usage: "the FOSSA server endpoint (default: 'https://app.fossa.com')"}
-	Title           = "title"
-	TitleF          = cli.StringFlag{Name: Short(Title), Usage: "the title of the FOSSA project (applies only to new projects) (default: the project name)"}
-	Fetcher         = "fetcher"
-	FetcherF        = cli.StringFlag{Name: Short(Fetcher), Usage: "type of fetcher to use for fossa. (default: 'custom')"}
-	Project         = "project"
-	ProjectF        = cli.StringFlag{Name: Short(Project), Usage: "this repository's URL or VCS endpoint (default: VCS remote 'origin')"}
-	Revision        = "revision"
-	RevisionF       = cli.StringFlag{Name: Short(Revision), Usage: "this repository's current revision hash (default: VCS hash HEAD)"}
-	Branch          = "branch"
-	BranchF         = cli.StringFlag{Name: Short(Branch), Usage: "this repository's current branch (default: current VCS branch)"}
-	ProjectURL      = "project-url"
-	ProjectURLF     = cli.StringFlag{Name: ShortUpper(ProjectURL), Usage: "this repository's home page"}
-	JIRAProjectKey  = "jira-project-key"
-	JIRAProjectKeyF = cli.StringFlag{Name: Short(JIRAProjectKey), Usage: "this repository's JIRA project key"}
-	Link            = "link"
-	LinkF           = cli.StringFlag{Name: ShortUpper(Link), Usage: "a link to attach to the current build"}
-	Team            = "team"
-	TeamF           = cli.StringFlag{Name: ShortUpper(Team), Usage: "this repository's team inside your organization (applies only to new projects)"}
-	Policy          = "policy"
-	PolicyF         = cli.StringFlag{Name: Policy, Usage: "the policy to assign to this project in FOSSA, (applies only to new projects)"}
+	API                  = []cli.Flag{EndpointF, TitleF, FetcherF, ProjectF, RevisionF, BranchF, ProjectURLF, JIRAProjectKeyF, LinkF, TeamF, PolicyF, ReleaseGroupF, ReleaseGroupVersionF}
+	Endpoint             = "endpoint"
+	EndpointF            = cli.StringFlag{Name: Short(Endpoint), Usage: "the FOSSA server endpoint (default: 'https://app.fossa.com')"}
+	Title                = "title"
+	TitleF               = cli.StringFlag{Name: Short(Title), Usage: "the title of the FOSSA project (applies only to new projects) (default: the project name)"}
+	Fetcher              = "fetcher"
+	FetcherF             = cli.StringFlag{Name: Short(Fetcher), Usage: "type of fetcher to use for fossa. (default: 'custom')"}
+	Project              = "project"
+	ProjectF             = cli.StringFlag{Name: Short(Project), Usage: "this repository's URL or VCS endpoint (default: VCS remote 'origin')"}
+	Revision             = "revision"
+	RevisionF            = cli.StringFlag{Name: Short(Revision), Usage: "this repository's current revision hash (default: VCS hash HEAD)"}
+	Branch               = "branch"
+	BranchF              = cli.StringFlag{Name: Short(Branch), Usage: "this repository's current branch (default: current VCS branch)"}
+	ProjectURL           = "project-url"
+	ProjectURLF          = cli.StringFlag{Name: ShortUpper(ProjectURL), Usage: "this repository's home page"}
+	JIRAProjectKey       = "jira-project-key"
+	JIRAProjectKeyF      = cli.StringFlag{Name: Short(JIRAProjectKey), Usage: "this repository's JIRA project key"}
+	Link                 = "link"
+	LinkF                = cli.StringFlag{Name: ShortUpper(Link), Usage: "a link to attach to the current build"}
+	Team                 = "team"
+	TeamF                = cli.StringFlag{Name: ShortUpper(Team), Usage: "this repository's team inside your organization (applies only to new projects)"}
+	Policy               = "policy"
+	PolicyF              = cli.StringFlag{Name: Policy, Usage: "the policy to assign to this project in FOSSA (applies only to new projects)"}
+	ReleaseGroup         = "release-group"
+	ReleaseGroupF        = cli.StringFlag{Name: ReleaseGroup, Usage: "the name of the release group to connect this project to"}
+	ReleaseGroupVersion  = "release-group-version"
+	ReleaseGroupVersionF = cli.StringFlag{Name: ReleaseGroupVersion, Usage: "the version of the release group to connect this project to"}
 )
 
 func WithGlobalFlags(f []cli.Flag) []cli.Flag {

--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze"
+	"github.com/fossas/fossa-cli/cmd/fossa/cmd/archive"
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/build"
 	initc "github.com/fossas/fossa-cli/cmd/fossa/cmd/init"
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/report"
@@ -39,6 +40,7 @@ var App = cli.App{
 		report.Cmd,
 		test.Cmd,
 		update.Cmd,
+		archive.Cmd,
 		analyze.NewCmd,
 	},
 }

--- a/cmd/fossa/main.go
+++ b/cmd/fossa/main.go
@@ -8,13 +8,13 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/analyze"
-	"github.com/fossas/fossa-cli/cmd/fossa/cmd/archive"
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/build"
 	initc "github.com/fossas/fossa-cli/cmd/fossa/cmd/init"
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/report"
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/test"
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/update"
 	"github.com/fossas/fossa-cli/cmd/fossa/cmd/upload"
+	"github.com/fossas/fossa-cli/cmd/fossa/cmd/upload_project"
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/cmd/fossa/flags"
 	"github.com/fossas/fossa-cli/cmd/fossa/setup"
@@ -40,7 +40,7 @@ var App = cli.App{
 		report.Cmd,
 		test.Cmd,
 		update.Cmd,
-		archive.Cmd,
+		upload_project.Cmd,
 		analyze.NewCmd,
 	},
 }

--- a/cmd/fossa/setup/setup.go
+++ b/cmd/fossa/setup/setup.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fossas/fossa-cli/api/fossa"
 	"github.com/fossas/fossa-cli/cmd/fossa/display"
 	"github.com/fossas/fossa-cli/config"
+	"github.com/fossas/fossa-cli/errors"
 )
 
 // SetContext initializes all application-level packages.
@@ -31,6 +32,13 @@ func SetContext(ctx *cli.Context, requiresAPIKey bool) error {
 		apiError := fossa.SetAPIKey(config.APIKey())
 		if apiError != nil {
 			return apiError
+		}
+	}
+
+	if (config.ReleaseGroup() != "" && config.ReleaseGroupVersion() == "") || (config.ReleaseGroup() == "" && config.ReleaseGroupVersion() != "") {
+		return &errors.Error{
+			Type:            errors.User,
+			Troubleshooting: "If you intend to associate this project with a release group, both --release-group and --release-group-version must be set.",
 		}
 	}
 

--- a/config/file.go
+++ b/config/file.go
@@ -34,6 +34,8 @@ type File interface {
 	Link() string
 	Team() string
 	Policy() string
+	ReleaseGroup() string
+	ReleaseGroupVersion() string
 
 	Modules() []module.Module
 }
@@ -85,6 +87,14 @@ func (_ NoFile) Team() string {
 }
 
 func (_ NoFile) Policy() string {
+	return ""
+}
+
+func (_ NoFile) ReleaseGroup() string {
+	return ""
+}
+
+func (_ NoFile) ReleaseGroupVersion() string {
 	return ""
 }
 

--- a/config/file.v1/file.go
+++ b/config/file.v1/file.go
@@ -21,18 +21,20 @@ type File struct {
 
 type CLIProperties struct {
 	// Upload configuration.
-	APIKey         string `yaml:"api_key,omitempty"`
-	Server         string `yaml:"server,omitempty"`
-	Fetcher        string `yaml:"fetcher,omitempty"` // Defaults to custom
-	Project        string `yaml:"project,omitempty"`
-	Title          string `yaml:"title,omitempty"`
-	Revision       string `yaml:"revision,omitempty"`
-	Branch         string `yaml:"branch,omitempty"`           // Only used with custom fetcher
-	ProjectURL     string `yaml:"project_url,omitempty"`      // Only used with custom fetcher
-	JIRAProjectKey string `yaml:"jira_project_key,omitempty"` // Only used with custom fetcher
-	Link           string `yaml:"link,omitempty"`
-	Team           string `yaml:"team,omitempty"`
-	Policy         string `yaml:"policy,omitempty"`
+	APIKey              string `yaml:"api_key,omitempty"`
+	Server              string `yaml:"server,omitempty"`
+	Fetcher             string `yaml:"fetcher,omitempty"` // Defaults to custom
+	Project             string `yaml:"project,omitempty"`
+	Title               string `yaml:"title,omitempty"`
+	Revision            string `yaml:"revision,omitempty"`
+	Branch              string `yaml:"branch,omitempty"`           // Only used with custom fetcher
+	ProjectURL          string `yaml:"project_url,omitempty"`      // Only used with custom fetcher
+	JIRAProjectKey      string `yaml:"jira_project_key,omitempty"` // Only used with custom fetcher
+	Link                string `yaml:"link,omitempty"`
+	Team                string `yaml:"team,omitempty"`
+	Policy              string `yaml:"policy,omitempty"`
+	ReleaseGroup        string `yaml:"release_group,omitempty"`
+	ReleaseGroupVersion string `yaml:"release_group_version,omitempty"`
 }
 
 type AnalyzeProperties struct {
@@ -146,6 +148,14 @@ func (file File) Team() string {
 
 func (file File) Policy() string {
 	return file.CLI.Policy
+}
+
+func (file File) ReleaseGroup() string {
+	return file.CLI.ReleaseGroup
+}
+
+func (file File) ReleaseGroupVersion() string {
+	return file.CLI.ReleaseGroupVersion
 }
 
 func (file File) Revision() string {

--- a/config/keys.go
+++ b/config/keys.go
@@ -121,6 +121,14 @@ func Policy() string {
 	return TryStrings(StringFlag(flags.Policy), file.Policy(), "")
 }
 
+func ReleaseGroup() string {
+	return TryStrings(StringFlag(flags.ReleaseGroup), file.ReleaseGroup(), "")
+}
+
+func ReleaseGroupVersion() string {
+	return TryStrings(StringFlag(flags.ReleaseGroupVersion), file.ReleaseGroupVersion(), "")
+}
+
 /**** Analysis configuration keys ****/
 
 func Options() (map[string]interface{}, error) {


### PR DESCRIPTION
## Description

Add support for a `fossa upload-project` command that is intended to behave identically to the UI archive scanning feature.

This PR also adds support to assign a project to a release group version from the CLI by supplying `--release-group <name>` and `--release-group-version <version>` to the command.

Example UI:
```
fossa archive temp --title new-title --release-group test --release-group-version 2.0
============================================================

    FOSSA Reports:
    https://app.fossa.com/projects/archive+testing%2F/refs/%2Ffossa-archive/6b15f78939019bba6ead53cd2d3a4b8d

============================================================
```

## Notes
I considered using one flag and splitting on a special character such as `--release-group <name>@<version>` but I decided to implement two separate flags. The main reason is to avoid unintended issues with splitting the strings on the backend and disallowing a certain special character. The second reason is to reduce confusion for the user who needs to manually add the character. I am favoring enforcing explicit declaration over the expense of the command looking a bit messy.
