### PR TITLE
Composer json license detection

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -370,6 +370,7 @@ test-suite unit-tests
     Clojure.ClojureSpec
     Cocoapods.PodfileLockSpec
     Cocoapods.PodfileSpec
+    Composer.ComposerJsonSpec
     Composer.ComposerLockSpec
     Conda.CondaListSpec
     Conda.EnvironmentYmlSpec

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -29,12 +29,12 @@ import Effect.Logger
 import Effect.ReadFS
 import Path
 import Path.IO qualified as PIO
+import Strategy.Composer qualified as Composer
 import Strategy.Maven qualified as Maven
 import Strategy.NuGet.Nuspec qualified as Nuspec
 import System.Exit (die)
 import System.IO (BufferMode (NoBuffering), hSetBuffering, stderr, stdout)
 import Types
-import qualified Strategy.Composer as Composer
 
 scanMain :: Path Abs Dir -> Bool -> IO ()
 scanMain basedir debug = do

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -34,6 +34,7 @@ import Strategy.NuGet.Nuspec qualified as Nuspec
 import System.Exit (die)
 import System.IO (BufferMode (NoBuffering), hSetBuffering, stderr, stdout)
 import Types
+import qualified Strategy.Composer as Composer
 
 scanMain :: Path Abs Dir -> Bool -> IO ()
 scanMain basedir debug = do
@@ -60,6 +61,7 @@ runAll ::
 runAll basedir = do
   single Maven.discover
   single Nuspec.discover
+  single Composer.discover
   where
     single f = withDiscoveredProjects f basedir runSingle
 

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -5,6 +5,7 @@ module Strategy.Composer (
   buildGraph,
   ComposerLock (..),
   CompDep (..),
+  ComposerProject(..),
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
@@ -83,7 +84,7 @@ analyzeLicenses :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> 
 analyzeLicenses path =
   maybe [] mkLicenseResult . license <$> readContentsJson licenseFileName
   where
-    licenseFileName = path </> $(mkRelFile "composer.lock")
+    licenseFileName = path </> $(mkRelFile "composer.json")
     mkLicenseResult = pure . LicenseResult (toFilePath licenseFileName)
 
 data ComposerLock = ComposerLock

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -164,6 +164,8 @@ newtype ComposerJson = ComposerJson
   }
   deriving (Eq, Ord, Show)
 
