### PR TITLE
Fix binary name in homebrew install

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,3 +39,6 @@ brews:
     commit_author:
       name: fossabot
       email: engineering@fossa.com
+
+    install: |
+      bin.install 'fossa'


### PR DESCRIPTION
## Description

Goreleaser changed its default behavior when generating homebrew formulas. Rather than searching for available binaries and using those to generate the install step, `goreleaser` now assumes that the binary name is the same as the project name unless told otherwise.

This is the goreleaser commit that broke our homebrew formula: https://github.com/goreleaser/goreleaser/commit/78b0097dc26d86543934eb842ca0cf012ca2d2bd#diff-4c1557cb946e49d7b4b6cc11072e60fa90199e2235d14ecf118eecd38673130d

This explicitly sets the binary name to `fossa` in the formula.

Fixes https://github.com/fossas/homebrew-tap/issues/2

## Acceptance Criteria

- Installation via `brew install fossas/tap/fossa` succeeds

## Testing plan

I used goreleaser to push a new formula to our homebrew tap. It can be installed via `brew install fossas/tap/fossa`