### PR TITLE
Deduplicate vendored deps

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## v3.0.1
+
+- Deduplicates `vendored-dependencies` entries when possible, and provides a better error message when not. ([#689](https://github.com/fossas/fossa-cli/pull/689))
+
 # Version 3 Changelog
 
 - Migrates source code from [spectrometer](https://github.com/fossas/spectrometer) into fossa-cli (this repository). 
@@ -7,10 +11,6 @@
 # Version 2 Changelog
 
 Releases for CLI 2.x can be found at: https://github.com/fossas/spectrometer/releases
-
-## v3.0.1
-
-- Deduplicates `vendored-dependencies` entries when possible, and provides a better error message when not. ([#689](https://github.com/fossas/fossa-cli/pull/689))
 
 ## v2.19.9
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Spectrometer Changelog
 
+## v3.0.1
+
+- Deduplicates `vendored-dependencies` entries when possible, and provides a better error message when not. ([#689](https://github.com/fossas/fossa-cli/pull/689))
+
 ## v2.19.9
 
 - Go: Fixes a regression, where deep dependencies were reported as direct dependencies. ([#443](https://github.com/fossas/spectrometer/pull/443/))

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -20,10 +20,12 @@ import Data.Aeson (
 import Data.Aeson.Extra
 import Data.ByteString.Lazy qualified as BS
 import Data.Functor.Extra ((<$$>))
-import Data.List (intercalate)
+import Data.List (intercalate, nub)
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion
 import Data.Text (Text)
+import Data.Text qualified as Text
 import Fossa.API.Types
 import Path hiding ((</>))
 import Srclib.Types (Locator (..))
@@ -64,7 +66,18 @@ compressAndUpload apiOpts arcDir tmpDir dependency = do
 -- Using this information, it uploads each vendored dependency and queues a build for the dependency.
 archiveUploadSourceUnit :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => Path Abs Dir -> ApiOpts -> [VendoredDependency] -> m [Locator]
 archiveUploadSourceUnit baseDir apiOpts vendoredDeps = do
-  archives <- withSystemTempDir "fossa-temp" (uploadArchives apiOpts vendoredDeps baseDir)
+  -- Users with many instances of vendored dependencies may accidentally have complete duplicates. Remove them.
+  let uniqDeps = nub vendoredDeps
+
+  -- However, users may also have vendored dependencies that have duplicate names but are not complete duplicates.
+  -- These aren't valid and can't be automatically handled, so fail the scan with them.
+  let duplicates = duplicateNames uniqDeps
+  if not $ null duplicates
+    then Diag.fatalText $ duplicateFailureBundle duplicates
+    else pure ()
+
+  -- At this point, we have a good list of deps, so go for it.
+  archives <- withSystemTempDir "fossa-temp" (uploadArchives apiOpts uniqDeps baseDir)
 
   -- archiveBuildUpload takes archives without Organization information. This orgID is appended when creating the build on the backend.
   -- We don't care about the response here because if the build has already been queued, we get a 401 response.
@@ -83,6 +96,24 @@ archiveUploadSourceUnit baseDir apiOpts vendoredDeps = do
 -- archiveNoUploadSourceUnit exists for when users run `fossa analyze -o` and do not upload their source units.
 archiveNoUploadSourceUnit :: [VendoredDependency] -> [Locator]
 archiveNoUploadSourceUnit = map (arcToLocator . forceVendoredToArchive)
+
+duplicateNames :: [VendoredDependency] -> [Text]
+duplicateNames deps = map extract $ filter isDuplicated (Map.toList . Map.fromListWith (+) . map pair $ deps)
+  where
+    extract :: (Text, Int) -> Text
+    extract (a, _) = a
+    isDuplicated :: (Text, Int) -> Bool
+    isDuplicated (_, c) = c > 1
+    pair :: VendoredDependency -> (Text, Int)
+    pair VendoredDependency{vendoredName} = (vendoredName, 1)
+
+duplicateFailureBundle :: [Text] -> Text
+duplicateFailureBundle names =
+  "The provided vendored dependencies contain the following duplicate names:\n\t"
+    <> Text.intercalate "\n\t" names
+    <> "\n\n"
+    <> "Vendored dependency entries may not specify duplicate names.\n"
+    <> "Please ensure that each vendored dependency entry has a unique name."
 
 forceVendoredToArchive :: VendoredDependency -> Archive
 forceVendoredToArchive dep = Archive (vendoredName dep) (fromMaybe "" $ vendoredVersion dep)


### PR DESCRIPTION
# Overview

If the user specifies fully duplicate values, we’ll simply deduplicate them. For example, this:
```yaml
vendored-dependencies:
- name: example_a
  path: ./some/path
  version: 1.0
- name: example_a
  path: ./some/path
  version: 1.0
```

Gets collapsed to this:
```yaml
vendored-dependencies:
- name: example_a
  path: ./some/path
  version: 1.0
```

However if a user specifies a duplicate name, but distinct path or version entries:
```yaml
vendored-dependencies:
- name: "example_a"
  path: ./some/path
- name: "example_a"
  path: ./some/other/path
```

We’ll fail with an error like this:

```shell
[ERROR] ----------
  An error occurred:

      The provided vendored dependencies contain the following duplicate names:
      	example_a

      Vendored dependency entries may not specify duplicate names.
      Please ensure that each vendored dependency entry has a unique name.

      Traceback:
        - Converting fossa-deps to partial API payload
        - fossa-deps
        - fossa-analyze
```

The reason is that in the second case, we can’t really handle it for them: they’ve given us ambiguous information.

## Acceptance criteria

The context behind this change is that if the user attempts to upload multiple `vendored-dependencies` errors that result in duplicate project IDs, the upload fails and the user is greeted with a cryptic error:

```
[ERROR] ----------
  An error occurred:

      An unknown error occurred when accessing the FOSSA API: VanillaHttpException (HttpExceptionRequest Request {
        <snip> 
      }) "{\"uuid\":\"9423ab26-be4e-4236-93f4-11f98ca5e739\",\"code\":3,\"message\":\"Sorry, we've encountered an unexpected error. We've recorded it. If you continue to see this, contact support at support@fossa.com and include the unique reference code: 9423ab26-be4e-4236-93f4-11f98ca5e739\",\"httpStatusCode\":500}"))

      Traceback:
        - Queuing a build for an archive project
        - Converting fossa-deps to partial API payload
        - fossa-deps
        - fossa-analyze
```

Meanwhile, on the server, the issue is that some of the uploaded dependencies had duplicate names:

```
UniqueConstraintError: Validation error
{"path":"project_id","message":"project_id must be unique","type":"unique violation","value":"archive+1/gson-2.8.5"}
```

This is especially prevalent in some projects with _many_ `vendored-dependencies` entries, which make it difficult for users to validate that they're not uploading duplicate names.

The intent behind this change is therefore to:

- Automatically handle fully duplicate entries. This not only reduces work on the CLI side, but avoids this error.
- Provide a more clear error message to users when they provide entries which would result in this error.

## Testing plan

1. Create a project with a `fossa-deps.yaml` inside replicating these examples.
2. Validate that the CLI takes the appropriate action as described in this PR.

An example project replicating this is attached here: [duplicate-vendored-deps.zip](https://github.com/fossas/fossa-cli/files/7541681/duplicate-vendored-deps.zip)

Download an extract this somewhere, eg `~/Downloads/duplicate-vendored-deps`.
Execute `cabal run fossa -- analyze ~/Downloads/duplicate-vendored-deps`.
Observe that the output is as follows:

```
[ERROR] ----------
  An error occurred:

      The provided vendored dependencies contain the following duplicate names:
      	libssl

      Vendored dependency entries may not specify duplicate names.
      Please ensure that each vendored dependency entry has a unique name.

      Traceback:
        - Converting fossa-deps to partial API payload
        - fossa-deps
        - fossa-analyze
```

Then edit the `fossa-deps.yml` to have the following structure instead:
```yaml
vendored-dependencies:
- name: libssl
  path: libssl
  version: 1
- name: libjson
  path: libjson
  version: 1
- name: libssl2
  path: libssl2
  version: 2
```

Execute `cabal run fossa -- analyze ~/Downloads/duplicate-vendored-deps`, and note that the analysis now succeeds.

## Risks

Not very risky.

## References

This is being done as a fix for an issue brought up by a user in Slack.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
