### PR TITLE
Improve archive dependency scanning

### DIFF
--- a/analyzers/maven/maven.go
+++ b/analyzers/maven/maven.go
@@ -140,6 +140,7 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	default:
 		if a.Options.Command != "" {
 			output, _, err := exec.Shell(exec.Cmd{
+				Dir:     a.Module.Dir,
 				Command: a.Options.Command,
 			})
 			if err != nil {

--- a/api/fossa/tar.go
+++ b/api/fossa/tar.go
@@ -38,25 +38,25 @@ type SignedURL struct {
 	SignedURL string
 }
 type UploadTarballOptions struct {
-	Name           string
-	Revision       string
-	Directory      string
-	IsDependency   bool
-	RawLicenseScan bool
-	Upload         bool
-	UploadOptions  UploadOptions
+	Name            string
+	Revision        string
+	Directory       string
+	IsDependency    bool
+	LicenseScanOnly bool
+	Upload          bool
+	UploadOptions   UploadOptions
 }
 
 // UploadTarballDependency uploads the directory specified to be treated on FOSSA as a dependency.
 func UploadTarballDependency(dir string, upload, rawLicenseScan bool) (Locator, error) {
 	return UploadTarball(UploadTarballOptions{
-		Name:           "",
-		Revision:       "",
-		Directory:      dir,
-		IsDependency:   true,
-		RawLicenseScan: rawLicenseScan,
-		Upload:         upload,
-		UploadOptions:  UploadOptions{},
+		Name:            "",
+		Revision:        "",
+		Directory:       dir,
+		IsDependency:    true,
+		LicenseScanOnly: rawLicenseScan,
+		Upload:          upload,
+		UploadOptions:   UploadOptions{},
 	})
 }
 
@@ -107,12 +107,12 @@ func UploadTarballString(name, s string, dependency, rawLicenseScan, upload bool
 	}
 
 	return tarballUpload(UploadTarballOptions{
-		Name:           name,
-		Revision:       "",
-		IsDependency:   dependency,
-		RawLicenseScan: rawLicenseScan,
-		Upload:         upload,
-		UploadOptions:  UploadOptions{},
+		Name:            name,
+		Revision:        "",
+		IsDependency:    dependency,
+		LicenseScanOnly: rawLicenseScan,
+		Upload:          upload,
+		UploadOptions:   UploadOptions{},
 	}, tarball, hash)
 }
 
@@ -306,12 +306,12 @@ func UploadTarballDependencyFiles(dir string, fileList []string, name string, up
 	}
 
 	return tarballUpload(UploadTarballOptions{
-		Name:           name,
-		Revision:       "",
-		IsDependency:   true,
-		RawLicenseScan: true,
-		Upload:         upload,
-		UploadOptions:  UploadOptions{},
+		Name:            name,
+		Revision:        "",
+		IsDependency:    true,
+		LicenseScanOnly: true,
+		Upload:          upload,
+		UploadOptions:   UploadOptions{},
 	}, tarball, hash)
 }
 
@@ -479,7 +479,7 @@ func tarballUpload(options UploadTarballOptions, tarball *os.File, hash []byte) 
 	if options.IsDependency {
 		parameters.Add("dependency", "true")
 	}
-	if options.RawLicenseScan {
+	if options.LicenseScanOnly {
 		parameters.Add("rawLicenseScan", "true")
 	}
 	if options.UploadOptions.Branch != "" {

--- a/cmd/fossa/cmd/analyze/analyze.go
+++ b/cmd/fossa/cmd/analyze/analyze.go
@@ -305,13 +305,13 @@ func Do(modules []module.Module, upload, rawModuleLicenseScan, devDeps bool) (an
 		// folder? Maybe "third-party folder" should be a separate module type?
 		if m.Type == pkg.Raw {
 			locator, err := fossa.UploadTarball(fossa.UploadTarballOptions{
-				Name:           m.Name,
-				Revision:       "",
-				Directory:      m.BuildTarget,
-				IsDependency:   rawModuleLicenseScan,
-				RawLicenseScan: rawModuleLicenseScan,
-				Upload:         upload,
-				UploadOptions:  fossa.UploadOptions{},
+				Name:            m.Name,
+				Revision:        "",
+				Directory:       m.BuildTarget,
+				IsDependency:    rawModuleLicenseScan,
+				LicenseScanOnly: rawModuleLicenseScan,
+				Upload:          upload,
+				UploadOptions:   fossa.UploadOptions{},
 			})
 			if err != nil {
 				log.Warnf("Could not upload raw module: %s", err.Error())

--- a/cmd/fossa/cmd/upload_project/upload_project.go
+++ b/cmd/fossa/cmd/upload_project/upload_project.go
@@ -40,12 +40,12 @@ func Run(ctx *cli.Context) error {
 	display.InProgress(fmt.Sprintf("Uploading directory: %s", dir))
 
 	locator, err := fossa.UploadTarball(fossa.UploadTarballOptions{
-		Name:           config.Project(),
-		Revision:       config.Revision(),
-		Directory:      dir,
-		RawLicenseScan: true,
-		IsDependency:   false,
-		Upload:         true,
+		Name:            config.Project(),
+		Revision:        config.Revision(),
+		Directory:       dir,
+		LicenseScanOnly: false,
+		IsDependency:    false,
+		Upload:          true,
 		UploadOptions: fossa.UploadOptions{
 			Branch:              config.Branch(),
 			JIRAProjectKey:      config.JIRAProjectKey(),


### PR DESCRIPTION
## Description
`RawLicenseScan` was a very unclear variable that led to unintended behavior with `fossa upload-project`. This PR improves the variable naming and fixes the logic with `fossa upload-project`

## Acceptance Criteria
Variable naming is more clear and upload project works as intended (Scans project for dependencies on the backend)

## Testing plan
I manually verified this worked with FOSSA cloud.