### PR TITLE
Adds rest of Integration tests

### DIFF
--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -14,10 +14,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - uses: cachix/install-nix-action@v15
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
     - name: Install alpine binary dependencies
       shell: sh
       run: |
         apk add bash xz-dev bzip2-dev bzip2-static upx curl jq
+
     - name: Debugging information
       run: |
         ghc --version || echo "no ghc"
@@ -33,6 +38,7 @@ jobs:
           ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-
           ${{ runner.os }}-${{ matrix.ghc }}-
           ${{ runner.os }}-
+
     - name: Update vendored binaries
       run: |
         mkdir vendor-bins

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ vendor-bins/
 
 # Debug output
 fossa.debug.json.gz
+
+# Integration Tests
+integration-test/artifacts/

--- a/integration-test/Analysis/CarthageSpec.hs
+++ b/integration-test/Analysis/CarthageSpec.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.CarthageSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.Carthage qualified as Carthage
+import Test.Hspec
+import Types (GraphBreadth (Complete))
+
+swiftQueue :: AnalysisTestFixture (Carthage.CarthageProject)
+swiftQueue =
+  AnalysisTestFixture
+    "SwiftQueue"
+    Carthage.discover
+    LocalEnvironment
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/lucas34/SwiftQueue/archive/refs/tags/5.0.2.tar.gz"
+      [reldir|carthage/SwiftQueue/|]
+      [reldir|SwiftQueue-5.0.2/|]
+
+spec :: Spec
+spec = do
+  testSuiteDepResultSummary swiftQueue "carthage" (DependencyResultsSummary 1 1 0 1 Complete)

--- a/integration-test/Analysis/ClojureSpec.hs
+++ b/integration-test/Analysis/ClojureSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.ClojureSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.Leiningen qualified as Leiningen
+import Test.Hspec
+import Types (GraphBreadth (Complete))
+
+clojureEnv :: FixtureEnvironment
+clojureEnv = NixEnv ["openjdk11", "clojure", "leiningen"]
+
+eastwood :: AnalysisTestFixture (Leiningen.LeiningenProject)
+eastwood =
+  AnalysisTestFixture
+    "eastwood"
+    Leiningen.discover
+    clojureEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/jonase/eastwood/archive/refs/tags/Release-1.0.0.tar.gz"
+      [reldir|clojure/eastwood/|]
+      [reldir|eastwood-Release-1.0.0/|]
+
+ring :: AnalysisTestFixture (Leiningen.LeiningenProject)
+ring =
+  AnalysisTestFixture
+    "ring"
+    Leiningen.discover
+    clojureEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/ring-clojure/ring/archive/refs/tags/1.9.4.tar.gz"
+      [reldir|clojure/ring/|]
+      [reldir|ring-1.9.4/|]
+
+spec :: Spec
+spec = do
+  testSuiteDepResultSummary eastwood "leiningen" (DependencyResultsSummary 10 7 3 1 Complete)
+  testSuiteDepResultSummary ring "leiningen" (DependencyResultsSummary 23 6 17 1 Complete)

--- a/integration-test/Analysis/CocoapodsSpec.hs
+++ b/integration-test/Analysis/CocoapodsSpec.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.CocoapodsSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.Cocoapods qualified as Cocoapods
+import Test.Hspec
+import Types (GraphBreadth (..))
+
+shadowsocksXNG :: AnalysisTestFixture (Cocoapods.CocoapodsProject)
+shadowsocksXNG =
+  AnalysisTestFixture
+    "ShadowsocksX-NG"
+    Cocoapods.discover
+    LocalEnvironment
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/shadowsocks/ShadowsocksX-NG/archive/refs/tags/v1.9.4.tar.gz"
+      [reldir|cocoapods/ShadowsocksX-NG/|]
+      [reldir|ShadowsocksX-NG-1.9.4/|]
+
+sDWebImage :: AnalysisTestFixture (Cocoapods.CocoapodsProject)
+sDWebImage =
+  AnalysisTestFixture
+    "SDWebImage"
+    Cocoapods.discover
+    LocalEnvironment
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/SDWebImage/SDWebImage/archive/refs/tags/5.12.0.tar.gz"
+      [reldir|cocoapods/ring/|]
+      [reldir|SDWebImage-5.12.0/|]
+
+spec :: Spec
+spec = do
+  testSuiteDepResultSummary shadowsocksXNG "cocoapods" (DependencyResultsSummary 6 6 0 1 Partial)
+  testSuiteDepResultSummary sDWebImage "cocoapods" (DependencyResultsSummary 4 4 0 1 Partial)

