### PR TITLE
Add support for titles with upload project

### DIFF
--- a/api/fossa/tar.go
+++ b/api/fossa/tar.go
@@ -41,6 +41,7 @@ type UploadTarballOptions struct {
 	Name            string
 	Revision        string
 	Directory       string
+	Title           string
 	IsDependency    bool
 	LicenseScanOnly bool
 	Upload          bool
@@ -476,6 +477,9 @@ func tarballUpload(options UploadTarballOptions, tarball *os.File, hash []byte) 
 	}
 
 	parameters := url.Values{}
+	if options.Title != "" {
+		parameters.Add("title", options.UploadOptions.Team)
+	}
 	if options.IsDependency {
 		parameters.Add("dependency", "true")
 	}

--- a/api/fossa/tar.go
+++ b/api/fossa/tar.go
@@ -478,7 +478,7 @@ func tarballUpload(options UploadTarballOptions, tarball *os.File, hash []byte) 
 
 	parameters := url.Values{}
 	if options.Title != "" {
-		parameters.Add("title", options.UploadOptions.Team)
+		parameters.Add("title", options.Title)
 	}
 	if options.IsDependency {
 		parameters.Add("dependency", "true")

--- a/cmd/fossa/cmd/upload_project/upload_project.go
+++ b/cmd/fossa/cmd/upload_project/upload_project.go
@@ -43,6 +43,7 @@ func Run(ctx *cli.Context) error {
 		Name:            config.Project(),
 		Revision:        config.Revision(),
 		Directory:       dir,
+		Title:           config.Title(),
 		LicenseScanOnly: false,
 		IsDependency:    false,
 		Upload:          true,


### PR DESCRIPTION
## Description

`fossa upload-project` currently doesn't support the `title` flag.

## Acceptance Criteria
The project title can be set with `--title` on the first upload