### PR TITLE
support mips64le architecture.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,11 +10,16 @@ builds:
     goarch:
       - amd64
       - arm64
+      - mips64le
     ignore:
       - goos: windows
         goarch: arm64
       - goos: darwin
         goarch: arm64
+      - goos: windows
+        goarch: mips64le
+      - goos: darwin
+        goarch: mips64le
     ldflags: -extldflags "-static" -s -w
       -X github.com/fossas/fossa-cli/cmd/fossa/version.version={{.Version}}
       -X github.com/fossas/fossa-cli/cmd/fossa/version.commit={{.Commit}}


### PR DESCRIPTION
hello，I am going to submit mips64le architecture，The main reasons for adding support for mips64le architecture are:
1. The mips64le architecture is also the mainstream cpu architecture (amd64, arm64), which is used by many users;
2. Golang supports cross compilation, and mips64le is officially supported.
Therefore, I hope that the release package also supports the mips64le architecture, which is convenient for more users. 

Signed-off-by: houfangdong houfangdong@loongson.com