--- a/integration-test/Analysis/ElixirSpec.hs
+++ b/integration-test/Analysis/ElixirSpec.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.ElixirSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Effect.Exec (AllowErr (Never), Command (Command))
+import Path
+import Strategy.Mix qualified as Mix
+import Test.Hspec
+import Types (GraphBreadth (Complete))
+
+elixirEnv :: FixtureEnvironment
+elixirEnv = NixEnv ["elixir"]
+
+mixBuildProjectCmd :: Command
+mixBuildProjectCmd = Command "mix" ["deps.get", "&&", "mix deps.compile"] Never
+
+absinthe :: AnalysisTestFixture (Mix.MixProject)
+absinthe =
+  AnalysisTestFixture
+    "absinthe"
+    Mix.discover
+    elixirEnv
+    (Just mixBuildProjectCmd)
+    $ FixtureArtifact
+      "https://github.com/absinthe-graphql/absinthe/archive/refs/tags/v1.6.6.tar.gz"
+      [reldir|elixir/absinthe/|]
+      [reldir|absinthe-1.6.6/|]
+
+spec :: Spec
+spec = do
+  testSuiteDepResultSummary absinthe "mix" (DependencyResultsSummary 4 4 1 1 Complete)

--- a/integration-test/Analysis/ErlangSpec.hs
+++ b/integration-test/Analysis/ErlangSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.ErlangSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.Rebar3 qualified as Rebar3
+import Test.Hspec
+import Types (GraphBreadth (Complete))
+
+erlangEnv :: FixtureEnvironment
+erlangEnv = NixEnv ["erlang", "rebar3"]
+
+cowboy :: AnalysisTestFixture (Rebar3.RebarProject)
+cowboy =
+  AnalysisTestFixture
+    "cowboy"
+    Rebar3.discover
+    erlangEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/ninenines/cowboy/archive/refs/tags/2.9.0.tar.gz"
+      [reldir|erlang/cowboy/|]
+      [reldir|cowboy-2.9.0/|]
+
+emqx :: AnalysisTestFixture (Rebar3.RebarProject)
+emqx =
+  AnalysisTestFixture
+    "emqx"
+    Rebar3.discover
+    erlangEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/emqx/emqx/archive/refs/tags/v4.3.10.tar.gz"
+      [reldir|erlang/emqx/|]
+      [reldir|emqx-4.3.10/|]
+
+spec :: Spec
+spec = do
+  testSuiteDepResultSummary cowboy "rebar3" (DependencyResultsSummary 2 2 0 1 Complete)
+  testSuiteDepResultSummary emqx "rebar3" (DependencyResultsSummary 0 0 0 1 Complete)

--- a/integration-test/Analysis/FixtureExpectationUtils.hs
+++ b/integration-test/Analysis/FixtureExpectationUtils.hs
@@ -4,33 +4,27 @@ module Analysis.FixtureExpectationUtils (
   -- * spec hooks
   withAnalysisOf,
 
+  -- * spec helpers
+  testSuiteDepResultSummary,
+
   -- * expectation helpers
   getDepResultsOf,
-  shouldFindProjectOf,
+  expectProject,
   expectDepResultsSummary,
-  expectNumDeps,
-  expectNumDirects,
-  expectNumEdges,
-  expectDep,
-  expectDirectDep,
-  expectEdgeBetween,
-  expectGraphBreadth,
-  expectNumManifests,
 ) where
 
 import Analysis.FixtureUtils (AnalysisTestFixture (..), FixtureArtifact (..), getArtifact, performDiscoveryAndAnalyses)
 import App.Fossa.Analyze.Types (AnalyzeProject)
 import Control.Algebra (Has)
 import Control.Effect.Lift (Lift, sendIO)
-import Control.Monad (unless)
-import Data.List (find, isInfixOf)
-import Data.String.Conversion (toString, toText)
+import Data.List (find)
+import Data.String.Conversion (toString)
 import Data.Text (Text)
 import Graphing
 import Path
 import Path.IO qualified as PIO
