### PR TITLE
YarnLock Analysis: When resolved field is missing, analysis will not fail

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## v3.0.11
+
+- Yarn: Fixes an issue, where entry missing `resolved` attribute in `yarn.lock` would throw exception. ([#741](https://github.com/fossas/fossa-cli/pull/741))
+
 ## v3.0.10
 
 - Gradle: Uses ResolutionAPI for gradle analysis. ([#740](https://github.com/fossas/fossa-cli/pull/740/))

--- a/cabal.project
+++ b/cabal.project
@@ -43,7 +43,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: 276fb494a22bbc50634a8ff8911d6b53782ab1ed
+  tag: fad6f63f8241e7b04325536bb617c5551d3bcbf0
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z

--- a/cabal.project
+++ b/cabal.project
@@ -43,7 +43,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: fad6f63f8241e7b04325536bb617c5551d3bcbf0
+  tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -50,7 +50,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: 276fb494a22bbc50634a8ff8911d6b53782ab1ed
+  tag: fad6f63f8241e7b04325536bb617c5551d3bcbf0
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -50,7 +50,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: fad6f63f8241e7b04325536bb617c5551d3bcbf0
+  tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -48,7 +48,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: 276fb494a22bbc50634a8ff8911d6b53782ab1ed
+  tag: fad6f63f8241e7b04325536bb617c5551d3bcbf0
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -48,7 +48,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: fad6f63f8241e7b04325536bb617c5551d3bcbf0
+  tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -50,7 +50,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: 276fb494a22bbc50634a8ff8911d6b53782ab1ed
+  tag: fad6f63f8241e7b04325536bb617c5551d3bcbf0
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -50,7 +50,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
-  tag: fad6f63f8241e7b04325536bb617c5551d3bcbf0
+  tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z

--- a/src/Strategy/Node/YarnV1/YarnLock.hs
+++ b/src/Strategy/Node/YarnV1/YarnLock.hs
@@ -116,13 +116,13 @@ buildGraph lockfile FlatDeps{..} = fmap hydrateDepEnvs . withLabeling toDependen
     promote EnvProduction $ unTag @Production directDeps
     promote EnvDevelopment $ unTag @Development devDeps
 
-getLocations :: YL.Remote -> [Text]
+getLocations :: Maybe YL.Remote -> [Text]
 getLocations = \case
-  YL.FileRemote url _ -> [url]
-  YL.FileRemoteNoIntegrity url -> [url]
-  YL.GitRemote url rev -> [url <> "@" <> rev]
-  YL.DirectoryLocal dirpath -> [dirpath]
-  YL.DirectoryLocalSymLinked dirpath -> [dirpath]
+  Just (YL.FileRemote url _) -> [url]
+  Just (YL.FileRemoteNoIntegrity url) -> [url]
+  Just (YL.GitRemote url rev) -> [url <> "@" <> rev]
+  Just (YL.DirectoryLocal dirpath) -> [dirpath]
+  Just (YL.DirectoryLocalSymLinked dirpath) -> [dirpath]
   _ -> []
 
 toDependency :: YarnV1Package -> Set YarnV1Label -> Dependency

--- a/test/Yarn/V1/YarnLockV1Spec.hs
+++ b/test/Yarn/V1/YarnLockV1Spec.hs
@@ -102,8 +102,22 @@ packageSix =
     , dependencyTags = mempty
     }
 
+packageSeven :: Dependency
+packageSeven =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "packageSeven"
+    , dependencyVersion = Just $ CEq "7.0.0"
+    , dependencyLocations = []
+    , dependencyEnvironments = mempty
+    , dependencyTags = mempty
+    }
+
 devPackageSix :: Dependency
 devPackageSix = insertEnvironment EnvDevelopment packageSix
+
+prodPackageSeven :: Dependency
+prodPackageSeven = insertEnvironment EnvProduction packageSeven
 
 packageOnce :: Dependency
 packageOnce =
@@ -122,7 +136,7 @@ prodPackageOnce = insertEnvironment EnvProduction packageOnce
 simpleFlatDeps :: FlatDeps
 simpleFlatDeps =
   FlatDeps
-    (applyTag @Production $ Set.fromList [NodePackage "packageOne" "^1.0.0", NodePackage "once" "^1.3.0"])
+    (applyTag @Production $ Set.fromList [NodePackage "packageOne" "^1.0.0", NodePackage "once" "^1.3.0", NodePackage "packageSeven" "^7.0.0"])
     (applyTag @Development $ Set.fromList [NodePackage "packageSix" "^6.0.0"])
     mempty
 
@@ -141,7 +155,7 @@ spec = do
     it' "should produce expected structure" $ do
       yarnLock <- parseFile $(mkRelFile "yarn.lock")
       graph <- buildGraph yarnLock mempty
-      expectDeps' [packageOne, packageTwo, packageThree, packageFour, packageFive, packageSix, packageOnce] graph
+      expectDeps' [packageOne, packageTwo, packageThree, packageFour, packageFive, packageSix, packageSeven, packageOnce] graph
       expectDirect' [] graph
       expectEdges'
         [ (packageOne, packageTwo)
@@ -154,8 +168,8 @@ spec = do
     it' "Should apply the correct dep environments" $ do
       yarnLock <- parseFile $(mkRelFile "yarn.lock")
       graph <- buildGraph yarnLock simpleFlatDeps
-      expectDeps' [prodPackageOne, prodPackageTwo, prodDevPackageThree, packageFour, packageFive, devPackageSix, prodPackageOnce] graph
-      expectDirect' [prodPackageOne, devPackageSix, prodPackageOnce] graph
+      expectDeps' [prodPackageOne, prodPackageTwo, prodDevPackageThree, packageFour, packageFive, devPackageSix, prodPackageSeven, prodPackageOnce] graph
+      expectDirect' [prodPackageOne, devPackageSix, prodPackageOnce, prodPackageSeven] graph
       expectEdges'
         [ (prodPackageOne, prodPackageTwo)
         , (prodPackageTwo, prodDevPackageThree)

--- a/test/Yarn/V1/testdata/yarn.lock
+++ b/test/Yarn/V1/testdata/yarn.lock
@@ -26,6 +26,9 @@ packageSix@^6.0.0:
   resolved "https://registry.npmjs.org/packageSix"
   dependencies:
     packageThree "^3.0.0"
+packageSeven@^7.0.0:
+  integrity "some-hash"
+  version "7.0.0"
 
 # To verify we look at both keys, when inferring direct dep
 # Key ordering is presumed to be not consistent


### PR DESCRIPTION
# Overview

Closes: https://github.com/fossas/team-analysis/issues/845

This PR, 
- Updates Yarn-lock library (Sibling PR: https://github.com/fossas/yarn2nix/pull/4)
- Makes resolved field optional per [Yarn.lock's implementation](https://github.com/yarnpkg/yarn/blob/master/src/lockfile/index.js#L45) 

This happens when we encounter package like this:

```
11190 "some-libc@^1.0.2":
11190   "integrity" "some-hash"
11200   "version" "1.0.9"
```

To do:

- [x] Update Reference to commit when sibling PR is merged. 
- [x] Update Changelog.md

## Acceptance criteria

- When resolved field is missing and package is not local directory or symlinked - we do not fail yarn.lock analysis

## Testing plan

1. Create yarn.lock file for simple node project
2. Remove resolved field from one of the entry
3. Rebuild fossa-cli by: `make install-dev`
4. Analyze this project using `fossa-dev analyze -o | jq` (it should complete without any errors)

## Risks

N/A

## References

Closes: https://github.com/fossas/team-analysis/issues/845

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
