### PR TITLE
Updates makefile to include cabal-fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ analyze:
 install-local: build
 	cp $(shell cabal list-bin fossa) ./fossa
 
+install-dev: build
+	cp $(shell cabal list-bin fossa) /usr/local/bin/fossa-dev
+
 check: check-fmt lint
 
 # Format everything (if this fails, update FMT_OPTS or use your IDE to format)
@@ -23,6 +26,8 @@ fmt:
 	@echo "Running fourmolu"
 	@fourmolu --version
 	@fourmolu --mode inplace ${FMT_OPTS} $(shell find ${FIND_OPTS})
+	@echo "Running cabal-fmt"
+	@cabal-fmt spectrometer.cabal --inplace
 
 # Confirm everything is formatted without changing anything
 check-fmt:
@@ -30,6 +35,8 @@ check-fmt:
 	@fourmolu --version
 	@fourmolu --mode check ${FMT_OPTS} $(shell find ${FIND_OPTS})
 	@echo "No formatting errors found"
+	@echo "Running cabal-fmt"
+	@cabal-fmt --check spectrometer.cabal
 
 # Lint everything (If this fails, update .hlint.yaml or report the failure)
 lint:


### PR DESCRIPTION
# Overview

- Adds `cabal-fmt` on `make fmt`, and `make check-fmt`
- Adds `make install-dev` option for install `fossa-dev` on local user's path