### PR TITLE
Refactor `fossa test` entrypoint

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -187,6 +187,7 @@ library
     App.Fossa.VSIDeps
     App.NewFossa.Config.Analyze
     App.NewFossa.Config.Common
+    App.NewFossa.Config.Test
     App.NewFossa.ConfigFile
     App.NewFossa.EnvironmentVars
     App.NewFossa.Main

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -227,6 +227,7 @@ library
     Control.Effect.StickyLogger
     Control.Effect.TaskPool
     Control.Exception.Extra
+    Control.Timeout
     Data.Aeson.Extra
     Data.Conduit.Extra
     Data.FileEmbed.Extra

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -20,8 +20,8 @@ import App.Types (ProjectRevision (projectName, projectRevision))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async qualified as Async
 import Control.Effect.Diagnostics (
-  Has,
   Diagnostics,
+  Has,
   ToDiagnostic (..),
   fatal,
   fatalText,

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -5,14 +5,18 @@ module App.Fossa.API.BuildWait (
   waitForSherlockScan,
   waitForScanCompletion,
   timeout,
-) where
+  timeout',
+  waitForScanCompletion',
+  waitForIssues',
+waitForSherlockScan') where
 
 import App.Fossa.FossaAPIV1 qualified as Fossa
 import App.Fossa.VPS.Scan.Core qualified as VPSCore
 import App.Fossa.VPS.Scan.ScotlandYard qualified as ScotlandYard
 import App.Types (ProjectRevision (projectName, projectRevision))
 import Control.Algebra (Has)
-import Control.Concurrent (threadDelay)
+import Control.Carrier.Threaded (fork, kill)
+import Control.Concurrent (MVar, newEmptyMVar, putMVar, threadDelay, tryTakeMVar)
 import Control.Concurrent.Async qualified as Async
 import Control.Effect.Diagnostics (
   Diagnostics,
@@ -21,9 +25,12 @@ import Control.Effect.Diagnostics (
   fatalText,
   recover,
  )
-import Control.Effect.Lift (Lift, sendIO)
+import Control.Effect.Exception (Lift, finally)
+import Control.Effect.Lift (sendIO)
 import Control.Effect.StickyLogger (StickyLogger, logSticky')
+import Control.Monad (when)
 import Data.Functor (($>))
+import Data.Maybe (isJust)
 import Data.Text (Text)
 import Effect.Logger (Logger, pretty, viaShow)
 import Fossa.API.Types (ApiOpts, Issues (..))
@@ -32,17 +39,26 @@ pollDelaySeconds :: Int
 pollDelaySeconds = 8
 
 data WaitError
-  = -- | we encountered the FAILED status on a build
+  = -- | We encountered the FAILED status on a build
     BuildFailed
+  | -- | We ran out of time locally, and aborted
+    LocalTimeout
   deriving (Eq, Ord, Show)
+
+newtype Cancel = Cancel Bool deriving (Eq, Ord, Show)
 
 instance ToDiagnostic WaitError where
   renderDiagnostic BuildFailed = "The build failed. Check the FOSSA webapp for more details."
+  renderDiagnostic LocalTimeout = "Build/Issue scan was not completed, and the CLI has locally timed out."
 
 -- | Wait for either a normal build completion or a monorepo scan completion.
 -- Try to detect the correct method, use provided fallback
 waitForScanCompletion ::
-  (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m, Has StickyLogger sig m) =>
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has StickyLogger sig m
+  ) =>
   ApiOpts ->
   ProjectRevision ->
   m ()
@@ -92,7 +108,10 @@ waitForMonorepoScan apiOpts revision = do
   pure ()
 
 waitForIssues ::
-  (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m) =>
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  ) =>
   ApiOpts ->
   ProjectRevision ->
   m Issues
@@ -131,3 +150,130 @@ timeout ::
   IO a ->
   IO (Maybe a)
 timeout seconds act = either id id <$> Async.race (Just <$> act) (threadDelay (seconds * 1_000_000) $> Nothing)
+
+-- | Wait for either a normal build completion or a monorepo scan completion.
+-- Try to detect the correct method, use provided fallback
+waitForScanCompletion' ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has StickyLogger sig m
+  ) =>
+  ApiOpts ->
+  ProjectRevision ->
+  MVar () ->
+  m ()
+waitForScanCompletion' apiopts revision cancelFlag = do
+  -- Route is new, this may fail on on-prem if they haven't updated
+  project <- recover $ Fossa.getProject apiopts revision
+
+  -- Try inferring, fallback to standard.
+  let runAsMonorepo = maybe False Fossa.projectIsMonorepo project
+
+  if runAsMonorepo
+    then waitForMonorepoScan' apiopts revision cancelFlag
+    else waitForBuild' apiopts revision cancelFlag
+
+-- | Wait for a "normal" (non-VPS) build completion
+waitForBuild' ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has StickyLogger sig m
+  ) =>
+  ApiOpts ->
+  ProjectRevision ->
+  MVar () ->
+  m ()
+waitForBuild' apiOpts revision cancelFlag = do
+  build <- Fossa.getLatestBuild apiOpts revision
+
+  case Fossa.buildTaskStatus (Fossa.buildTask build) of
+    Fossa.StatusSucceeded -> pure ()
+    Fossa.StatusFailed -> fatal BuildFailed
+    otherStatus -> do
+      logSticky' $ "[ Waiting for build completion... last status: " <> viaShow otherStatus <> " ]"
+      sendIO $ threadDelay (pollDelaySeconds * 1_000_000)
+      waitForBuild' apiOpts revision cancelFlag
+
+-- | Wait for monorepo scan completion
+waitForMonorepoScan' ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has StickyLogger sig m
+  ) =>
+  ApiOpts ->
+  ProjectRevision ->
+  MVar () ->
+  m ()
+waitForMonorepoScan' apiOpts revision cancelFlag = do
+  checkForCancel cancelFlag
+  Fossa.Organization orgId _ <- Fossa.getOrganization apiOpts
+  let locator = VPSCore.createLocator (projectName revision) orgId
+
+  logSticky' "[ Getting latest scan ID ]"
+  scan <- ScotlandYard.getLatestScan apiOpts locator (projectRevision revision)
+
+  logSticky' "[ Waiting for monorepo scan... ]"
+  waitForSherlockScan apiOpts locator (ScotlandYard.responseScanId scan)
+
+waitForIssues' ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  ) =>
+  ApiOpts ->
+  ProjectRevision ->
+  MVar () ->
+  m Issues
+waitForIssues' apiOpts revision cancelFlag = do
+  checkForCancel cancelFlag
+  issues <- Fossa.getIssues apiOpts revision
+  case issuesStatus issues of
+    "WAITING" -> do
+      sendIO $ threadDelay (pollDelaySeconds * 1_000_000)
+      waitForIssues apiOpts revision
+    _ -> pure issues
+
+-- | Wait for sherlock scan completion (VPS)
+waitForSherlockScan' ::
+  (Has Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m, Has StickyLogger sig m) =>
+  ApiOpts ->
+  VPSCore.Locator ->
+  MVar () ->
+  -- | scan ID
+  Text ->
+  m ()
+waitForSherlockScan' apiOpts locator cancelFlag scanId = do
+  checkForCancel cancelFlag
+  scan <- ScotlandYard.getScan apiOpts locator scanId
+  case ScotlandYard.responseScanStatus scan of
+    Just "AVAILABLE" -> pure ()
+    Just "ERROR" -> fatalText "The component scan failed. Check the FOSSA webapp for more details."
+    Just otherStatus -> do
+      logSticky' $ "[ Waiting for component scan... last status: " <> pretty otherStatus <> " ]"
+      sendIO $ threadDelay (pollDelaySeconds * 1_000_000)
+      waitForSherlockScan' apiOpts locator cancelFlag scanId
+    Nothing -> do
+      sendIO $ threadDelay (pollDelaySeconds * 1_000_000)
+      waitForSherlockScan' apiOpts locator cancelFlag scanId
+
+checkForCancel ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  ) =>
+  MVar () ->
+  m ()
+checkForCancel mvar = do
+  x <- sendIO $ tryTakeMVar mvar
+  when (isJust x) $ fatal LocalTimeout
+
+timeout' :: (Has (Lift IO) sig m) => Int -> (MVar () -> m a) -> m a
+timeout' seconds act = do
+  mvar <- sendIO newEmptyMVar
+  handle <- sendIO $
+    fork $ do
+      threadDelay $ seconds * 1_000_000
+      putMVar mvar ()
+  act mvar `finally` kill handle

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -1,75 +1,63 @@
+{-# LANGUAGE BlockArguments #-}
+
 module App.Fossa.Test (
-  testMain,
-  TestOutputType (..),
+  testSubCommand,
 ) where
 
 import App.Fossa.API.BuildWait (
-  timeout,
-  waitForIssues,
-  waitForScanCompletion,
+  timeout',
+  waitForIssues',
+  waitForScanCompletion',
  )
-import App.Fossa.ProjectInference (
-  inferProjectCached,
-  inferProjectDefault,
-  inferProjectFromVCS,
-  mergeOverride,
- )
+import App.NewFossa.Config.Test (OutputFormat (TestOutputJson, TestOutputPretty), TestCliOpts, TestConfig)
+import App.NewFossa.Config.Test qualified as Config
+import App.NewFossa.Subcommand (SubCommand)
 import App.Types (
-  BaseDir (BaseDir),
-  OverrideProject,
   ProjectRevision (projectName, projectRevision),
  )
-import Control.Carrier.Diagnostics (logWithExit_, (<||>))
+import Control.Algebra (Has)
 import Control.Carrier.StickyLogger (logSticky, runStickyLogger)
-import Control.Effect.Lift (sendIO)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Lift, sendIO)
 import Data.Aeson qualified as Aeson
