### PR TITLE
Allow unnecessary escapes in rebar.config

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## Unreleased
+
+- Rebar: Fix `rebar.config` parser failing on unneccessary escapes. ([#764](https://github.com/fossas/fossa-cli/pull/764))
+
 ## v3.0.15
 
 - Improve archive upload logging. ([#761](https://github.com/fossas/fossa-cli/pull/761)) 

--- a/src/Strategy/Erlang/ConfigParser.hs
+++ b/src/Strategy/Erlang/ConfigParser.hs
@@ -149,7 +149,13 @@ parseErlString :: Parser ErlValue
 parseErlString = ErlString . toText . concat <$> some (lexeme quotedString)
 
 quotedString :: Parser String
-quotedString = char '\"' >> manyTill L.charLiteral (char '\"')
+quotedString = char '\"' *> manyTill takeOne (char '\"')
+  where
+    takeOne :: Parser Char
+    takeOne = L.charLiteral <|> takeOneEscaped
+
+    takeOneEscaped = char '\\' *> escapedChar
+    escapedChar = label "escaped character in string" anySingle 
 
 parseTuple :: Parser ErlValue
 parseTuple = ErlTuple <$ symbol "{" <*> parseErlValue `sepBy1` symbol "," <* symbol "}"

--- a/src/Strategy/Erlang/ConfigParser.hs
+++ b/src/Strategy/Erlang/ConfigParser.hs
@@ -155,7 +155,7 @@ quotedString = char '\"' *> manyTill takeOne (char '\"')
     takeOne = L.charLiteral <|> takeOneEscaped
 
     takeOneEscaped = char '\\' *> escapedChar
-    escapedChar = label "escaped character in string" anySingle 
+    escapedChar = label "escaped character in string" anySingle
 
 parseTuple :: Parser ErlValue
 parseTuple = ErlTuple <$ symbol "{" <*> parseErlValue `sepBy1` symbol "," <* symbol "}"

--- a/test/Erlang/ConfigParserSpec.hs
+++ b/test/Erlang/ConfigParserSpec.hs
@@ -16,7 +16,7 @@ parseMatch parser input expected = parse parser "" input `shouldParse` expected
 
 spec :: Spec
 spec = do
-  describe "Erlang config parser" $ do
+  fdescribe "Erlang config parser" $ do
     rawText <- runIO $ TIO.readFile "test/Erlang/testdata/rebar.config"
     oneWithEverything <- runIO $ TIO.readFile "test/Erlang/testdata/stresstest.config"
     it "should succeed on a real input file" $
@@ -112,17 +112,18 @@ spec = do
               , ErlArray [atom "arr1"]
               , ErlArray [ErlTuple [atom "key", ErlString "value"]]
               , ErlTuple [atom "number", ErlInt 5678] -- Literal
+              , ErlTuple [atom "escapedString", ErlString "{{erts_vsn}}/bin/erl"]
               ]
           ]
 
-  describe "radix parser" $
+  fdescribe "radix parser" $
     it "should parse number strings correctly" $ do
       intLiteralInBase 2 "11001" `shouldBe` 25
       intLiteralInBase 8 "1234" `shouldBe` 0o1234
       intLiteralInBase 10 "1234" `shouldBe` 1234
       intLiteralInBase 16 "abcd" `shouldBe` 0xabcd
       intLiteralInBase 36 "1z" `shouldBe` 71 -- (36 * 2 - 1)
-  describe "alphaNumToInt" $
+  fdescribe "alphaNumToInt" $
     it "should provide the correct value for chars" $ do
       alphaNumToInt 'a' `shouldBe` 10
       alphaNumToInt 'B' `shouldBe` 11

--- a/test/Erlang/testdata/stresstest.config
+++ b/test/Erlang/testdata/stresstest.config
@@ -11,5 +11,8 @@
     33#wes,
     [arr1],
     [{key, "value"}],
-    {number, 5678}
+    {number, 5678},
+
+    % We found this one in the wild and it broke the parser
+    {escapedString, "\{\{erts_vsn\}\}/bin/erl"}
 }.


### PR DESCRIPTION
# Overview

Given this string in a `rebar.config` file: `"\{\{erts_vsn\}\}/bin/erl"`, we were failing to parse the file.  This is because those backslashes are unnecessary, and erlang's parser simply removes them.  The string should parse into `"{{erts_vsn}}/bin/erl"` (which is valid erlang on its own).

We can resolve this by adding a backslash-discarding char parser in the Erlang string parser, as a fallback to the normal string character parser. 

## Acceptance criteria

- Tests pass
- New tests introduce the correct problem, which the new code should solve.

## Testing plan

Unit tests should be sufficient, since we have extensive tests for this parser (thanks for writing those tests, past me!).

## References

closes fossas/team-analysis#860

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] ~If this PR introduced a user-visible change, I added documentation into `docs/`.~
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] ~I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).~
- [x] I linked this PR to any referenced GitHub issues, if they exist.