+-- | composer.json and its license key is documented
+-- [here](https://getcomposer.org/doc/04-schema.md#license)
 instance FromJSON ComposerJson where
   parseJSON = withObject "ComposerJson" $ \obj ->
     ComposerJson <$> obj .:? "license" .!= ComposerLicenses []

--- a/test/Composer/ComposerJsonSpec.hs
+++ b/test/Composer/ComposerJsonSpec.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Composer.ComposerJsonSpec (spec) where
+
+import App.Pathfinder.Types (LicenseAnalyzeProject (licenseAnalyzeProject))
+import Path (mkRelDir, mkRelFile, toFilePath, (</>))
+import Path.IO (getCurrentDir)
+import Strategy.Composer (ComposerProject (..))
+import Test.Effect
+import Test.Hspec (Spec, anyException, describe, it, runIO, shouldThrow)
+import Types (License (..), LicenseResult (..), LicenseType (LicenseSPDX))
+
+spec :: Spec
+spec = do
+  currentDir <- runIO getCurrentDir
+  describe "composer.json LicenseAnalyzeProject" $ do
+    it' "Reads a composer.json with a single license string" $
+      let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_single")
+          project =
+            ComposerProject
+              { composerDir = baseDir
+              , composerLock = currentDir </> $(mkRelFile "not_tested_here")
+              }
+       in do
+            licenses <- licenseAnalyzeProject project
+            licenses
+              `shouldBe'` [ LicenseResult
+                              { licenseFile = toFilePath $ baseDir </> $(mkRelFile "composer.json")
+                              , licensesFound =
+                                  [ License
+                                      { licenseType = LicenseSPDX
+                                      , licenseValue = "MIT"
+                                      }
+                                  ]
+                              }
+                          ]
+
+    it' "Reads a composer.json with multiple license strings" $
+      let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_many")
+          project =
+            ComposerProject
+              { composerDir = baseDir
+              , composerLock = currentDir </> $(mkRelFile "not_tested_here")
+              }
+       in do
+            licenses <- licenseAnalyzeProject project
+            licenses
+              `shouldBe'` [ LicenseResult
+                              { licenseFile = toFilePath $ baseDir </> $(mkRelFile "composer.json")
+                              , licensesFound =
+                                  [ License
+                                      { licenseType = LicenseSPDX
+                                      , licenseValue = "MIT"
+                                      }
+                                  , License
+                                      { licenseType = LicenseSPDX
+                                      , licenseValue = "GPL"
+                                      }
+                                  , License
+                                      { licenseType = LicenseSPDX
+                                      , licenseValue = "BSD"
+                                      }
+                                  ]
+                              }
+                          ]
+
+    it "Fails to read a composer.json which is out of schema" $
+      let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_bad_schema")
+          project =
+            ComposerProject
+              { composerDir = baseDir
+              , composerLock = currentDir </> $(mkRelFile "not_tested_here")
+              }
+       in do
+            shouldThrow (runTestEffects $ licenseAnalyzeProject project >> pure ()) anyException

--- a/test/Composer/ComposerJsonSpec.hs
+++ b/test/Composer/ComposerJsonSpec.hs
@@ -4,9 +4,16 @@ module Composer.ComposerJsonSpec (spec) where
 
 import App.Pathfinder.Types (LicenseAnalyzeProject (licenseAnalyzeProject))
 import Control.Effect.Diagnostics qualified as Diagnostics
-import Path (mkRelDir, mkRelFile, toFilePath, (</>))
+import Path (
+  Abs,
+  Dir,
+  Path,
+  mkRelDir,
+  mkRelFile,
+  toFilePath,
+  (</>),
+ )
 import Path.IO (getCurrentDir)
-import Path.Posix (Abs, Dir, Path)
 import Strategy.Composer (ComposerProject (..))
 import Test.Effect (it', shouldBe')
 import Test.Hspec (Spec, describe, runIO)

--- a/test/Composer/ComposerJsonSpec.hs
+++ b/test/Composer/ComposerJsonSpec.hs
@@ -6,7 +6,7 @@ import App.Pathfinder.Types (LicenseAnalyzeProject (licenseAnalyzeProject))
 import Control.Effect.Diagnostics qualified as Diagnostics
 import Path (mkRelDir, mkRelFile, toFilePath, (</>))
 import Path.IO (getCurrentDir)
-import Path.Posix (Dir, Path)
+import Path.Posix (Abs, Dir, Path)
 import Strategy.Composer (ComposerProject (..))
 import Test.Effect (it', shouldBe')
 import Test.Hspec (Spec, describe, runIO)
@@ -44,30 +44,40 @@ licenseResult licenses baseDir =
       }
   ]
 
+composerProject :: Path Abs Dir -> ComposerProject
+composerProject baseDir =
+  ComposerProject
+    { composerDir = baseDir
+    , composerLock = (baseDir </> $(mkRelFile "not_tested_here"))
+    , composerJson = Just $ baseDir </> $(mkRelFile "composer.json")
+    }
+
 spec :: Spec
 spec = do
   currentDir <- runIO getCurrentDir
   describe "composer.json LicenseAnalyzeProject" $ do
     it' "Reads a composer.json with a single license string" $ do
-        let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_single")
-        let project = ComposerProject baseDir $ currentDir </> $(mkRelFile "not_tested_here")
-        licenses <- licenseAnalyzeProject project
-        licenses `shouldBe'` licenseResult oneLicense baseDir
+      let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_single")
+      licenses <- licenseAnalyzeProject (composerProject baseDir)
+      licenses `shouldBe'` licenseResult oneLicense baseDir
 
     it' "Reads a composer.json with multiple license strings" $ do
-        let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_many")
-        let project = ComposerProject baseDir $ currentDir </> $(mkRelFile "not_tested_here")
-        licenses <- licenseAnalyzeProject project
-        licenses `shouldBe'` licenseResult manyLicenses baseDir
+      let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_many")
+      licenses <- licenseAnalyzeProject (composerProject baseDir)
+      licenses `shouldBe'` licenseResult manyLicenses baseDir
 
     it' "Reads a composer.json with no license key" $ do
-        let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_no_license")
-        let project = ComposerProject baseDir $ currentDir </> $(mkRelFile "not_tested_here")
-        licenses <- licenseAnalyzeProject project
-        licenses `shouldBe'` []
+      let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_no_license")
+      licenses <- licenseAnalyzeProject (composerProject baseDir)
+      licenses `shouldBe'` licenseResult [] baseDir
 
     it' "Fails to read a composer.json which is out of schema" $ do
