### PR TITLE
Log `vendored-dependency` processing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## v3.0.1
+
+- Adds logging to `vendored-dependencies` processing. ([#703](https://github.com/fossas/fossa-cli/pull/703))
+
 # Version 3 Changelog
 
 - Migrates source code from [spectrometer](https://github.com/fossas/spectrometer) into fossa-cli (this repository). 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -355,7 +355,7 @@ analyze (BaseDir basedir) destination override unpackArchives jsonOutput include
       then do
         logInfo "Running in VSI only mode, skipping manual source units"
         pure Nothing
-      else Diag.context "fossa-deps" $ analyzeFossaDepsFile basedir apiOpts
+      else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir apiOpts
   let additionalSourceUnits :: [SourceUnit]
       additionalSourceUnits = catMaybes [manualSrcUnits, vsiResults, binarySearchResults]
 

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module App.Fossa.ArchiveUploader (
   archiveUploadSourceUnit,
   archiveNoUploadSourceUnit,
@@ -8,6 +10,8 @@ import App.Fossa.FossaAPIV1 qualified as Fossa
 import Codec.Archive.Tar qualified as Tar
 import Codec.Compression.GZip qualified as GZip
 import Control.Carrier.Diagnostics qualified as Diag
+import Control.Carrier.StickyLogger (StickyLogger, logSticky)
+import Control.Effect.Diagnostics (context)
 import Control.Effect.Lift
 import Control.Effect.Path (withSystemTempDir)
 import Crypto.Hash
@@ -43,26 +47,28 @@ instance FromJSON VendoredDependency where
       <*> (unTextLike <$$> obj .:? "version")
       <* forbidMembers "vendored dependencies" ["type", "license", "url", "description"] obj
 
-uploadArchives :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => ApiOpts -> [VendoredDependency] -> Path Abs Dir -> Path Abs Dir -> m [Archive]
+uploadArchives :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m) => ApiOpts -> [VendoredDependency] -> Path Abs Dir -> Path Abs Dir -> m [Archive]
 uploadArchives apiOpts deps arcDir tmpDir = traverse (compressAndUpload apiOpts arcDir tmpDir) deps
 
-compressAndUpload :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => ApiOpts -> Path Abs Dir -> Path Abs Dir -> VendoredDependency -> m Archive
-compressAndUpload apiOpts arcDir tmpDir dependency = do
-  compressedFile <- sendIO $ compressFile tmpDir arcDir (toString $ vendoredPath dependency)
+compressAndUpload :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m) => ApiOpts -> Path Abs Dir -> Path Abs Dir -> VendoredDependency -> m Archive
+compressAndUpload apiOpts arcDir tmpDir VendoredDependency{..} = context "compressing and uploading vendored deps" $ do
+  logSticky $ "Compressing '" <> vendoredName <> "' at '" <> vendoredPath <> "'"
+  compressedFile <- sendIO $ compressFile tmpDir arcDir (toString vendoredPath)
 
-  depVersion <- case vendoredVersion dependency of
+  depVersion <- case vendoredVersion of
     Nothing -> sendIO $ hashFile compressedFile
     Just version -> pure version
 
-  signedURL <- Fossa.getSignedURL apiOpts depVersion (vendoredName dependency)
+  signedURL <- Fossa.getSignedURL apiOpts depVersion vendoredName
 
+  logSticky $ "Uploading '" <> vendoredName <> "' to secure S3 bucket"
   _ <- Fossa.archiveUpload signedURL compressedFile
 
-  pure $ Archive (vendoredName dependency) depVersion
+  pure $ Archive vendoredName depVersion
 
 -- archiveUploadSourceUnit receives a list of vendored dependencies, a root path, and API settings.
 -- Using this information, it uploads each vendored dependency and queues a build for the dependency.
-archiveUploadSourceUnit :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => Path Abs Dir -> ApiOpts -> [VendoredDependency] -> m [Locator]
+archiveUploadSourceUnit :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m) => Path Abs Dir -> ApiOpts -> [VendoredDependency] -> m [Locator]
 archiveUploadSourceUnit baseDir apiOpts vendoredDeps = do
   archives <- withSystemTempDir "fossa-temp" (uploadArchives apiOpts vendoredDeps baseDir)
 

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -26,6 +26,7 @@ import Data.Aeson (
 
 import App.Fossa.ArchiveUploader
 import Control.Effect.Lift
+import Control.Effect.StickyLogger (StickyLogger)
 import Data.Aeson.Extra
 import Data.Aeson.Types (Parser)
 import Data.Functor.Extra ((<$$>))
@@ -45,7 +46,7 @@ data FoundDepsFile
   = ManualYaml (Path Abs File)
   | ManualJSON (Path Abs File)
 
-analyzeFossaDepsFile :: (Has Diagnostics sig m, Has ReadFS sig m, Has (Lift IO) sig m) => Path Abs Dir -> Maybe ApiOpts -> m (Maybe SourceUnit)
+analyzeFossaDepsFile :: (Has Diagnostics sig m, Has ReadFS sig m, Has (Lift IO) sig m, Has StickyLogger sig m) => Path Abs Dir -> Maybe ApiOpts -> m (Maybe SourceUnit)
 analyzeFossaDepsFile root maybeApiOpts = do
   maybeDepsFile <- findFossaDepsFile root
   case maybeDepsFile of
@@ -77,7 +78,7 @@ findFossaDepsFile root = do
     (_, _, True) -> pure $ Just $ ManualJSON jsonFile
     (False, False, False) -> pure Nothing
 
-toSourceUnit :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path Abs Dir -> FoundDepsFile -> ManualDependencies -> Maybe ApiOpts -> m SourceUnit
+toSourceUnit :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has StickyLogger sig m) => Path Abs Dir -> FoundDepsFile -> ManualDependencies -> Maybe ApiOpts -> m SourceUnit
 toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts = do
   -- If the file exists and we have no dependencies to report, that's a failure.
   when (hasNoDeps manualDeps) $ fatalText "No dependencies found in fossa-deps file"


### PR DESCRIPTION
# Overview

Adds sticky logging to `vendored-dependency` processing.

## Acceptance criteria

The context for this change is that when users have lots of vendored dependencies, or a small number of large vendored dependencies, they can run multiple minutes without the CLI outputting anything. Sometimes this causes users to feel that the CLI is locked up, causing them to exit the program and send in a support request.
(Aside: this is a quirk of the fact that we search for and upload `vendored-dependencies` before we do the standard analysis flow.)

The intent of this change is to make it more obvious when the CLI is performing blocking analysis, so that the user can:

- Feel confident the CLI is actually doing things.
- Troubleshoot which of their archives is causing it to take a long time to process (if needed).

## Testing plan

I created an example project with some large vendored dependencies: [huge-vendored-dependencies.zip](https://github.com/fossas/fossa-cli/files/7542486/huge-vendored-dependencies.zip) (this zip file just contains a `fossa-deps.yml` and a `load.sh` file; execute `load.sh` to download the vendored dependencies).

I then ran `fossa analyze` on this project before these changes, and noted that the CLI appeared to be doing nothing. However, that clearly wasn't the case, as I observed it using CPU in Activity Monitor.

I then applied the changes in this PR, and observed that I now see sticky log output indicating what the CLI is doing. Reproduced in `--debug` form, this is what you should expect to see:

```
[DEBUG] Compressing 'glfw' at 'vendored/glfw'
[DEBUG] Uploading 'glfw' to secure S3 bucket
[DEBUG] Compressing 'postgres' at 'vendored/postgres'
[DEBUG] Uploading 'postgres' to secure S3 bucket
[DEBUG] Compressing 'tesseract' at 'vendored/tesseract'
[DEBUG] Uploading 'tesseract' to secure S3 bucket
[DEBUG] [ 0 Waiting / 1 Running / 0 Completed ]
[DEBUG] [ 0 Waiting / 4 Running / 0 Completed ]
...
[ INFO]
[ INFO] Using project name: `large-vendored-deps`
[ INFO] Using revision: `1637023472`
[ INFO] Using branch: `No branch (detached HEAD)`
[ INFO] ============================================================

      View FOSSA Report:
      https://app.fossa.com/projects/custom+24357%2flarge-vendored-deps/refs/branch/master/1637023472

  ============================================================
```

Note: we don't get the nice "sticky context" logging standard analysis does; I think this is because we don't qualify for `StickyDiagC` since we're not dispatching with `withTaskPool capabilities updateProgress . runAtomicCounter`. I didn't think this was worth spending a lot of time trying to make work.

## Risks

This is all informational; I don't expect major risk here.

## References

This is a result of a slack conversation with an end user while on-duty.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
