### PR TITLE
Removes cliv1 reference from the cabal project dependency

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -6,7 +6,6 @@ build-type:         Simple
 extra-source-files:
   scripts/depgraph-maven-plugin-3.3.0.jar
   scripts/jsondeps.gradle
-  vendor-bins/cliv1
   vendor-bins/syft
   vendor-bins/wiggins
 


### PR DESCRIPTION
# Overview

Removes redundant cli-v1 file dependency.  