### PR TITLE
Fixes Yarn.Lock V1 missing direct dependency (sometimes)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## v3.0.6
+
+- Yarn: Fixes a bug with yarn v1 lock file analysis, where direct dependencies were not reported sometimes. ([#716](https://github.com/fossas/fossa-cli/pull/716))
+
 ## v3.0.5
 
 - Nim: Adds support for dependency analysis using `nimble.lock` file. ([#711](https://github.com/fossas/fossa-cli/pull/711))

--- a/test/Yarn/V1/YarnLockV1Spec.hs
+++ b/test/Yarn/V1/YarnLockV1Spec.hs
@@ -105,10 +105,24 @@ packageSix =
 devPackageSix :: Dependency
 devPackageSix = insertEnvironment EnvDevelopment packageSix
 
+packageOnce :: Dependency
+packageOnce =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "once"
+    , dependencyVersion = Just $ CEq "1.4.0"
+    , dependencyLocations = ["https://registry.npmjs.org/once"]
+    , dependencyEnvironments = mempty
+    , dependencyTags = mempty
+    }
+
+prodPackageOnce :: Dependency
+prodPackageOnce = insertEnvironment EnvProduction packageOnce
+
 simpleFlatDeps :: FlatDeps
 simpleFlatDeps =
   FlatDeps
-    (applyTag @Production $ Set.fromList [NodePackage "packageOne" "^1.0.0"])
+    (applyTag @Production $ Set.fromList [NodePackage "packageOne" "^1.0.0", NodePackage "once" "^1.3.0"])
     (applyTag @Development $ Set.fromList [NodePackage "packageSix" "^6.0.0"])
     mempty
 
@@ -127,7 +141,7 @@ spec = do
     it' "should produce expected structure" $ do
       yarnLock <- parseFile $(mkRelFile "yarn.lock")
       graph <- buildGraph yarnLock mempty
-      expectDeps' [packageOne, packageTwo, packageThree, packageFour, packageFive, packageSix] graph
+      expectDeps' [packageOne, packageTwo, packageThree, packageFour, packageFive, packageSix, packageOnce] graph
       expectDirect' [] graph
       expectEdges'
         [ (packageOne, packageTwo)
@@ -140,8 +154,8 @@ spec = do
     it' "Should apply the correct dep environments" $ do
       yarnLock <- parseFile $(mkRelFile "yarn.lock")
       graph <- buildGraph yarnLock simpleFlatDeps
-      expectDeps' [prodPackageOne, prodPackageTwo, prodDevPackageThree, packageFour, packageFive, devPackageSix] graph
-      expectDirect' [prodPackageOne, devPackageSix] graph
+      expectDeps' [prodPackageOne, prodPackageTwo, prodDevPackageThree, packageFour, packageFive, devPackageSix, prodPackageOnce] graph
+      expectDirect' [prodPackageOne, devPackageSix, prodPackageOnce] graph
       expectEdges'
         [ (prodPackageOne, prodPackageTwo)
         , (prodPackageTwo, prodDevPackageThree)

--- a/test/Yarn/V1/testdata/yarn.lock
+++ b/test/Yarn/V1/testdata/yarn.lock
@@ -26,3 +26,9 @@ packageSix@^6.0.0:
   resolved "https://registry.npmjs.org/packageSix"
   dependencies:
     packageThree "^3.0.0"
+
+# To verify we look at both keys, when inferring direct dep
+# Key ordering is presumed to be not consistent
+once@^1.0.0, once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/once"


### PR DESCRIPTION
# Overview

This PR, fixes YarnV1 analysis defect, in which we were missing direct dependency sometimes.
 
## Acceptance criteria

- YarnV1 analysis always graphs all valid direct dependencies

## Testing plan

Given following `package.json`, and `yarn.lock` file

```json
{
  "name": "example-project",
  "dependencies": {
      "pngjs": "6.0.0",
      "once": "1.4.0"
  },
  "devDependencies": {
      "mocha": "*"
  }
}
```

Running, `fossa analyze` will produce:

Previously: dependency once will be missing from dependency graph
Now: dependency once will be included in dependency graph

## Risks

- N/A

## References

Closes  https://github.com/fossas/team-analysis/issues/824

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
