### PR TITLE
add cabal-fmt to CI, separate lints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,47 +169,6 @@ jobs:
         name: ${{ runner.os }}-binaries
         path: release
 
-  # Run linter and format checkers independently, so you see errors from both.
-  linter-check:
-    name: linter-check
-    runs-on: ubuntu-latest
-    container: ghcr.io/fossas/haskell-dev-tools:8.10.4
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Run hlint
-      run: |
-        make lint
-
-    - name: Check Markdown links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-quiet-mode: 'yes'
-        config-file: '.markdown-link-check.json'
-
-    - name: Disallow empty Markdown links
-      run: |
-        ! grep ']()' **/*.md
-
-  format-check:
-    name: formatter-check
-    runs-on: ubuntu-latest
-    container: ghcr.io/fossas/haskell-dev-tools:8.10.4
-
-    steps:
-    - uses: actions/checkout@v2
-
-    # Run the formatter
-    - name: run fourmolu
-      run: |
-        make fmt
-
-    # If git has changes, then the formatter check fails.
-    - name: check git status
-      run: |
-        git diff --exit-code
-
   create-release:
     name: create-release
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,70 @@
+name: Static analysis
+on: push
+
+jobs:
+  # Run linter and format checkers independently, so you see errors from both.
+  linter-check:
+    name: linter-check
+    runs-on: ubuntu-latest
+    container: ghcr.io/fossas/haskell-dev-tools:8.10.4
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run hlint
+      run: |
+        make lint
+
+  link-check:
+    name: link-check
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Check Markdown links
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        config-file: '.markdown-link-check.json'
+
+    - name: Disallow empty Markdown links
+      run: |
+        ! grep ']()' **/*.md
+
+  format-check:
+    name: formatter-check
+    runs-on: ubuntu-latest
+    container: ghcr.io/fossas/haskell-dev-tools:8.10.4
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Run the formatter
+    - name: run fourmolu
+      run: |
+        make fmt
+
+    # If git has changes, then the formatter check fails.
+    - name: check git status
+      run: |
+        git diff --exit-code
+
+  cabal-format-check:
+    name: cabal-format-check
+    runs-on: ubuntu-latest
+    container: ghcr.io/fossas/haskell-dev-tools:8.10.4
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Run the formatter
+    - name: "run cabal-fmt"
+      run: |
+        cabal-fmt -i spectrometer.cabal
+
+    # If git has changes, then the formatter check fails.
+    - name: check git status
+      run: |
+        git diff --exit-code
+

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -281,9 +281,9 @@ library
     Strategy.Maven.Pom.PomFile
     Strategy.Maven.Pom.Resolver
     Strategy.Mix
-    Strategy.Node
     Strategy.Nim
     Strategy.Nim.NimbleLock
+    Strategy.Node
     Strategy.Node.Npm.PackageLock
     Strategy.Node.PackageJson
     Strategy.Node.YarnV1.YarnLock


### PR DESCRIPTION
# Overview

Add `cabal-fmt -i` check to CI, move linter/formatter checks to separate CI job, so we don't have to re-run builds in all cases.