### PR TITLE
Fix node_modules strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       # gets better performance. The trade-off is that the CircleCI image is
       # cached but the FOSSA CLI image has build tools baked into it (but also
       # is correspondingly larger).
-      - image: circleci/golang:1
+      - image: circleci/golang:1.16
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ build: $(BIN)/fossa
 
 $(BIN)/fossa: $(GO_BINDATA) $(GENNY) $(shell find . -name *.go)
 	go mod download
-	go mod tidy
 	go generate ./...
 	go build -o $@ $(GCFLAGS) $(LDFLAGS) github.com/fossas/fossa-cli/cmd/fossa
 

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ build: $(BIN)/fossa
 
 $(BIN)/fossa: $(GO_BINDATA) $(GENNY) $(shell find . -name *.go)
 	go mod download
+	go mod tidy
 	go generate ./...
 	go build -o $@ $(GCFLAGS) $(LDFLAGS) github.com/fossas/fossa-cli/cmd/fossa
 

--- a/analyzers/nodejs/nodejs.go
+++ b/analyzers/nodejs/nodejs.go
@@ -240,10 +240,15 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 
 		log.Debug("Using fallback of node_modules")
 	}
+	deps, err := npm.FromNodeModules(a.Module.BuildTarget, a.DevDeps)
+	if err == nil {
+		return deps, nil
+	}
 
+	log.Warnf("Could not determine deps from node_modules")
 	log.Debug("Using fallback of yarn lockfile check")
 
-	deps, err := a.Yarn.List(a.Module.BuildTarget, a.DevDeps)
+	deps, err = a.Yarn.List(a.Module.BuildTarget, a.DevDeps)
 	if err == nil && len(deps.Direct) > 0 {
 		return deps, nil
 	}

--- a/analyzers/nodejs/nodejs.go
+++ b/analyzers/nodejs/nodejs.go
@@ -241,15 +241,9 @@ func (a *Analyzer) Analyze() (graph.Deps, error) {
 		log.Debug("Using fallback of node_modules")
 	}
 
-	deps, err := npm.FromNodeModules(a.Module.BuildTarget, a.DevDeps)
-	if err == nil {
-		return deps, nil
-	}
-
-	log.Warnf("Could not determine deps from node_modules")
 	log.Debug("Using fallback of yarn lockfile check")
 
-	deps, err = a.Yarn.List(a.Module.BuildTarget, a.DevDeps)
+	deps, err := a.Yarn.List(a.Module.BuildTarget, a.DevDeps)
 	if err == nil && len(deps.Direct) > 0 {
 		return deps, nil
 	}

--- a/buildtools/npm/manifest.go
+++ b/buildtools/npm/manifest.go
@@ -184,6 +184,9 @@ func fromModulesHelper(pathToModule string, moduleProjects map[pkg.ID]pkg.Packag
 			return err
 		}
 
+		if _, exists := moduleProjects[modulePackage.ID]; exists {
+			continue
+		}
 		moduleProjects[modulePackage.ID] = modulePackage
 
 		err = fromModulesHelper(pathToDepModule, moduleProjects, devDeps)


### PR DESCRIPTION
## Description
A customer is seeing an issue where after the command `npm ls --production` fails, we infinitely recurse through their `node_modules` directory.

The strategy appears to be infinitely recursing if any manifest in the `node_modules` dir refers to another manifest in the `node_modules`. I'm not sure if this strategy ever worked.

This PR is fixing the recursion by exiting when we reach a node that we have already seen before.

## Acceptance Criteria
Running analysis with `strategy: package.json` succeeds and does not infinitely recurse.

## Testing plan
I tested this on the FOSSA core repository with and without my changes. Without the changes, I saw an infinite recursion. 

## Risks
The risks are very low. This removes the potential for infinite recursion and does not add any new failure cases to the CLI. The largest risk is that recursing without this check somehow provided superior data, however, I am unable to see how that would be the case.
