### PR TITLE
Fix Maven parsing error with "Downloaded" line

### DIFF
--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -169,7 +169,7 @@ func ParseDependencyTree(stdin string) (graph.Deps, error) {
 		if line == "[INFO]" || line == "[INFO] " || line == "[INFO] ------------------------------------------------------------------------" {
 			started = false
 		}
-		if strings.HasPrefix(line, "[INFO] Downloading ") || strings.HasPrefix(line, "[WARNING]") {
+		if strings.HasPrefix(line, "[INFO] Download") || strings.HasPrefix(line, "[WARNING]") {
 			continue
 		}
 		if strings.HasPrefix(line, "Download") {

--- a/buildtools/maven/testdata/dos.out
+++ b/buildtools/maven/testdata/dos.out
@@ -5,6 +5,8 @@
 [INFO] --------------------------------[ jar ]---------------------------------
 [INFO] 
 [INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ fossa ---
+[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/jdiff/jdiff/1.0.9/jdiff-1.0.9.pom (144 B at 6.0 kB/s)
+[INFO] Downloading from central: https://repo.maven.apache.org/maven2/jdiff/jdiff/1.0.9/jdiff-1.0.9.pom (144 B at 6.0 kB/s
 Downloading: http://somewhere.com
 [INFO] fossa:test:jar:1-SNAPSHOT
 [INFO] +- dep:one:jar:1.0.0:compile


### PR DESCRIPTION
## Description
This PR addresses an issue with the Maven parser that would fail when it encountered lines that began with `[INFO] Downloaded`. 

I am unsure if this is new maven behavior since we have never come across this before, but it appears to be affecting a few users in scenarios where it was not before. 

## Acceptance Criteria
- The fossa-cli can parse the full user test output that it was previously failing on.
- The fossa-cli can handle `[INFO] Downloaded` lines anywhere the dependency graph was created.

## Testing plan
- Ran the user's full output through the CLI to validate that it could successfully parse the list and get a dependency graph.
- I also wrote a test to drive the solution which contained the problematic `[INFO] Downloaded` line.
- Validated that the fix does not change any behavior with existing Maven parsing.

## Risks
No known risks that I can think of.