### PR TITLE
fix ant subdirectoy analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
     <<: *defaults
     working_directory: /go/src/github.com/fossas/fossa-cli
     docker:
-      - image: circleci/golang:1
+      - image: circleci/golang:1.16.0
     steps:
       - checkout
       - run:
@@ -117,7 +117,7 @@ jobs:
   installer-test:
     <<: *defaults
     docker:
-      - image: circleci/golang:1
+      - image: circleci/golang:1.16.0
     steps:
       - run:
           name: Make folders
@@ -140,7 +140,7 @@ jobs:
     <<: *defaults
     working_directory: /go/src/github.com/fossas/fossa-cli
     docker:
-      - image: circleci/golang:1
+      - image: circleci/golang:1.16.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       # gets better performance. The trade-off is that the CircleCI image is
       # cached but the FOSSA CLI image has build tools baked into it (but also
       # is correspondingly larger).
-      - image: circleci/golang:1
+      - image: circleci/golang:1.16.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       # gets better performance. The trade-off is that the CircleCI image is
       # cached but the FOSSA CLI image has build tools baked into it (but also
       # is correspondingly larger).
-      - image: circleci/golang:1.16.0
+      - image: circleci/golang:1
     steps:
       - checkout
       - run:
@@ -90,7 +90,7 @@ jobs:
     <<: *defaults
     working_directory: /go/src/github.com/fossas/fossa-cli
     docker:
-      - image: circleci/golang:1.16.0
+      - image: circleci/golang:1
     steps:
       - checkout
       - run:
@@ -117,7 +117,7 @@ jobs:
   installer-test:
     <<: *defaults
     docker:
-      - image: circleci/golang:1.16.0
+      - image: circleci/golang:1
     steps:
       - run:
           name: Make folders
@@ -140,7 +140,7 @@ jobs:
     <<: *defaults
     working_directory: /go/src/github.com/fossas/fossa-cli
     docker:
-      - image: circleci/golang:1.16.0
+      - image: circleci/golang:1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       # gets better performance. The trade-off is that the CircleCI image is
       # cached but the FOSSA CLI image has build tools baked into it (but also
       # is correspondingly larger).
-      - image: circleci/golang:1.12.0
+      - image: circleci/golang:1.16.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       # gets better performance. The trade-off is that the CircleCI image is
       # cached but the FOSSA CLI image has build tools baked into it (but also
       # is correspondingly larger).
-      - image: circleci/golang:1.16.0
+      - image: circleci/golang:1.12.0
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ build: $(BIN)/fossa
 
 $(BIN)/fossa: $(GO_BINDATA) $(GENNY) $(shell find . -name *.go)
 	go mod download
+	go mod tidy
 	go generate ./...
 	go build -o $@ $(GCFLAGS) $(LDFLAGS) github.com/fossas/fossa-cli/cmd/fossa
 

--- a/analyzers/ant/ant.go
+++ b/analyzers/ant/ant.go
@@ -62,11 +62,12 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 	}
 
 	log.Debugf("resolving ant libs in: %s", libdir)
-	if ok, err := files.ExistsFolder(a.Module.Dir, libdir); !ok || err != nil {
-		return graph.Deps{}, errors.New("unable to resolve library directory, try specifying it using the `modules.options.libdir` property in `.fossa.yml`")
+	libdirPath := filepath.Join(a.Module.Dir, libdir)
+	if ok, err := files.ExistsFolder(libdirPath); !ok || err != nil {
+		return graph.Deps{}, errors.New("unable to resolve library directory, try specifying it using the `lib-directory` option in `.fossa.yml`")
 	}
 
-	deps, graphErr := ant.Graph(libdir)
+	deps, graphErr := ant.Graph(libdirPath)
 	if graphErr != nil {
 		return graph.Deps{}, graphErr
 	}


### PR DESCRIPTION
## Description
This ticket addresses an issue with Ant analysis not being able to scan projects with lib directories located in different directories than the `build.xml` file.

Closes https://github.com/fossas/team-analysis/issues/539

## Acceptance Criteria
`lib-directories` that are located in subdirectories of an ant project, when the ant project is located in a subdirectory of the root, are properly scanned. 

## Testing plan

- Construct a project with a `build.xml` file in a subdirectory. Example `test/build.xml`
- Add a `lib` directory with at least 1 dependency to a deeper subdirectory `test/tmp/lib`
- Configure the CLI properly with the `lib-directory` option and run `fossa analyze`

## Risks
There are no risks with this. I considered the fact that maybe this is not backward compatible, however, due to the fact we were previously checking if the lid directory existed (in the correct location) we are not breaking any workflow that is not already broken.