-import Test.Hspec (Expectation, HasCallStack, expectationFailure, shouldNotBe)
-import Types (Dependency (..), DependencyResults (..), DiscoveredProject (..), GraphBreadth)
+import Test.Hspec (Expectation, Spec, aroundAll, describe, expectationFailure, it, shouldBe, shouldNotBe)
+import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth)
 
 -- | Tabulated property of the DependencyResult.
 data DependencyResultsSummary = DependencyResultsSummary
@@ -42,6 +36,17 @@ data DependencyResultsSummary = DependencyResultsSummary
   }
   deriving (Show, Eq, Ord)
 
+summarize :: DependencyResults -> DependencyResultsSummary
+summarize dr =
+  DependencyResultsSummary
+    (length . vertexList $ gr)
+    (length . directList $ gr)
+    (length . edgesList $ gr)
+    (length . dependencyManifestFiles $ dr)
+    (dependencyGraphBreadth dr)
+  where
+    gr = dependencyGraph dr
+
 -- | Performs discovery and analysis for all discovered project for provided analysis integration fixture.
 withAnalysisOf ::
   (Has (Lift IO) sig m, AnalyzeProject a, MonadFail m) =>
@@ -51,92 +56,45 @@ withAnalysisOf ::
 withAnalysisOf a runTest = do
   extractedDir <- getArtifact (artifact a)
   res <- performDiscoveryAndAnalyses extractedDir a
-  _ <- case scopedDir . artifact $ a of
-    Nothing -> runTest (res, extractedDir)
-    Just sd -> runTest (res, extractedDir </> sd)
+  _ <- runTest (res, extractedDir </> (scopedDir . artifact $ a))
   sendIO $ PIO.removeDirRecur extractedDir
 
--- Expectation Helpers
--- Provides expectation functions for graph properties and dependency resulting.
-
 -- | Retrieves a dependency result from discovered project of a given type and path.
-getDepResultsOf :: [(DiscoveredProject a, DependencyResults)] -> (Text, Path Abs Dir) -> Maybe DependencyResults
-getDepResultsOf result (projType, projPath) = snd <$> withProjectOfType result (projType, projPath)
+getDepResultsOf ::
+  [(DiscoveredProject a, DependencyResults)] ->
+  (Text, Path Abs Dir) ->
+  Maybe DependencyResults
+getDepResultsOf result (projType, projPath) =
+  snd <$> withProjectOfType result (projType, projPath)
 
 -- | Expects a discovered project of type at given path.
-shouldFindProjectOf :: (Show a, Eq a) => (Text, Path Abs Dir) -> [(DiscoveredProject a, DependencyResults)] -> Expectation
-shouldFindProjectOf (projType, projPath) result = fst <$> withProjectOfType result (projType, projPath) `shouldNotBe` Nothing
-
--- | Expects number of dependencies in dependency results graphing.
-expectNumDeps :: Int -> Maybe DependencyResults -> Expectation
-expectNumDeps numDeps = expectOnDepGraph numDeps (shouldBeEqual "number of dependencies") (length . vertexList)
-
--- | Expects number of direct dependencies in dependency results graphing.
-expectNumDirects :: Int -> Maybe DependencyResults -> Expectation
-expectNumDirects numDirects = expectOnDepGraph numDirects (shouldBeEqual "number of direct dependencies") (length . directList)
-
--- | Expects number of edges in depndency graphing results.
-expectNumEdges :: Int -> Maybe DependencyResults -> Expectation
-expectNumEdges numEdges = expectOnDepGraph numEdges (shouldBeEqual "number of edges") (length . edgesList)
-
--- | Expects a dependency in dependency results graphing.
-expectDep :: Dependency -> Maybe DependencyResults -> Expectation
-expectDep dep = expectOnDepGraph [dep] (shouldContain "dependency within graph") vertexList
-
--- | Expects a direct dependency in dependency results graphing.
-expectDirectDep :: Dependency -> Maybe DependencyResults -> Expectation
-expectDirectDep dep = expectOnDepGraph [dep] (shouldContain "direct dependency within graph") directList
-
--- | Expects edge between two dependency in dependency results graphing.
-expectEdgeBetween :: Dependency -> Dependency -> Maybe DependencyResults -> Expectation
-expectEdgeBetween depFrom depTo = expectOnDepGraph [(depFrom, depTo)] (shouldContain "edges within graph") edgesList
-
--- | Expects graph breadth from dependency result.
-expectGraphBreadth :: GraphBreadth -> Maybe DependencyResults -> Expectation
-expectGraphBreadth breadth depResult = case depResult of
-  Nothing -> expectationFailure "expected to have dependency graph, for property assertion, but received nothing!"
-  Just dr -> shouldBeEqual "graph type to be" (dependencyGraphBreadth dr) breadth
-
--- | Expects number of manifest files from dependency result.
-expectNumManifests :: Int -> Maybe DependencyResults -> Expectation
-expectNumManifests numManifests depResult = case depResult of
-  Nothing -> expectationFailure "expected to have dependency graph, for property assertion, but received nothing!"
-  Just dr -> shouldBeEqual "graph type to be" (length $ dependencyManifestFiles dr) numManifests
+expectProject ::
+  (Show a, Eq a) =>
+  (Text, Path Abs Dir) ->
+  [(DiscoveredProject a, DependencyResults)] ->
+  Expectation
+expectProject (projType, projPath) result =
+  fst <$> withProjectOfType result (projType, projPath) `shouldNotBe` Nothing
 
 -- | Expects summary of dependency results from dependency result.
 expectDepResultsSummary :: DependencyResultsSummary -> Maybe DependencyResults -> Expectation
