### PR TITLE
Adds resolution API strategy for gradle

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## v3.0.10
 
-- Gradle: Uses ResolutionAPI for gradle analysis. ([#]())
+- Gradle: Uses ResolutionAPI for gradle analysis. ([#740](https://github.com/fossas/fossa-cli/pull/740/))
 - Cleans up duplicated internal hashing primitives ([#737](https://github.com/fossas/fossa-cli/pull/737))
 - Adds a prerequisite required for future VSI improvements ([#736](https://github.com/fossas/fossa-cli/pull/736))
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # Fossa CLI Changelog
 
-## Unreleased
+## v3.0.10
 
+- Gradle: Uses ResolutionAPI for gradle analysis. ([#]())
 - Cleans up duplicated internal hashing primitives ([#737](https://github.com/fossas/fossa-cli/pull/737))
 - Adds a prerequisite required for future VSI improvements ([#736](https://github.com/fossas/fossa-cli/pull/736))
 

--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -120,7 +120,7 @@ This tactic runs a Gradle [init script](https://docs.gradle.org/current/userguid
 
 This init script is implemented [here](https://github.com/fossas/fossa-cli/blob/master/scripts/jsondeps.gradle) and bundled into the CLI during compilation.
 
-The script works by iterating through configurations, resolving their dependencies, and then serializing those dependencies into JSON.
+The script works by iterating through configurations, getting resolution result for the configuration, and then serializing those dependencies into JSON. Please note that we currently only support analysis for builds using gradle v3.3 or greater.
 
 ### Parsing `gradle :dependencies`
 

--- a/scripts/jsondeps.gradle
+++ b/scripts/jsondeps.gradle
@@ -1,190 +1,183 @@
-// This Gradle init script adds a `jsonDeps` task that outputs the dependencies
-// of each subproject as JSON.
-//
-// If you're debugging this script, you can directly run this on a Gradle project
-// by running `gradle -I/path/to/script $TASK` e.g.
-// `gradle -I/tmp/jsondeps.gradle :jsonDeps`. This lets you see the output
-// directly.
-//
-// Useful documentation:
-// - Gradle init scripts: https://docs.gradle.org/current/userguide/init_scripts.html
-// - Gradle subprojects: https://docs.gradle.org/current/userguide/multi_project_builds.html
-// - Gradle configurations: https://docs.gradle.org/current/userguide/declaring_dependencies.html
-// - Gradle build script primer: https://docs.gradle.org/current/userguide/groovy_build_script_primer.html
-// - Gradle init script API reference:
-//   - https://docs.gradle.org/current/dsl/org.gradle.api.Project.html#org.gradle.api.Project:allprojects(groovy.lang.Closure)
-//   - https://docs.gradle.org/current/javadoc/index.html
-//
-// ----
-//
-// The resulting JSON output is a map of configuration names to an array of
-// top-level dependencies.
-//
-// Dependencies have a "type", either "project" or "package"
-//
-// "project" dependencies look like: `{ "type": "project", "name": ":project-name" }`
-// "package" dependencies look like: `{ "type": "package", "name": "group:module", "version": "1.0", "dependencies": [] }`
-//
-// Semantically:
-//
-// type ConfigurationName = Text
-// type Name = Text
-// type Version = Text
-//
-// type Output = Map ConfigurationName [Dependency]
-//
-// data Dependency =
-//     Project Name -- first-party (sub)projects
-//   | Package Name Version [Dependency]
+/* 
+
+This Gradle init script adds a `jsonDeps` task that outputs the dependencies
+of each subproject as JSON.
+
+If you're debugging this script, you can directly run this on a Gradle project
+by running `gradle -I/path/to/script $TASK` e.g.
+    `gradle -I/tmp/jsondeps.gradle :jsonDeps`. This lets you see the output directly.
+
+Useful documentation:
+- Gradle init scripts: https://docs.gradle.org/current/userguide/init_scripts.html
+- Gradle subprojects: https://docs.gradle.org/current/userguide/multi_project_builds.html
+- Gradle configurations: https://docs.gradle.org/current/userguide/declaring_dependencies.html
+- Gradle build script primer: https://docs.gradle.org/current/userguide/groovy_build_script_primer.html
+- Gradle init script API reference:
+  - https://docs.gradle.org/current/dsl/org.gradle.api.Project.html#org.gradle.api.Project:allprojects(groovy.lang.Closure)
+  - https://docs.gradle.org/current/javadoc/index.html
+
+----
+
+There are two form of generated JSON: (1) from resolution API. 
 
 
-// TODO: Only print debug logging when running in debug mode?
+## For (1) Resolution API:
+-------------------------
+
+    The resulting JSON output is a list of all configuration with adjacency map of dependencies.
+
+    For a project resulting json is:    
+    ```
+        {
+            resolvedProjectName: ..
+            resolvedProjectConfigurations: [
+                {
+                    resolvedConfigurationName: ...,
+                    resolvedConfigurationDirectComponents: [
+                        { "type": "project", "name": ":project-name" }, 
+                        ....
+                    ],
+                    resolvedConfigurationDependencies: [
+                        {
+                            "resolvedComponentNode": { "type": "project", "name": ":project-name" }
+                            "resolvedComponentOutgoing": [
+                                { "type": "package", "name": "group:module", "version": "1.0" },
+                                ...
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ```
+*/
+
 allprojects {
     task jsonDeps {
         doLast {
-            def depToJSON
-            // resolvedDep: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolvedDependency.html
-            depToJSON = { resolvedDep ->
-                println "DEBUG: Resolved dep"
-                println resolvedDep
 
-                println "DEBUG: Module artifacts"
-                println resolvedDep.moduleArtifacts
-                println resolvedDep.moduleArtifacts.size()
+            def printTrace = { message, scope ->
+                println "TRACE (${scope}): ${message}"
+            }
 
-                // moduleArtifacts never returns null, but sometimes this
-                // iterator can be empty (for dependencies with no artifacts
-                // e.g. `jackson-bom`).
-                //
-                // See also:
-                // - https://docs.gradle.org/current/userguide/declaring_dependencies.html#sub:module_dependencies
-                // - https://stackoverflow.com/questions/67328406/what-is-junit-bom-and-junit-platform-for-and-should-i-include-them-in-gradle-de
-                if (resolvedDep.moduleArtifacts.size() == 0) {
-                    println "DEBUG: Dependency has no module artifacts"
+            // These will be included as debug logs in CLI!
+            def printDebugToFossa = { message, scope ->
+                println "FOSSA-DEBUG (${scope}): ${message}"
+            }
+
+            // Uses configuration resolution api to serialize adjacency map of dependencies to json. 
+            // This is recommended approach to infer resolved graph. 
+            // 
+            // See:
+            //  - https://github.com/gradle/gradle/issues/5953#issuecomment-404514591
+            //  - 
+            // 
+            // Reference:
+            // - https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolvableDependencies.html
+            // - https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/Configuration.html#getIncoming--
+            def resolvedConfigToJSON = { resolvedConfig -> 
+                def getComponentName = { component -> 
+                    if (component instanceof ProjectComponentIdentifier) { return "${component.projectPath}"}
+                    if (component instanceof ModuleComponentIdentifier) { return "${component.group}:${component.module}"}
+                    printTrace("Component is not project or module: ${component}", "resolvedConfigToJSON")
                     return null
                 }
 
-                // artifact: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolvedArtifact.html
-                def artifact = resolvedDep.moduleArtifacts.iterator().next()
-
-                println "DEBUG: Artifact"
-                println artifact
-
-                // artifact.id: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/component/ComponentArtifactIdentifier.html
-                // artifact.id.componentIdentifier: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/component/ComponentIdentifier.html
-                def id = artifact.id.componentIdentifier
-                def json = "{"
-
-                // A "project component identifier" is a dependency that refers
-                // to another Gradle subproject (as opposed to a third-party
-                // dependency). We don't care about these for now.
-                if (id instanceof ProjectComponentIdentifier) {
-                    // Minor problem here: we don't get the specific configuration used for the subproject.
-                    // The default is the configuration named "default"
-                    json += "\"type\":\"project\",\"name\":\"${id.projectPath}\""
-                } else if (id instanceof ModuleComponentIdentifier) {
-                    // A "module" is a third-party dependency. Almost all
-                    // modules have "artifacts", which is the actual dependency
-                    // code that gets downloaded.
-                    json += "\"type\":\"package\",\"name\":\"${id.group}:${id.module}\",\"version\":\"${id.version}\","
-                    def childResults = []
-                    if (!resolvedDep.children.isEmpty()) {
-                        // childResolvedDep: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolvedDependency.html
-                        resolvedDep.children.each { childResolvedDep ->
-                            def result = depToJSON childResolvedDep
-                            if (result != null) {
-                                childResults << result
-                            }
-                        }
-                    }
-                    json += "\"dependencies\":["
-                    json += childResults.join(",")
-                    json += "]"
-                } else {
-                    // The other possibility here is "LibraryBinaryIdentifier".
-                    // See: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/component/package-summary.html
-                    return null; // FUTURE: binary dependencies in the filetree
+                def componentToJson = { component -> 
+                    if (component instanceof ProjectComponentIdentifier) { return "{\"type\":\"project\",\"name\":\"${getComponentName(component)}\"}"}
+                    if (component instanceof ModuleComponentIdentifier) { return "{\"type\":\"package\",\"name\":\"${getComponentName(component)}\",\"version\":\"${component.version}\"}"}
+                    printTrace("Component is not project or module: ${component}", "resolvedConfigToJSON")
+                    return null
                 }
 
-                json += "}"
+                def resolutionResult = resolvedConfig.incoming.resolutionResult
+                def adjacencyMap = [:]
+                def directComponents = []
+                def loggedWarnings = []
+                
+                // Refs:
+                // -----
+                // resolutionResult: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolvableDependencies.html#getResolutionResult--
+                // getAllComponents(): https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/result/ResolutionResult.html#getAllComponents--
+                // resolvedComponent: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/result/ComponentResult.html
+                // getDependencies(): https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/result/ResolvedComponentResult.html#getDependencies--
+                // resolvedDep: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/result/DependencyResult.html
+                // - 
+                resolvedConfig.incoming.resolutionResult.getAllComponents().each { resolvedComponent ->
+                    if (resolvedComponent instanceof UnresolvedComponentResult) {
+                        printDebugToFossa("Could not resolve component: ${resolvedComponent.getAttempted()}", "resolvedConfigToJSON")
+                        return;
+                    } 
+                    
+                    resolvedComponent.getDependencies().each { resolvedDep ->     
+                        if (resolvedDep instanceof UnresolvedDependencyResult) {
+                            printDebugToFossa("Could not resolve dependency: ${resolvedDep.getAttempted()}", "resolvedConfigToJSON")
+                            return;
+                        }
+                        
+                        def resolvedDependencyId = resolvedDep.getSelected().getId()
+                        if (resolvedDependencyId != resolvedComponent.getId()) {
+                            adjacencyMap.get(resolvedComponent, []) << resolvedDependencyId
+                        }
+                    }
+                }
 
+                // Sort for reproducibility - ordering matches that of, 
+                // official gradle scan plugin dependencies results
+                directComponents = adjacencyMap.get(resolutionResult.getRoot(), [])
+                directComponents.sort { getComponentName(it) }                          
+
+                def json = "{"
+                json += "\"resolvedConfigurationName\": \"${resolvedConfig.getName()}\","
+                json += "\"resolvedConfigurationDirectComponents\": [${directComponents.collect() { componentToJson(it) }.join(',')}],"
+                json += "\"resolvedConfigurationDependencies\": ["
+
+                adjacencyMap.eachWithIndex { node, listOfConnectedNodes, i ->
+                    def connectedNodesJson = listOfConnectedNodes.sort { getComponentName(it) }.collect() { componentToJson(it) }.join(",")
+                    json += "{"
+                    json += "\"resolvedComponentNode\": ${componentToJson(node.getId())},"
+                    json += "\"resolvedComponentOutgoing\": [${connectedNodesJson}]"
+                    json += "}"
+                    if (i < adjacencyMap.size() - 1 ) {
+                        json += ","
+                    }
+                }
+                json += "]"                
+                json += "}"
                 return json
             }
 
-            // config: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/Configuration.html
-            def configToKeyValue = { config ->
-                def jsonDeps = []
-                // config.resolvedConfiguration: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolvedConfiguration.html
-                config.resolvedConfiguration.getFirstLevelModuleDependencies().each { dep ->
-                    println "DEBUG: Found direct dependency in configuration"
-                    println dep
-                    def result = depToJSON dep
-                    if (result != null) {
-                        jsonDeps << result
-                    }
-                }
-                def combined = jsonDeps.join(",")
-                return "\"${config.name}\":[${combined}]"
-            }
 
-            // Gets dependencies of resolved configurations.
-            // If the configuration is not resolvable, or exception is thrown returns 0 dependencies.
-            // 
-            // Note:
-            // -----
-            // Some configurations aren't meant to be resolved, because they're just meant to be containers of
-            // dependency constraints. This only occurs for gradle version v3.3 onwards.
-            // 
-            // References:
-            // -----------
-            // - https://discuss.gradle.org/t/what-is-a-configuration-which-cant-be-directly-resolved/30721
-            // - https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs
-            def getResolvedConfigDepsOrEmptyOf = { config -> 
-                def configsDeps = null              
-                try {
-                    // We know that we are working against gradle version greater or equal to v3.3
-                    // So, configuration has resolvable property. If the configuration is not resolvable return null.
-                    if (config.respondsTo("isCanBeResolved") && !config.isCanBeResolved()) {
-                        println "DEBUG: Configuration is not resolvable"
-                        return null
-                    }
 
-                    // At this point, we know one of these must be true: 
-                    // - We are on Gradle v3.3 or newer (because isCanBeResolved is present) and the configuration is resolvable (isCanBeResolved() == true, therefore did not exit early above).
-                    // - We are on Gradle v3.2.1 or older (because isCanBeResolved is not present). Configurations in Gradle v3.2.1 or older are always resolvable.
-                    configsDeps = configToKeyValue config
-                    println configsDeps
-                    println "DEBUG: Configuration is resolved"
-                } catch (Exception ignored) {
-                    println "DEBUG: An exception occurred"
-                    println ignored
-                    ignored.printStackTrace()
-                }
-                return configsDeps
-            }
-
-            // project: https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html
-            def projectToJSON = { project ->
+            def projectToJsonWithResolutionApi = { project ->
                 def jsonConfigs = []
                 project.configurations.each { config ->
-                    println "DEBUG: Trying to resolve configuration"
-                    println config
-                    def jsonConfigWithDeps = getResolvedConfigDepsOrEmptyOf config
-                    if (jsonConfigWithDeps != null) {
-                        jsonConfigs << jsonConfigWithDeps
+                    def result = null
+
+                    try {
+                        // If we are in gradle v3.3 or greater (isCanBeResolved method should exists)
+                        // And if configuration is not resolvable, disregard current config for dependency resolution.
+                        if (config.respondsTo("isCanBeResolved") && !config.isCanBeResolved()) {
+                            printDebugToFossa ("Configuration is not resolvable: ${config}!", "projectToJsonWithResolutionApi")
+                            return null
+                        }
+                        result = resolvedConfigToJSON (config)
+                        jsonConfigs << result
+                    } catch (Exception ignored) {
+                        printDebugToFossa("${ignored}", "projectToJsonWithResolutionApi")
                     }
                 }
-                def combined = jsonConfigs.join(",")
-                return "{${combined}}"
+                return "{ \"resolvedProjectName\": \"${project.path}\", \"resolvedProjectConfigurations\": [${jsonConfigs.join(",")}]}"
             }
+            
 
-            def result = projectToJSON project
+            def resultWithResolutionApi = projectToJsonWithResolutionApi project
 
-            // We use the "JSONDEPS_" prefix to print output. This is why it's
+            // We use the "RESOLUTIONAPI_JSONDEPS_*" to print output. This is why it's
             // safe for us to print a bunch of other debugging messages
             // everywhere else - the parser in Spectrometer ignores those
             // messages.
-            println "JSONDEPS_${project.path}_${result}"
+            println "RESOLUTIONAPI_JSONDEPS_${project.path}_${resultWithResolutionApi}"
         }
     }
 }

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -273,6 +273,8 @@ library
     Strategy.Gomodules
     Strategy.Googlesource.RepoManifest
     Strategy.Gradle
+    Strategy.Gradle.Common
+    Strategy.Gradle.ResolutionApi
     Strategy.Haskell.Cabal
     Strategy.Haskell.Stack
     Strategy.Leiningen
@@ -390,7 +392,8 @@ test-suite unit-tests
     Go.GopkgTomlSpec
     Go.TransitiveSpec
     Googlesource.RepoManifestSpec
-    Gradle.GradleSpec
+    Gradle.CommonSpec
+    Gradle.ResolutionApiSpec
     Graphing.HydrateSpec
     GraphingSpec
     GraphUtil

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -15,17 +15,10 @@
 -- - Gradle init scripts: https://docs.gradle.org/current/userguide/init_scripts.html
 module Strategy.Gradle (
   discover,
-  buildGraph,
-  JsonDep (..),
-  PackageName (..),
-  ConfigName (..),
-
-  -- * for testing
-  packagePathsWithJson,
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeExperimentalPreferences (..), AnalyzeProject, analyzeProject)
-import Control.Algebra (Has, run)
+import Control.Algebra (Has)
 import Control.Carrier.Reader (Reader)
 import Control.Effect.Diagnostics (
   Diagnostics,
@@ -38,45 +31,37 @@ import Control.Effect.Diagnostics (
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Path (withSystemTempDir)
 import Control.Effect.Reader (asks)
-import Data.Aeson (FromJSON (..), ToJSON, Value (..), decodeStrict, withObject, (.:))
-import Data.Aeson.Types (Parser, unexpected)
+import Data.Aeson (ToJSON)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
 import Data.FileEmbed (embedFile)
-import Data.Foldable (find, for_)
+import Data.Foldable (find)
 import Data.List (isPrefixOf)
-import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Set.NonEmpty (nonEmpty, toSet)
-import Data.String.Conversion (decodeUtf8, encodeUtf8, toString, toText)
+import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import DepTypes (
-  DepEnvironment (..),
-  DepType (MavenType, SubprojectType),
   Dependency (..),
-  VerConstraint (CEq),
-  insertEnvironment,
  )
 import Discovery.Walk (WalkStep (..), fileName, walk')
 import Effect.Exec (AllowErr (..), Command (..), Exec, execThrow)
-import Effect.Grapher (LabeledGrapher, direct, edge, label, withLabeling)
-import Effect.Logger (Logger, logWarn)
+import Effect.Logger (Logger, Pretty (pretty), logDebug, logWarn)
 import Effect.ReadFS (ReadFS, doesFileExist)
 import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Path (Abs, Dir, File, Path, fromAbsDir, parent, parseRelFile, (</>))
-import Strategy.Android.Util (isDefaultAndroidDevConfig, isDefaultAndroidTestConfig)
+import Strategy.Gradle.Common (
+  ConfigName (..),
+  getDebugMessages,
+ )
+import Strategy.Gradle.ResolutionApi qualified as ResolutionApi
 import System.FilePath qualified as FilePath
 import Types (BuildTarget (..), DependencyResults (..), DiscoveredProject (..), FoundTargets (..), GraphBreadth (..))
-
-newtype ConfigName = ConfigName {unConfigName :: Text} deriving (Eq, Ord, Show, FromJSON)
-newtype GradleLabel = Env DepEnvironment deriving (Eq, Ord, Show)
-newtype PackageName = PackageName {unPackageName :: Text} deriving (Eq, Ord, Show, FromJSON)
 
 -- Run the init script on a set of subprojects. Note that this runs the
 -- `:jsonDeps` task on every subproject in one command. This is helpful for
@@ -249,6 +234,7 @@ getDeps ::
   , Has ReadFS sig m
   , Has Diagnostics sig m
   , Has (Reader AnalyzeExperimentalPreferences) sig m
+  , Has Logger sig m
   ) =>
   FoundTargets ->
   GradleProject ->
@@ -274,6 +260,7 @@ analyze ::
   , Has ReadFS sig m
   , Has Diagnostics sig m
   , Has (Reader AnalyzeExperimentalPreferences) sig m
+  , Has Logger sig m
   ) =>
   FoundTargets ->
   Path Abs Dir ->
@@ -294,116 +281,10 @@ analyze foundTargets dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
     pure $ maybe Set.empty (Set.map ConfigName) configs
 
   let text = decodeUtf8 $ BL.toStrict stdout
-  let packagesToOutput = parseJsonDeps text
-  context "Building dependency graph" $ pure (buildGraph packagesToOutput onlyConfigurations)
+  let resolvedProjects = ResolutionApi.parseResolutionApiJsonDeps text
+  let graphFromResolutionApi = ResolutionApi.buildGraph resolvedProjects (onlyConfigurations)
 
-packagePathsWithJson :: [Text] -> [(PackageName, Text)]
-packagePathsWithJson = map (\line -> let (x, y) = Text.breakOn "_{" line in (PackageName x, Text.drop 1 y))
+  -- Log debug messages as seen in gradle script
+  sequence_ $ logDebug . pretty <$> (getDebugMessages text)
 
-parseJsonDeps :: Text -> Map (PackageName, ConfigName) [JsonDep]
-parseJsonDeps text = Map.fromList packagePathsWithDecoded
-  where
-    textLines :: [Text]
-    textLines = Text.lines (Text.filter (/= '\r') text)
-
-    -- Output lines from the init script are of the format:
-    -- JSONDEPS_:project-path_{"configName":[{"type":"package", ...}, ...], ...}
-    --
-    -- See the init script's implementation for details.
-    jsonDepsLines :: [Text]
-    jsonDepsLines = mapMaybe (Text.stripPrefix "JSONDEPS_") textLines
-
-    packagePathsWithDecoded :: [((PackageName, ConfigName), [JsonDep])]
-    packagePathsWithDecoded = do
-      (name, outJson) <- packagePathsWithJson jsonDepsLines
-      let configMap = fromMaybe mempty . decodeStrict $ encodeUtf8 outJson
-      (configName, deps) <- Map.toList configMap
-      pure ((name, ConfigName configName), deps)
-
--- TODO: use LabeledGraphing to add labels for environments
-buildGraph :: Map (PackageName, ConfigName) [JsonDep] -> Set ConfigName -> Graphing Dependency
-buildGraph projectsAndDeps onlyConfigs = run . withLabeling toDependency $ Map.traverseWithKey addProject filteredProjectAndDeps
-  where
-    filteredProjectAndDeps :: Map (PackageName, ConfigName) [JsonDep]
-    filteredProjectAndDeps = Map.filterWithKey (\(_, config) _ -> isConfigIncluded config) (projectsAndDeps)
-
-    isConfigExcluded :: ConfigName -> Bool
-    isConfigExcluded c = not (Set.null onlyConfigs) && Set.notMember c onlyConfigs
-
-    isConfigIncluded :: ConfigName -> Bool
-    isConfigIncluded = not . isConfigExcluded
-
-    -- add top-level projects from the output
-    addProject :: Has (LabeledGrapher JsonDep GradleLabel) sig m => (PackageName, ConfigName) -> [JsonDep] -> m ()
-    addProject (projName, configName) projDeps = do
-      let projAsDep = ProjectDep $ unPackageName projName
-          envLabel = configNameToLabel configName
-      direct projAsDep
-      label projAsDep envLabel
-      for_ projDeps $ \dep -> do
-        edge projAsDep dep
-        mkRecursiveEdges dep envLabel
-
-    -- Infers environment label based on the name of configuration.
-    -- Ref: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph
-    configNameToLabel :: ConfigName -> GradleLabel
-    configNameToLabel conf =
-      if (not . Set.null $ onlyConfigs)
-        then Env $ EnvOther (unConfigName conf) -- We only have specified configs, so we mark them all as Other
-        else case unConfigName conf of -- We have no specified configs, so we have to guess the correct Env.
-          "compileOnly" -> Env EnvDevelopment
-          x | x `elem` ["testImplementation", "testCompileOnly", "testRuntimeOnly", "testCompileClasspath", "testRuntimeClasspath"] -> Env EnvTesting
-          x | isDefaultAndroidDevConfig x -> Env EnvDevelopment
-          x | isDefaultAndroidTestConfig x -> Env EnvTesting
-          x -> Env $ EnvOther x
-
-    toDependency :: JsonDep -> Set GradleLabel -> Dependency
-    toDependency dep = foldr applyLabel $ jsonDepToDep dep
-
-    applyLabel :: GradleLabel -> Dependency -> Dependency
-    applyLabel lbl dep = case lbl of
-      Env env -> insertEnvironment env dep
-
-    -- build edges between deps, recursively
-    mkRecursiveEdges :: Has (LabeledGrapher JsonDep GradleLabel) sig m => JsonDep -> GradleLabel -> m ()
-    mkRecursiveEdges (ProjectDep x) envLabel = label (ProjectDep x) envLabel
-    mkRecursiveEdges jsondep@(PackageDep _ _ deps) envLabel = do
-      label jsondep envLabel
-      for_ deps $ \child -> do
-        edge jsondep child
-        mkRecursiveEdges child envLabel
-
-    jsonDepToDep :: JsonDep -> Dependency
-    jsonDepToDep (ProjectDep name) = projectToDep name
-    jsonDepToDep (PackageDep name version _) =
-      Dependency
-        { dependencyType = MavenType
-        , dependencyName = name
-        , dependencyVersion = Just (CEq version)
-        , dependencyLocations = []
-        , dependencyEnvironments = mempty
-        , dependencyTags = Map.empty
-        }
-
-    projectToDep name =
-      Dependency
-        { dependencyType = SubprojectType
-        , dependencyName = name
-        , dependencyVersion = Nothing
-        , dependencyLocations = []
-        , dependencyEnvironments = mempty
-        , dependencyTags = Map.empty
-        }
-
-data JsonDep
-  = ProjectDep Text -- name
-  | PackageDep Text Text [JsonDep] -- name version deps
-  deriving (Eq, Ord, Show)
-
-instance FromJSON JsonDep where
-  parseJSON = withObject "JsonDep" $ \obj -> do
-    ty <- obj .: "type" :: Parser Text
-    case ty of
-      "project" -> ProjectDep <$> obj .: "name"
-      "package" -> PackageDep <$> obj .: "name" <*> obj .: "version" <*> obj .: "dependencies"
-      _ -> unexpected (String ty)
+  context "Building dependency graph" $ pure graphFromResolutionApi

--- a/src/Strategy/Gradle/Common.hs
+++ b/src/Strategy/Gradle/Common.hs
@@ -1,0 +1,57 @@
+module Strategy.Gradle.Common (
+  packagePathsWithJson,
+  getLinesWithPrefix,
+  configNameToLabel,
+  getDebugMessages,
+  ConfigName (..),
+  GradleLabel (..),
+  PackageName (..),
+  ProjectName (..),
+
+  -- * for testing
+  getLogWithPrefix,
+) where
+
+import Data.Aeson (FromJSON)
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import DepTypes (DepEnvironment (..))
+import Strategy.Android.Util (isDefaultAndroidDevConfig, isDefaultAndroidTestConfig)
+
+newtype ConfigName = ConfigName {unConfigName :: Text} deriving (Eq, Ord, Show, FromJSON)
+newtype GradleLabel = Env DepEnvironment deriving (Eq, Ord, Show)
+newtype PackageName = PackageName {unPackageName :: Text} deriving (Eq, Ord, Show, FromJSON)
+newtype ProjectName = ProjectName {unProjectName :: Text} deriving (Eq, Ord, Show, FromJSON)
+
+packagePathsWithJson :: [Text] -> [(PackageName, Text)]
+packagePathsWithJson = map (\line -> let (x, y) = Text.breakOn "_{" line in (PackageName x, Text.drop 1 y))
+
+getLinesWithPrefix :: Text -> Text -> [Text]
+getLinesWithPrefix text prefix = prefixLines
+  where
+    textLines :: [Text]
+    textLines = Text.lines (Text.filter (/= '\r') text)
+
+    prefixLines :: [Text]
+    prefixLines = mapMaybe (Text.stripPrefix prefix) textLines
+
+configNameToLabel :: Text -> GradleLabel
+configNameToLabel conf =
+  case conf of
+    "compileOnly" -> Env EnvDevelopment
+    x | x `elem` ["testImplementation", "testCompileOnly", "testRuntimeOnly", "testCompileClasspath", "testRuntimeClasspath"] -> Env EnvTesting
+    x | isDefaultAndroidDevConfig x -> Env EnvDevelopment
+    x | isDefaultAndroidTestConfig x -> Env EnvTesting
+    x -> Env $ EnvOther x
+
+getDebugMessages :: Text -> [Text]
+getDebugMessages text = getLogWithPrefix text "FOSSA-DEBUG"
+
+-- | Gets the log message for matching identifier. Applies to gradle init script log format.
+-- Log format of the gradle script is: 'identifier (scope): message'
+--
+-- >>> getLogWithPrefix "SOME-PREFIX (some scope): some message/n DEBUG (some scope): some debug message" "SOME-PREFIX"
+-- ["some message"]
+getLogWithPrefix :: Text -> Text -> [Text]
+getLogWithPrefix text prefix = map (Text.strip . Text.drop 2 . snd . Text.breakOn "):") $ getLinesWithPrefix text prefix

--- a/src/Strategy/Gradle/ResolutionApi.hs
+++ b/src/Strategy/Gradle/ResolutionApi.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Strategy.Gradle.ResolutionApi (
+  ResolvedProject (..),
+  ResolvedDependency (..),
+  ResolvedComponent (..),
+  ResolvedConfiguration (..),
+  buildGraph,
+  parseResolutionApiJsonDeps,
+) where
+
+import Control.Algebra (Has)
+import Data.Aeson (
+  FromJSON (parseJSON),
+  Value (String),
+  decodeStrict,
+  withObject,
+  (.:),
+ )
+import Data.Aeson.Types (Parser, unexpected)
+import Data.Foldable (for_)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (mapMaybe)
+import Data.Set qualified as Set
+import Data.String.Conversion (encodeUtf8)
+import Data.Text (Text)
+import DepTypes (
+  DepEnvironment (EnvOther),
+  DepType (MavenType, SubprojectType),
+  Dependency (..),
+  VerConstraint (CEq),
+  insertEnvironment,
+ )
+import Effect.Grapher (LabeledGrapher, deep, direct, edge, label, run, withLabeling)
+import GHC.Generics (Generic)
+import Graphing (Graphing)
+import Strategy.Gradle.Common (
+  ConfigName (unConfigName),
+  GradleLabel (Env),
+  ProjectName (..),
+  configNameToLabel,
+  getLinesWithPrefix,
+  packagePathsWithJson,
+ )
+
+data ResolvedProject = ResolvedProject
+  { resolvedProjectName :: ProjectName
+  , resolvedProjectConfigurations :: [ResolvedConfiguration]
+  }
+  deriving (Show, Eq, Ord, Generic, FromJSON)
+
+data ResolvedConfiguration = ResolvedConfiguration
+  { resolvedConfigurationName :: ConfigName
+  , resolvedConfigurationDirectComponents :: [ResolvedDependency]
+  , resolvedConfigurationDependencies :: [ResolvedComponent]
+  }
+  deriving (Show, Eq, Ord, Generic, FromJSON)
+
+data ResolvedComponent = ResolvedComponent
+  { resolvedComponentNode :: ResolvedDependency
+  , resolvedComponentOutgoing :: [ResolvedDependency]
+  }
+  deriving (Show, Eq, Ord, Generic, FromJSON)
+
+data ResolvedDependency
+  = ProjectDependency Text
+  | PackageDependency Text Text
+  deriving (Show, Eq, Ord)
+
+instance FromJSON ResolvedDependency where
+  parseJSON = withObject "ResolvedDependency" $ \obj -> do
+    ty <- obj .: "type" :: Parser Text
+    case ty of
+      "project" -> ProjectDependency <$> obj .: "name"
+      "package" ->
+        PackageDependency
+          <$> obj .: "name"
+          <*> obj .: "version"
+      _ -> unexpected (String ty)
+
+parseResolutionApiJsonDeps :: Text -> [ResolvedProject]
+parseResolutionApiJsonDeps text = packagePathsWithDecoded
+  where
+    jsonDepsLines :: [Text]
+    jsonDepsLines = getLinesWithPrefix text "RESOLUTIONAPI_JSONDEPS_"
+
+    packagePathsWithDecoded :: [ResolvedProject]
+    packagePathsWithDecoded = mapMaybe (\(_, outJson) -> decodeStrict $ encodeUtf8 outJson) (packagePathsWithJson jsonDepsLines)
+
+-- | Builds graph using gradle's resolution api.
+-- Reference: https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/result/ResolutionResult.html
+buildGraph :: [ResolvedProject] -> Set.Set ConfigName -> Graphing Dependency
+buildGraph projects onlyConfigs = run . withLabeling toDependency $ mapM_ addConfig applicableConfigurations
+  where
+    applicableConfigurations :: [ResolvedConfiguration]
+    applicableConfigurations = filter (isConfigIncluded . resolvedConfigurationName) configurations
+
+    configurations :: [ResolvedConfiguration]
+    configurations = concatMap resolvedProjectConfigurations projects
+
+    isConfigIncluded :: ConfigName -> Bool
+    isConfigIncluded c = (Set.null onlyConfigs) || Set.member c onlyConfigs
+
+    addConfig :: Has (LabeledGrapher ResolvedDependency GradleLabel) sig m => ResolvedConfiguration -> m ()
+    addConfig resolvedConfig = do
+      let configLabel = toGradleLabel $ resolvedConfigurationName resolvedConfig
+
+      for_ (resolvedConfigurationDirectComponents resolvedConfig) $ \directDep -> do
+        label directDep configLabel
+        direct directDep
+
+      for_ (resolvedConfigurationDependencies resolvedConfig) $ \rcDepAdjacency -> do
+        let parentDep = resolvedComponentNode rcDepAdjacency
+        label parentDep configLabel
+        deep parentDep
+
+        for_ (resolvedComponentOutgoing rcDepAdjacency) $ \childDep -> do
+          deep childDep
+          label childDep configLabel
+          edge parentDep childDep
+
+    -- Infers environment label based on the name of configuration.
+    -- Ref: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph
+    toGradleLabel :: ConfigName -> GradleLabel
+    toGradleLabel conf =
+      if not $ Set.null onlyConfigs
+        then Env $ EnvOther (unConfigName conf) -- We only have specified configs, so we mark them all as Other.
+        else configNameToLabel (unConfigName conf) -- We have no specified configs, so we have to guess the correct Env.
+    toDependency :: ResolvedDependency -> Set.Set GradleLabel -> Dependency
+    toDependency dep = foldr applyLabel $ fromResolvedDep dep
+
+    applyLabel :: GradleLabel -> Dependency -> Dependency
+    applyLabel lbl dep = case lbl of
+      Env env -> insertEnvironment env dep
+
+    fromResolvedDep :: ResolvedDependency -> Dependency
+    fromResolvedDep (ProjectDependency name) =
+      Dependency
+        { dependencyType = SubprojectType
+        , dependencyName = name
+        , dependencyVersion = Nothing
+        , dependencyLocations = []
+        , dependencyEnvironments = mempty
+        , dependencyTags = Map.empty
+        }
+    fromResolvedDep (PackageDependency name version) =
+      Dependency
+        { dependencyType = MavenType
+        , dependencyName = name
+        , dependencyVersion = Just $ CEq version
+        , dependencyLocations = []
+        , dependencyEnvironments = mempty
+        , dependencyTags = Map.empty
+        }

--- a/test/Gradle/CommonSpec.hs
+++ b/test/Gradle/CommonSpec.hs
@@ -1,0 +1,21 @@
+module Gradle.CommonSpec (
+  spec,
+) where
+
+import Strategy.Gradle.Common (PackageName (PackageName), getLogWithPrefix, packagePathsWithJson)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "packagePathsWithJson" $ do
+    it "should break package and jsonText correctly for project with _" $ do
+      packagePathsWithJson ["sub-project_{}"] `shouldBe` [(PackageName "sub-project", "{}")]
+      packagePathsWithJson ["sub_project_{}"] `shouldBe` [(PackageName "sub_project", "{}")]
+      packagePathsWithJson ["sub-project__{}"] `shouldBe` [(PackageName "sub-project_", "{}")]
+      packagePathsWithJson ["subProject_{}"] `shouldBe` [(PackageName "subProject", "{}")]
+
+  describe "getLogWithPrefix" $ do
+    it "should get only messages matching prefix" $ do
+      getLogWithPrefix "FOSSA-WARNING (someScope): some warning message" "FOSSA-WARNING" `shouldBe` ["some warning message"]
+      getLogWithPrefix "ERROR (someScope): some error message" "ERROR" `shouldBe` ["some error message"]
+      getLogWithPrefix "DEBUG (someScope): some debug message" "FOSSA-WARNING" `shouldBe` []

--- a/test/Gradle/ResolutionApiSpec.hs
+++ b/test/Gradle/ResolutionApiSpec.hs
@@ -1,22 +1,25 @@
-module Gradle.GradleSpec (
+module Gradle.ResolutionApiSpec (
   spec,
 ) where
 
-import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text)
 import DepTypes
-import GraphUtil
+import GraphUtil (expectDeps, expectDirect, expectEdges)
 import Graphing (Graphing, empty)
-import Strategy.Gradle (
-  ConfigName (..),
-  JsonDep (..),
-  PackageName (..),
-  buildGraph,
-  packagePathsWithJson,
+import Strategy.Gradle.Common (
+  ConfigName (ConfigName),
+  ProjectName (ProjectName),
  )
-import Test.Hspec
+import Strategy.Gradle.ResolutionApi (
+  ResolvedComponent (ResolvedComponent),
+  ResolvedConfiguration (..),
+  ResolvedDependency (..),
+  ResolvedProject (..),
+  buildGraph,
+ )
+import Test.Hspec (Spec, describe, it, shouldBe)
 
 projectOne :: Dependency
 projectOne =
@@ -107,35 +110,54 @@ packageFour = mkMavenDep "mygroup:packageFour" EnvTesting
 packageFive :: Dependency
 packageFive = mkMavenDep "mygroup:packageFive" EnvTesting
 
-gradleOutput :: Map (Text, Text) [JsonDep]
+gradleOutput :: [ResolvedProject]
 gradleOutput =
-  Map.fromList
-    [ ((":projectOne", "config"), [ProjectDep ":projectTwo", ProjectDep ":projectFour", ProjectDep ":projectFive"])
-    , ((":projectTwo", "compileOnly"), [ProjectDep ":projectThree", PackageDep "mygroup:packageOne" "1.0.0" []])
-    , ((":projectThree", "testCompileOnly"), [PackageDep "mygroup:packageTwo" "2.0.0" []])
-    , ((":projectFour", "testCompileClasspath"), [PackageDep "mygroup:packageFour" "2.0.0" []])
-    , ((":projectFive", "testRuntimeClasspath"), [PackageDep "mygroup:packageFive" "2.0.0" []])
-    ]
-
-wrapKeys :: (Text, Text) -> (PackageName, ConfigName)
-wrapKeys (a, b) = (PackageName a, ConfigName b)
+  [ ResolvedProject
+      (ProjectName ":projectOne")
+      [ ResolvedConfiguration
+          (ConfigName "config")
+          [ProjectDependency ":projectOne"]
+          [ResolvedComponent (ProjectDependency ":projectOne") [ProjectDependency ":projectTwo", ProjectDependency ":projectFour", ProjectDependency ":projectFive"]]
+      ]
+  , ResolvedProject
+      (ProjectName ":projectTwo")
+      [ ResolvedConfiguration
+          (ConfigName "compileOnly")
+          [ProjectDependency ":projectTwo"]
+          [ResolvedComponent (ProjectDependency ":projectTwo") [ProjectDependency ":projectThree", PackageDependency "mygroup:packageOne" "1.0.0"]]
+      ]
+  , ResolvedProject
+      (ProjectName ":projectThree")
+      [ ResolvedConfiguration
+          (ConfigName "testCompileOnly")
+          [ProjectDependency ":projectThree"]
+          [ResolvedComponent (ProjectDependency ":projectThree") [PackageDependency "mygroup:packageTwo" "2.0.0"]]
+      ]
+  , ResolvedProject
+      (ProjectName ":projectFour")
+      [ ResolvedConfiguration
+          (ConfigName "testCompileClasspath")
+          [ProjectDependency ":projectFour"]
+          [ResolvedComponent (ProjectDependency ":projectFour") [PackageDependency "mygroup:packageFour" "2.0.0"]]
+      ]
+  , ResolvedProject
+      (ProjectName ":projectFive")
+      [ ResolvedConfiguration
+          (ConfigName "testRuntimeClasspath")
+          [ProjectDependency ":projectFive"]
+          [ResolvedComponent (ProjectDependency ":projectFive") [PackageDependency "mygroup:packageFive" "2.0.0"]]
+      ]
+  ]
 
 spec :: Spec
 spec = do
-  describe "packagePathsWithJson" $ do
-    it "should break package and jsonText correctly for project with _" $ do
-      packagePathsWithJson ["sub-project_{}"] `shouldBe` [(PackageName "sub-project", "{}")]
-      packagePathsWithJson ["sub_project_{}"] `shouldBe` [(PackageName "sub_project", "{}")]
-      packagePathsWithJson ["sub-project__{}"] `shouldBe` [(PackageName "sub-project_", "{}")]
-      packagePathsWithJson ["subProject_{}"] `shouldBe` [(PackageName "subProject", "{}")]
-
   describe "buildGraph" $ do
     it "should produce an empty graph for empty input" $ do
-      let graph = buildGraph Map.empty (Set.fromList [])
+      let graph = buildGraph [] Set.empty
       graph `shouldBe` (empty :: Graphing Dependency)
 
     it "should produce expected output" $ do
-      let graph = buildGraph (Map.mapKeys wrapKeys gradleOutput) (Set.fromList [])
+      let graph = buildGraph gradleOutput Set.empty
       expectDeps [projectOne, projectTwo, projectThree, packageOne, packageTwo, projectFour, projectFive, packageFour, packageFive] graph
       expectDirect [projectOne, projectTwo, projectThree, projectFour, projectFive] graph
       expectEdges
@@ -152,12 +174,12 @@ spec = do
 
     it "should filter configurations when provided" $ do
       let filteredConfig = "testRuntimeClasspath"
-      let graph = buildGraph (Map.mapKeys wrapKeys gradleOutput) (Set.fromList [ConfigName filteredConfig])
+      let graph = buildGraph gradleOutput (Set.fromList [ConfigName filteredConfig])
       let projectFiveCustomEnv = projectFive{dependencyEnvironments = Set.singleton $ EnvOther filteredConfig}
       let packageFiveCustomEnv = packageFive{dependencyEnvironments = Set.singleton $ EnvOther filteredConfig}
 
-      expectDeps [projectFiveCustomEnv, packageFiveCustomEnv] graph
       expectDirect [projectFiveCustomEnv] graph
+      expectDeps [projectFiveCustomEnv, packageFiveCustomEnv] graph
       expectEdges
         [ (projectFiveCustomEnv, packageFiveCustomEnv)
         ]


### PR DESCRIPTION
I'm opening this PR again, as my rebase modified existing history, which I don't want to do. 

This is summation of following previously accepted PRs:

- https://github.com/fossas/fossa-cli/pull/727
- https://github.com/fossas/fossa-cli/pull/720

## Overview

When analyzing android gradle builds, which are multi project, and multi-module with android variants, we are hitting:

```
org.gradle.internal.component.AmbiguousVariantSelectionException: The consumer was configured to find an API of a component, preferably optimized for Android, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'release', attribute 'partner' with value 'xxx', attribute 'org.jetbrains.kotlin.platform.type' with value 'androidJvm'. However we cannot choose between the following variants of project :common:yyy-xxx:
  - Configuration ':common:yyy-xxx:releaseApiElements' variant android-aidl declares an API of a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'release', attribute 'org.jetbrains.kotlin.platform.type' with value 'androidJvm':
      - Unmatched attributes:
          - Provides attribute 'artifactType' with value 'android-aidl' but the consumer didn't ask for it
          - Provides attribute 'com.android.build.gradle.internal.attributes.VariantAttr' with value 'release' but the consumer didn't ask for it
          - Doesn't say anything about its target Java environment (preferred optimized for Android)
          - Doesn't say anything about partner (required 'xxx')
```

This PR, changes:

- Gradle `jsondeps.gradle` script to include results from using gradle's resolution result api
- Builds the graph using gradle's resolution result api

Prerequisite PR: https://github.com/fossas/fossa-cli/pull/720

## Acceptance criteria

- Gradle: CLI can analyze multi module android project.

## Testing plan

**Test cases:**

Android Multi-Module (with Library) Test:

- [x] https://github.com/HaenaraShin/Android-Multi-Module-Sample.git
- [x] https://github.com/JeroenMols/ModularizationExample.git 

Regression Test:

- [x] https://github.com/gradle/gradle-build-scan-quickstart.git
- [x] https://github.com/danieldisu/GradleKotlinStarter.git
- [x] https://github.com/gwonsungjun/gradle-multi-module.git)


**To test,**

1. Perform fossa analysis: `fossa analyze -o | jq`. Ensure results are reported.
2. Compare result of (1) against, `.\gradlew build --scan` results. Number of dependencies, and dependencies edges should be exactly the same.

## Risks

This changes default gradle tactic, so there is high blast zone if there is edge case unaccounted for. 

## Open Question

~Should we introduce this change behind experimental configuration flag? Instead of drastically changing existing tactic?~

We will replace existing tactic.

## References

Closes: https://github.com/fossas/team-analysis/issues/817

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