-import Data.Functor (void)
 import Data.String.Conversion (decodeUtf8)
-import Data.Text.IO (hPutStrLn)
-import Effect.Exec (runExecIO)
 import Effect.Logger (
+  Logger,
   Severity (SevInfo),
   logError,
   logInfo,
   logStdout,
   pretty,
-  withDefaultLogger,
  )
-import Effect.ReadFS (runReadFSIO)
-import Fossa.API.Types (ApiOpts, Issues (..))
+import Fossa.API.Types (Issues (..))
 import System.Exit (exitFailure)
-import System.IO (stderr)
 
-data TestOutputType
-  = -- | pretty output format for issues
-    TestOutputPretty
-  | -- | use json output for issues
-    TestOutputJson
+testSubCommand :: SubCommand TestCliOpts TestConfig
+testSubCommand = Config.mkSubCommand testMain
 
 testMain ::
-  BaseDir ->
-  ApiOpts ->
-  Severity ->
-  -- | timeout (seconds)
-  Int ->
-  TestOutputType ->
-  OverrideProject ->
-  IO ()
-testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType override = do
-  void . timeout timeoutSeconds . withDefaultLogger logSeverity . runStickyLogger SevInfo $
-    logWithExit_ . runReadFSIO . runExecIO $ do
-      revision <- mergeOverride override <$> (inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir)
-
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has Logger sig m
+  ) =>
+  TestConfig ->
+  m ()
+testMain config = runStickyLogger SevInfo $
+  timeout' (Config.unTimeoutSeconds $ Config.timeoutSeconds config) $
+    \cancelFlag -> do
+      let apiOpts = Config.apiOpts config
+          revision = Config.projectRevision config
+          outputType = Config.outputFormat config
       logInfo ""
       logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
       logInfo ("Using revision: `" <> pretty (projectRevision revision) <> "`")
 
       logSticky "[ Waiting for build completion... ]"
 