-expectDepResultsSummary depResultSummary depResult = do
-  expectNumEdges (numEdges depResultSummary) depResult
-  expectNumDeps (numDeps depResultSummary) depResult
-  expectNumDirects (numDirectDeps depResultSummary) depResult
-  expectGraphBreadth (graphType depResultSummary) depResult
-  expectNumManifests (numManifestFiles depResultSummary) depResult
-
--- --------------------------------
--- Internal Expectation helpers
-
-withProjectOfType :: [(DiscoveredProject a, DependencyResults)] -> (Text, Path Abs Dir) -> Maybe (DiscoveredProject a, DependencyResults)
-withProjectOfType result (projType, projPath) = find (\(dr, _) -> projectType dr == projType && projectPath dr == projPath) result
-
-shouldSatisfyWithMsg :: (a -> a -> Bool) -> Text -> a -> a -> Expectation
-shouldSatisfyWithMsg comparator errorMsg expected actual = expectTrue (toString errorMsg) (comparator expected actual)
-  where
-    expectTrue :: HasCallStack => String -> Bool -> Expectation
-    expectTrue msg b = unless b (expectationFailure msg)
-
-expectOnDepGraph :: a -> (a -> a -> Expectation) -> (Graphing Dependency -> a) -> Maybe DependencyResults -> Expectation
-expectOnDepGraph expected expectationRunner getter depResult = case depResult of
+expectDepResultsSummary depResultSummary depResult = case depResult of
   Nothing -> expectationFailure "expected to have dependency graph, for property assertion, but received nothing!"
-  Just d -> expectationRunner (getter $ dependencyGraph d) expected
+  Just dr -> summarize dr `shouldBe` depResultSummary
 
-shouldBeEqual :: (Eq a, Show a) => Text -> a -> a -> Expectation
-shouldBeEqual errorScope expected actual = shouldSatisfyWithMsg (==) errorMsg expected actual
-  where
-    errorMsg :: Text
-    errorMsg = "For " <> errorScope <> " - expected: " <> toText (show expected) <> ", but got: " <> toText (show actual)
+withProjectOfType ::
+  [(DiscoveredProject a, DependencyResults)] ->
+  (Text, Path Abs Dir) ->
+  Maybe (DiscoveredProject a, DependencyResults)
+withProjectOfType result (projType, projPath) =
+  find (\(dr, _) -> projectType dr == projType && projectPath dr == projPath) result
 
