### PR TITLE
fix: Remove evicted SBT dependencies

### DIFF
--- a/buildtools/sbt/parse.go
+++ b/buildtools/sbt/parse.go
@@ -65,6 +65,10 @@ func ParseDependencyGraph(graph Graph, evicted string) (pkg.Imports, pkg.Deps, e
 
 	pkgs := make(pkg.Deps)
 	for id, imports := range deps {
+		_, isEvicted := replacements[id]
+		if isEvicted {
+			continue
+		}
 		pkgs[id] = pkg.Package{
 			ID:      id,
 			Imports: imports,

--- a/buildtools/sbt/sbt_test.go
+++ b/buildtools/sbt/sbt_test.go
@@ -74,9 +74,17 @@ func TestSanityCheckParseDependencyTree(t *testing.T) {
 
 	_, pkgs, err := sbt.ParseDependencyGraph(graph.Graph, string(evicted))
 	assert.NoError(t, err)
+	assert.NotEmpty(t, pkgs)
 
 	for id, pkg := range pkgs {
 		assert.Equal(t, id, pkg.ID)
+	}
+
+	replacements := sbt.ParseEvicted(string(evicted))
+	for id := range pkgs {
+		for source := range replacements {
+			assert.NotEqual(t, id, source)
+		}
 	}
 }
 
@@ -142,6 +150,7 @@ func TestFilterLines(t *testing.T) {
 		assert.True(t, actual, line)
 	}
 }
+
 func findPackage(packages map[pkg.ID]pkg.Package, name, revision string) pkg.Package {
 	for id := range packages {
 		if id.Name == name && id.Revision == revision {


### PR DESCRIPTION
## Description

This PR fixes [ZD-2838](https://fossa.zendesk.com/agent/tickets/2838).

SBT has a notion of "evicted" dependencies, which are dependencies versions that were considered but rejected because they conflicted with other versions.

Normally, evicted dependencies aren't reflected in the output of `sbt :dependencyGraphMl`, which is the output the CLI parses for SBT's dependency graph. Dependencies in this graph show their original resolved versions, even if those resolved versions will actually be rejected at build time.

SBT provides an `sbt :evicted` task that prints out a list of dependencies whose versions are rejected, and which version is chosen instead.

For example fixture outputs of these commands, see the dependency graph [here](https://github.com/fossas/fossa-cli/blob/a63843689fbc32ce4c5dc64b378570c25b2afdbc/buildtools/sbt/testdata/sbt_dependencygraphml-prisma.xml) and the eviction output [here](https://github.com/fossas/fossa-cli/blob/a63843689fbc32ce4c5dc64b378570c25b2afdbc/buildtools/sbt/testdata/sbt_evicted_nocolor-prisma).

The CLI analyzes SBT dependencies by:

1. Running `sbt :dependencyGraphMl` and parsing the resulting XML file.
2. Running `sbt :evicted` to get a list of evicted dependencies.
3. Replacing all evicted dependencies in the graph from (1) with their corrected versions.

This PR fixes a bug in step (3) where evicted dependency graph _edges_ were correctly replaced, but the dependencies themselves were not removed.

## Acceptance Criteria

- Evicted dependencies no longer appear in dependency graph node lists.

## Testing plan

- Print out the dependency graph in the SBT unit test, check that it's sensible, and check that it does not include evicted dependencies (compare against the evictions output file).
- Use `go test ./buildtools/sbt` for this.
- Undo the buildtool logic changes, see that the test breaks.