### PR TITLE
Update genny calls to not use gopath

### DIFF
--- a/buildtools/composer/composer.go
+++ b/buildtools/composer/composer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fossas/fossa-cli/exec"
 )
 
-//go:generate bash -c "genny -in=$GOPATH/src/github.com/fossas/fossa-cli/graph/readtree.go gen 'Generic=Package' | sed -e 's/package graph/package composer/' > readtree_generated.go"
+//go:generate bash -c "genny -in=../../graph/readtree.go gen 'Generic=Package' | sed -e 's/package graph/package composer/' > readtree_generated.go"
 
 // A Composer can return the output of the `show` and `install` commands.
 type Composer interface {

--- a/buildtools/gradle/gradle.go
+++ b/buildtools/gradle/gradle.go
@@ -158,7 +158,7 @@ func (s ShellCommand) DependencyTasks() ([]string, error) {
 	return projects, nil
 }
 
-//go:generate bash -c "genny -in=$GOPATH/src/github.com/fossas/fossa-cli/graph/readtree.go gen 'Generic=Dependency' | sed -e 's/package graph/package gradle/' > readtree_generated.go"
+//go:generate bash -c "genny -in=../../graph/readtree.go gen 'Generic=Dependency' | sed -e 's/package graph/package gradle/' > readtree_generated.go"
 
 func ParseDependencies(stdout string) ([]Dependency, map[Dependency][]Dependency, error) {
 	r := regexp.MustCompile(`^((?:[|+]? +)*[\\+]--- )(.*)$`)

--- a/buildtools/leiningen/leiningen.go
+++ b/buildtools/leiningen/leiningen.go
@@ -68,7 +68,7 @@ func ValidBinary(dir string) (string, error) {
 	return lein, err
 }
 
-//go:generate bash -c "genny -in=$GOPATH/src/github.com/fossas/fossa-cli/graph/readtree.go gen 'Generic=Dependency' | sed -e 's/package graph/package leiningen/' > readtree_generated.go"
+//go:generate bash -c "genny -in=../../graph/readtree.go gen 'Generic=Dependency' | sed -e 's/package graph/package leiningen/' > readtree_generated.go"
 
 // DependencyGraph uses a Shell's Cmd to generate leiningen formatted output which is
 // converted to a dependency graph.

--- a/buildtools/maven/maven.go
+++ b/buildtools/maven/maven.go
@@ -153,7 +153,7 @@ func (m *Maven) tryDependencyCommands(subGoal, dir, buildTarget string) (stdout 
 	return output, err
 }
 
-//go:generate bash -c "genny -in=$GOPATH/src/github.com/fossas/fossa-cli/graph/readtree.go gen 'Generic=Dependency' | sed -e 's/package graph/package maven/' > readtree_generated.go"
+//go:generate bash -c "genny -in=../../graph/readtree.go gen 'Generic=Dependency' | sed -e 's/package graph/package maven/' > readtree_generated.go"
 
 func ParseDependencyTree(stdin string) (graph.Deps, error) {
 	var modules [][]string


### PR DESCRIPTION
## Description
If a dev does not have a clone in their `GOPATH` (and they shouldn't need to after we switched to gomod), then `genny` will fail, as it was explicitly using `$GOPATH`.  This has been fixed by using relative file paths.

## Acceptance Criteria
* Run `go generate ./...` at the project root, no files named `readtree_generated.go` should be altered.

## Testing plan
Checkout this pr, Run `make clean && make build` in your local environment, confirm no significant changes to generated files.

## Risks
Might break builds if working directory from genny invocation is not guaranteed.

## Notes
Tried using `$GOMOD` (from `go env`), but that was somehow not set during `go:generate`