-shouldContain :: (Eq a, Show a) => Text -> [a] -> [a] -> Expectation
-shouldContain errorScope expected actual = shouldSatisfyWithMsg (isInfixOf) errorMsg expected actual
-  where
-    errorMsg :: Text
-    errorMsg = "For " <> errorScope <> " - expected to contain: " <> toText (show actual) <> ", but it was not part of: " <> toText (show expected)
+testSuiteDepResultSummary :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> Text -> DependencyResultsSummary -> Spec
+testSuiteDepResultSummary fixture projType depResultSummary =
+  aroundAll (withAnalysisOf fixture) $
+    describe (toString $ testName fixture) $ do
+      it "should find targets" $ \(result, extractedDir) ->
+        expectProject (projType, extractedDir) result
+
+      it "should have expected dependency results" $ \(result, extractedDir) ->
+        depResultSummary `expectDepResultsSummary` getDepResultsOf result (projType, extractedDir)

--- a/integration-test/Analysis/FixtureUtils.hs
+++ b/integration-test/Analysis/FixtureUtils.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Analysis.FixtureUtils (

--- a/integration-test/Analysis/GoSpec.hs
+++ b/integration-test/Analysis/GoSpec.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.GoSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.Gomodules qualified as Gomodules
+import Test.Hspec
+
+goEnv :: FixtureEnvironment
+goEnv = NixEnv ["go"]
+
+vault :: AnalysisTestFixture (Gomodules.GomodulesProject)
+vault =
+  AnalysisTestFixture
+    "vault"
+    Gomodules.discover
+    goEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/hashicorp/vault/archive/refs/tags/v1.9.1.tar.gz"
+      [reldir|go/vault/|]
+      [reldir|vault-1.9.1/|]
+
+testVault :: Spec
+testVault =
+  aroundAll (withAnalysisOf vault) $ do
+    describe "vault" $ do
+      it "should find targets" $ \(result, extractedDir) -> do
+        expectProject ("gomod", extractedDir) result
+        length result `shouldBe` 7
+
+spec :: Spec
+spec = do
+  testVault

--- a/integration-test/Analysis/MavenSpec.hs
+++ b/integration-test/Analysis/MavenSpec.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.MavenSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.Maven qualified as Maven
+import Test.Hspec
+
+mavenEnv :: FixtureEnvironment
+mavenEnv = NixEnv ["maven", "jdk11"]
+
+keycloak :: AnalysisTestFixture (Maven.MavenProject)
+keycloak =
+  AnalysisTestFixture
+    "keycloak"
+    Maven.discover
+    mavenEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/keycloak/keycloak/archive/refs/tags/15.1.0.tar.gz"
+      [reldir|maven/keycloak/|]
+      [reldir|keycloak-15.1.0//|]
+
+testKeycloak :: Spec
+testKeycloak =
+  aroundAll (withAnalysisOf keycloak) $ do
+    describe "keycloak" $ do
+      it "should find targets" $ \(result, extractedDir) ->
+        expectProject ("maven", extractedDir) result
+
+spec :: Spec
+spec = do
+  testKeycloak

--- a/integration-test/Analysis/NugetSpec.hs
+++ b/integration-test/Analysis/NugetSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.NugetSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.NuGet.PackageReference qualified as PackageReference
+import Strategy.NuGet.PackagesConfig qualified as PackagesConfig
+import Test.Hspec
+import Types
+
+serviceStack :: (Path Abs Dir -> TestC IO [DiscoveredProject a]) -> AnalysisTestFixture a
+serviceStack discoveryFunc =
+  AnalysisTestFixture
+    "ServiceStack"
+    discoveryFunc
+    LocalEnvironment
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/ServiceStack/ServiceStack/archive/refs/tags/v5.13.2.tar.gz"
+      [reldir|nuget/ServiceStack/|]
+      [reldir|servicestack-5.13.2//|]
+
+testServiceStackForPkgReferences :: Spec
+testServiceStackForPkgReferences =
+  aroundAll (withAnalysisOf $ serviceStack PackageReference.discover) $ do
+    describe "ServiceStack" $ do
+      it "should find targets" $ \(result, _) -> do
+        length result `shouldBe` 64
+
+testServiceStackForPkgConfig :: Spec
+testServiceStackForPkgConfig =
+  aroundAll (withAnalysisOf $ serviceStack PackagesConfig.discover) $ do
+    describe "ServiceStack" $ do
+      it "should find targets" $ \(result, _) -> do
+        length result `shouldBe` 4
+
+spec :: Spec
+spec = do
+  testServiceStackForPkgReferences
+  testServiceStackForPkgConfig

--- a/integration-test/Analysis/Python/PipenvSpec.hs
+++ b/integration-test/Analysis/Python/PipenvSpec.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.Python.PipenvSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.Python.Pipenv qualified as Pipenv
+import Test.Hspec
+import Types (GraphBreadth (Complete))
+
+pipenv :: AnalysisTestFixture (Pipenv.PipenvProject)
+pipenv =
+  AnalysisTestFixture
+    "pipenv"
+    Pipenv.discover
+    LocalEnvironment
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/pypa/pipenv/archive/refs/tags/v2021.11.23.tar.gz"
+      [reldir|python/pipenv/pipenv/|]
+      [reldir|pipenv-2021.11.23/|]
+
+spec :: Spec
+spec = do
+  testSuiteDepResultSummary pipenv "pipenv" (DependencyResultsSummary 90 90 0 1 Complete)

--- a/integration-test/Analysis/Python/PoetrySpec.hs
+++ b/integration-test/Analysis/Python/PoetrySpec.hs
@@ -16,20 +16,12 @@ poetry =
     "poetry"
     Poetry.discover
     LocalEnvironment
+    Nothing
     $ FixtureArtifact
       "https://github.com/python-poetry/poetry/archive/72497bcb66b5a1cc20e3aa95973c523a22b05bfa.tar.gz"
       [reldir|python/poetry/poetry/|]
-      $ Just [reldir|poetry-72497bcb66b5a1cc20e3aa95973c523a22b05bfa/|]
-
-testPoetrySrcRepo :: Spec
-testPoetrySrcRepo =
-  aroundAll (withAnalysisOf poetry) $ do
-    describe "poetry" $ do
-      it "should find targets" $ \(result, extractedDir) -> do
-        shouldFindProjectOf ("poetry", extractedDir) result
-      it "should have expected dependency results" $ \(result, extractedDir) -> do
-        (DependencyResultsSummary 66 29 69 1 Complete) `expectDepResultsSummary` (getDepResultsOf result ("poetry", extractedDir))
+      [reldir|poetry-72497bcb66b5a1cc20e3aa95973c523a22b05bfa/|]
 
 spec :: Spec
 spec = do
-  testPoetrySrcRepo
+  testSuiteDepResultSummary poetry "poetry" (DependencyResultsSummary 66 29 69 1 Complete)

--- a/integration-test/Analysis/Python/SetuptoolsSpec.hs
+++ b/integration-test/Analysis/Python/SetuptoolsSpec.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.Python.SetuptoolsSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.Python.Setuptools qualified as Setuptools
+import Test.Hspec
+import Types (GraphBreadth (..))
+
+theFuck :: AnalysisTestFixture (Setuptools.SetuptoolsProject)
+theFuck =
+  AnalysisTestFixture
+    "theFuck"
+    Setuptools.discover
+    LocalEnvironment
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/nvbn/thefuck/archive/refs/tags/3.31.tar.gz"
+      [reldir|python/setuptools/thefuck/|]
+      [reldir|thefuck-3.31/|]
+
+flask :: AnalysisTestFixture (Setuptools.SetuptoolsProject)
+flask =
+  AnalysisTestFixture
+    "flask"
+    Setuptools.discover
+    LocalEnvironment
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/pallets/flask/archive/refs/tags/2.0.2.tar.gz"
+      [reldir|python/setuptools/flask/|]
+      [reldir|flask-2.0.2/|]
+
+spec :: Spec
+spec = do
+  testSuiteDepResultSummary theFuck "setuptools" (DependencyResultsSummary 16 16 0 2 Partial)
+  testSuiteDepResultSummary flask "setuptools" (DependencyResultsSummary 4 4 0 1 Partial)

--- a/integration-test/Analysis/RustSpec.hs
+++ b/integration-test/Analysis/RustSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.RustSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.Cargo qualified as Cargo
+import Test.Hspec
+import Types (GraphBreadth (Complete))
+
+rustEnv :: FixtureEnvironment
+rustEnv = NixEnv ["rustc", "cargo"]
+
+bat :: AnalysisTestFixture (Cargo.CargoProject)
+bat =
+  AnalysisTestFixture
+    "bat"
+    Cargo.discover
+    rustEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/sharkdp/bat/archive/refs/tags/v0.18.3.tar.gz"
+      [reldir|rust/bat/|]
+      [reldir|bat-0.18.3//|]
+
+fd :: AnalysisTestFixture (Cargo.CargoProject)
+fd =
+  AnalysisTestFixture
+    "fd"
+    Cargo.discover
+    rustEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/sharkdp/fd/archive/refs/tags/v8.3.0.tar.gz"
+      [reldir|rust/fd/|]
+      [reldir|fd-8.3.0/|]
+
+spec :: Spec
+spec = do
+  testSuiteDepResultSummary bat "cargo" (DependencyResultsSummary 146 29 269 1 Complete)
+  testSuiteDepResultSummary fd "cargo" (DependencyResultsSummary 71 25 137 1 Complete)

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -443,9 +443,19 @@ test-suite integration-tests
   main-is:            test.hs
   ghc-options:        -threaded
   other-modules:
+    Analysis.CarthageSpec
+    Analysis.ClojureSpec
+    Analysis.CocoapodsSpec
+    Analysis.ElixirSpec
+    Analysis.ErlangSpec
     Analysis.FixtureExpectationUtils
     Analysis.FixtureUtils
+    Analysis.MavenSpec
+    Analysis.NugetSpec
+    Analysis.Python.PipenvSpec
     Analysis.Python.PoetrySpec
+    Analysis.Python.SetuptoolsSpec
+    Analysis.RustSpec
 
   build-tool-depends: hspec-discover:hspec-discover ^>=2.8.2
   build-depends:

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -450,6 +450,7 @@ test-suite integration-tests
     Analysis.ErlangSpec
     Analysis.FixtureExpectationUtils
     Analysis.FixtureUtils
+    Analysis.GoSpec
     Analysis.MavenSpec
     Analysis.NugetSpec
     Analysis.Python.PipenvSpec

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -1,6 +1,7 @@
 module Strategy.Cargo (
   discover,
   CargoMetadata (..),
+  CargoProject (..),
   NodeDependency (..),
   NodeDepKind (..),
   PackageId (..),

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -8,6 +8,7 @@ module Strategy.Carthage (
   analyze,
   ResolvedEntry (..),
   EntryType (..),
+  CarthageProject (..),
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -3,6 +3,7 @@ module Strategy.Cocoapods (
   findProjects,
   getDeps,
   mkProject,
+  CocoapodsProject (..),
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -3,6 +3,7 @@ module Strategy.Gomodules (
   findProjects,
   getDeps,
   mkProject,
+  GomodulesProject (..),
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)

--- a/src/Strategy/Mix.hs
+++ b/src/Strategy/Mix.hs
@@ -2,6 +2,7 @@ module Strategy.Mix (
   discover,
   findProjects,
   mkProject,
+  MixProject (..),
 ) where
 
 import Control.Effect.Diagnostics (Diagnostics, context)

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -7,6 +7,7 @@ module Strategy.NuGet.PackageReference (
   mkProject,
   buildGraph,
   PackageReference (..),
+  PackageReferenceProject (..),
   ItemGroup (..),
   Package (..),
 ) where

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -10,6 +10,7 @@ module Strategy.Python.Pipenv (
   PipfileMeta (..),
   PipfileSource (..),
   PipfileDep (..),
+  PipenvProject (..),
   buildGraph,
 ) where
 

--- a/src/Strategy/Python/Setuptools.hs
+++ b/src/Strategy/Python/Setuptools.hs
@@ -3,6 +3,7 @@ module Strategy.Python.Setuptools (
   findProjects,
   getDeps,
   mkProject,
+  SetuptoolsProject (..),
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)

--- a/src/Strategy/Rebar3.hs
+++ b/src/Strategy/Rebar3.hs
@@ -1,4 +1,5 @@
 module Strategy.Rebar3 (
+  RebarProject (..),
   discover,
   findProjects,
   getDeps,


### PR DESCRIPTION
# Overview

Adds rest of integration test to reach parity with spectrometer-test

- Adds Elixir
- Adds Erlang
- Adds Rust
- Adds Maven
- Adds Nuget
- Adds Cocoapods
- Adds Carthage
- Adds Setuptools
- Adds Pipenv
- Adds gomod

Noticeably following are missing: 

- Gradle (missing in spectromter-test as well)
- Haskell (missing in spectromter-test as well)
- SwiftPM (missing in spectromter-test as well)

## Acceptance criteria

Integration test can be ran from workflow.