-        let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_bad_schema")
-        let project = ComposerProject baseDir $ currentDir </> $(mkRelFile "not_tested_here")
-        maybeLicenses <- Diagnostics.recover $ licenseAnalyzeProject project
-        maybeLicenses `shouldBe'` Nothing
+      let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_bad_schema")
+      maybeLicenses <- Diagnostics.recover . licenseAnalyzeProject $ composerProject baseDir
+      maybeLicenses `shouldBe'` Nothing
+
+    it' "Returns [] if no composer.json exists" $ do
+      let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/")
+      let missingJsonProject = (composerProject baseDir){composerJson = Nothing}
+      licenses <- licenseAnalyzeProject missingJsonProject
+      licenses `shouldBe'` []

--- a/test/Composer/ComposerJsonSpec.hs
+++ b/test/Composer/ComposerJsonSpec.hs
@@ -3,73 +3,71 @@
 module Composer.ComposerJsonSpec (spec) where
 
 import App.Pathfinder.Types (LicenseAnalyzeProject (licenseAnalyzeProject))
+import Control.Effect.Diagnostics qualified as Diagnostics
 import Path (mkRelDir, mkRelFile, toFilePath, (</>))
 import Path.IO (getCurrentDir)
+import Path.Posix (Dir, Path)
 import Strategy.Composer (ComposerProject (..))
-import Test.Effect
-import Test.Hspec (Spec, anyException, describe, it, runIO, shouldThrow)
+import Test.Effect (it', shouldBe')
+import Test.Hspec (Spec, describe, runIO)
 import Types (License (..), LicenseResult (..), LicenseType (LicenseSPDX))
+
+oneLicense :: [License]
+oneLicense =
+  [ License
+      { licenseType = LicenseSPDX
+      , licenseValue = "MIT"
+      }
+  ]
+
+manyLicenses :: [License]
+manyLicenses =
+  [ License
+      { licenseType = LicenseSPDX
+      , licenseValue = "MIT"
+      }
+  , License
+      { licenseType = LicenseSPDX
+      , licenseValue = "GPL"
+      }
+  , License
+      { licenseType = LicenseSPDX
+      , licenseValue = "BSD"
+      }
+  ]
+
+licenseResult :: [License] -> Path a Dir -> [LicenseResult]
+licenseResult licenses baseDir =
+  [ LicenseResult
+      { licenseFile = toFilePath $ baseDir </> $(mkRelFile "composer.json")
+      , licensesFound = licenses
+      }
+  ]
 
 spec :: Spec
 spec = do
   currentDir <- runIO getCurrentDir
   describe "composer.json LicenseAnalyzeProject" $ do
-    it' "Reads a composer.json with a single license string" $
-      let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_single")
-          project =
-            ComposerProject
-              { composerDir = baseDir
-              , composerLock = currentDir </> $(mkRelFile "not_tested_here")
-              }
-       in do
-            licenses <- licenseAnalyzeProject project
-            licenses
-              `shouldBe'` [ LicenseResult
-                              { licenseFile = toFilePath $ baseDir </> $(mkRelFile "composer.json")
-                              , licensesFound =
-                                  [ License
-                                      { licenseType = LicenseSPDX
-                                      , licenseValue = "MIT"
-                                      }
-                                  ]
-                              }
-                          ]
+    it' "Reads a composer.json with a single license string" $ do
+        let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_single")
+        let project = ComposerProject baseDir $ currentDir </> $(mkRelFile "not_tested_here")
+        licenses <- licenseAnalyzeProject project
+        licenses `shouldBe'` licenseResult oneLicense baseDir
 
-    it' "Reads a composer.json with multiple license strings" $
-      let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_many")
-          project =
-            ComposerProject
-              { composerDir = baseDir
-              , composerLock = currentDir </> $(mkRelFile "not_tested_here")
-              }
-       in do
-            licenses <- licenseAnalyzeProject project
-            licenses
-              `shouldBe'` [ LicenseResult
-                              { licenseFile = toFilePath $ baseDir </> $(mkRelFile "composer.json")
-                              , licensesFound =
-                                  [ License
-                                      { licenseType = LicenseSPDX
-                                      , licenseValue = "MIT"
-                                      }
-                                  , License
-                                      { licenseType = LicenseSPDX
-                                      , licenseValue = "GPL"
-                                      }
-                                  , License
-                                      { licenseType = LicenseSPDX
-                                      , licenseValue = "BSD"
-                                      }
-                                  ]
-                              }
-                          ]
+    it' "Reads a composer.json with multiple license strings" $ do
+        let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_many")
+        let project = ComposerProject baseDir $ currentDir </> $(mkRelFile "not_tested_here")
+        licenses <- licenseAnalyzeProject project
+        licenses `shouldBe'` licenseResult manyLicenses baseDir
 