-      waitForScanCompletion apiOpts revision
+      waitForScanCompletion' apiOpts revision cancelFlag
 
       logSticky "[ Waiting for issue scan completion... ]"
-      issues <- waitForIssues apiOpts revision
+      issues <- waitForIssues' apiOpts revision cancelFlag
       logSticky ""
       logInfo ""
 
@@ -88,8 +76,3 @@ testMain (BaseDir basedir) apiOpts logSeverity timeoutSeconds outputType overrid
               TestOutputJson -> logStdout . decodeUtf8 . Aeson.encode $ issues
 
           sendIO exitFailure
-
-  -- we call exitSuccess/exitFailure in each branch above. the only way we get
-  -- here is if we time out
-  hPutStrLn stderr "Timed out while waiting for issues scan"
-  exitFailure

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -43,7 +43,7 @@ testMain ::
   TestConfig ->
   m ()
 testMain config = runStickyLogger SevInfo $
-  timeout' (Config.unTimeoutSeconds $ Config.timeoutSeconds config) $
+  timeout' (Config.timeout config) $
     \cancelFlag -> do
       let apiOpts = Config.apiOpts config
           revision = Config.projectRevision config

--- a/src/App/NewFossa/Config/Test.hs
+++ b/src/App/NewFossa/Config/Test.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module App.NewFossa.Config.Test (
+  TestCliOpts,
+  TestConfig (..),
+  OutputFormat (..),
+  TimeoutSeconds (..),
+  mkSubCommand,
+) where
+
+import App.NewFossa.Config.Common (
+  GlobalOpts (..),
+  baseDirArg,
+  collectBaseDir,
+  collectRevisionData,
+  globalOpts,
+  validateApiKey,
+ )
+import App.NewFossa.ConfigFile (ConfigFile, resolveConfigFile)
+import App.NewFossa.EnvironmentVars (EnvVars)
+import App.NewFossa.Subcommand (EffStack, GetSeverity (getSeverity), SubCommand (SubCommand))
+import App.Types (BaseDir, OverrideProject (OverrideProject), ProjectRevision)
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  Validator,
+  runValidation,
+  validationBoundary,
+ )
+import Control.Effect.Lift (Lift, sendIO)
+import Effect.Exec (Exec)
+import Effect.Logger (Logger, Severity (SevDebug, SevInfo))
+import Effect.ReadFS (ReadFS)
+import Fossa.API.Types (ApiOpts (ApiOpts))
+import Options.Applicative (
+  InfoMod,
+  Parser,
+  auto,
+  flag,
+  help,
+  long,
+  option,
+  progDesc,
+  value,
+ )
+import Path.IO (getCurrentDir)
+
+data OutputFormat
+  = TestOutputPretty
+  | TestOutputJson
+  deriving (Eq, Ord, Show)
+
+newtype TimeoutSeconds = TimeoutSeconds
+  { unTimeoutSeconds :: Int
+  }
+  deriving (Eq, Ord, Show)
+
+data TestCliOpts = TestCliOpts
+  { globals :: GlobalOpts
+  , testTimeout :: Int
+  , testOutputType :: OutputFormat
+  , testBaseDir :: FilePath
+  }
+  deriving (Eq, Ord, Show)
+
+instance GetSeverity TestCliOpts where
+  getSeverity TestCliOpts{globals = GlobalOpts{optDebug}} = if optDebug then SevDebug else SevInfo
+
+data TestConfig = TestConfig
+  { baseDir :: BaseDir
+  , apiOpts :: ApiOpts
+  , timeoutSeconds :: TimeoutSeconds
+  , outputFormat :: OutputFormat
+  , projectRevision :: ProjectRevision
+  }
+
+testInfo :: InfoMod a
+testInfo = progDesc "Check for issues from FOSSA and exit non-zero when issues are found"
+
+mkSubCommand :: (TestConfig -> EffStack ()) -> SubCommand TestCliOpts TestConfig
+mkSubCommand = SubCommand "test" testInfo parser loadConfig mergeOpts
+
+parser :: Parser TestCliOpts
+parser =
+  TestCliOpts
+    <$> globalOpts
+    <*> option
+      auto
+      ( mconcat
+          [ long "timeout"
+          , help "Duration to wait for build completion (in seconds)"
+          , value oneHourInSeconds
+          ]
+      )
+    <*> flag TestOutputPretty TestOutputJson (long "json" <> help "Output issues as json")
+    <*> baseDirArg
+
+oneHourInSeconds :: Int
+oneHourInSeconds = 60 * 60
+
+loadConfig ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has ReadFS sig m
+  , Has Logger sig m
+  ) =>
+  TestCliOpts ->
+  m (Maybe ConfigFile)
+loadConfig TestCliOpts{globals = GlobalOpts{optConfig}} = do
+  -- FIXME: We eventually want to use the basedir to inform the config file root
+  configRelBase <- sendIO getCurrentDir
+  resolveConfigFile configRelBase optConfig
+
+mergeOpts ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has ReadFS sig m
+  , Has Exec sig m
+  ) =>
+  Maybe ConfigFile ->
+  EnvVars ->
+  TestCliOpts ->
+  m TestConfig
+mergeOpts maybeConfig envvars TestCliOpts{..} = do
+  baseDir <- collectBaseDir testBaseDir
+  apiOpts <- collectApiOpts maybeConfig envvars globals
+  let timeout = TimeoutSeconds testTimeout
+  revision <-
+    collectRevisionData baseDir maybeConfig $
+      OverrideProject (optProjectName globals) (optProjectRevision globals) Nothing
+  runValidation $
+    TestConfig
+      <$> baseDir
+      <*> apiOpts
+      <*> pure timeout
+      <*> pure testOutputType
+      <*> revision
+
+collectApiOpts :: (Has Diagnostics sig m) => Maybe ConfigFile -> EnvVars -> GlobalOpts -> m (Validator ApiOpts)
+collectApiOpts maybeconfig envvars globals = validationBoundary $ do
+  apikey <- validateApiKey maybeconfig envvars globals
+  let baseuri = optBaseUrl globals
+  pure $ ApiOpts baseuri apikey

