### PR TITLE
Add ARM64 in supported architectures in install.sh and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The following commands will execute scripts to fetch and install the latest [Git
 brew install fossas/tap/fossa
 ```
 
-### MacOS (Darwin) or Linux amd64:
+### MacOS (Darwin) or Linux amd64/arm64:
 ```bash
 curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
 ```

--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,7 @@ is_supported_platform() {
     windows/amd64) found=0 ;;
     darwin/amd64) found=0 ;;
     linux/amd64) found=0 ;;
+    linux/arm64) found=0 ;;
   esac
   return $found
 }


### PR DESCRIPTION
**Updates:**
Added ARM64 in supported architectures in install.sh and README.md

@zlav,

Added ARM64 in supported architectures in `install.sh` to use "https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh" for installing fossa binary directly in arm64 platform.