-    it "Fails to read a composer.json which is out of schema" $
-      let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_bad_schema")
-          project =
-            ComposerProject
-              { composerDir = baseDir
-              , composerLock = currentDir </> $(mkRelFile "not_tested_here")
-              }
-       in do
-            shouldThrow (runTestEffects $ licenseAnalyzeProject project >> pure ()) anyException
+    it' "Reads a composer.json with no license key" $ do
+        let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_no_license")
+        let project = ComposerProject baseDir $ currentDir </> $(mkRelFile "not_tested_here")
+        licenses <- licenseAnalyzeProject project
+        licenses `shouldBe'` []
+
+    it' "Fails to read a composer.json which is out of schema" $ do
+        let baseDir = currentDir </> $(mkRelDir "test/Composer/testdata/composer_json_bad_schema")
+        let project = ComposerProject baseDir $ currentDir </> $(mkRelFile "not_tested_here")
+        maybeLicenses <- Diagnostics.recover $ licenseAnalyzeProject project
+        maybeLicenses `shouldBe'` Nothing

--- a/test/Composer/testdata/composer_json_bad_schema/composer.json
+++ b/test/Composer/testdata/composer_json_bad_schema/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "fossa/fakeproject",
+    "type": "project",
+    "description": "A test PHP project",
+    "keywords": [
+        "framework",
+        "test"
+    ],
+    "license": 12345
+}

--- a/test/Composer/testdata/composer_json_many/composer.json
+++ b/test/Composer/testdata/composer_json_many/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "fossa/fakeproject",
+    "type": "project",
+    "description": "A test PHP project",
+    "keywords": [
+        "framework",
+        "test"
+    ],
+    "license": ["MIT",
+                "GPL",
+                "BSD"]
+}

--- a/test/Composer/testdata/composer_json_no_license/composer.json
+++ b/test/Composer/testdata/composer_json_no_license/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "fossa/fakeproject",
+    "type": "project",
+    "description": "A test PHP project",
+    "keywords": [
+        "framework",
+        "test"
+    ]
+}

--- a/test/Composer/testdata/composer_json_single/composer.json
+++ b/test/Composer/testdata/composer_json_single/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "fossa/fakeproject",
+    "type": "project",
+    "description": "A test PHP project",
+    "keywords": [
+        "framework",
+        "test"
+    ],
+    "license": "MIT"
+}

--- a/test/Test/Effect.hs
+++ b/test/Test/Effect.hs
@@ -8,6 +8,7 @@ module Test.Effect (
   shouldMatchList',
   it',
   runTestEffects',
+  runTestEffects,
 ) where
 
 import Control.Effect.Lift (Has, Lift, sendIO)

--- a/test/Test/Effect.hs
+++ b/test/Test/Effect.hs
@@ -8,7 +8,6 @@ module Test.Effect (
   shouldMatchList',
   it',
   runTestEffects',
-  runTestEffects,
 ) where
 
 import Control.Effect.Lift (Has, Lift, sendIO)


### PR DESCRIPTION
# Overview

The intent of this change is to add support for finding licenses in PHP projects with a `composer.json` file to the `pathfinder` sub-command of fossa-cli.

## Acceptance criteria

If a `composer.json` file is present, fossa-cli should parse it and extract the contents of its `license` key.

## Testing plan

I added several unit tests which verify that the new `LicenseAnalyzeProject` for `ComposerProject`s will read and find single or multiple licenses listed when a directory has a `composer.json` file. In addition, there are test cases for when no `composer.json` file is present, when the `license` key does not exist, or when the `license` key is out of schema.

As an additional test, I ran pathfinder in a composer project with licenses and verified using the debug output that the licenses were discovered properly.

## Risks

I would like reviewers to pay particular attention to the tests, as well as comment if they think there are necessary integration tests that should be added.

## References

This closes fossas/team-analysis#861

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