--- a/src/App/NewFossa/Main.hs
+++ b/src/App/NewFossa/Main.hs
@@ -3,6 +3,7 @@
 module App.NewFossa.Main (appMain) where
 
 import App.Fossa.Analyze qualified as Analyze
+import App.Fossa.Test qualified as Test
 import App.NewFossa.Subcommand (GetSeverity, SubCommand (..), runSubCommand)
 import App.Version (fullVersionDescription)
 import Control.Monad (join)
@@ -50,6 +51,7 @@ subcommands =
   hsubparser $
     mconcat
       [ decodeSubCommand Analyze.analyzeSubCommand
+      , decodeSubCommand Test.testSubCommand
       ]
 
 decodeSubCommand :: GetSeverity a => SubCommand a b -> Mod CommandFields (IO ())

--- a/src/Control/Timeout.hs
+++ b/src/Control/Timeout.hs
@@ -1,0 +1,68 @@
+-- Provide tools for internal-cancellation functions, built for the funcitons in 'App.Fossa.API.BuildWait'
+
+module Control.Timeout (
+  Cancel,
+  shouldCancelRightNow,
+  checkForCancel,
+  timeout',
+) where
+
+import Control.Carrier.Threaded (fork, kill)
+import Control.Concurrent (
+  MVar,
+  isEmptyMVar,
+  newEmptyMVar,
+  putMVar,
+  threadDelay,
+ )
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  ToDiagnostic,
+  fatal,
+ )
+import Control.Effect.Exception (finally)
+import Control.Effect.Lift (Has, Lift, sendIO)
+import Control.Monad (when)
+
+-- Opaque wrapper around MVar (sort of like an atomic variable)
+-- Only created by using `timeout'`
+newtype Cancel = Cancel (MVar ()) deriving (Eq)
+
+-- Whether a cancellable should cancel right now, or poll again.
+-- Use checkForCancel instead if you want to fail
+shouldCancelRightNow :: Cancel -> IO Bool
+shouldCancelRightNow (Cancel mvar) = not <$> isEmptyMVar mvar
+
+-- | @checkForCancel err cancel@ will return @fatal err@
+-- if @shouldCancelRightnow cancel@ returns true.
+checkForCancel ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , ToDiagnostic err
+  ) =>
+  err ->
+  Cancel ->
+  m ()
+checkForCancel err cancel = do
+  should <- sendIO $ shouldCancelRightNow cancel
+  when should $ fatal err
+
+-- | @timeout' seconds act@ will allow internal cancellation functions to be
+-- used, by passing a cancellation token ('Cancel') to act.
+-- The intended usage is:
+-- @
+-- timeout' 10 $ \cancelToken -> do
+--   longRunningComputation cancelFlag
+-- @
+-- Which will run @longRunningComputation@ until it returns a value or until the 10 seconds have expired.
+timeout' :: (Has (Lift IO) sig m) => Int -> (Cancel -> m a) -> m a
+timeout' seconds act = do
+  mvar <- sendIO newEmptyMVar
+  handle <- sendIO $
+    fork $ do
+      threadDelay $ seconds * 1_000_000
+      putMVar mvar ()
+  -- We need 'finally' here, because `act` can short-circuit.
+  -- If we don't use it, we might join the thread, which
+  -- requires the timeout to fully expire.
+  act (Cancel mvar) `finally` kill handle

