### PR TITLE
Fix Goreleaser after deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Tag branch for release 
+          name: Tag branch for release
           command: |
             [[ $CLI_RELEASE_TAG == v* ]]
             git tag $CLI_RELEASE_TAG

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ brews:
     description: "Fast, portable and reliable dependency analysis for any codebase. Supports license & vulnerability scanning for large monoliths. Language-agnostic; integrates with 20+ build systems."
     homepage: "https://fossa.com"
 
-    github:
+    tap:
       owner: fossas
       name: homebrew-tap
 

--- a/buildtools/rpm/rpm.go
+++ b/buildtools/rpm/rpm.go
@@ -151,7 +151,7 @@ func (s Shell) yumInstall(target string) *errors.Error {
 		return &errors.Error{
 			Cause:           err,
 			Type:            errors.Exec,
-			Troubleshooting: fmt.Sprintf("The command `yum %s` could not be run and %s could not be installed.\nstderr: %s\nstdout: %s", strings.Join(arguments, " "), target, stderr, stdout),
+			Troubleshooting: fmt.Sprintf("The command `yum %s` could not be run and %s could not be installed. Ensure you are runnning analysis in an environment where the specified RPM can be installed. \nstderr: %s\nstdout: %s", strings.Join(arguments, " "), target, stderr, stdout),
 			Link:            "https://github.com/fossas/fossa-cli/blob/master/docs/integrations/rpm.md#rpm",
 			Message:         fmt.Sprintf("This may not cause any issues but could prevent accurate dependency and license information from being found. If you believe that %s does not need to be installed and accurate information has been found please ignore this error.", target),
 		}

--- a/buildtools/yarn/yarn.go
+++ b/buildtools/yarn/yarn.go
@@ -66,10 +66,9 @@ type Child struct {
 
 func (y SystemYarn) List(dir string, devDependencies bool) (graph.Deps, error) {
 	listCmd := exec.Cmd{
-		Name:    y.Cmd,
-		Argv:    []string{"list", "--json"},
-		Dir:     dir,
-		WithEnv: map[string]string{"NODE_ENV": "production"},
+		Name: y.Cmd,
+		Argv: []string{"list", "--json"},
+		Dir:  dir,
 	}
 	if !devDependencies {
 		listCmd.WithEnv = map[string]string{"NODE_ENV": "production"}


### PR DESCRIPTION
## Description
Goreleaser deprecated the `Github` field in favor of the `tap` field.


## Testing plan
I ssh'd into the release pipeline, changed the field, and rereleased the project to see that this will succeed.


