### PR TITLE
fix: brew upgrade failing since v1.1.4

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,3 +39,6 @@ brews:
     commit_author:
       name: fossabot
       email: engineering@fossa.com
+
+    install: |
+      bin.install "fossa"


### PR DESCRIPTION
## Description

As described in #651 `brew upgrade fossas/tap/fossa` is failing with an error `No such file or directory - fossa-cli` since v1.1.4 was released

This is because the binary in the zipped files is called `fossa` but the brew tap refers to a binary called `fossa-cli`

The issue seems to have been introduced when fossa-bot updated the Homebrew tap with [this commit](https://github.com/fossas/homebrew-tap/commit/06452263353f5438f84b8b1a7487f9481f99d50a#diff-a74fefab164fb062b1a5603e1a828450a0d5c32fa29382f80e3035ee3a7f9037).

```
  def install
    bin.install "fossa-cli" # refers to fossa-cli, but the binary being shipped is called "fossa"
  end
```

If I understand right, fossa-bot is using GoReleaser to update [homebrew-tap](https://github.com/fossas/homebrew-tap).

This change adds a custom install script step in the GoReleaser config, to set the home-brew script to use "fossa" for the binary name instead of "fossa-cli" when fossa-cli is next released:
```
  def install
    bin.install "fossa"
  end
```

GoReleaser Documentation: https://goreleaser.com/customization/homebrew/
```
    # Custom install script for brew.
    # Default is 'bin.install "program"'.
    install: |
      bin.install "program"
```

## Acceptance Criteria

- Users can successfully upgrade fossa cli using `brew upgrade fossas/tap/fossa`

## Testing plan

I assume testing will require a fresh release of the fossa cli.

## Screenshots

### Before state

<img width="970" alt="Screenshot 2021-02-27 at 14 16 30" src="https://user-images.githubusercontent.com/47084657/109396535-01294000-792a-11eb-8ecd-67c5bce21f85.png">

## Risks

Risk of breaking the home brew tap, causing problems on brew upgrade. This is already broken as far as I can tell, so worst case it stays broken.

## Notes

N/A