--- a/src/Control/Timeout.hs
+++ b/src/Control/Timeout.hs
@@ -4,6 +4,8 @@ module Control.Timeout (
   Cancel,
   shouldCancelRightNow,
   checkForCancel,
+  Duration (..),
+  durationToMicro,
   timeout',
 ) where
 
@@ -28,8 +30,13 @@ import Control.Monad (when)
 -- Only created by using `timeout'`
 newtype Cancel = Cancel (MVar ()) deriving (Eq)
 
+data Duration
+  = Seconds Int
+  | Minutes Int
+  | MicroSeconds Int
+
 -- Whether a cancellable should cancel right now, or poll again.
--- Use checkForCancel instead if you want to fail
+-- Use checkForCancel instead if you want to fail.
 shouldCancelRightNow :: Cancel -> IO Bool
 shouldCancelRightNow (Cancel mvar) = not <$> isEmptyMVar mvar
 
@@ -47,22 +54,40 @@ checkForCancel err cancel = do
   should <- sendIO $ shouldCancelRightNow cancel
   when should $ fatal err
 
--- | @timeout' seconds act@ will allow internal cancellation functions to be
+-- | @timeout' duration act@ will allow internal cancellation functions to be
 -- used, by passing a cancellation token ('Cancel') to act.
+-- A negative duration is the same as no time, and will set the cancel flag
+-- almost immediately.
+--
 -- The intended usage is:
 -- @
