### PR TITLE
Improve archive upload logging

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## v3.0.15
+
+- Improve archive upload logging. ([#761](https://github.com/fossas/fossa-cli/pull/761)) 
+
 ## v3.0.14
 
 - Maven: Updates implementation to delineate classifier, and consequently maven dependencies with classifier can be scanned without failure in FOSSA. ([#755](https://github.com/fossas/fossa-cli/pull/755/))

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -68,7 +68,7 @@ compressAndUpload apiOpts arcDir tmpDir VendoredDependency{..} = context "compre
 
   logSticky $ "Uploading '" <> vendoredName <> "' to secure S3 bucket"
   res <- Fossa.archiveUpload signedURL compressedFile
-  logDebug $ pretty res
+  logDebug $ pretty $ show res
 
   pure $ Archive vendoredName depVersion
 

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -31,8 +31,10 @@ import Data.Maybe (fromMaybe)
 import Data.String.Conversion
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Effect.Logger (Logger, logDebug)
 import Fossa.API.Types
 import Path hiding ((</>))
+import Prettyprinter (Pretty (pretty))
 import Srclib.Types (Locator (..))
 import System.FilePath.Posix
 
@@ -50,10 +52,10 @@ instance FromJSON VendoredDependency where
       <*> (unTextLike <$$> obj .:? "version")
       <* forbidMembers "vendored dependencies" ["type", "license", "url", "description"] obj
 
-uploadArchives :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m) => ApiOpts -> [VendoredDependency] -> Path Abs Dir -> Path Abs Dir -> m [Archive]
+uploadArchives :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m, Has Logger sig m) => ApiOpts -> [VendoredDependency] -> Path Abs Dir -> Path Abs Dir -> m [Archive]
 uploadArchives apiOpts deps arcDir tmpDir = traverse (compressAndUpload apiOpts arcDir tmpDir) deps
 
-compressAndUpload :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m) => ApiOpts -> Path Abs Dir -> Path Abs Dir -> VendoredDependency -> m Archive
+compressAndUpload :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m, Has Logger sig m) => ApiOpts -> Path Abs Dir -> Path Abs Dir -> VendoredDependency -> m Archive
 compressAndUpload apiOpts arcDir tmpDir VendoredDependency{..} = context "compressing and uploading vendored deps" $ do
   logSticky $ "Compressing '" <> vendoredName <> "' at '" <> vendoredPath <> "'"
   compressedFile <- sendIO $ compressFile tmpDir arcDir (toString vendoredPath)
@@ -65,13 +67,14 @@ compressAndUpload apiOpts arcDir tmpDir VendoredDependency{..} = context "compre
   signedURL <- Fossa.getSignedURL apiOpts depVersion vendoredName
 
   logSticky $ "Uploading '" <> vendoredName <> "' to secure S3 bucket"
-  _ <- Fossa.archiveUpload signedURL compressedFile
+  res <- Fossa.archiveUpload signedURL compressedFile
+  logDebug $ pretty res
 
   pure $ Archive vendoredName depVersion
 
 -- archiveUploadSourceUnit receives a list of vendored dependencies, a root path, and API settings.
 -- Using this information, it uploads each vendored dependency and queues a build for the dependency.
-archiveUploadSourceUnit :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m) => Path Abs Dir -> ApiOpts -> [VendoredDependency] -> m [Locator]
+archiveUploadSourceUnit :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m, Has Logger sig m) => Path Abs Dir -> ApiOpts -> [VendoredDependency] -> m [Locator]
 archiveUploadSourceUnit baseDir apiOpts vendoredDeps = do
   -- Users with many instances of vendored dependencies may accidentally have complete duplicates. Remove them.
   let uniqDeps = nub vendoredDeps

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -375,18 +375,16 @@ archiveUpload ::
   (Has (Lift IO) sig m, Has Diagnostics sig m) =>
   SignedURL ->
   FilePath ->
-  m String
+  m LbsResponse
 archiveUpload signedArcURI arcFile = fossaReq $ do
   let arcURL = URI.mkURI $ signedURL signedArcURI
 
   uri <- fromMaybeText ("Invalid URL: " <> signedURL signedArcURI) arcURL
   validatedURI <- fromMaybeText ("Invalid URI: " <> toText (show uri)) (useURI uri)
 
-  res <- context ("Uploading project archive to " <> signedURL signedArcURI) $ case validatedURI of
+  context ("Uploading project archive to " <> signedURL signedArcURI) $ case validatedURI of
     Left (url, options) -> uploadArchiveRequest url options
     Right (url, options) -> uploadArchiveRequest url options
-
-  pure $ show res
   where
     uploadArchiveRequest url options = reqCb PUT url (ReqBodyFile arcFile) lbsResponse options (pure . requestEncoder)
 

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -60,7 +60,6 @@ import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Word (Word8)
-import Debug.Trace (traceM)
 import Effect.Logger
 import Fossa.API.Types (ApiOpts, ArchiveComponents, Issues, SignedURL, signedURL, useApiOpts)
 import Network.HTTP.Client qualified as C

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -34,6 +34,7 @@ import Data.List.NonEmpty qualified as NE
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
 import DepTypes (DepType (..))
