### PR TITLE
Increases default timeout to 1hr

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # Fossa CLI Changelog
 
+## v3.0.3
+
+- Increases default timeout to 3600 seconds (1 hour) for commands listed below ([#712](https://github.com/fossas/fossa-cli/pull/712))
+  - `fossa test`
+  - `fossa container test`
+  - `fossa vps test`
+  - `fossa report`
+  - `fossa vps report`
+
 ## v3.0.2
 
 - Nuget (projectassetsjson): Ignores project type dependencies in reporting ([#704](https://github.com/fossas/fossa-cli/pull/704))

--- a/docs/references/subcommands/report.md
+++ b/docs/references/subcommands/report.md
@@ -16,7 +16,7 @@ fossa report attribution
 
 ### Specifying a report timeout
 
-By default, `fossa report` waits a maximum of 10 minutes for report contents. To override the default timeout, use, e.g.:
+By default, `fossa report` waits a maximum of 3600 seconds (1 hour) for report contents. To override the default timeout, use, e.g.:
 
 ```sh
 fossa report attribution --timeout 60

--- a/docs/references/subcommands/test.md
+++ b/docs/references/subcommands/test.md
@@ -10,7 +10,7 @@ The test command checks whether the most-recent scan of your FOSSA project raise
 
 ### Specifying a timeout
 
-By default, `fossa test` waits a maximum of 10 minutes for issue scan results. To override the default timeout, use, e.g.:
+By default, `fossa test` waits a maximum of 3600 seconds (1 hour) for issue scan results. To override the default timeout, use, e.g.:
 
 ```sh
 fossa test --timeout 60

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -139,6 +139,9 @@ import Types (TargetFilter)
 windowsOsName :: String
 windowsOsName = "mingw32"
 
+oneHourInSeconds :: Int
+oneHourInSeconds = 3600
+
 mainPrefs :: ParserPrefs
 mainPrefs =
   prefs $
@@ -518,7 +521,7 @@ reportCmd =
 testOpts :: Parser TestOptions
 testOpts =
   TestOptions
-    <$> option auto (long "timeout" <> help "Duration to wait for build completion (in seconds)" <> value 600)
+    <$> option auto (long "timeout" <> help "Duration to wait for build completion (in seconds)" <> value oneHourInSeconds)
     <*> flag Test.TestOutputPretty Test.TestOutputJson (long "json" <> help "Output issues as json")
     <*> baseDirArg
 
@@ -537,7 +540,7 @@ vpsReportOpts :: Parser VPSReportOptions
 vpsReportOpts =
   VPSReportOptions
     <$> switch (long "json" <> help "Output the report in JSON format (Currently required).")
-    <*> option auto (long "timeout" <> help "Duration to wait for build completion (in seconds)" <> value 600)
+    <*> option auto (long "timeout" <> help "Duration to wait for build completion (in seconds)" <> value oneHourInSeconds)
     <*> vpsReportCmd
     <*> baseDirArg
 
@@ -558,7 +561,7 @@ vpsReportCmd =
 vpsTestOpts :: Parser VPSTestOptions
 vpsTestOpts =
   VPSTestOptions
-    <$> option auto (long "timeout" <> help "Duration to wait for build completion (in seconds)" <> value 600)
+    <$> option auto (long "timeout" <> help "Duration to wait for build completion (in seconds)" <> value oneHourInSeconds)
     <*> flag VPSTest.TestOutputPretty VPSTest.TestOutputJson (long "json" <> help "Output issues as json")
     <*> baseDirArg
 
@@ -647,7 +650,7 @@ containerAnalyzeOpts =
 containerTestOpts :: Parser ContainerTestOptions
 containerTestOpts =
   ContainerTestOptions
-    <$> option auto (long "timeout" <> help "Duration to wait for build completion (in seconds)" <> value 600)
+    <$> option auto (long "timeout" <> help "Duration to wait for build completion (in seconds)" <> value oneHourInSeconds)
     <*> flag ContainerTest.TestOutputPretty ContainerTest.TestOutputJson (long "json" <> help "Output issues as json")
     <*> imageTextArg
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -508,7 +508,7 @@ reportOpts :: Parser ReportOptions
 reportOpts =
   ReportOptions
     <$> switch (long "json" <> help "Output the report in JSON format (Currently required).")
-    <*> option auto (long "timeout" <> help "Duration to wait for build completion (in seconds)" <> value 600)
+    <*> option auto (long "timeout" <> help "Duration to wait for build completion (in seconds)" <> value oneHourInSeconds)
     <*> reportCmd
     <*> baseDirArg
 


### PR DESCRIPTION
# Overview

Increases default timeout to 1hr for:

- `fossa test`
- `fossa vps test`
- `fossa container test`
- `fossa report`
- `fossa vps report`

## Acceptance criteria

- Default timeout is 1 hour for `fossa test`
- Default timeout is 1 hour for `fossa vps test`
- Default timeout is 1 hour for `fossa container test`
- Default timeout is 1 hour for `fossa report`
- Default timeout is 1 hour for `fossa vps report`

## Testing plan

Although this is const value change,

If you want to test, mock following endpoint to always return non-complete status.

- `:endpoint/api/cli/:locator/latest_build` (e.g. status RUNNING)
- `:endpoint/api/cli/:locator/issues`  (eg. status WAITING)

## Risks

N/A

## References

Closes https://github.com/fossas/team-analysis/issues/820

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