--- timeout' 10 $ \cancelToken -> do
+-- timeout' duration $ \cancelToken -> do
 --   longRunningComputation cancelFlag
 -- @
--- Which will run @longRunningComputation@ until it returns a value or until the 10 seconds have expired.
-timeout' :: (Has (Lift IO) sig m) => Int -> (Cancel -> m a) -> m a
-timeout' seconds act = do
+--
+-- Which will run @longRunningComputation@ until it returns, and set the cancel
+-- flag after the duration expires.  For a cancellation to occur, 
+-- @longRunningComputation@ must return a value early by checking the cancel
+-- flag with 'checkForCancel'.  If @longRunningComputation@ does not check the
+-- cancel flag, or doesn't return early when the flag is set, no timeout will
+-- occur.
+timeout' :: (Has (Lift IO) sig m) => Duration -> (Cancel -> m a) -> m a
+timeout' duration act = do
+  -- We start with an empty MVar to signal that we're not ready to cancel.
   mvar <- sendIO newEmptyMVar
-  handle <- sendIO $
-    fork $ do
-      threadDelay $ seconds * 1_000_000
-      putMVar mvar ()
+  handle <- sendIO . fork $ do
+    threadDelay $ durationToMicro duration
+    -- We fill the MVar here, which is the cancel signal.
+    putMVar mvar ()
   -- We need 'finally' here, because `act` can short-circuit.
   -- If we don't use it, we might join the thread, which
   -- requires the timeout to fully expire.
   act (Cancel mvar) `finally` kill handle
+
+-- threadDelay only accepts microseconds, so we simplfy that with the tiny
+-- abstraction of 'Duration'.
+durationToMicro :: Duration -> Int
+durationToMicro = \case
+  Seconds n -> n * 1_000_000
+  Minutes n -> n * 60_000_000
+  MicroSeconds n -> n

--- a/src/Control/Timeout.hs
+++ b/src/Control/Timeout.hs
@@ -66,7 +66,7 @@ checkForCancel err cancel = do
 -- @
 --
 -- Which will run @longRunningComputation@ until it returns, and set the cancel
--- flag after the duration expires.  For a cancellation to occur, 
+-- flag after the duration expires.  For a cancellation to occur,
 -- @longRunningComputation@ must return a value early by checking the cancel
 -- flag with 'checkForCancel'.  If @longRunningComputation@ does not check the
 -- cancel flag, or doesn't return early when the flag is set, no timeout will


### PR DESCRIPTION
# Overview

closes fossas/team-analysis#829

## Acceptance criteria

Same as  #738, but for `fossa test`.

Additionally, `timeout` now has an effectful counterpart: `timeout'`.  To use it, correctly, you must also use the new functions in the buildwait module: `waitForIssues'`, `waitForScanCompletion'`, `waitForSherlockScan'`.  The old functions are unsafe, since they infinitely loop and must be killed from the outside.

Note that `fossa test` is feature-complete, even though `fossa analyze` does not support monorepo, `fossa test` does.

## Testing plan

Run `fossa test`, in any scenario.

## Risks

- New timeout module, infinite loops are possible if stuff is done wrong.
- As with all of the tickets in the fossas/team-analysis#796 project, configuration is being rewritten, so that needs to be checked.

## References

Task Ticket: fossas/team-analysis#829
Project Ticket: fossas/team-analysis#796

## Checklist

- [x] ~I added tests for this PR's change (or confirmed tests are not viable).~
- [x] ~If this PR introduced a user-visible change, I added documentation into `docs/`.~
- [x] ~I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.~
- [x] ~I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).~
- [x] I linked this PR to any referenced GitHub issues, if they exist.
