### PR TITLE
Fix npm installation for correctness and security

### DIFF
--- a/buildtools/npm/npm.go
+++ b/buildtools/npm/npm.go
@@ -67,7 +67,7 @@ func (n SystemNPM) Clean(dir string) error {
 func (n SystemNPM) Install(dir string) error {
 	_, _, err := exec.Run(exec.Cmd{
 		Name: n.Cmd,
-		Argv: []string{"install", "--production"},
+		Argv: []string{"ci", "--ignore-scripts", "--production"},
 		Dir:  dir,
 	})
 	if err != nil && !n.AllowErr {


### PR DESCRIPTION
## changes and why:

- switch from `npm install` to `npm ci` that respects the contents of package-lock.json
- add --ignore-scripts to avoid executing malicious scripts for a fossa user who's otherwise secure in their build pipeline

--ignore-scripts could depend on external configuration or be passed from the top as well,

## context

Many npm packages consumers set up their pipelines to avoid consequences of running postinstall scripts from all packages in their dependencies in case a tiny irrelevant package gets taken over by a malicious actor. 

https://dev.to/naugtur/get-safe-and-remain-productive-with-can-i-ignore-scripts-2ddc
https://snyk.io/blog/npm-security-malicious-code-in-oss-npm-packages/

## discussion

Let's discuss if the change I suggested makes sense for the overall usecase. Maybe you support incredibly old versions of npm and a bit of if-else is necessary here? Or should the --ignore-scripts param be also documented?
Postinstall scripts can do anything, so they can also install additional packages probably. It's less of an omission than skipping entire devDependencies where frontend build tool plugins might exist and they could be adding polyfills and other code to the final shippable bundle. So if running --production and documenting it so is fine, --ignore-scripts should be much less controversial. 