### PR TITLE
Install script: Add logging to warn users when wget/curl fails and when temp file is not usable

### DIFF
--- a/install-latest.sh
+++ b/install-latest.sh
@@ -249,9 +249,9 @@ http_download_curl() {
   source_url=$2
   header=$3
   if [ -z "$header" ]; then
-    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url") || (log_debug "curl command failed." && return 1)
   else
-    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url") || (log_debug "curl command failed." && return 1)
   fi
   if [ "$code" != "200" ]; then
     log_debug "http_download_curl received HTTP status $code"
@@ -264,9 +264,9 @@ http_download_wget() {
   source_url=$2
   header=$3
   if [ -z "$header" ]; then
-    wget -q -O "$local_file" "$source_url"
+    wget -q -O "$local_file" "$source_url" || (log_debug "wget command failed." && return 1)
   else
-    wget -q --header "$header" -O "$local_file" "$source_url"
+    wget -q --header "$header" -O "$local_file" "$source_url" || (log_debug "wget command failed." && return 1)
   fi
 }
 http_download() {
@@ -283,6 +283,15 @@ http_download() {
 }
 http_copy() {
   tmp=$(mktemp)
+  if [ ! -w "$tmp" ];
+  then
+    log_crit "Generated tempory file ${tmp} is not writable!"
+  fi
+  if [ ! -r "$tmp" ];
+  then
+    log_crit "Generated tempory file ${tmp} is not readable!"
+  fi
+
   http_download "${tmp}" "$1" "$2" || return 1
   body=$(cat "$tmp")
   rm -f "${tmp}"


### PR DESCRIPTION
# Overview

Adds logging statement, when

- wget command fails
- curl command fails
- when temporary file created with `mktemp` is not readable
- when temporary file created with `mktemp` is not writable

## Acceptance criteria

- Diagnostics messages are printed when temp file is not readable
- Diagnostics messages are printed when temp file is not writable
- Diagnostics messages are printed when curl fails
- Diagnostics messages are printed when wget fails

## Testing plan

To intentionally cause curl/wget failure, pass mock SSL_cert file, or use bash alias. 

```
SSL_CERT_FILE=some-mockfile ./install-latest.sh -d
```

## Risks

N/A

## References

https://github.com/fossas/team-analysis/issues/863

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
