### PR TITLE
Go: `go mod graph` and `go list` tactic (pass #2)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## v3.0.7
+
+- Go: `go mod graph` is used as default tactic for gomod strategy. ([#707](https://github.com/fossas/fossa-cli/pull/707))
+
 ## v3.0.6
 
 - Yarn: Fixes a bug with yarn v1 lock file analysis, where direct dependencies were not reported sometimes. ([#716](https://github.com/fossas/fossa-cli/pull/716))

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -7,7 +7,26 @@ way to do dependency management.
 
 Find all files named `go.mod`
 
-## Analysis: golist
+## Analysis
+
+We attempt to perform the following strategies in order (first succeeding strategy's results are selected):
+
+1. go mod graph and golist
+2. go list
+3. gomod
+
+## Strategy: go mod graph and golist
+
+Discovery: find go.mod files
+
+1. We execute `go mod graph` to retrieve all edges, and all considered versions of the module.
+2. We execute `go list -m -json all` to identify the main module, selected version of the module, and whether the module is direct dependency (using `Indirect` field from the command response)
+3. We create a dependencies graph from using the result of (1) in the following fashion:
+   1. We remove the main module from the dependency graph
+   2. We label all direct modules, as a direct dependency
+   3. We filter out module versions that were not selected - we know selected module versions from step (2). We do this, since the output of `go mod graph`, does return only the selected version, used in the build list! 
+
+## Strategy: golist
 
 Discovery: find go.mod files
 
@@ -36,7 +55,7 @@ We run `go list -m -json all`, which produces, e.g.,:
 
 For package dependencies that aren't using gomodules, a pseudo-version (`v0.0.0-TIMESTAMP-COMMITID`) is present instead. We use the commit ID as the version.
 
-## Analysis: gomod
+## Strategy: gomod
 
 We parse the go.mod file, which looks something like:
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -261,6 +261,7 @@ library
     Strategy.Go.GlideLock
     Strategy.Go.GoList
     Strategy.Go.Gomod
+    Strategy.Go.GoModGraph
     Strategy.Go.GopkgLock
     Strategy.Go.GopkgToml
     Strategy.Go.Transitive
@@ -380,6 +381,7 @@ test-suite unit-tests
     Go.GlideLockSpec
     Go.GoListSpec
     Go.GomodSpec
+    Go.GoModGraphSpec
     Go.GopkgLockSpec
     Go.GopkgTomlSpec
     Go.TransitiveSpec

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -380,8 +380,8 @@ test-suite unit-tests
     Fossa.API.TypesSpec
     Go.GlideLockSpec
     Go.GoListSpec
-    Go.GomodSpec
     Go.GoModGraphSpec
+    Go.GomodSpec
     Go.GopkgLockSpec
     Go.GopkgTomlSpec
     Go.TransitiveSpec

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -42,4 +42,5 @@ data ProjectResult = ProjectResult
 
 shouldKeepUnreachableDeps :: Text -> Bool
 shouldKeepUnreachableDeps "swift" = True
+shouldKeepUnreachableDeps "gomod" = True
 shouldKeepUnreachableDeps _ = False

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -3,6 +3,7 @@
 module Strategy.Go.GoList (
   analyze',
   Require (..),
+  GoListModule (..),
 ) where
 
 import Control.Effect.Diagnostics hiding (fromMaybe)

--- a/src/Strategy/Go/GoModGraph.hs
+++ b/src/Strategy/Go/GoModGraph.hs
@@ -122,7 +122,7 @@ buildGraph fromToMods mainMod selectedMods directMods applyMVS =
     . Graphing.induceJust
     . Graphing.gmap withSelection
     . Graphing.promoteToDirect (`member` directMods)
-    . Graphing.shrink (\m -> m == fromMaybe impossibleMod mainMod)
+    . Graphing.shrink (\m -> m /= fromMaybe impossibleMod mainMod)
     . Graphing.edges
     $ fromToMods
   where
@@ -160,9 +160,9 @@ analyze dir = do
   -- Get selected module version from mvs selection using `go list`
   -- `go list` reports final versions that will be used in a build for all direct and deep dependencies
   goListStdout <- context ("Getting selected dependencies versions using, " <> toText (show goListJsonCmd)) $ execThrow dir goListJsonCmd
-  (mainMod, directMods, selectedMods) <- case decodeMany goListStdout of
+  (mainMod, selectedMods, directMods) <- case decodeMany goListStdout of
     Left (path, err) -> fatal (CommandParseError goListJsonCmd (toText (formatError path err)))
-    Right (mods :: [GoListModule]) -> pure (onlyMain mods, onlyDirects mods, withoutMain mods)
+    Right (mods :: [GoListModule]) -> pure (onlyMain mods, withoutMain mods, onlyDirects mods)
 
   -- Command 'go mod graph' reports, all module version considered (not just final version selected)
   -- For this reason, we filter out versions of module, not used in build using (versions provided by 'go list')

--- a/src/Strategy/Go/GoModGraph.hs
+++ b/src/Strategy/Go/GoModGraph.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Strategy.Go.GoModGraph (
+  analyze,
+
+  -- * for testing
+  GoGraphMod (..),
+  parseGoModGraph,
+  parseGoGraphMod,
+  buildGraph,
+) where
+
+import Control.Effect.Diagnostics hiding (fromMaybe)
+import Control.Monad (void)
+import Data.Aeson.Internal (formatError)
+import Data.Foldable (find)
+import Data.Map qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.SemVer qualified as SemVer
+import Data.SemVer.Internal (Version (..))
+import Data.Set (Set, fromList, member, notMember)
+import Data.String.Conversion (toText)
+import Data.Text (Text)
+import Data.Void (Void)
+import DepTypes (
+  DepType (GoType),
+  Dependency (..),
+  VerConstraint (CEq),
+ )
+import Effect.Exec (
+  AllowErr (Never),
+  Command (..),
+  Exec,
+  ExecErr (CommandParseError),
+  execParser,
+  execThrow,
+ )
+import Graphing qualified
+import Path
+import Strategy.Go.GoList (GoListModule (GoListModule, isIndirect, isMain, path, version))
+import Strategy.Go.Gomod (PackageVersion (..), parsePackageVersion)
+import Strategy.Go.Transitive (decodeMany)
+import Text.Megaparsec (
+  MonadParsec (eof),
+  Parsec,
+  empty,
+  optional,
+  parse,
+  sepEndBy,
+  some,
+  try,
+  (<|>),
+ )
+import Text.Megaparsec.Char (alphaNumChar, char)
+import Text.Megaparsec.Char.Lexer qualified as Lexer
+import Types (GraphBreadth (..))
+
+-- * Parsing
+
+type Parser = Parsec Void Text
+
+sc :: Parser ()
+sc = Lexer.space (void $ some $ char ' ') empty empty
+
+lexeme :: Parser a -> Parser a
+lexeme = Lexer.lexeme sc
+
+symbol :: Text -> Parser Text
+symbol = Lexer.symbol sc
+
+-- * Commands
+
+goModGraphCmd :: Command
+goModGraphCmd =
+  Command
+    { cmdName = "go"
+    , cmdArgs = ["mod", "graph"]
+    , cmdAllowErr = Never
+    }
+
+goListJsonCmd :: Command
+goListJsonCmd =
+  Command
+    { cmdName = "go"
+    , cmdArgs = ["list", "-m", "-json", "all"]
+    , cmdAllowErr = Never
+    }
+
+data GoGraphMod = GoGraphMod
+  { goGraphModName :: Text
+  , goGraphModVersion :: Maybe PackageVersion
+  }
+  deriving (Show, Eq, Ord)
+
+-- * Parsers
+
+-- | Parses go mode entry from 'go mod graph'.
+parseGoGraphMod :: Parser GoGraphMod
+parseGoGraphMod = do
+  name <- toText <$> lexeme (some (alphaNumChar <|> char '/' <|> char '-' <|> char '.' <|> char '_' <|> char '~'))
+  version <- optional $ do
+    _ <- try $ symbol "@"
+    lexeme (parsePackageVersion lexeme)
+  pure $ GoGraphMod name version
+
+toGoModVersion :: Text -> Maybe PackageVersion
+toGoModVersion modVersion = case parse (parsePackageVersion lexeme) "go module version" modVersion of
+  Left _ -> Nothing
+  Right vc -> Just vc
+
+-- | Parses output of 'go mod graph'.
+parseGoModGraph :: Parser [(GoGraphMod, GoGraphMod)]
+parseGoModGraph = parseGoModPair `sepEndBy` (symbol "\n" <|> symbol "\r") <* eof
+  where
+    parseGoModPair :: Parser (GoGraphMod, GoGraphMod)
+    parseGoModPair = (,) <$> parseGoGraphMod <*> parseGoGraphMod
+
+-- Builds graph from edges, main module, and selected module version set.
+buildGraph :: [(GoGraphMod, GoGraphMod)] -> Maybe GoGraphMod -> Set GoGraphMod -> Set GoGraphMod -> Bool -> Graphing.Graphing Dependency
+buildGraph fromToMods mainMod selectedMods directMods applyMVS =
+  Graphing.gmap toDependency
+    . Graphing.induceJust
+    . Graphing.gmap withSelection
+    . Graphing.promoteToDirect (`member` directMods)
+    . Graphing.shrink (\m -> m == fromMaybe impossibleMod mainMod)
+    . Graphing.edges
+    $ fromToMods
+  where
+    -- module name must have at-least one character
+    impossibleMod :: GoGraphMod
+    impossibleMod = GoGraphMod "" Nothing
+
+    withSelection :: GoGraphMod -> Maybe GoGraphMod
+    withSelection m = if m `notMember` selectedMods && applyMVS then Nothing else Just m
+
+    toDependency :: GoGraphMod -> Dependency
+    toDependency GoGraphMod{..} =
+      Dependency
+        { dependencyType = GoType
+        , dependencyName = goGraphModName
+        , dependencyVersion = toVersion <$> goGraphModVersion
+        , dependencyLocations = []
+        , dependencyEnvironments = mempty
+        , dependencyTags = Map.empty
+        }
+
+    toVersion :: PackageVersion -> VerConstraint
+    toVersion v = case v of
+      NonCanonical n -> CEq n
+      Pseudo commitHash -> CEq commitHash
+      Semantic semver -> CEq ("v" <> SemVer.toText semver{_versionMeta = []})
+
+analyze ::
+  ( Has Exec sig m
+  , Has Diagnostics sig m
+  ) =>
+  Path Abs Dir ->
+  m (Graphing.Graphing Dependency, GraphBreadth)
+analyze dir = do
+  -- Get selected module version from mvs selection using `go list`
+  -- `go list` reports final versions that will be used in a build for all direct and deep dependencies
+  goListStdout <- context ("Getting selected dependencies versions using, " <> toText (show goListJsonCmd)) $ execThrow dir goListJsonCmd
+  (mainMod, directMods, selectedMods) <- case decodeMany goListStdout of
+    Left (path, err) -> fatal (CommandParseError goListJsonCmd (toText (formatError path err)))
+    Right (mods :: [GoListModule]) -> pure (onlyMain mods, onlyDirects mods, withoutMain mods)
+
+  -- Command 'go mod graph' reports, all module version considered (not just final version selected)
+  -- For this reason, we filter out versions of module, not used in build using (versions provided by 'go list')
+  -- Further, we use provided 'Indirect' property to infer if the module is "direct" (provided by 'go list')
+  --
+  -- By filtering out (not selected mod version), replicate https://golang.org/ref/mod#minimal-version-selection
+  -- Reference: https://github.com/golang/exp/tree/master/cmd/modgraphviz
+  let filterModsNotUsedInBuild = True
+  goModGraphStdout <- context ("Getting selected dependencies versions using, " <> toText (show goModGraphCmd)) $ execParser parseGoModGraph dir goModGraphCmd
+  let graph = buildGraph goModGraphStdout mainMod selectedMods directMods filterModsNotUsedInBuild
+
+  pure (graph, Complete)
+  where
+    toGoGraphMod :: GoListModule -> GoGraphMod
+    toGoGraphMod GoListModule{..} = GoGraphMod path (toGoModVersion =<< version)
+
+    withoutMain :: [GoListModule] -> Set GoGraphMod
+    withoutMain = fromList . map toGoGraphMod . filter (not . isMain)
+
+    onlyDirects :: [GoListModule] -> Set GoGraphMod
+    onlyDirects = fromList . map toGoGraphMod . filter (not . isIndirect)
+
+    onlyMain :: [GoListModule] -> Maybe GoGraphMod
+    onlyMain mods = toGoGraphMod <$> find isMain mods

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -14,6 +14,7 @@ import Effect.ReadFS
 import GHC.Generics (Generic)
 import Path (Abs, Dir, File, Path)
 import Strategy.Go.GoList qualified as GoList
+import Strategy.Go.GoModGraph qualified as GoModGraph
 import Strategy.Go.Gomod qualified as Gomod
 import Types
 
@@ -52,7 +53,8 @@ getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => Gomodule
 getDeps project = do
   (graph, graphBreadth) <-
     context "Gomodules" $
-      context "Dynamic analysis" (GoList.analyze' (gomodulesDir project))
+      context "Dynamic analysis using go mod graph" (GoModGraph.analyze (gomodulesDir project))
+        <||> context "Dynamic analysis using go list" (GoList.analyze' (gomodulesDir project))
         <||> context "Static analysis" (Gomod.analyze' (gomodulesGomod project))
   pure $
     DependencyResults

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -54,6 +54,8 @@ getDeps project = do
   (graph, graphBreadth) <-
     context "Gomodules" $
       context "Dynamic analysis using go mod graph" (GoModGraph.analyze (gomodulesDir project))
+        -- Go List tactic is only kept in consideration, in event go mod graph fails.
+        -- In reality, this is highly unlikely scenario, and should almost never happen.
         <||> context "Dynamic analysis using go list" (GoList.analyze' (gomodulesDir project))
         <||> context "Static analysis" (Gomod.analyze' (gomodulesGomod project))
   pure $

--- a/test/Go/GoModGraphSpec.hs
+++ b/test/Go/GoModGraphSpec.hs
@@ -1,0 +1,159 @@
+module Go.GoModGraphSpec (spec) where
+
+import Data.Map qualified as Map
+import Data.SemVer (version)
+import Data.Set qualified as Set
+import Data.Text
+import Data.Text.IO qualified as TIO
+import Data.Void (Void)
+import GraphUtil (expectDeps, expectDirect, expectEdges)
+import Strategy.Go.GoModGraph (GoGraphMod (GoGraphMod), buildGraph, parseGoGraphMod, parseGoModGraph)
+import Strategy.Go.Gomod (PackageVersion (NonCanonical, Pseudo, Semantic))
+import Test.Hspec (Expectation, Spec, describe, it, runIO)
+import Test.Hspec.Megaparsec (shouldParse)
+import Text.Megaparsec (Parsec, parse, runParser)
+import Types (DepType (GoType), Dependency (..), VerConstraint (CEq))
+
+semver :: Int -> Int -> Int -> PackageVersion
+semver x y z = Semantic $ version x y z [] []
+
+parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
+parseMatch parser input expected = parse parser "" input `shouldParse` expected
+
+mkGoMod :: Text -> Text -> GoGraphMod
+mkGoMod name ver = GoGraphMod name (Just $ NonCanonical ver)
+
+mkDep :: Text -> Text -> Dependency
+mkDep name ver = Dependency GoType name (Just $ CEq ver) [] mempty Map.empty
+
+spec :: Spec
+spec = do
+  specParse
+  specGraph
+
+specGraph :: Spec
+specGraph = do
+  describe "buildGraph" $ do
+    -- Test case graph is from: https://golang.org/ref/mod#minimal-version-selection (first diagram)
+    let testEdges =
+          [ (GoGraphMod "Main" Nothing, mkGoMod "A" "1.2")
+          , (GoGraphMod "Main" Nothing, mkGoMod "B" "1.2")
+          , -- from A
+            (mkGoMod "A" "1.1", mkGoMod "C" "1.1")
+          , (mkGoMod "A" "1.2", mkGoMod "C" "1.3")
+          , -- from B
+            (mkGoMod "B" "1.2", mkGoMod "C" "1.4")
+          , (mkGoMod "B" "1.3", mkGoMod "E" "1.1")
+          , -- from C
+            (mkGoMod "C" "1.1", mkGoMod "D" "1.1")
+          , (mkGoMod "C" "1.2", mkGoMod "D" "1.1")
+          , (mkGoMod "C" "1.3", mkGoMod "D" "1.2")
+          , (mkGoMod "C" "1.4", mkGoMod "D" "1.2")
+          , -- from E
+            (mkGoMod "E" "1.1", mkGoMod "F" "1.1")
+          , -- from F
+            (mkGoMod "F" "1.1", mkGoMod "E" "1.1")
+          ]
+
+    let testSelectedMods =
+          Set.fromList
+            [ mkGoMod "A" "1.2"
+            , mkGoMod "B" "1.2"
+            , mkGoMod "C" "1.4"
+            , mkGoMod "D" "1.2"
+            ]
+    let directMods = Set.fromList [mkGoMod "A" "1.2", mkGoMod "B" "1.2"]
+
+    it "should should remove main module, and produce graphing with minimal version selection (MVS)" $ do
+      -- Act
+      let graph = buildGraph testEdges (Just $ GoGraphMod "Main" Nothing) testSelectedMods directMods True
+      print graph
+
+      -- Assert
+      let depA = mkDep "A" "1.2"
+      let depB = mkDep "B" "1.2"
+      let depC = mkDep "C" "1.4"
+      let depD = mkDep "D" "1.2"
+
+      expectDeps [depA, depB, depC, depD] graph
+      expectEdges [(depB, depC), (depC, depD)] graph
+      expectDirect [depA, depB] graph
+
+    it "should should remove main module, and produce graphing with all module versioning" $ do
+      -- Act
+      let graph = buildGraph testEdges (Just $ GoGraphMod "Main" Nothing) testSelectedMods directMods False
+      print graph
+
+      -- Assert
+      let depA1_1 = mkDep "A" "1.1"
+      let depA1_2 = mkDep "A" "1.2"
+      let depB1_2 = mkDep "B" "1.2"
+      let depB1_3 = mkDep "B" "1.3"
+      let depC1_1 = mkDep "C" "1.1"
+      let depC1_2 = mkDep "C" "1.2"
+      let depC1_3 = mkDep "C" "1.3"
+      let depC1_4 = mkDep "C" "1.4"
+      let depD1_1 = mkDep "D" "1.1"
+      let depD1_2 = mkDep "D" "1.2"
+      let depE1_1 = mkDep "E" "1.1"
+      let depF1_1 = mkDep "F" "1.1"
+
+      expectDeps
+        [ depA1_1
+        , depA1_2
+        , depB1_2
+        , depB1_3
+        , depC1_1
+        , depC1_2
+        , depC1_3
+        , depC1_4
+        , depD1_1
+        , depD1_2
+        , depE1_1
+        , depF1_1
+        ]
+        graph
+      expectEdges
+        [ -- A
+          (depA1_1, depC1_1)
+        , (depA1_2, depC1_3)
+        , -- B
+          (depB1_2, depC1_4)
+        , (depB1_3, depE1_1)
+        , -- C
+          (depC1_1, depD1_1)
+        , (depC1_2, depD1_1)
+        , (depC1_3, depD1_2)
+        , (depC1_4, depD1_2)
+        , -- E
+          (depE1_1, depF1_1)
+        , -- F
+          (depF1_1, depE1_1)
+        ]
+        graph
+      expectDirect [depA1_2, depB1_2] graph
+
+specParse :: Spec
+specParse = do
+  describe "parseGoGraphMod" $ do
+    let shouldParseInto = parseMatch parseGoGraphMod
+
+    it "should parse module without version" $ do
+      "github.com/Microsoft/go-winio" `shouldParseInto` GoGraphMod "github.com/Microsoft/go-winio" Nothing
+
+    it "should parse module with semver version" $ do
+      "go-winio@v0.5.0" `shouldParseInto` GoGraphMod "go-winio" (Just $ semver 0 5 0)
+
+    it "should parse module with pseudo semver version" $ do
+      "go-winio@v0.0.0-20210619224110-3f7ff695adc6" `shouldParseInto` GoGraphMod "go-winio" (Just $ Pseudo "3f7ff695adc6")
+
+    it "should parse module with non canonical version" $ do
+      "go-winio@LATEST" `shouldParseInto` GoGraphMod "go-winio" (Just $ NonCanonical "LATEST")
+
+  describe "go mod graph parser" $ do
+    trivialInput <- runIO (TIO.readFile "test/Go/testdata/go.mod.graph.stdout")
+    it "parses a trivial example" $ do
+      runParser parseGoModGraph "" trivialInput
+        `shouldParse` [ (GoGraphMod "main" Nothing, GoGraphMod "dep" (Just $ semver 0 5 0))
+                      , (GoGraphMod "dep" (Just $ semver 0 5 0), GoGraphMod "depB" (Just $ semver 0 6 0))
+                      ]

--- a/test/Go/testdata/go.mod.graph.stdout
+++ b/test/Go/testdata/go.mod.graph.stdout
@@ -1,0 +1,2 @@
+main dep@v0.5.0
+dep@v0.5.0 depB@v0.6.0


### PR DESCRIPTION
# Overview

Adds golang (go mod graph) tactic, which uses `go mod graph`, and `go list -m -json all` to construct dependency graph!

## Acceptance criteria

- When `go mod graph` command can be executed, `go mod graph` tactic is favored!
- `go mod graph` tactic does not include golang's stdlib
- `go mod graph` tactic does not include main module
- `go mod graph` tactic includes only selected version of the module (same as build list)
- `go mod graph` tactic labels direct dependencies
- `go mod graph` tactic reports all build list dependencies

## Testing plan

1. Clone https://github.com/opstrace/opstrace.git or any open source go project (must use go module)
2. Perform `go mod tidy`
3. Perform `fossa analyze -o | jq`, ensure direct dependencies matches that of go.mod file after performing step (2)
4. Perform `go list -m all`, ensure all dependencies listed are included in the graphing produced by `fossa analyze`

## Risks

I'm adding this as preferred tactic, and as consequence of that, 
- Users will not see stdlib anymore in the dependency graphing results

Go's dependency tooling has varying support per different golang version, and performs resolution differently (which is problematic), but from my testing - I did not run into any issues.

## References

Closes https://github.com/fossas/team-analysis/issues/813
Closes https://github.com/fossas/team-analysis/issues/659

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
