### PR TITLE
Remove the name field from package-lock

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## v3.0.13
+
+- `package-lock.json` parser ignores name field. ([#757](https://github.com/fossas/fossa-cli/pull/757)) 
+
 ## v3.0.12
 
 - log4j: Adds `fossa log4j` command to identify log4j dependencies. ([#744](https://github.com/fossas/fossa-cli/pull/744))

--- a/docs/references/strategies/languages/nodejs/nodejs.md
+++ b/docs/references/strategies/languages/nodejs/nodejs.md
@@ -9,5 +9,5 @@ The nodejs buildtool ecosystem consists of two major toolchains: the `npm` cli a
 | [packagejson][packagejson] | ✅          | ❌        | ❌    |
 
 [yarn](yarn.md)
-[npm](npmcli.md)
+[npm](npm-lockfile.md)
 [packagejson](packagejson.md)

--- a/docs/references/strategies/languages/nodejs/npm-lockfile.md
+++ b/docs/references/strategies/languages/nodejs/npm-lockfile.md
@@ -6,7 +6,9 @@ The `package-lock.json` file is generated when npm modifies `node_modules` or `p
 
 ## Project Discovery
 
-Search for all files named `package.json` and check if they have a corresponding `package-lock.json` file in the same directory, ignoring directories named `node_modules`.
+Search for files named `package.json` and check for a corresponding `package-lock.json` in the same directory, ignoring directories named `node_modules`.
+
+> Note: When using NPM workspaces, only the root of the project will have a `package-lock.json`. The other `package.json` files in the project directory will be combined to determine which dependencies are direct and which ones are development.
 
 ## Analysis
 

--- a/docs/references/strategies/languages/nodejs/npm.md
+++ b/docs/references/strategies/languages/nodejs/npm.md
@@ -2,16 +2,12 @@
 
 ## Requirements
 
-**Ideal**
+A `package.json` file is required to be present all types of npm analysis.
 
-At least one of:
-- `npm` tool installed
-- `package-lock.json` file present in your project
+Running `npm install` and generating a `package-lock.json` file will provide significantly better results. This allows FOSSA to detect the full dependency graph.
 
-**Minimum**
-
-- `package.json` file present in your project
+> Note: The `package-lock.json` file is expected to be located in the same directory as the `package.json` file.
 
 ## Project discovery
 
-Directories containing `package-lock.json`/`package.json` files are considered npm projects. `node_modules` subdirectories are skipped.
+Directories containing `package.json` files are considered npm projects. `node_modules` subdirectories are skipped.

--- a/docs/references/strategies/languages/nodejs/npmcli.md
+++ b/docs/references/strategies/languages/nodejs/npmcli.md
@@ -1,20 +1,16 @@
-# Npm (cli)
+# Npm Lockfile
 
-The npm cli is the canonical package manager for nodejs projects.
+The `package-lock.json` file is generated when npm modifies `node_modules` or `package.json` and describes the exact dependency tree generated. One example of this is when `npm install` is run.
+
+> Note: In old versions of npm, `package-lock.json` was only modified when dependencies were installed.
 
 ## Project Discovery
 
-`npmlock`: Find all files named `package-lock.json`, not descending into
-directories named `node_modules`
+Search for all files named `package.json` and check if they have a corresponding `package-lock.json` file in the same directory, ignoring directories named `node_modules`.
 
-## Analysis: npmlock
+## Analysis
 
-The package lock json file is generated when npm modifies `node_modules` or
-`package.json` and describes the exact dependency tree generated.
-
-> Note: In old versions of npm, package-lock.json was only modified when dependencies were installed.
-
-This dependency tree contains information about a dependency's version, its transitive dependencies, the URL where the dependency is located at, and whether or not the dependency is used as a development dependency or not. The transitive dependency information is listed in an unintuitive way. Under each dependency there may be two fields, `requires` and `dependencies` as in the following example:
+Opening a `package-lock.json` file reveals the project's dependency tree. This dependency tree contains information about a dependency's version, its transitive dependencies, the URL where the dependency is located at, and whether or not the dependency is used as a development dependency or not. The transitive dependency information is listed in an unintuitive way. Under each dependency there may be two fields, `requires` and `dependencies` as in the following example:
 
 ```json
     "babel-code-frame": {

--- a/docs/references/strategies/languages/nodejs/yarn.md
+++ b/docs/references/strategies/languages/nodejs/yarn.md
@@ -7,7 +7,7 @@ transitive dependencies, its location, and its resolved version.
 
 ## Project Discovery
 
-Find all files named `yarn.lock`, as well as any associated `package.json` files.
+Find all files named `yarn.lock` which have a corresponding `package.json` file.
 
 ## Analysis
 

--- a/src/Strategy/Node/Npm/PackageLock.hs
+++ b/src/Strategy/Node/Npm/PackageLock.hs
@@ -28,7 +28,7 @@ import Path
 import Strategy.Node.PackageJson (Development, FlatDeps (devDeps, directDeps), NodePackage (pkgName), Production)
 
 newtype NpmPackageJson = NpmPackageJson
-  { packageDependencies :: Map Text NpmDep }
+  {packageDependencies :: Map Text NpmDep}
   deriving (Eq, Ord, Show)
 
 data NpmDep = NpmDep

--- a/src/Strategy/Node/Npm/PackageLock.hs
+++ b/src/Strategy/Node/Npm/PackageLock.hs
@@ -27,10 +27,8 @@ import Graphing (Graphing)
 import Path
 import Strategy.Node.PackageJson (Development, FlatDeps (devDeps, directDeps), NodePackage (pkgName), Production)
 
-data NpmPackageJson = NpmPackageJson
-  { packageName :: Text
-  , packageDependencies :: Map Text NpmDep
-  }
+newtype NpmPackageJson = NpmPackageJson
+  { packageDependencies :: Map Text NpmDep }
   deriving (Eq, Ord, Show)
 
 data NpmDep = NpmDep
@@ -45,8 +43,7 @@ data NpmDep = NpmDep
 
 instance FromJSON NpmPackageJson where
   parseJSON = withObject "NpmPackageJson" $ \obj ->
-    NpmPackageJson <$> obj .: "name"
-      <*> obj .: "dependencies"
+    NpmPackageJson <$> obj .: "dependencies"
 
 instance FromJSON NpmDep where
   parseJSON = withObject "NpmDep" $ \obj ->

--- a/test/Node/NpmLockSpec.hs
+++ b/test/Node/NpmLockSpec.hs
@@ -12,8 +12,7 @@ import Test.Hspec
 mockInput :: NpmPackageJson
 mockInput =
   NpmPackageJson
-    { packageName = "example"
-    , packageDependencies =
+    { packageDependencies =
         Map.fromList
           [
             ( "packageOne"


### PR DESCRIPTION
## Overview

Currently, our `package-lock.json` parser fails when the optional top-level field `name` is missing. This PR removes all references to `name` since we don't use it for analysis.

## Acceptance criteria

- Running `fossa analyze` on a project with a `project-lock.json` file without the top-level `name` field succeeds. 

## Testing plan

Tested by running on a `package-lock.json` file without the `name` field before and after the changes in this PR.

## Risks

None that I'm aware of.

## References

Deepak had an issue analyzing a project.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
