### PR TITLE
Fixes package-lock json, not including dev deps

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -19,6 +19,9 @@
 - suggest: {lhs: x <&> f, rhs: f <$> x}
 - suggest: {lhs: Data.Text.pack x, rhs: Data.String.Conversion.toText x}
 - suggest: {lhs: Data.Text.unpack x, rhs: Data.String.Conversion.toString x}
+- suggest: {lhs: Data.List.foldl x, rhs: Data.List.foldl' x}
+- suggest: {lhs: "(Data.Set.size x) == 0" , rhs: "Data.Set.null x"}
+- suggest: {lhs: "(Data.Set.size x) /= 0" , rhs: "not $ Data.Set.null x"}
 
 # Forbidden items, only allowed in compile-time code, or test code.
 - functions:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## v3.0.4
+
+- Npm: Fixes a bug where dev dependencies were not included in result when using `--include-unused-deps` ([#710](https://github.com/fossas/fossa-cli/pull/710))
+
 ## v3.0.3
 
 - Increases default timeout to 3600 seconds (1 hour) for commands listed below ([#712](https://github.com/fossas/fossa-cli/pull/712))

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -56,6 +56,7 @@ import Algebra.Graph.AdjacencyMap qualified as AM
 import Algebra.Graph.AdjacencyMap.Algorithm qualified as AMA
 import Algebra.Graph.AdjacencyMap.Extra qualified as AME
 import Data.Bifunctor (bimap)
+import Data.List (foldl')
 import Data.Set qualified as Set
 import Prelude hiding (filter)
 import Prelude qualified
@@ -145,7 +146,7 @@ shrink f = Graphing . AME.shrink f' . unGraphing
 --
 --  When node (3) is shrinked, 8 will be promoted to direct, and 4 will be not be promoted as direct.
 shrinkWithoutPromotionToDirect :: forall a. Ord a => (a -> Bool) -> Graphing a -> Graphing a
-shrinkWithoutPromotionToDirect f gr = foldl withoutEdgeToRoot shrinkedGraph jumpedDirects
+shrinkWithoutPromotionToDirect f gr = foldl' withoutEdgeToRoot shrinkedGraph jumpedDirects
   where
     shrinkedGraph :: Graphing a
     shrinkedGraph = shrink f gr
@@ -159,7 +160,7 @@ shrinkWithoutPromotionToDirect f gr = foldl withoutEdgeToRoot shrinkedGraph jump
             (Set.fromList . directList $ gr)
 
     hasPredecessors :: Graphing a -> a -> Bool
-    hasPredecessors g n = Set.size (AM.preSet n $ toAdjacencyMap g) /= 0
+    hasPredecessors g n = not $ Set.null (AM.preSet n $ toAdjacencyMap g)
 
     withoutEdgeToRoot :: Graphing a -> a -> Graphing a
     withoutEdgeToRoot g n = Graphing . AM.removeEdge Root (Node n) $ unGraphing g

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -37,6 +37,7 @@ module Graphing (
   filter,
   shrink,
   shrinkSingle,
+  shrinkWithoutPromotionToDirect,
   pruneUnreachable,
   stripRoot,
   promoteToDirect,
@@ -129,6 +130,23 @@ shrink f = Graphing . AME.shrink f' . unGraphing
     f' :: Node a -> Bool
     f' Root = True
     f' (Node a) = f a
+
+-- | Unlike @shrink@ when root vertices are deleted, their successor are not promoted as direct.
+shrinkWithoutPromotionToDirect :: forall a. Ord a => (a -> Bool) -> Graphing a -> Graphing a
+shrinkWithoutPromotionToDirect f gr = foldl withoutEdge shrinkedGraph jumpedDirects
+  where
+    shrinkedGraph :: Graphing a
+    shrinkedGraph = shrink f gr
+
+    jumpedDirects :: [a]
+    jumpedDirects =
+      Set.toList $
+        Set.difference
+          (Set.fromList . directList $ shrinkedGraph)
+          (Set.fromList . directList $ gr)
+
+    withoutEdge :: Graphing a -> a -> Graphing a
+    withoutEdge g n = Graphing . AM.removeEdge Root (Node n) $ unGraphing g
 
 -- | Delete a vertex in a Grahing, preserving the overall structure by rewiring edges through the delted vertex.
 --

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -152,7 +152,7 @@ shrinkWithoutPromotionToDirect f gr = foldl' withoutEdgeToRoot shrinkedGraph jum
     shrinkedGraph = shrink f gr
 
     -- Identify direct nodes after shrinking the graph on predicate,
-    -- that were not part of direct nodes previously and have predecessors. 
+    -- that were not part of direct nodes previously and have predecessors.
     jumpedDirects :: [a]
     jumpedDirects =
       Set.toList $

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -151,6 +151,8 @@ shrinkWithoutPromotionToDirect f gr = foldl' withoutEdgeToRoot shrinkedGraph jum
     shrinkedGraph :: Graphing a
     shrinkedGraph = shrink f gr
 
+    -- Identify direct nodes after shrinking the graph on predicate,
+    -- that were not part of direct nodes previously and have predecessors. 
     jumpedDirects :: [a]
     jumpedDirects =
       Set.toList $

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -64,7 +64,7 @@ toSourceUnit leaveUnfiltered ProjectResult{..} =
     renderedPath = toText (toFilePath projectResultPath)
 
     filteredGraph :: Graphing Dependency
-    filteredGraph = Graphing.shrink ff projectResultGraph
+    filteredGraph = Graphing.shrinkWithoutPromotionToDirect ff projectResultGraph
       where
         ff =
           if leaveUnfiltered

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -98,6 +98,24 @@ spec = do
       expectDeps [1, 2, 4, 6, 7] graph'
       expectEdges [(1, 2), (2, 4), (2, 6), (2, 7)] graph'
 
+    it "should promote to direct, if and only if no predecessors exist" $ do
+      --   1 -> 2 -> 5 -> 6
+      --        \       \
+      --         \       7
+      --   3 ----> 4
+      --    \
+      --     8
+
+      let graph :: Graphing Int
+          graph = Graphing.edges [(1, 2), (3, 4), (3, 8), (2, 4), (2, 5), (5, 7), (5, 6)] <> Graphing.directs [1, 3]
+
+          graph' :: Graphing Int
+          graph' = Graphing.shrinkWithoutPromotionToDirect (\x -> x /= 3 && x /= 5) graph
+
+      expectDirect [1, 8] graph'
+      expectDeps [1, 2, 4, 6, 7, 8] graph'
+      expectEdges [(1, 2), (2, 4), (2, 6), (2, 7)] graph'
+
   describe "stripRoot" $ do
     let graph :: Graphing Int
         graph = Graphing.directs [1] <> Graphing.edges [(1, 2), (1, 3), (2, 4), (3, 6)]

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -81,6 +81,23 @@ spec = do
       expectDeps [1, 4, 5] graph'
       expectEdges [(1, 4), (4, 5)] graph'
 
+  describe "shrinkWithoutPromotionToDirect" $ do
+    it "should preserve set of direct nodes" $ do
+      -- 1 -> 2 -> 5 -> 6
+      --      \    \
+      --       \    7
+      -- 3 ----> 4
+
+      let graph :: Graphing Int
+          graph = Graphing.edges [(1, 2), (3, 4), (2, 4), (2, 5), (5, 7), (5, 6)] <> Graphing.directs [1, 3]
+
+          graph' :: Graphing Int
+          graph' = Graphing.shrinkWithoutPromotionToDirect (\x -> x /= 3 && x /= 5) graph
+
+      expectDirect [1] graph'
+      expectDeps [1, 2, 4, 6, 7] graph'
+      expectEdges [(1, 2), (2, 4), (2, 6), (2, 7)] graph'
+
   describe "stripRoot" $ do
     let graph :: Graphing Int
         graph = Graphing.directs [1] <> Graphing.edges [(1, 2), (1, 3), (2, 4), (3, 6)]

--- a/test/Node/NpmLockSpec.hs
+++ b/test/Node/NpmLockSpec.hs
@@ -21,7 +21,7 @@ mockInput =
                 { depVersion = "1.0.0"
                 , depDev = False
                 , depResolved = Just "https://example.com/one.tgz"
-                , depRequires = Map.fromList [("packageTwo", "2.0.0")]
+                , depRequires = Map.fromList [("packageTwo", "2.0.0"), ("packageSeven", "7.0.0")]
                 , depDependencies =
                     Map.fromList
                       [
@@ -48,11 +48,41 @@ mockInput =
                 }
             )
           ,
+            ( "packageSeven"
+            , NpmDep
+                { depVersion = "7.0.0"
+                , depDev = False
+                , depResolved = Just "https://example.com/seven.tgz"
+                , depRequires = mempty
+                , depDependencies = mempty
+                }
+            )
+          ,
             ( "packageFour"
             , NpmDep
                 { depVersion = "file:abc/def"
                 , depDev = False
                 , depResolved = Nothing
+                , depRequires = mempty
+                , depDependencies = mempty
+                }
+            )
+          ,
+            ( "packageFive"
+            , NpmDep
+                { depVersion = "5.0.0"
+                , depDev = True
+                , depResolved = Just "https://example.com/five.tgz"
+                , depRequires = Map.fromList [("packageSix", "6.0.0")]
+                , depDependencies = mempty
+                }
+            )
+          ,
+            ( "packageSix"
+            , NpmDep
+                { depVersion = "6.0.0"
+                , depDev = True
+                , depResolved = Just "https://example.com/six.tgz"
                 , depRequires = mempty
                 , depDependencies = mempty
                 }
@@ -93,16 +123,51 @@ packageThree =
     , dependencyTags = Map.empty
     }
 
+packageFive :: Dependency
+packageFive =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "packageFive"
+    , dependencyVersion = Just (CEq "5.0.0")
+    , dependencyLocations = ["https://example.com/five.tgz"]
+    , dependencyEnvironments = Set.singleton EnvDevelopment
+    , dependencyTags = Map.empty
+    }
+
+packageSix :: Dependency
+packageSix =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "packageSix"
+    , dependencyVersion = Just (CEq "6.0.0")
+    , dependencyLocations = ["https://example.com/six.tgz"]
+    , dependencyEnvironments = Set.singleton EnvDevelopment
+    , dependencyTags = Map.empty
+    }
+
+packageSeven :: Dependency
+packageSeven =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "packageSeven"
+    , dependencyVersion = Just (CEq "7.0.0")
+    , dependencyLocations = ["https://example.com/seven.tgz"]
+    , dependencyEnvironments = Set.singleton EnvProduction
+    , dependencyTags = Map.empty
+    }
+
 spec :: Spec
 spec = do
   describe "buildGraph" $ do
     it "should produce expected output" $ do
-      let graph = buildGraph mockInput $ Set.fromList ["packageOne", "packageThree"]
-      expectDeps [packageOne, packageTwo, packageThree] graph
-      expectDirect [packageOne, packageThree] graph
+      let graph = buildGraph mockInput (Set.fromList ["packageOne", "packageThree", "packageFive"])
+      expectDeps [packageOne, packageTwo, packageThree, packageFive, packageSix, packageSeven] graph
+      expectDirect [packageOne, packageThree, packageFive] graph
       expectEdges
         [ (packageOne, packageTwo)
+        , (packageOne, packageSeven)
         , (packageTwo, packageThree)
         , (packageThree, packageOne)
+        , (packageFive, packageSix)
         ]
         graph


### PR DESCRIPTION
# Overview

Includes dev deps for pkg-lock analysis when `--include-unused-deps` is used. 

## Acceptance criteria

When --include-unused-deps flag is applied with npm target with package-lock, all dependencies are included.

## Testing plan

1. touch `package.json`

```
{
    "name": "example-project",
    "dependencies": {
        "pngjs": "6.0.0",
        "once": "1.4.0"
    },
    "devDependencies": {
      "mocha": "*"
    }
}
```

2. `npm install` (v7.21.1)
3. `fossa analyze --include-unused-deps | jq`
4. Note all dependencies are included (including dev deps)
5. `fossa analyze | jq` (note, mocha and it's transitive deps are not included)

## Out of Scope

yarn

## Risks

N/A

## References

https://github.com/fossas/team-analysis/issues/811
https://github.com/fossas/team-analysis/issues/809

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
