### PR TITLE
Fixes .net graphing for project.assets.json target type

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Fossa CLI Changelog
 
+## v3.0.2
+
+- Nuget (projectassetsjson): Ignores project type dependencies in reporting ([#704](https://github.com/fossas/fossa-cli/pull/704))
+- Nuget (projectassetsjson): Fixes a bug, where indirect dependencies where appearing as direct dependencies([#704](https://github.com/fossas/fossa-cli/pull/704))
+
 ## v3.0.1
 
 - Deduplicates `vendored-dependencies` entries when possible, and provides a better error message when not. ([#689](https://github.com/fossas/fossa-cli/pull/689))

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -47,6 +47,7 @@ module Graphing (
   fromList,
   toList,
   unfold,
+  unfoldDeep,
 ) where
 
 import Algebra.Graph.AdjacencyMap (AdjacencyMap)
@@ -229,6 +230,31 @@ deeps = Graphing . AM.vertices . map Node
 -- __Unfold does not work for recursive inputs__
 unfold :: forall dep res. Ord res => [dep] -> (dep -> [dep]) -> (dep -> res) -> Graphing res
 unfold seed getDeps toDependency = directs directNodes <> edges builtEdges
+  where
+    directNodes :: [res]
+    directNodes = map toDependency seed
+
+    builtEdges :: [(res, res)]
+    builtEdges = map (bimap toDependency toDependency) (edgesFrom seed)
+
+    edgesFrom :: [dep] -> [(dep, dep)]
+    edgesFrom nodes = do
+      node <- nodes
+      let children = getDeps node
+      map (node,) children ++ edgesFrom children
+
+-- | @unfoldDeep dep getDeps toDependency@ unfolds a graph, given:
+--
+-- - The @dep@ dependencies in the graph
+--
+-- - A way to @getDeps@ for a dependency
+--
+-- - A way to convert a dependency @toDependency@
+--
+-- __unfoldDeep does not work for recursive inputs__
+-- __unfoldDeep marks all dependencies as deeps__
+unfoldDeep :: forall dep res. Ord res => [dep] -> (dep -> [dep]) -> (dep -> res) -> Graphing res
+unfoldDeep seed getDeps toDependency = deeps directNodes <> edges builtEdges
   where
     directNodes :: [res]
     directNodes = map toDependency seed

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -245,7 +245,7 @@ unfold seed getDeps toDependency = directs directNodes <> edges builtEdges
 
 -- | @unfoldDeep dep getDeps toDependency@ unfolds a graph, given:
 --
--- - The @dep@ dependencies in the graph
+-- - The @deep@ dependencies in the graph
 --
 -- - A way to @getDeps@ for a dependency
 --

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -7,21 +7,31 @@ module Strategy.NuGet.ProjectAssetsJson (
   mkProject,
   buildGraph,
   ProjectAssetsJson (..),
+
+  -- * for testing
+  approxEql,
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics hiding (fromMaybe)
 import Data.Aeson
+import Data.Aeson.Types (Parser)
+import Data.HashMap.Strict qualified as HM
 import Data.Map.Strict qualified as Map
 import Data.Maybe
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.String.Conversion (toString)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Traversable (for)
 import DepTypes
 import Discovery.Walk
 import Effect.ReadFS
 import GHC.Generics (Generic)
-import Graphing (Graphing, unfold)
+import Graphing (Graphing, empty, gmap, promoteToDirect, shrink, unfoldDeep)
 import Path
+import Text.Read (readMaybe)
 import Types
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject ProjectAssetsJsonProject]
@@ -68,46 +78,99 @@ analyze' file = do
       , dependencyManifestFiles = [file]
       }
 
-newtype ProjectAssetsJson = ProjectAssetsJson
-  { targets :: Map.Map Text (Map.Map Text DependencyInfo)
-  }
-  deriving (Show)
-
-instance FromJSON ProjectAssetsJson where
-  parseJSON = withObject "ProjectAssetsJson" $ \obj ->
-    ProjectAssetsJson <$> obj .: "targets"
-
-data DependencyInfo = DependencyInfo
-  { depType :: Text
-  , deepDeps :: Map.Map Text Text
-  }
-  deriving (Show)
-
-instance FromJSON DependencyInfo where
-  parseJSON = withObject "Dependency" $ \obj ->
-    DependencyInfo <$> obj .: "type"
-      <*> obj .:? "dependencies" .!= Map.empty
-
 data NuGetDep = NuGetDep
   { depName :: Text
   , depVersion :: Text
   , completeDepType :: Text
   , completeDeepDeps :: Map.Map Text Text
   }
-  deriving (Show)
+  deriving (Show, Eq, Ord)
+
+data ProjectAssetsJson = ProjectAssetsJson
+  { targets :: Map.Map Text (Map.Map Text DependencyInfo)
+  , projectFramework :: Map.Map Text (Set Text)
+  }
+  deriving (Show, Eq, Ord)
+
+data DependencyInfo = DependencyInfo
+  { depType :: Text
+  , deepDeps :: Map.Map Text Text
+  }
+  deriving (Show, Eq, Ord)
+
+instance FromJSON DependencyInfo where
+  parseJSON = withObject "Dependency" $ \obj ->
+    DependencyInfo <$> obj .: "type"
+      <*> obj .:? "dependencies" .!= Map.empty
+
+instance FromJSON ProjectAssetsJson where
+  parseJSON = withObject "ProjectAssetsJson" $ \obj -> do
+    targets <- obj .: "targets"
+    projectFrameworks <- obj .: "project" |> "frameworks"
+    deps <- parseFramework projectFrameworks
+    pure $ ProjectAssetsJson targets deps
+    where
+      (|>) :: FromJSON a => Parser Object -> Text -> Parser a
+      (|>) parser key = do
+        obj <- parser
+        obj .: key
+
+      parseFrameworkDeps :: Value -> Parser (Set Text)
+      parseFrameworkDeps = withObject "parseFrameworkDeps" $ \o -> do
+        depsObj :: Maybe Object <- o .:? "dependencies"
+        deps <- case depsObj of
+          Nothing -> pure []
+          Just hm -> pure (fst <$> HM.toList hm)
+        pure $ Set.fromList deps
+
+      parseFramework :: Value -> Parser (Map.Map Text (Set Text))
+      parseFramework = withObject "parseFramework" $ \o -> do
+        projectFrameworks <- for (HM.toList o) $ \(framework, kv) -> do
+          frameworkDeps <- parseFrameworkDeps kv
+          pure (framework, frameworkDeps)
+        pure $ Map.fromList projectFrameworks
 
 buildGraph :: ProjectAssetsJson -> Graphing Dependency
-buildGraph project = unfold direct deepList toDependency
+buildGraph project = foldr (<>) Graphing.empty graphsOfTargetFrameworks
   where
-    direct :: [NuGetDep]
-    direct = concatMap (mapMaybe convertDep . Map.toList) (Map.elems (targets project))
+    graphsOfTargetFrameworks =
+      map
+        (graphOfFramework $ projectFramework project)
+        (Map.toList $ targets project)
 
-    convertDep :: (Text, DependencyInfo) -> Maybe NuGetDep
-    convertDep (depString, dep) = case Text.splitOn "/" depString of
+graphOfFramework :: Map.Map Text (Set Text) -> (Text, Map.Map Text DependencyInfo) -> Graphing Dependency
+graphOfFramework projectFrameworkDeps (targetFramework, targetFrameworkDeps) =
+  withoutTags
+    . withoutProjects
+    . promoteToDirect isDirectDep
+    $ unfoldDeep allResolvedDeps getTransitiveDeps toDependency
+  where
+    withoutTags :: Graphing Dependency -> Graphing Dependency
+    withoutTags = Graphing.gmap (\d -> d{dependencyTags = Map.empty})
+
+    withoutProjects :: Graphing Dependency -> Graphing Dependency
+    withoutProjects = Graphing.shrink (not . isProjectDep)
+
+    isDirectDep :: Dependency -> Bool
+    isDirectDep d = dependencyName d `elem` (getProjectDirectDepsByFramework)
+
+    isProjectDep :: Dependency -> Bool
+    isProjectDep Dependency{..} = case Map.lookup "type" dependencyTags of
+      Nothing -> False
+      Just tags -> "project" `elem` tags
+
+    allResolvedDeps :: [NuGetDep]
+    allResolvedDeps = mapMaybe toNugetDep $ Map.toList targetFrameworkDeps
+
+    toNugetDep :: (Text, DependencyInfo) -> Maybe NuGetDep
+    toNugetDep (depString, dep) = case Text.splitOn "/" depString of
       [name, ver] -> Just $ NuGetDep name ver (depType dep) (deepDeps dep)
       _ -> Nothing
 
-    deepList nugetDep = (\(x, y) -> NuGetDep x y "" Map.empty) <$> Map.toList (completeDeepDeps nugetDep)
+    getTransitiveDeps :: NuGetDep -> [NuGetDep]
+    getTransitiveDeps nugetDep = concat $ (\(name, _) -> filter (\d -> depName d == name) allResolvedDeps) <$> Map.toList (completeDeepDeps nugetDep)
+
+    toDependency :: NuGetDep -> Dependency
     toDependency NuGetDep{..} =
       Dependency
         { dependencyType = NuGetType
@@ -115,5 +178,65 @@ buildGraph project = unfold direct deepList toDependency
         , dependencyVersion = Just (CEq depVersion)
         , dependencyLocations = []
         , dependencyEnvironments = mempty
-        , dependencyTags = Map.empty
+        , dependencyTags = Map.fromList [("type", [completeDepType])] -- we provide tag, for shrinking project deps!
         }
+
+    -- Note:
+    --  Project's framework's identifier do not always match 1:1 with (resolved) target framework.
+    --  This is because, target framework has different identifier scheme (long form, short form).
+    --  This is very hard to parse, given changing scheme with nuget version, as well as .net identifiers.
+    getProjectDirectDepsByFramework :: Set Text
+    getProjectDirectDepsByFramework =
+      -- There is only one framework or all frameworks have same direct deps
+      if allEqual (Map.elems projectFrameworkDeps)
+        then allProjectSpecDeps
+        else case (Map.lookup targetFramework projectFrameworkDeps) of
+          Just s -> s
+          Nothing -> do
+            -- We could not find exact framework, fallback to equivalent match.
+            -- At last resort, report all direct deps from all framework.
+            let simplifiedProjectFrameworks =
+                  Map.elems $
+                    Map.filterWithKey (\pF _ -> pF `approxEql` targetFramework) projectFrameworkDeps
+            fromMaybe allProjectSpecDeps (listToMaybe simplifiedProjectFrameworks)
+
+    allProjectSpecDeps :: Set Text
+    allProjectSpecDeps = Set.unions $ Map.elems projectFrameworkDeps
+
+    allEqual :: Eq a => [a] -> Bool
+    allEqual [] = True
+    allEqual (x : xs) = all (== x) xs
+
+-- | Check if two framework identifier are equivalent.
+-- FIXME: This hack, although works for 99+% targets, deterministic approach is needed (ideally we replicate nuget)
+-- Reference: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+approxEql :: Text -> Text -> Bool
+approxEql targetF projectF
+  | targetF == projectF = True
+  | simplified targetF == simplified projectF = True
+  | otherwise = numbersOnly targetF == numbersOnly projectF
+  where
+    simplified :: Text -> Text
+    simplified candidate =
+      foldr
+        (uncurry Text.replace)
+        candidate
+        [ (".NETFramework", "net")
+        , (".NETPlatform", "dotnet")
+        , (".NETStandard", "netstandard")
+        , (".NETCoreApp", "netcoreapp")
+        , ("netcoreapp5.0", "net5.0")
+        , (",Version=", "")
+        , (",Version=v", "")
+        , (".NETPlatform,Version=v0.0", ".NETPlatform,Version=v5.0")
+        ]
+
+    withoutMetaAndProfile :: Text -> Text
+    withoutMetaAndProfile t = foldr (\b v -> fst $ Text.breakOn b v) (simplified t) ["/", "+", "-", ","]
+
+    removeTailingZeros :: [Char] -> [Char]
+    removeTailingZeros cs = reverse $ dropWhile (== '0') $ reverse cs
+
+    numbersOnly :: Text -> Int
+    numbersOnly t =
+      fromMaybe 0 $ readMaybe (removeTailingZeros $ filter (`elem` ['0' .. '9']) (toString . withoutMetaAndProfile $ t)) :: Int

--- a/test/NuGet/ProjectAssetsJsonSpec.hs
+++ b/test/NuGet/ProjectAssetsJsonSpec.hs
@@ -4,7 +4,10 @@ module NuGet.ProjectAssetsJsonSpec (
 
 import Data.Aeson
 import Data.ByteString qualified as BS
+import Data.Foldable (for_)
 import Data.Map.Strict qualified as Map
+import Data.String.Conversion (toString)
+import Data.Text (Text)
 import DepTypes
 import GraphUtil
 import Strategy.NuGet.ProjectAssetsJson
@@ -54,16 +57,161 @@ dependencyFour =
     , dependencyTags = Map.empty
     }
 
+dependencyFive :: Dependency
+dependencyFive =
+  Dependency
+    { dependencyType = NuGetType
+    , dependencyName = "five"
+    , dependencyVersion = Just (CEq "5.0.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = mempty
+    , dependencyTags = Map.empty
+    }
+
+-- | Reference: https://github.com/NuGet/NuGet.Client/blob/820bfe9d5e5e4e7bf0b6310c285db7b07aff3087/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+testCasesForEquivalentFrameworks :: [(Text, Text)]
+testCasesForEquivalentFrameworks =
+  [ -- Short
+    ("45", "net45")
+  , ("40", "net40")
+  , ("35", "net35")
+  , ("4.5", "net45")
+  , ("4.0", "net40")
+  , ("3.5", "net35")
+  , ("2.0", "net20")
+  , -- Portables
+    (".NETPortable40-Profile1", ".NETPortable,Version=v4.0,Profile=Profile1")
+  , -- Full names
+    (".NETPlatform,Version=v1.0", ".NETPlatform,Version=v1.0")
+  , (".NETPlatform,Version=v5.0", ".NETPlatform,Version=v5.0")
+  , (".NETFramework,Version=v4.5", ".NETFramework,Version=v4.5")
+  , ("NETFramework,Version=v4.5", ".NETFramework,Version=v4.5")
+  , (".NETPortable,Version=v0.0,Profile=Profile7", ".NETPortable,Version=v0.0,Profile=Profile7")
+  , -- Short to Full
+    ("net45", ".NETFramework,Version=v4.5")
+  , ("net10", ".NETFramework,Version=v1.0")
+  , ("net20", ".NETFramework,Version=v2.0")
+  , ("net40", ".NETFramework,Version=v4.0")
+  , ("net35", ".NETFramework,Version=v3.5")
+  , ("net40-client", ".NETFramework,Version=v4.0,Profile=Client")
+  , ("net5.0", ".NetCoreApp,Version=v5.0")
+  , ("net5.0", "net5.0")
+  , ("net", ".NETFramework,Version=v0.0")
+  , ("net10.1.2.3", ".NETFramework,Version=v10.1.2.3")
+  , ("net10.0", ".NETFramework,Version=v10.0")
+  , ("net45-cf", ".NETFramework,Version=v4.5,Profile=CompactFramework")
+  , ("uap10.0", "UAP,Version=v10.0")
+  , ("netstandard", ".NETStandard,Version=v0.0")
+  , ("netstandard1.0", ".NETStandard,Version=v1.0")
+  , ("netstandard1.0", ".NETStandard,Version=v1.0.0")
+  , ("netstandard0.9", ".NETStandard,Version=v0.9")
+  , ("netstandard1.1", ".NETStandard,Version=v1.1")
+  , ("netstandard1.2", ".NETStandard,Version=v1.2")
+  , ("netstandard1.3", ".NETStandard,Version=v1.3")
+  , ("netstandard1.4", ".NETStandard,Version=v1.4")
+  , ("netstandard1.5", ".NETStandard,Version=v1.5")
+  , ("netcoreapp", ".NETCoreApp,Version=v0.0")
+  , ("netcoreapp1.0", ".NETCoreApp,Version=v1.0")
+  , ("netcoreapp1.5", ".NETCoreApp,Version=v1.5")
+  , ("netcoreapp2.0", ".NetCoreApp,Version=v2.0")
+  , ("netcoreapp3.0", ".NetCoreApp,Version=v3.0")
+  , ("net5.0", "netcoreapp5.0")
+  , ("net5.0-windows", "netcoreapp5.0-windows")
+  , ("net5.0-windows10.0", "netcoreapp5.0-windows10.0")
+  , ("net5.0-android", "net5.0-android")
+  , ("net5.0-android", "net5.0-android0.0")
+  , ("net5.0-android10.0", "net5.0-android10")
+  , ("net5.0-ios14.0", "net5.0-ios14.0")
+  , ("net5.0-macos10.0", "net5.0-macos10.0")
+  , ("net5.0-watchos1.0", "net5.0-watchos1.0")
+  , ("net5.0-tvos1.0", "net5.0-tvos1.0")
+  , ("net5.0-windows10.0", "net5.0-windows10.0")
+  , ("net5.0-macos10.15.2.3", "net5.0-macos10.15.2.3")
+  , -- Common
+    ("net40", "net4")
+  , ("net40", "net40")
+  , ("net4", "net40")
+  , ("net4", "net4")
+  , ("net45", "net45")
+  , ("net451", "net451")
+  , ("net461", "net461")
+  , ("net462", "net462")
+  , ("win8", "win8")
+  , ("win81", "win81")
+  , ("netstandard", "netstandard")
+  , ("netstandard1.0", "netstandard1.0")
+  , ("netstandard1.0", "netstandard10")
+  , ("netstandard10", "netstandard1.0")
+  , ("netstandard10", "netstandard10")
+  , ("netstandard1.1", "netstandard1.1")
+  , ("netstandard1.1", "netstandard11")
+  , ("netstandard11", "netstandard1.1")
+  , ("netstandard11", "netstandard11")
+  , ("netstandard1.2", "netstandard1.2")
+  , ("netstandard1.2", "netstandard12")
+  , ("netstandard12", "netstandard1.2")
+  , ("netstandard12", "netstandard12")
+  , ("netstandard1.3", "netstandard1.3")
+  , ("netstandard1.3", "netstandard13")
+  , ("netstandard13", "netstandard1.3")
+  , ("netstandard13", "netstandard13")
+  , ("netstandard1.4", "netstandard1.4")
+  , ("netstandard1.4", "netstandard14")
+  , ("netstandard14", "netstandard1.4")
+  , ("netstandard14", "netstandard14")
+  , ("netstandard1.5", "netstandard1.5")
+  , ("netstandard1.5", "netstandard15")
+  , ("netstandard15", "netstandard1.5")
+  , ("netstandard15", "netstandard15")
+  , ("netstandard1.6", "netstandard1.6")
+  , ("netstandard1.6", "netstandard16")
+  , ("netstandard16", "netstandard1.6")
+  , ("netstandard16", "netstandard16")
+  , ("netstandard1.7", "netstandard1.7")
+  , ("netstandard1.7", "netstandard17")
+  , ("netstandard17", "netstandard1.7")
+  , ("netstandard17", "netstandard17")
+  , ("netstandard2.0", "netstandard2.0")
+  , ("netstandard2.0", "netstandard20")
+  , ("netstandard20", "netstandard2.0")
+  , ("netstandard20", "netstandard20")
+  , ("netstandard2.1", "netstandard2.1")
+  , ("netstandard2.1", "netstandard21")
+  , ("netstandard21", "netstandard2.1")
+  , ("netstandard21", "netstandard21")
+  , ("netcoreapp2.1", "netcoreapp2.1")
+  , ("netcoreapp2.1", "netcoreapp21")
+  , ("netcoreapp21", "netcoreapp2.1")
+  , ("netcoreapp21", "netcoreapp21")
+  , ("netcoreapp3.1", "netcoreapp3.1")
+  , ("netcoreapp3.1", "netcoreapp31")
+  , ("netcoreapp31", "netcoreapp3.1")
+  , ("netcoreapp31", "netcoreapp31")
+  , ("net5.0", "net5.0")
+  , ("net50", "net5.0")
+  , ("net452", ".NETFramework,Version=v4.5.2/win7-x86")
+  , ("net472", ".NETFramework,Version=4.7.2")
+  ]
+
 spec :: Spec
 spec = do
   testFile <- runIO (BS.readFile "test/NuGet/testdata/project.assets.json")
+
+  describe "approxEqlFramework" $ do
+    it "should return false when provided with equivalent framework" $ do
+      (approxEql "net472" ".NETFramework,Version=4.5.2") `shouldBe` False
+      (approxEql "netstandard2.0" ".NETStandard,Version=3.0") `shouldBe` False
+
+    for_ testCasesForEquivalentFrameworks $ \(candidateLhs, candidateRhs) -> do
+      it ("should return true when, comparing " <> (toString candidateLhs) <> " ~ " <> (toString candidateRhs)) $ do
+        approxEql candidateLhs candidateRhs `shouldBe` True
 
   describe "project.assets.json analyzer" $ do
     it "reads a file and constructs an accurate graph" $ do
       case eitherDecodeStrict testFile of
         Right res -> do
           let graph = buildGraph res
-          expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour] graph
+          expectDeps [dependencyOne, dependencyTwo, dependencyThree, dependencyFour, dependencyFive] graph
           expectDirect [dependencyOne, dependencyTwo, dependencyFour] graph
           expectEdges [(dependencyOne, dependencyThree)] graph
-        Left _ -> expectationFailure "failed to parse"
+        Left err -> expectationFailure $ show err

--- a/test/NuGet/ProjectAssetsJsonSpec.hs
+++ b/test/NuGet/ProjectAssetsJsonSpec.hs
@@ -10,7 +10,7 @@ import Data.String.Conversion (toString)
 import Data.Text (Text)
 import DepTypes
 import GraphUtil
-import Strategy.NuGet.ProjectAssetsJson
+import Strategy.NuGet.ProjectAssetsJson (FrameworkName (..), approxEql, buildGraph)
 import Test.Hspec
 
 dependencyOne :: Dependency
@@ -198,13 +198,13 @@ spec = do
   testFile <- runIO (BS.readFile "test/NuGet/testdata/project.assets.json")
 
   describe "approxEqlFramework" $ do
-    it "should return false when provided with equivalent framework" $ do
-      (approxEql "net472" ".NETFramework,Version=4.5.2") `shouldBe` False
-      (approxEql "netstandard2.0" ".NETStandard,Version=3.0") `shouldBe` False
+    it "should return false when provided with not equivalent framework" $ do
+      approxEql (FrameworkName "net472") (FrameworkName ".NETFramework,Version=4.5.2") `shouldBe` False
+      approxEql (FrameworkName "netstandard2.0") (FrameworkName ".NETStandard,Version=3.0") `shouldBe` False
 
     for_ testCasesForEquivalentFrameworks $ \(candidateLhs, candidateRhs) -> do
       it ("should return true when, comparing " <> (toString candidateLhs) <> " ~ " <> (toString candidateRhs)) $ do
-        approxEql candidateLhs candidateRhs `shouldBe` True
+        approxEql (FrameworkName candidateLhs) (FrameworkName candidateRhs) `shouldBe` True
 
   describe "project.assets.json analyzer" $ do
     it "reads a file and constructs an accurate graph" $ do

--- a/test/NuGet/testdata/project.assets.json
+++ b/test/NuGet/testdata/project.assets.json
@@ -1,6 +1,6 @@
 {
-      "version" : 1,
-      "targets" : {
+      "version": 1,
+      "targets": {
             ".NETFramework,Version=v4.0": {
                   "one/1.0.0": {
                         "type": "package",
@@ -10,11 +10,42 @@
                   },
                   "two/2.0.0": {
                         "type": "package"
+                  },
+                  "three/3.0.0": {
+                        "type": "package"
+                  },
+                  "six/6.0.0": {
+                        "type": "project",
+                        "dependencies": {
+                              "five": "5.0.0",
+                              "otherProject": "1.0.0"
+                        }
+                  },
+                  "five/5.0.0": {
+                        "type": "package"
+                  },
+                  "otherProject/1.0.0": {
+                        "type": "project",
+                        "compile": {
+                              "bin/placeholder/otherProject.dll": {}
+                        }
                   }
             },
             ".NETFramework,Version=v4.0/Win32": {
                   "four/4.0.0": {
-                        "type": "dependency"
+                        "type": "package"
+                  }
+            }
+      },
+      "project": {
+            "frameworks": {
+                  "net4.0": {
+                        "targetAlias": "net4.0",
+                        "dependencies": {
+                              "one": {},
+                              "two": {},
+                              "four": {}
+                        }
                   }
             }
       }


### PR DESCRIPTION
# Overview

This PR introduces a change that ensures for `projectassetsjson` targets, 

- Project type dependencies are shrinked (and not reported)
- It correctly labels direct dependency based on `project.[framework]` data

## Acceptance criteria

- For target `projectassetsjson` type, dependencies of type project are not reported
- For target `projectassetsjson` type, dependencies are differentiated between direct and deep

## Testing plan

- Create .net project (or refer to any open source project.assets.json from github)
- Perform `fossa analyze -o | jq`, ensure produced dependency graphing,
   - reports all dependencies of package type
   - does not report dependencies of project type (if it has any transitive dependencies of package type, they are reported)
   - direct dependencies are correctly identified

## Risks

I did not like hack included with framework name matching, but I can't really move forward without having access to windows pc for complete testing. 

I do think, what I have should address 99+% cases. We still maintain previous behaviour (which was ignoring project's framework) when we are not able to find matching framework. 

## References

Closes https://github.com/fossas/team-analysis/issues/791
Closes https://github.com/fossas/team-analysis/issues/790

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
