### PR TITLE
Document experimental flags

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Fossa CLI Changelog
 
-## Unreleased
+## v3.0.9
 
 - Makes experimental flags discoverable and documents them. ([#723](https://github.com/fossas/fossa-cli/pull/723))
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## Unreleased
+
+- Makes experimental flags discoverable and documents them. ([#723](https://github.com/fossas/fossa-cli/pull/723))
+
 ## v3.0.6
 
 - Yarn: Fixes a bug with yarn v1 lock file analysis, where direct dependencies were not reported sometimes. ([#716](https://github.com/fossas/fossa-cli/pull/716))

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,3 +62,8 @@ Reference guides provide an exhaustive listing of all CLI functionality. If you 
   - [`.fossa.yml`](./references/files/fossa-yml.md)
   - [`fossa-deps.{yml,json}`](./references/files/fossa-deps.md)
 - [CLI analysis strategies](./references/strategies/README.md)
+- Experimental
+  - [Experimental options overview](./references/experimental/README.md)
+  - CLI Commands
+    - [`fossa experimental-link-user-defined-dependency-binary`](./references/experimental/subcommands/experimental-link-user-defined-dependency-binary.md)
+  

--- a/docs/references/experimental/README.md
+++ b/docs/references/experimental/README.md
@@ -1,0 +1,57 @@
+## Experimental Features
+
+At FOSSA, we like to develop in the open. 
+This helps us get feedback from our users early and often, and helps our users take advantage of the newest cutting edge featues we're working on.
+
+FOSSA also has strong commitments to backwards compatibility and support.
+We respect the fact that we live in the CI pipeline, and we want to avoid anything that would get in the way of our users shipping software.
+
+These two commitments are hard to reconcile: developing in the open means some level of backwards-incompatible changes and potential user disruption.
+Our way of bridging this gap is "experimental options", which offer a peek into what we're working on next while still retaining the flexibility to iterate.
+
+### What denotes an experimental feature?
+
+Experimental features are always prefixed by `experimental`. For example, the flag `--output` is _not_ experimental, while the hypothetical flag `--experimental-text-output` would be.
+In the case where we are testing out new functionality for an existing feature, we may simply prepend `experimental`: to reuse the previous example, a new output format might be tested under simply `--experimental-output`.
+
+### When are experimental features used?
+
+Experimental features are _always_ opt-in. This means that we'll never turn on an experimental feature unless the user explicitly enables it!
+
+### CLI Versioning with experimental features
+
+Experimental features aren't considered part of our semver-style versioning scheme. This lets us focus on only stable features in the version scheme and gives us the room we need to experiment in the open.
+This means that experimental features may be introduced, change in backwards incompatible ways, or even be removed in a `PATCH` release (`x.x.PATCH`).
+
+That being said, we do try to maintain backwards compatibility, and if we can't we will try our best to issue deprecation warnings before making backwards-incompatible changes to experimental features.
+
+### Feature promotion
+
+When experimental features are promoted, we perform the following steps:
+
+1. We add the feature without an `experimental` prefix.
+2. We mark the `experimental`-prefixed version of the feature as deprecated, and log warnings when it's used.
+3. After at least two CLI releases we remove the `experimental`-prefixed version of the feature.
+
+Once an experimental feature is promoted it's considered part of our backwards compatibility goals and is considered part of our semver-style CLI versioned releases.
+
+### Support level
+
+We do our best to support our users using experimental features! If you have a question or a problem about the experimental feature, send us an email or open an issue. 
+We'd appreciate if you'd include:
+
+- In the title/subject, whether you are using experimental features.
+- In the body, the features you're using (ideally along with your actual command being run).
+
+The main difference compared to stable features is that we don't consider experimental features to be "critical", meaning that we consider them to be something that users can stop using to unblock their CI pipeline.
+As such, our first recommendation if you're in a situation where an experimental feature is blocking your CI pipeline is to disable the feature (but still send us a support request, we'd like to know about it)!
+
+### Submitting feedback
+
+We love getting feedback from our users, and feedback on experimental options is no different!
+If you send us an email or open an issue relating to an experimental feature, we'd appreciate if you'd include:
+
+- In the title/subject, whether you are using experimental features.
+- In the body, the features you're using (ideally along with your actual command being run).
+
+This helps us route the feedback to the person who owns the feature!

--- a/docs/references/experimental/README.md
+++ b/docs/references/experimental/README.md
@@ -1,7 +1,7 @@
 ## Experimental Features
 
 At FOSSA, we like to develop in the open. 
-This helps us get feedback from our users early and often, and helps our users take advantage of the newest cutting edge featues we're working on.
+This helps us get feedback from our users early and often, and helps our users take advantage of the newest cutting-edge features we're working on.
 
 FOSSA also has strong commitments to backwards compatibility and support.
 We respect the fact that we live in the CI pipeline, and we want to avoid anything that would get in the way of our users shipping software.

--- a/docs/references/experimental/binary-discovery/README.md
+++ b/docs/references/experimental/binary-discovery/README.md
@@ -1,52 +1,29 @@
-## Binary Discovery
-
-### What is it?
+# Binary Discovery
 
 FOSSA supports the ability to flag all binary dependencies discovered in your project source tree as unlicensed dependencies via an opt-in flag.
 
-The core idea behind this feature is that some organizations wish to validate all potential sources of intellectual property rights, and binaries are potential sources of intellectual property rights data for which we typically cannot automatically discover licensing information.
+The core idea behind this feature is that some organizations wish to validate all potential sources of intellectual property rights,
+and binaries are potential sources of intellectual property rights data for which we typically cannot automatically discover licensing information.
 
-FOSSA detects binaries in the same manner as git: we inspect the first 8000 bytes of the file (or the whole file if less than 8000 bytes).
-If it contains a NUL (`0`) byte, we consider the file to be binary.
+## Discovery
 
-### Displaying discovered binaries
+Find all files that contain a NUL (`0`) byte in the first 8000 bytes of the file.
 
-Binaries discovered via this feature are displayed in the FOSSA UI as `user` dependencies.
+## Analysis
 
-The name of the dependency is the path to the binary within the project, and the version of the dependency is the hash of the binary file that was discovered.
-The description of the dependency is "Binary discovered in source tree".
+The following strategies are implemented in a "fallback" manner, 
+meaning that for any matching file extension we try strategies in the order listed here until a strategy succeeds.
 
-### Correcting discovered binaries
+| File Extension   | Analysis                       |
+|------------------|--------------------------------|
+| `.jar` or `.aar` | Read `pom.xml`                 |
+| `.jar` or `.aar` | Read `MANIFEST.MF`             |
+| Anything else    | Create user-defined dependency |
 
-Most binaries cannot be statically analyzed for licensing or other information. As such, users need to correct the information about the binary using the standard FOSSA corrections flow.
-Users can edit the information about the binary, such as its name or licensing information. Users may also ignore binaries that are not relevant.
+### Read `pom.xml`
 
-These corrections persist in future revisions of the project so long as the binary does not move to a different path in the project.
-If it does, the binary appears in the list again without any corrections.
-If the binary content changes but stays at the same location on disk, these corrections persist and a different hash is displayed in the version field of the dependency.
-
-### Filtering discovered binaries
-
-This feature has the potential to be quite noisy, as most projects have many binary files.
-
-This feature supports the standard path filters used in FOSSA CLI (via `--exclude-path` and `--only-path` flags, or [.fossa.yml](../../files/fossa-yml.md#paths-)) to customize which paths are scanned.
-
-### Inspecting binaries
-
-Some binaries are capable of being inspected to pre-fill information.
-
-#### JAR
-
-We have two tactics for unpacking information from a JAR:
-
-1. Read a `pom.xml` file from inside `META-INF`
-2. Read `META-INF/MANIFEST.MF`
-
-We prefer the `pom.xml` if present, and only fallback to `META-INF/MANIFEST.MF` if `pom.xml` is not found.
-
-#### Read `pom.xml`
-
-We unpack the JAR and search inside the `META-INF` directory for `pom.xml` files. We then select the `pom.xml` with the *shortest path* and use that as the representative `pom.xml` for the JAR.
+We unpack the archive and search inside the `META-INF` directory for `pom.xml` files.
+We then select the `pom.xml` with the *shortest path* and use that as the representative `pom.xml` for the JAR.
 
 From the `pom.xml` we read:
 
@@ -54,15 +31,18 @@ From the `pom.xml` we read:
 - `project.version` is used for the dependency version.
 - Entries in `project.licenses` are extracted for their `name` field, which are concatenated and used as the dependency license.
 
-#### Read `META-INF/MANIFEST.MF`
+### Read `MANIFEST.MF`
 
-We unpack the JAR and search inside for a `META-INF/MANIFEST.MF` file.
+We unpack the archive and search inside for a `META-INF/MANIFEST.MF` file.
 
 From that file we read:
 
 - `Bundle-SymbolicName`, if present, is used for the dependency description. If `Bundle-SymbolicName` is not present, we fallback to `Implementation-Title`.
 - `Implementation-Version` is used for the dependency version.
 
-#### AAR
+### Create user-defined dependency
 
-AAR files are treated identically to JAR files.
+Binaries discovered via this feature are displayed in the FOSSA UI as `user` dependencies.
+
+The name of the dependency is the path to the binary within the project, and the version of the dependency is the hash of the binary file that was discovered.
+The description of the dependency is "Binary discovered in source tree".

--- a/docs/references/experimental/binary-discovery/README.md
+++ b/docs/references/experimental/binary-discovery/README.md
@@ -1,0 +1,67 @@
+## Binary Discovery
+
+### What is it?
+
+FOSSA supports the ability to flag all binary dependencies discovered in your project source tree as unlicensed dependencies via an opt in flag.
+
+The core idea behind this feature is that some organizations wish to validate all potential sources of intellectual property rights, and binaries are potential sources of intellectual property rights data for which we typically cannot automatically discover licensing information.
+
+FOSSA detects binaries in the same manner as git: we inspect the first 8000 bytes of the file (or the whole file if less than 8000 bytes).
+If it contains a NUL (`0`) byte, we consider the file to be binary.
+
+### Displaying discovered binaries
+
+Binaries discovered via this feature are displayed in the FOSSA UI as `user` dependencies.
+
+The name of the dependency is the path to the binary within the project, and the version of the dependency is the hash of the binary file that was discovered.
+The description of the dependency is "Binary discovered in source tree".
+
+### Correcting discovered binaries
+
+Most binaries cannot be statically analyzed for licensing or other information. As such, users need to correct the information about the binary using the standard FOSSA corrections flow.
+Users are able to edit the information about the binary, such as its name or licensing information. Users may also ignore binaries that are not relevant.
+
+These corrections persist in future revisions of the project so long as the binary does not move to a different path in the project.
+If it does, the binary appears in the list again without any corrections.
+If the binary content changes but stays at the same location on disk, these corrects persist and a different hash is displayed in the version field of the dependency.
+
+### Filtering discovered binaries
+
+This feature has the potential to be quite noisy, as most projects have many binary files.
+This feature supports the standard `--exclude-path` and `--only-path` flags to customize the parts of the project inspected for binaries.
+
+### Inspecting binaries
+
+Some binaries are capable of being inspected to pre-fill information.
+
+#### JAR
+
+We have two tactics for unpacking information from a JAR:
+
+1. Read a `pom.xml` file from inside `META-INF`
+2. Read `META-INF/MANIFEST.MF`
+
+We prefer the `pom.xml` if present, and only fallback to `META-INF/MANIFEST.MF` if `pom.xml` is not found.
+
+#### Read `pom.xml`
+
+We unpack the JAR and search inside the `META-INF` directory for `pom.xml` files. We then select the `pom.xml` with the *shortest path* and use that as the representative `pom.xml` for the JAR.
+
+From the `pom.xml` we read:
+
+- `project.groupId` and `project.artifactId` are combined to make the dependency description.
+- `project.version` is used for the dependency version.
+- Entries in `project.licenses` are extracted for their `name` field, which are concatenated and used as the dependency license.
+
+#### Read `META-INF/MANIFEST.MF`
+
+We unpack the JAR and search inside for a `META-INF/MANIFEST.MF` file. 
+
+From that file we read:
+
+- `Bundle-SymbolicName`, if present, is used for the dependency description. If `Bundle-SymbolicName` is not present, we fallback to `Implementation-Title`.
+- `Implementation-Version` is used for the dependency version.
+
+#### AAR
+
+AAR files are treated identically to JAR files.

--- a/docs/references/experimental/binary-discovery/README.md
+++ b/docs/references/experimental/binary-discovery/README.md
@@ -2,7 +2,7 @@
 
 ### What is it?
 
-FOSSA supports the ability to flag all binary dependencies discovered in your project source tree as unlicensed dependencies via an opt in flag.
+FOSSA supports the ability to flag all binary dependencies discovered in your project source tree as unlicensed dependencies via an opt-in flag.
 
 The core idea behind this feature is that some organizations wish to validate all potential sources of intellectual property rights, and binaries are potential sources of intellectual property rights data for which we typically cannot automatically discover licensing information.
 
@@ -19,16 +19,17 @@ The description of the dependency is "Binary discovered in source tree".
 ### Correcting discovered binaries
 
 Most binaries cannot be statically analyzed for licensing or other information. As such, users need to correct the information about the binary using the standard FOSSA corrections flow.
-Users are able to edit the information about the binary, such as its name or licensing information. Users may also ignore binaries that are not relevant.
+Users can edit the information about the binary, such as its name or licensing information. Users may also ignore binaries that are not relevant.
 
 These corrections persist in future revisions of the project so long as the binary does not move to a different path in the project.
 If it does, the binary appears in the list again without any corrections.
-If the binary content changes but stays at the same location on disk, these corrects persist and a different hash is displayed in the version field of the dependency.
+If the binary content changes but stays at the same location on disk, these corrections persist and a different hash is displayed in the version field of the dependency.
 
 ### Filtering discovered binaries
 
 This feature has the potential to be quite noisy, as most projects have many binary files.
-This feature supports the standard `--exclude-path` and `--only-path` flags to customize the parts of the project inspected for binaries.
+
+This feature supports the standard path filters used in FOSSA CLI (via `--exclude-path` and `--only-path` flags, or [.fossa.yml](../../files/fossa-yml.md#paths-)) to customize which paths are scanned.
 
 ### Inspecting binaries
 

--- a/docs/references/experimental/binary-discovery/README.md
+++ b/docs/references/experimental/binary-discovery/README.md
@@ -55,7 +55,7 @@ From the `pom.xml` we read:
 
 #### Read `META-INF/MANIFEST.MF`
 
-We unpack the JAR and search inside for a `META-INF/MANIFEST.MF` file. 
+We unpack the JAR and search inside for a `META-INF/MANIFEST.MF` file.
 
 From that file we read:
 

--- a/docs/references/experimental/monorepo/README.md
+++ b/docs/references/experimental/monorepo/README.md
@@ -4,7 +4,7 @@
 
 FOSSA experimentally supports scanning large monorepo projects which have potentially many licenses spread out across its files. The monorepo feature also supports inferring build graph information depending on the type of monorepo project.
 
-Currently, the only supported monorepo type is the Android Open Source Project ([AOSP](#AOSP)).
+Currently, the only supported monorepo type is the Android Open Source Project ([AOSP](#android-open-source-project-aosp-)).
 
 Currently, this also disables all other FOSSA strategies, and therefore does not do any dependency analysis.
 
@@ -14,13 +14,14 @@ Monorepo support requires a feature flag enabled in your FOSSA organization. If 
 
 ### Interacting with Monorepo Scans
 
-When viewing a Monorepo project in the FOSSA UI, users will a list of files and directories with metadata that was collected during the scan. In this UI, files can be filtered by metadata such as (but not limited to)
+When viewing a Monorepo project in the FOSSA service, FOSSA displays a list of files and directories with metadata collected during the scan.
+In this UI, files can be filtered by metadata such as (but not limited to)
 1. which licenses they contain
 2. whether they appear in the build graph
 
 ### Running a Monorepo Scan
 
-In order to run a monorepo scan, pass `--experimental-enable-monorepo aosp` to `fossa analyze`. A minimal invocation would look like:
+To run a monorepo scan, pass `--experimental-enable-monorepo aosp` to `fossa analyze`. A minimal invocation would look like:
 ```bash
 fossa analyze \
   --experimental-enable-monorepo aosp \
@@ -29,14 +30,17 @@ fossa analyze \
 
 ### Filtering Specific Paths
 
-Since monorepos have a tendency to be huge, it's sometimes useful to exclude certain paths from the scan, or to specify a single class of paths to include. The syntax for these exclusions is globbing (along with support for `**`). This feature supports the standard `--exclude-path` and `--only-path` flags to customize which paths are scanned.
+Since monorepos tend to be huge, it's sometimes useful to exclude certain paths from the scan, or to specify a single class of paths to include.
+The syntax for these exclusions is globbing (along with support for `**`).
+
+This feature supports the standard path filters used in FOSSA CLI (via `--exclude-path` and `--only-path` flags, or [.fossa.yml](../../files/fossa-yml.md#paths-)) to customize which paths are scanned.
 
 ### Additional Flags
 
 Monorepo scans support the [standard set of `fossa analyze` flags](../../subcommands/analyze.md#specifying-fossa-project-details).
 
-## AOSP
+## Android Open Source Project (AOSP)
 
 ### Build Graphs
 
-In order for build graph information to be inferred, ninja files (which are a prerequisite for a build) must be present under the directory being scanned.
+To infer build graph information, ninja files (which are a prerequisite for a build) must be present under the directory being scanned.

--- a/docs/references/experimental/monorepo/README.md
+++ b/docs/references/experimental/monorepo/README.md
@@ -1,0 +1,3 @@
+## Monorepo Projects
+
+TODO: Work with Enrico to fill this out.

--- a/docs/references/experimental/monorepo/README.md
+++ b/docs/references/experimental/monorepo/README.md
@@ -1,3 +1,42 @@
 ## Monorepo Projects
 
-TODO: Work with Enrico to fill this out.
+### What is it?
+
+FOSSA experimentally supports scanning large monorepo projects which have potentially many licenses spread out across its files. The monorepo feature also supports inferring build graph information depending on the type of monorepo project.
+
+Currently, the only supported monorepo type is the Android Open Source Project ([AOSP](#AOSP)).
+
+Currently, this also disables all other FOSSA strategies, and therefore does not do any dependency analysis.
+
+### Prerequisites
+
+Monorepo support requires a feature flag enabled in your FOSSA organization. If you're interested in using this feature please contact us!
+
+### Interacting with Monorepo Scans
+
+When viewing a Monorepo project in the FOSSA UI, users will a list of files and directories with metadata that was collected during the scan. In this UI, files can be filtered by metadata such as (but not limited to)
+1. which licenses they contain
+2. whether they appear in the build graph
+
+### Running a Monorepo Scan
+
+In order to run a monorepo scan, pass `--experimental-enable-monorepo aosp` to `fossa analyze`. A minimal invocation would look like:
+```bash
+fossa analyze \
+  --experimental-enable-monorepo aosp \
+  /path/to/aosp/project
+```
+
+### Filtering Specific Paths
+
+Since monorepos have a tendency to be huge, it's sometimes useful to exclude certain paths from the scan, or to specify a single class of paths to include. The syntax for these exclusions is globbing (along with support for `**`). This feature supports the standard `--exclude-path` and `--only-path` flags to customize which paths are scanned.
+
+### Additional Flags
+
+Monorepo scans support the [standard set of `fossa analyze` flags](../../subcommands/analyze.md#specifying-fossa-project-details).
+
+## AOSP
+
+### Build Graphs
+
+In order for build graph information to be inferred, ninja files (which are a prerequisite for a build) must be present under the directory being scanned.

--- a/docs/references/experimental/msb/README.md
+++ b/docs/references/experimental/msb/README.md
@@ -1,0 +1,68 @@
+## Multi Stage Builds
+
+Multi-stage buiilds allows users give FOSSA metadata attached to a binary ahead of time (for example, a team working on an internal library can tell FOSSA about that library as part of that CI process).
+FOSSA then can detect binaries that are registered as dependencies in downstream projects that include that binary in their source tree when running with [VSI enabled](../vsi/README.md).
+
+### Use Cases
+
+#### Vendor a known binary
+
+Multi-stage builds supports the ability to link metadata to binaries (example: `name`, `version`, `license`) for which you do not have the source available.
+The binary will be identified within the org by its unique fingerprint as it is shared internally between the projects it will appear as a regular direct dependency with all of the specified metadata that was previously specified.
+Such binary can be a library purchased from a vendor, or a prebuilt open source project.
+
+#### Vendor an internal binary
+
+If the team building the internal binary links the binary to its project, multi-stage build support can identify such binaries vendored into the directory structure of another project.
+Linking will preserve all of the metadata known about the artifact during the linking.
+
+The upstream library project will be shown as a direct dependency of the project that is vendoring the binary artifact, and upstream project’s dependencies are shown as deep dependencies of the vendoring project.
+
+#### Build a binary used downstream
+
+Multi-stage builldds supports the ability to link your output binaries when analyzing your project to support the internal binary use case.
+This allows you to configure the CI pipeline for your project to always keep the linked binary up to date.
+
+### Link a binary’s fingerprint to a user project
+
+When the source of a library is available, FOSSA can scan that library for its dependencies and associate one or more binaries with the project.
+Then, when scanning a downstream project that uses one of those binaries, all the dependency information from the library will appear as deep dependency information for the downstream project.
+
+To link one or more binaries to a project, use `--experimental-link-project-binary`.
+
+Example:
+
+```bash
+fossa analyze --experimental-enable-vsi \
+  --experimental-link-project-binary <BIN_DIR>
+```
+
+### Link a binary’s fingerprint to a user-defined dependency
+
+When the source of a binary library is not available, FOSSA can still surface a binary as a user-defined dependency when it is present in a downstream project, so long as the dependency information has been linked to the binary ahead of time.
+
+To link one or more binaries to a set of user-defined dependency metadata, use the subcommand `experimental-link-user-defined-dependency-binary`.
+
+Example:
+
+```bash
+fossa experimental-link-user-defined-dependency-binary [DIR] \
+  --name <NAME> \
+  --version <VERSION> \
+  --license <LICENSE>
+```
+
+Optionally, a project homepage and/or a description may be provided.
+
+Example:
+
+```bash
+fossa experimental-link-user-defined-dependency-binary [DIR] \
+  --name <NAME> \
+  --version <VERSION> \
+  --license <LICENSE> \
+  --description <DESCRIPTION> \
+  --homepage <HOMEPAGE>
+```
+
+**Note**: Similar to the `analyze` subcommand, this supports the `--endpoint` and `--fossa-api-key` commands to customize how the client connects to FOSSA.

--- a/docs/references/experimental/msb/README.md
+++ b/docs/references/experimental/msb/README.md
@@ -1,13 +1,13 @@
 ## Multi Stage Builds
 
-Multi-stage buiilds allows users give FOSSA metadata attached to a binary ahead of time (for example, a team working on an internal library can tell FOSSA about that library as part of that CI process).
+The _Multi-stage builds_ feature allows users give FOSSA metadata attached to a binary ahead of time (for example, a team working on an internal library can tell FOSSA about that library as part of that CI process).
 FOSSA then can detect binaries that are registered as dependencies in downstream projects that include that binary in their source tree when running with [VSI enabled](../vsi/README.md).
 
 ### Use Cases
 
 #### Vendor a known binary
 
-Multi-stage builds supports the ability to link metadata to binaries (example: `name`, `version`, `license`) for which you do not have the source available.
+The _Multi-stage builds_ feature supports the ability to link metadata to binaries (example: `name`, `version`, `license`) for which you do not have the source available.
 The binary will be identified within the org by its unique fingerprint as it is shared internally between the projects it will appear as a regular direct dependency with all of the specified metadata that was previously specified.
 Such binary can be a library purchased from a vendor, or a prebuilt open source project.
 
@@ -20,7 +20,7 @@ The upstream library project will be shown as a direct dependency of the project
 
 #### Build a binary used downstream
 
-Multi-stage builldds supports the ability to link your output binaries when analyzing your project to support the internal binary use case.
+The _Multi-stage builds_ feature supports the ability to link your output binaries when analyzing your project to support the internal binary use case.
 This allows you to configure the CI pipeline for your project to always keep the linked binary up to date.
 
 ### Link a binary’s fingerprint to a user project

--- a/docs/references/experimental/subcommands/experimental-link-user-defined-dependency-binary.md
+++ b/docs/references/experimental/subcommands/experimental-link-user-defined-dependency-binary.md
@@ -1,0 +1,4 @@
+## `fossa experimental-link-user-defined-dependency-binary`
+
+`experimental-link-user-defined-dependency-binary` is a subcommand used to link binaries produced from a project to that project as part of the "multi-stage builds" experimental feature.
+For more information, see the [multi stage builds overview](../msb/README.md).

--- a/docs/references/experimental/vsi/README.md
+++ b/docs/references/experimental/vsi/README.md
@@ -1,0 +1,74 @@
+## Vendored Source Identification
+
+Some projects, especially C or C++ projects, vendor open source libraries in directories adjacent to the first party code being developed in-house.
+FOSSA's Vendored Source Identification is intended to support identifying and categorizing such vendored libraries.
+
+### How does it work?
+
+FOSSA fingerprints all files in your project and uploads those fingerprints to our analysis service.
+The analysis service then uses a proprietary algorithm to compare those fingerprints with the fingerprints in our database of open source projects.
+
+### Prerequisites
+
+VSI support requires a feature flag enabled in your FOSSA organization. If you're interested in using this feature please contact us!
+
+### FAQ
+
+#### Why not always enable VSI?
+
+VSI is more computationally intensive, and therefore takes longer to run.
+For this reason, we recommend only enabling it when you are reasonably confident that you will obtain useful information by enabling it.
+
+To explain, enabling VSI causes the CLI to:
+
+1. Fingerprint all files in the project
+2. Send those fingerprints to the FOSSA analysis service for vendored source identification
+3. Wait for remote analysis to complete
+
+This process has undergone a lot of optimization to improve its performance (and this is an area we’re continually investing in), but it will never be as fast as scanning local files for dependency information.
+
+#### Failed to resolve dependencies for FOSSA projects
+
+> _Note: This example mentions functionality provided by the "multi-stage builds" family of features; it's documented here because you're likely to see this error during an `--experimental-enable-vsi` run._
+> _For more information on multi-stage builds see the [multi stage builds overview](../msb/README.md)._
+
+Let's say we have two C projects: `LibProject` and `CliProject`.
+`LibProject` is a library that is used inside `CliProject`, and we want to report that relationship in FOSSA, such that dependencies of `LibProject` appear as deep dependencies of `CliProject`.
+
+Let's go further and say our CI pipeline for `LibProject` looks like this, where we compile its output binary (`libproject.o`) into the directory `out/`:
+
+```bash
+make build -o out
+```
+
+We can then integrate FOSSA here to essentially tie the fingerprint of that `libproject.o` binary to `LibProject` in FOSSA:
+
+```bash
+make build -o out
+fossa analyze --experimental-link-project-binary out --experimental-enable-vsi
+```
+
+This causes FOSSA to store a record saying "whenever I see a file with the same cryptographic fingerprint as `libproject.o` in a future scan, I know that means `LibProject`".
+
+Later, when we scan `CliProject`, so long as it contains a copy of `libproject.o` inside, we'll then perform the following steps:
+
+1. The CLI will determine that `LibProject` is a dependency of `CliProject`, because it sees that copy of `libproject.o` inside the `CliProject` directory tree.
+2. The CLI will then ask the FOSSA server for the list of `LibProject`'s dependencies.
+3. The CLI will then report to the FOSSA server that `LibProject` is a dependency of `CliProject`, and include `LibProject`'s dependencies as deep dependencies.
+
+The trouble is, what happens if the user scanning `CliProject` doesn't have access to view the dependencies of `LibProject`?
+
+In that case, we fail with an error like this one:
+
+```bash
+Failed to resolve dependencies for the following FOSSA projects:
+  custom+1/libproject$1635972409
+
+You may not have access to the projects, or they may not exist (see the warnings below for details).
+If desired you can use --experimental-skip-vsi-graph to skip resolving the dependencies of these projects.
+```
+
+This is the CLI telling us "I know `LibProject` is a dependency of `CliProject`, but I can't view `LibProject` in the FOSSA server, so I don't know its dependencies and therefore I can't report its dependencies as deep dependencies of `CliProject`".
+
+The best way to handle this is to ensure that anyone using `LibProject` as a dependency has access to view it in FOSSA, so that they can get an accurate dependency graph.
+However, as a workaround, the user may also use `--experimental-skip-vsi-graph custom+1/libproject$1635972409`, which tells the CLI "that's OK, I know you can't see it, and I'm OK with not getting the deep dependencies from that project".

--- a/docs/references/experimental/vsi/README.md
+++ b/docs/references/experimental/vsi/README.md
@@ -1,4 +1,4 @@
-## Vendored Source Identification
+## Vendored Source Identification (VSI)
 
 Some projects, especially C or C++ projects, vendor open source libraries in directories adjacent to the first party code being developed in-house.
 FOSSA's Vendored Source Identification is intended to support identifying and categorizing such vendored libraries.

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -64,3 +64,17 @@ We support the following archive formats:
 - `.tar.gz`
 - `.jar`
 - `.rpm`
+
+### Experimental Options
+
+_Important: For support and other general information, refer to the [experimental options overview](../experimental/README.md) before using experimental options._
+
+In addition to the [standard flags](#specifying-fossa-project-details), the analyze command supports the following experimental flags:
+
+| Name                                                    | Description                                                                                                                                                         |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--experimental-enable-vsi`                             | Enable the vendored source indentification engine. For more information, see the [vendored source indentification overview](../experimental/vsi/README.md).         |
+| `--experimental-enable-binary-discovery`                | Enable reporting binary files as unlicensed dependencies. For more information, see the [binary discovery overview](../experimental/binary-discovery/README.md).    |
+| `--experimental-link-project-binary './some-dir'`       | Link the provided binary files to the project being analyzed. For more information, see the [multi stage builds overview](../experimental/msb/README.md).           |
+| `--experimental-skip-vsi-graph 'custom+1/some$locator'` | Skip resolving the dependencies of the given project that was previously linked via `--experimental-link-project-binary`.                                           |
+| `--experimental-enable-monorepo 'monorepo-type'`        | Scan the project in monorepo mode. For more information, see the [monorepo overview](../experimental/monorepo/README.md).                                           |

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -91,43 +91,7 @@ import Effect.Logger (
   withDefaultLogger,
  )
 import Fossa.API.Types (ApiKey (..), ApiOpts (..))
-import Options.Applicative (
-  Alternative (many, (<|>)),
-  Parser,
-  ParserPrefs,
-  argument,
-  auto,
-  command,
-  customExecParser,
-  eitherReader,
-  flag,
-  flag',
-  fullDesc,
-  header,
-  help,
-  helpShowGlobals,
-  helper,
-  hidden,
-  hsubparser,
-  info,
-  infoOption,
-  internal,
-  long,
-  metavar,
-  option,
-  optional,
-  prefs,
-  progDesc,
-  short,
-  showHelpOnError,
-  str,
-  strOption,
-  subparser,
-  subparserInline,
-  switch,
-  value,
-  (<**>),
- )
+import Options.Applicative (Alternative (many, (<|>)), Parser, ParserPrefs, argument, auto, command, customExecParser, eitherReader, flag, fullDesc, header, help, helpShowGlobals, helper, hidden, hsubparser, info, infoOption, internal, long, metavar, option, optional, prefs, progDesc, short, showHelpOnError, str, strOption, subparser, subparserInline, switch, value, (<**>))
 import Path (Abs, Dir, File, Path, Rel, parseAbsDir, parseRelDir)
 import System.Environment (lookupEnv)
 import System.Exit (die)
@@ -400,6 +364,12 @@ commands =
               (ContainerCommand <$> containerOpts)
               (progDesc "Run in Container Scan mode")
           )
+        <> command
+          "experimental-link-user-defined-dependency-binary"
+          ( info
+              (AssertUserDefinedBinariesCommand <$> assertUserDefinedBinariesOpts)
+              (progDesc "Link one or more binary fingerprints as a user-defined dependency")
+          )
     )
 
 hiddenCommands :: Parser Command
@@ -417,12 +387,6 @@ hiddenCommands =
           ( info
               (DumpBinsCommand <$> baseDirArg)
               (progDesc "Output all embedded binaries to specified path")
-          )
-        <> command
-          "experimental-link-user-defined-dependency-binary"
-          ( info
-              (AssertUserDefinedBinariesCommand <$> assertUserDefinedBinariesOpts)
-              (progDesc "Link one or more binary fingerprints as a user-defined dependency")
           )
     )
 
@@ -449,21 +413,20 @@ analyzeOpts =
 
 vsiAnalyzeOpt :: Parser VSIAnalysisMode
 vsiAnalyzeOpt =
-  flag' VSIAnalysisEnabled (long "enable-vsi" <> hidden)
-    <|> pure VSIAnalysisDisabled
+  flag VSIAnalysisDisabled VSIAnalysisEnabled (long "experimental-enable-vsi" <> help "Analyzes project files on disk to detect vendored open source libraries")
+    <|> flag VSIAnalysisDisabled VSIAnalysisEnabled (long "enable-vsi" <> hidden)
 
 binaryDiscoveryOpt :: Parser BinaryDiscoveryMode
 binaryDiscoveryOpt =
-  flag' BinaryDiscoveryEnabled (long "experimental-enable-binary-discovery" <> hidden)
-    <|> pure BinaryDiscoveryDisabled
+  flag BinaryDiscoveryDisabled BinaryDiscoveryEnabled (long "experimental-enable-binary-discovery" <> help "Reports binary files as unlicensed dependencies")
 
 iatAssertionOpt :: Parser AnalyzeVSIAssertionMode
 iatAssertionOpt =
-  (AnalyzeVSIAssertionEnabled <$> strOption (long "experimental-link-project-binary" <> hidden))
+  (AnalyzeVSIAssertionEnabled <$> strOption (long "experimental-link-project-binary" <> metavar "DIR" <> help "Links output binary files to this project in FOSSA"))
     <|> pure AnalyzeVSIAssertionDisabled
 
 skipVSIGraphResolutionOpt :: Parser VSI.Locator
-skipVSIGraphResolutionOpt = (option (eitherReader parseLocator) (long "experimental-skip-vsi-graph" <> hidden))
+skipVSIGraphResolutionOpt = (option (eitherReader parseLocator) (long "experimental-skip-vsi-graph" <> metavar "LOCATOR" <> help "Skip resolving the dependencies of the given project in FOSSA"))
   where
     parseLocator :: String -> Either String VSI.Locator
     parseLocator s = case VSI.parseLocator (toText s) of
@@ -479,7 +442,7 @@ filterOpt = option (eitherReader parseFilter) (long "filter" <> help "(deprecate
 monorepoOpts :: Parser MonorepoAnalysisOpts
 monorepoOpts =
   MonorepoAnalysisOpts
-    <$> optional (strOption (long "experimental-enable-monorepo" <> metavar "MODE" <> help "scan the project in the experimental monorepo mode. Supported modes: aosp"))
+    <$> optional (strOption (long "experimental-enable-monorepo" <> metavar "MODE" <> help "scan the project in monorepo mode. Supported modes: aosp"))
 
 pathOpt :: String -> Either String (Path Rel Dir)
 pathOpt = first show . parseRelDir

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -353,12 +353,6 @@ commands =
               (progDesc "List available analysis-targets in a directory (projects and sub-projects)")
           )
         <> command
-          "vps"
-          ( info
-              (VPSCommand <$> vpsOpts)
-              (progDesc "Run in Vendored Package Scan mode")
-          )
-        <> command
           "container"
           ( info
               (ContainerCommand <$> containerOpts)
@@ -387,6 +381,12 @@ hiddenCommands =
           ( info
               (DumpBinsCommand <$> baseDirArg)
               (progDesc "Output all embedded binaries to specified path")
+          )
+        <> command
+          "vps"
+          ( info
+              (VPSCommand <$> vpsOpts)
+              (progDesc "Run in Vendored Package Scan mode")
           )
     )
 


### PR DESCRIPTION
# Overview

- Updates `experimental` prefixed flags to no longer be hidden from help output.
- Hides the `vps` subcommand, which is deprecated.
- Renames `enable-vsi` to `experimental-enable-vsi`, leaving the original there as a hidden flag.
  - We've communicated to existing VSI beta users that `enable-vsi` is experimental regardless of the lacking prefix, but this canonicalizes it for future users.
  - The reason for this disconnect is that `enable-vsi` existed prior to the `experimental` prefix concept.
- Adds documentation for these flags to the user guide.

## Acceptance criteria

Gathering user feedback on experimental functionality is useful, so long as it's properly explained what users should expect with the feature (and what level of support they should expect when using the feature).

Documenting and making experimental functionality discoverable allows for more users to gain visibility into what we're working on, which empowers them to potentially use it for their own workflows and give us feedback on that functionality.

Approving this PR indicates:

- You agree that experimental flags should be shown in the help output.
- You agree that experimental flags and options should be documented.
- You agree with the documentation as written.

## Testing plan

- I ran the CLI with `-h` to validate that the flags now appear in the help text.
- I ran the CLI with the options to validate that it still works properly.

## Risks

Making experimental functionality discoverable may lead to users depending on experimental functionality that is altered in an incompatible way or outright removed in future versions of the CLI. While this is not ideal, giving ourselves this flexibility is exactly why we're using an `experimental` prefix, so we'll need to plan messaging to handle this.

## References

Closes https://github.com/fossas/team-analysis/issues/741

## Notes

I decided against adding these to the config file _for now._ The entrypoint refactor is going on and I didn't want to mess with that, plus some of the options (in particular monorepo) are set up in such a way that it's unclear how best to set this up.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
