### PR TITLE
Send projectURL on upload-project

### DIFF
--- a/api/fossa/tar.go
+++ b/api/fossa/tar.go
@@ -495,6 +495,9 @@ func tarballUpload(options UploadTarballOptions, tarball *os.File, hash []byte) 
 	if options.UploadOptions.Team != "" {
 		parameters.Add("team", options.UploadOptions.Team)
 	}
+	if options.UploadOptions.ProjectURL != "" {
+		parameters.Add("projectURL", options.UploadOptions.ProjectURL)
+	}
 	if options.UploadOptions.Policy != "" {
 		parameters.Add("policy", options.UploadOptions.Policy)
 	}

--- a/cmd/fossa/cmd/upload_project/upload_project.go
+++ b/cmd/fossa/cmd/upload_project/upload_project.go
@@ -52,6 +52,7 @@ func Run(ctx *cli.Context) error {
 			JIRAProjectKey:      config.JIRAProjectKey(),
 			Team:                config.Team(),
 			Policy:              config.Policy(),
+			ProjectURL:          config.ProjectURL(),
 			ReleaseGroup:        config.ReleaseGroup(),
 			ReleaseGroupVersion: config.ReleaseGroupVersion(),
 		},


### PR DESCRIPTION
## Description
It seems that `-P` or `--project-url` does not send over a project URL when using the `upload-project` subcommand.

## Acceptance Criteria
- [ ] Project URL should be visible under project > general settings.