### PR TITLE
Fixes Gradle Analysis when sub projects have _ in the name

### DIFF
--- a/test/Gradle/GradleSpec.hs
+++ b/test/Gradle/GradleSpec.hs
@@ -9,7 +9,13 @@ import Data.Text (Text)
 import DepTypes
 import GraphUtil
 import Graphing (Graphing, empty)
-import Strategy.Gradle (ConfigName (..), JsonDep (..), PackageName (..), buildGraph)
+import Strategy.Gradle (
+  ConfigName (..),
+  JsonDep (..),
+  PackageName (..),
+  buildGraph,
+  packagePathsWithJson,
+ )
 import Test.Hspec
 
 projectOne :: Dependency
@@ -116,6 +122,13 @@ wrapKeys (a, b) = (PackageName a, ConfigName b)
 
 spec :: Spec
 spec = do
+  describe "packagePathsWithJson" $ do
+    it "should break package and jsonText correctly for project with _" $ do
+      packagePathsWithJson ["sub-project_{}"] `shouldBe` [(PackageName "sub-project", "{}")]
+      packagePathsWithJson ["sub_project_{}"] `shouldBe` [(PackageName "sub_project", "{}")]
+      packagePathsWithJson ["sub-project__{}"] `shouldBe` [(PackageName "sub-project_", "{}")]
+      packagePathsWithJson ["subProject_{}"] `shouldBe` [(PackageName "subProject", "{}")]
+
   describe "buildGraph" $ do
     it "should produce an empty graph for empty input" $ do
       let graph = buildGraph Map.empty (Set.fromList [])


### PR DESCRIPTION
# Overview

This PR fixes gradle analysis for projects containing _ in their name.

## Acceptance criteria

- The CLI includes dependencies for projects whose name contains underscore(s)

## Testing plan

Create gradle project with _ in the name:

```groovy
// in sub_project/build.gradle
plugins {
  id 'java'
}
repositories {
  mavenCentral()
}
dependencies {
  implementation('com.google.guava:guava:31.0.1-jre')
}

```

```groovy
// build.gradle
plugins {
  id 'java'
}

```

1. Run `fossa analyze -o | jq`

It should contain `mvn+com.google.guava:guava$31.0.1-jre` as direct dependency. 

## Risks

N/A

## References

Closes https://github.com/fossas/team-analysis/issues/806

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
