### PR TITLE
Nuget: Project Assets Json - fixes infinite loop

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## v3.0.8
+
+- Nuget: Fixes analysis performance when working with `project.assets.json` ([#733](https://github.com/fossas/fossa-cli/pull/733))
+
 ## v3.0.7
 
 - Go: `go mod graph` is used as default tactic for gomod strategy. ([#707](https://github.com/fossas/fossa-cli/pull/707))

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -17,7 +17,7 @@ import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics hiding (fromMaybe)
 import Data.Aeson
 import Data.Aeson.Types (Parser)
-import Data.Foldable (for_, traverse_)
+import Data.Foldable (for_)
 import Data.HashMap.Strict qualified as HM
 import Data.Map.Strict qualified as Map
 import Data.Maybe
@@ -150,13 +150,11 @@ instance FromJSON ProjectAssetsJson where
           pure (FrameworkName framework, frameworkDeps)
         pure $ Map.fromList projectFrameworks
 
-newtype NugetLabel = Env DepEnvironment deriving (Eq, Ord, Show)
-
 buildGraph :: ProjectAssetsJson -> Graphing Dependency
 buildGraph project = Graphing.gmap toDependency $ run . evalGrapher $ graphsOfTargetFrameworks
   where
     graphsOfTargetFrameworks =
-      traverse_
+      traverse
         (graphOfFramework $ projectFramework project)
         (Map.toList $ targets project)
 


### PR DESCRIPTION
# Overview

This PR, changes graphing method to ensure, we build graph iteratively.

## Acceptance criteria

- Nuget analyzer for `project.assets.json` does not lead to infinite loop

## Testing plan

- Perform analysis against provided debug bundle in referenced ticket.

Expected: `fossa analyze` should complete within seconds.

## Risks

N/A

## References

Closes https://github.com/fossas/team-analysis/issues/850

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
