### PR TITLE
Refactor `sinkHash`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## Unreleased
+
+- Cleans up duplicated internal hashing primitives ([#737](https://github.com/fossas/fossa-cli/pull/737))
+
 ## v3.0.9
 
 - Makes experimental flags discoverable and documents them. ([#723](https://github.com/fossas/fossa-cli/pull/723))

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -213,6 +213,7 @@ library
     Control.Effect.TaskPool
     Control.Exception.Extra
     Data.Aeson.Extra
+    Data.Conduit.Extra
     Data.FileEmbed.Extra
     Data.Flag
     Data.Functor.Extra

--- a/src/Data/Conduit/Extra.hs
+++ b/src/Data/Conduit/Extra.hs
@@ -1,0 +1,18 @@
+module Data.Conduit.Extra (
+  sinkHash,
+) where
+
+import Conduit (ConduitT, Void, await)
+import Crypto.Hash (Digest, HashAlgorithm, hashFinalize, hashInit, hashUpdate)
+import Data.ByteString (ByteString)
+
+-- | Hashes a stream of 'ByteString'@s@ and creates a digest @d@.
+-- Adapted from @sinkHash@ in https://hackage.haskell.org/package/cryptonite-conduit-0.2.2/docs/src/Crypto-Hash-Conduit.html
+sinkHash :: (Monad m, HashAlgorithm hash) => ConduitT ByteString Void m (Digest hash)
+sinkHash = sink hashInit
+  where
+    sink ctx = do
+      b <- await
+      case b of
+        Nothing -> pure $! hashFinalize ctx
+        Just bs -> sink $! hashUpdate ctx bs

--- a/test/Discovery/ArchiveSpec.hs
+++ b/test/Discovery/ArchiveSpec.hs
@@ -4,11 +4,12 @@ module Discovery.ArchiveSpec (spec) where
 
 import Conduit (await, runConduitRes, sourceFile, (.|))
 import Control.Algebra (Has)
-import Control.Carrier.Diagnostics (Diagnostics, fatalText, runDiagnostics)
+import Control.Carrier.Diagnostics (Diagnostics, fatalOnIOException, fatalText, runDiagnostics)
 import Control.Carrier.Finally (runFinally)
 import Control.Effect.Exception (IOException, Lift, catch)
 import Control.Effect.Lift (sendIO)
 import Crypto.Hash (Digest, SHA256, hashFinalize, hashInit, hashUpdate)
+import Data.Conduit.Extra (sinkHash)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.String.Conversion (ToText (..))
@@ -193,23 +194,14 @@ hashFiles dir = do
     mkRel (p, a) = case tryMakeRelative dir p of
       Rel f -> pure (f, a)
       Abs _ -> fatalText $ "Unable to make " <> toText p <> " relative to '" <> toText dir <> "'"
+    hashToPair path = do
+      hash <- hashFile path
+      pure (path, toText . show $ hash)
     collect _ _ files = do
-      fps <- traverse hashFilePair files
+      fps <- traverse hashToPair files
       pure (fps, WalkContinue)
 
 -- | Adapted from fingerprint hashing, but kept separate so that if the fingerprint implementation changes we don't see errors here.
 -- TODO: Maybe basic file hashing should be in ReadFS?
-hashFilePair :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path Abs File -> m (Path Abs File, Text)
-hashFilePair file = do
-  (h :: Digest SHA256) <- hashFile $ toFilePath file
-  pure (file, toText . show $ h)
-  where
-    sinkHash = sink hashInit
-    hashFile fp =
-      sendIO (runConduitRes (sourceFile fp .| sinkHash))
-        `catch` (\(e :: IOException) -> fatalText ("unable to hash file: " <> toText (show e)))
-    sink ctx = do
-      b <- await
-      case b of
-        Nothing -> return $! hashFinalize ctx
-        Just bs -> sink $! hashUpdate ctx bs
+hashFile :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path Abs File -> m (Digest SHA256)
+hashFile file = (fatalOnIOException "hash file") . sendIO . runConduitRes $ sourceFile (toFilePath file) .| sinkHash

--- a/test/Discovery/ArchiveSpec.hs
+++ b/test/Discovery/ArchiveSpec.hs
@@ -2,13 +2,13 @@
 
 module Discovery.ArchiveSpec (spec) where
 
-import Conduit (await, runConduitRes, sourceFile, (.|))
+import Conduit (runConduitRes, sourceFile, (.|))
 import Control.Algebra (Has)
 import Control.Carrier.Diagnostics (Diagnostics, fatalOnIOException, fatalText, runDiagnostics)
 import Control.Carrier.Finally (runFinally)
-import Control.Effect.Exception (IOException, Lift, catch)
+import Control.Effect.Exception (Lift)
 import Control.Effect.Lift (sendIO)
-import Crypto.Hash (Digest, SHA256, hashFinalize, hashInit, hashUpdate)
+import Crypto.Hash (Digest, SHA256)
 import Data.Conduit.Extra (sinkHash)
 import Data.Map (Map)
 import Data.Map qualified as Map


### PR DESCRIPTION
# Overview

Refactors `sinkHash` into a primitive exposed in `Data.Conduit.Extra`, as suggested here: https://github.com/fossas/fossa-cli/pull/735#discussion_r765102962

## Acceptance criteria

No more duplicate `sinkHash` implementations.

## Testing plan

I relied on automated tests.

## Risks

Not risky.

## References

https://github.com/fossas/fossa-cli/pull/735#discussion_r765102962

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
