### PR TITLE
Ignore debug output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ vendor-bins/
 # Executables
 /fossa
 /fossa-?dev
+
+# Debug output
+fossa.debug.json.gz


### PR DESCRIPTION
# Overview

Adds `fossa.debug.json.gz` to `.gitignore`.

## Acceptance criteria

If we execute `cabal run fossa -- analyze --debug`, this file is generated at the project root, but it shouldn't be accidentally committed.