### PR TITLE
Support Apple M1 platform without workaround in install-latest.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,6 @@ FOSSA CLI provides an install script that downloads the latest release from GitH
 curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
 ```
 
-#### macOS with Apple M1 Silicon
-
-We do not currently support ARM as a target architecture. You can work around this on M1 Mac devices using the M1's x86_64 emulation.
-
-```bash
-arch -x86_64 /bin/bash -c "$(curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh)"
-```
-
 #### Windows with Powershell
 
 ```powershell

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -64,6 +64,7 @@ is_supported_platform() {
   case "$platform" in
     windows/amd64) found=0 ;;
     darwin/amd64) found=0 ;;
+    darwin/arm64) found=0 ;;
     linux/amd64) found=0 ;;
   esac
   return $found
@@ -176,6 +177,7 @@ uname_arch() {
   arch=$(uname -m)
   case $arch in
     x86_64) arch="amd64" ;;
+    arm64) arch="arm64" ;;
     x86) arch="386" ;;
     i686) arch="386" ;;
     i386) arch="386" ;;
@@ -341,6 +343,29 @@ End of functions from https://github.com/client9/shlib
 ------------------------------------------------------------------------
 EOF
 
+###############################################
+# Gets the binary filename (without extentsion)
+# used in repo release.
+#
+# Globals:
+#   PROJECT_NAME
+#   VERSION
+#   OS
+#   ARCH
+# Arguments:
+#   None
+################################################
+get_binary_name() {
+  name=${PROJECT_NAME}_${VERSION}_${OS}_${ARCH}
+  case ${PLATFORM} in
+    darwin/arm64)
+      log_info "Platform ${PLATFORM} (m1 silicon) detected, using compatible darwin/amd64 binary instead."
+      name=${PROJECT_NAME}_${VERSION}_${OS}_${ARCH}
+      ;;
+  esac
+  echo "$name"
+}
+
 PROJECT_NAME="fossa"
 OWNER=fossas
 REPO="fossa-cli"
@@ -372,11 +397,12 @@ adjust_os
 
 adjust_arch
 
-log_info "found version: ${VERSION} for ${TAG}/${OS}/${ARCH}"
 
-NAME=${PROJECT_NAME}_${VERSION}_${OS}_${ARCH}
+NAME=$(get_binary_name)
 TARBALL=${NAME}.${FORMAT}
 TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
+log_info "found fossa-cli ${VERSION} binary for ${PLATFORM} at ${TARBALL_URL}"
+
 CHECKSUM=${PROJECT_NAME}_${VERSION}_checksums.txt
 CHECKSUM_URL=${GITHUB_DOWNLOAD}/${TAG}/${CHECKSUM}
 

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -360,7 +360,7 @@ get_binary_name() {
   case ${PLATFORM} in
     darwin/arm64)
       log_info "Platform ${PLATFORM} (m1 silicon) detected, using compatible darwin/amd64 binary instead."
-      name=${PROJECT_NAME}_${VERSION}_${OS}_${ARCH}
+      name=${PROJECT_NAME}_${VERSION}_${OS}_amd64
       ;;
   esac
   echo "$name"


### PR DESCRIPTION
# Overview

Implements workaround for apple m1 platform within install-latest script. 

With this change,
- fossa-cli for v3 or greater can be installed without needing to use workaround. 

## Acceptance criteria

- Install script works for apple m1 silicon platform

## Testing plan

- Test install script on x64 mac
- Test install script on m1 mac
- Test install script on x64 linux

You can do by performing (note using PR branch's install script):

```
curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/feat/supports-m1-natively/install-latest.sh | bash
```

## Risks

N/A

## References

Closes following:
- https://github.com/fossas/team-analysis/issues/713
- https://github.com/fossas/fossa-cli/issues/697
- https://github.com/fossas/fossa-cli/issues/679


## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
