### PR TITLE
Increases timeout for dependency scan from 10min to 30min

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -40,4 +40,4 @@ jobs:
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: |
-          fossa test
+          fossa test --timeout 1800


### PR DESCRIPTION
# Overview

Increases  timeout for dependency scan from 10min to 30min for CI test (getting frequent timeouts)