### PR TITLE
Use 'go list' to determine transitive dependencies for gomodules projects

### DIFF
--- a/buildtools/gomodules/gomodules.go
+++ b/buildtools/gomodules/gomodules.go
@@ -57,6 +57,34 @@ func New(dir string) (Resolver, error) {
 	return resolver, nil
 }
 
+// Return the "module path" from a go.mod file
+//
+// A file containing:
+//
+//     module example.com/foo
+//
+// Returns "example.com/foo"
+func ModulePath(modFile string) (string, error) {
+	mod, err := files.Read(modFile)
+	if err != nil {
+		return "", err
+	}
+
+	for _, line := range strings.Split(string(mod), "\n") {
+		trimLine := strings.TrimSpace(line)
+		splitLine := strings.Split(trimLine, " ")
+
+		if len(splitLine) < 2 {
+			continue
+		}
+
+		if splitLine[0] == "module" {
+			return splitLine[1], nil
+		}
+	}
+	return "", errors.New("no \"module\" directive found in go.mod")
+}
+
 // ModGraph returns the dependencies found in a `go.mod` file.
 // We cannot resolve a graph so we make all dependencies direct.
 func ModGraph(filename string) (graph.Deps, error) {

--- a/buildtools/gomodules/gomodules_test.go
+++ b/buildtools/gomodules/gomodules_test.go
@@ -54,6 +54,13 @@ func TestResolver(t *testing.T) {
 	assert.Equal(t, buildtools.ErrNoRevisionForPackage, err)
 }
 
+func TestModulePath(t *testing.T) {
+	modPath, err := gomodules.ModulePath("testdata/go.mod")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "test/package", modPath)
+}
+
 func TestGoModGraph(t *testing.T) {
 	depGraph, err := gomodules.ModGraph("testdata/go.mod")
 	assert.NoError(t, err)


### PR DESCRIPTION
Our golang dependency analysis is quite complex, and best-case analysis with `go list` [is predicated on everything taking place within the `GOPATH`](https://github.com/fossas/fossa-cli/blob/83303918cc2ea8cb833d60a4a1114c6ce841395b/analyzers/golang/project.go#L76-L86). This was fine until golang introduced gomodules for package management, which can exist outside of the `GOPATH`.

This PR adds a special case to golang project creation for gomodules projects. Instead of determining the module import path and project dir via a combination of VCS and `GOPATH`, we rely on the location and contents of `go.mod` to give us that information.