+import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS, doesFileExist, readContentsJson, readContentsYaml)
 import Fossa.API.Types
 import Path
@@ -46,7 +47,7 @@ data FoundDepsFile
   = ManualYaml (Path Abs File)
   | ManualJSON (Path Abs File)
 
-analyzeFossaDepsFile :: (Has Diagnostics sig m, Has ReadFS sig m, Has (Lift IO) sig m, Has StickyLogger sig m) => Path Abs Dir -> Maybe ApiOpts -> m (Maybe SourceUnit)
+analyzeFossaDepsFile :: (Has Diagnostics sig m, Has ReadFS sig m, Has (Lift IO) sig m, Has StickyLogger sig m, Has Logger sig m) => Path Abs Dir -> Maybe ApiOpts -> m (Maybe SourceUnit)
 analyzeFossaDepsFile root maybeApiOpts = do
   maybeDepsFile <- findFossaDepsFile root
   case maybeDepsFile of
@@ -78,7 +79,7 @@ findFossaDepsFile root = do
     (_, _, True) -> pure $ Just $ ManualJSON jsonFile
     (False, False, False) -> pure Nothing
 
-toSourceUnit :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has StickyLogger sig m) => Path Abs Dir -> FoundDepsFile -> ManualDependencies -> Maybe ApiOpts -> m SourceUnit
+toSourceUnit :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has StickyLogger sig m, Has Logger sig m) => Path Abs Dir -> FoundDepsFile -> ManualDependencies -> Maybe ApiOpts -> m SourceUnit
 toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts = do
   -- If the file exists and we have no dependencies to report, that's a failure.
   when (hasNoDeps manualDeps) $ fatalText "No dependencies found in fossa-deps file"

--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -93,7 +93,7 @@ walkDir ::
 walkDir handler topdir =
   context "Walking the filetree" $
     void $
-      --makeAbsolute topdir >>= walkAvoidLoop Set.empty
+      -- makeAbsolute topdir >>= walkAvoidLoop Set.empty
       walkAvoidLoop Set.empty topdir
   where
     walkAvoidLoop traversed curdir = do


### PR DESCRIPTION
# Overview

While debugging some archive upload errors I noticed some areas where we could improve the archive logging. This PR includes changes to
1. Debug log the API response for archive uploads
2. Appends the archive name to the log when we get a signed S3 endpoint

Debug output now includes the following log for any archive uploads. This shows us the status and the exact URL the archive was uploaded to. This will greatly help us understand what is happening in on-prem environments that have archive upload problems.
```
[DEBUG] LbsResponse (Response {responseStatus = Status {statusCode = 200, statusMessage = "OK"}, responseVersion = HTTP/1.1, responseHeaders = [("x-amz-id-2","MVdVyat6YP+THQ3f7aWpCQoHiadEhw1L4ec/dw4tOA6Z8bIYmnn/gwChcQa2w3WskMCKEpURALI="),("x-amz-request-id","Y2KHCMB08ZTNTPMD"),("Date","Wed, 12 Jan 2022 21:38:54 GMT"),("x-amz-version-id","8XFoSnTs7hVB8tH3FxUdfiN5PVkcwD1E"),("x-amz-expiration","expiry-date=\"Sat, 12 Feb 2022 00:00:00 GMT\", rule-id=\"Remove old archive components\""),("x-amz-server-side-encryption","AES256"),("ETag","\"0f0f3da948ed786e9548fd1d290ff3ac\""),("Server","AmazonS3"),("Content-Length","0")], responseBody = "", responseCookieJar = CJ {expose = []}, responseClose' = ResponseClose, responseOriginalRequest = Request {
    host                 = "s3.us-east-1.amazonaws.com"
    port                 = 443
    secure               = True
    requestHeaders       = []
    path                 = "/blob.fossa.io/archive_components/archive%2B6214/embedded-project%240f0f3da948ed786e9548fd1d290ff3ac"
    queryString          = "?Content-Type=binary%2Foctet-stream&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAZDFO432533QBHWAA%2F20220112%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220112T213853Z&X-Amz-Expires=300&X-Amz-Signature=57d5468f7e0d2791f4815c29724358b5048002d5b10fd622162f84406e64ac55&X-Amz-SignedHeaders=host"
    method               = "PUT"
    proxy                = Nothing
    rawBody              = False
    redirectCount        = 10
    responseTimeout      = ResponseTimeoutDefault
    requestVersion       = HTTP/1.1
    proxySecureMode      = ProxySecureWithConnect
  }
  })
```

## Acceptance criteria

Better logs for archive uploads

## Testing plan

I tested the changes locally and observed that the logs were improved when running `fossa analyze --debug`

## Risks

None that I can think of.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
