### PR TITLE
Compile on an M1 Mac

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -39,7 +39,7 @@ source-repository-package
 -- Current implementation of yarn-lock throws runtime error, as described by patches:
 -- (a) https://github.com/Profpatsch/yarn2nix/pull/73
 -- (b) https://github.com/Profpatsch/yarn2nix/pull/72
--- TODO: Remove once, both PRs are merged. 
+-- TODO: Remove once, both PRs are merged.
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
@@ -47,3 +47,7 @@ source-repository-package
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z
+
+package *
+  extra-include-dirs: /opt/homebrew/include
+  extra-lib-dirs: /opt/homebrew/lib


### PR DESCRIPTION
# Overview

On M1 macs, homebrew installs to `/opt/homebrew`. To make compilation work, we need to tell cabal that libraries are in `/opt/homebrew/lib` and includes are in `/opt/homebrew/include`.

## Acceptance criteria

* `cabal build` should work on an M1 Mac
* `cabal build` should still work on everything else
* We shouldn't slow down the build too much

## Testing plan

- [ ] On an M1 mac, run `cabal build`.
- [ ] On a different computer, run `cabal build`

Verify that both builds work.

To make sure that this will not cause a failure when one of the directories does not exist, I ran `cabal build` with the `package *` stanza like this:

```
package *
  extra-include-dirs: /opt/homebrew/include,/foo/does/not/exist
  extra-lib-dirs: /opt/homebrew/lib
```

## Risks

I think this will force a long compile for everyone the first time they compile after this is merged.

## References

https://github.com/haskell/cabal/issues/2997

There are two other ways to fix this.

One is to just add the extra dirs for the packages that need it. Currently, this is just `lzma`. So instead of `package *`, you could do:

```
package lzma
  extra-include-dirs: /opt/homebrew/include
  extra-lib-dirs: /opt/homebrew/lib
```

This would speed up compile times a bit, but we could recreate this error without knowing it when adding new dependencies.

Another option is to not make any changes in our codebase, but instead ask people to make the changes in their `~/.cabal/config` file, by adding these two lines:

```
extra-include-dirs: /opt/homebrew/include
extra-lib-dirs: /opt/homebrew/lib
```

The drawback to this is that this change isn't obvious even if we document it, so people will be frustrated or lose time.

One thing that does not work is to add flags to your `cabal build` invocation. The `--extra-include-dirs` and `--extra-lib-dirs` flags do not actually do anything (see https://github.com/haskell/cabal/issues/2997).

```
cabal build --extra-include-dirs=/opt/homebrew/include --extra-lib-dirs=/opt/homebrew/lib
```

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
