### PR TITLE
NodeJS - Add support for NPM7

### DIFF
--- a/buildtools/npm/npm.go
+++ b/buildtools/npm/npm.go
@@ -40,10 +40,10 @@ func (n SystemNPM) List(dir string, devDeps bool) (Output, error) {
 	listCmd := exec.Cmd{
 		Name: n.Cmd,
 		Dir:  dir,
-		Argv: []string{"ls", "--json"},
+		Argv: []string{"ls", "--json", "--all"},
 	}
 	if !devDeps {
-		listCmd.Argv = []string{"ls", "--json", "--production"}
+		listCmd.Argv = []string{"ls", "--json", "--all", "--production"}
 	}
 
 	stdout, _, err := exec.Run(listCmd)


### PR DESCRIPTION
NPM7 changed npm ls command. '--all' is required to get deep dependencies.

## Description
As in described in Issue #672, NPM 7 changed npm ls behavior. `--all` option is required to have deep dependencies listed. 

Fossa cli uses npm ls internally to get the list of dependencies, so to add support to the latest version, the --all option shall be added. 


