### PR TITLE
VSI Rewrite: Drop plugin usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ vendor-bins/
 # Executables
 /fossa
 /fossa-?dev
+/release
 
 # Debug output
 fossa.debug.json.gz

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## v3.0.16
+
+- Improves the overall performance and progress reporting of VSI scans. ([#765](https://github.com/fossas/fossa-cli/pull/765))
+
 ## v3.0.15
 
 - Improve archive upload logging. ([#761](https://github.com/fossas/fossa-cli/pull/761)) 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -120,6 +120,7 @@ common deps
     , unordered-containers         ^>=0.2.10
     , vector                       ^>=0.12.0.3
     , versions                     ^>=5.0.0
+    , word8                        ^>=0.1.3
     , xml                          ^>=1.3.14
     , yaml                         ^>=0.11.1
     , yarn-lock                    ^>=0.6.5

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -170,6 +170,7 @@ library
     App.Fossa.VPS.Scan.ScotlandYard
     App.Fossa.VPS.Test
     App.Fossa.VPS.Types
+    App.Fossa.VSI.Analyze
     App.Fossa.VSI.Fingerprint
     App.Fossa.VSI.IAT.AssertRevisionBinaries
     App.Fossa.VSI.IAT.AssertUserDefinedBinaries

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -54,7 +54,7 @@ import Control.Carrier.TaskPool (
   withTaskPool,
  )
 import Control.Concurrent (getNumCapabilities)
-import Control.Effect.Diagnostics (fatalText, fromMaybeText, recover, (<||>))
+import Control.Effect.Diagnostics (Diagnostics, fatalText, fromMaybeText, recover, (<||>))
 import Control.Effect.Exception (Lift)
 import Control.Effect.Lift (sendIO)
 import Control.Monad (when)
@@ -350,7 +350,7 @@ analyze (BaseDir basedir) destination override unpackArchives jsonOutput include
 
   -- additional source units are built outside the standard strategy flow, because they either
   -- require additional information (eg API credentials), or they return additional information (eg user deps).
-  vsiResults <- Diag.context "analyze-vsi" $ analyzeVSI modeVSIAnalysis apiOpts basedir filters modeVSISkipResolution
+  vsiResults <- Diag.context "analyze-vsi" . runStickyLogger SevInfo $ analyzeVSI modeVSIAnalysis apiOpts basedir override filters modeVSISkipResolution
   binarySearchResults <- Diag.context "discover-binaries" $ analyzeDiscoverBinaries modeBinaryDiscovery basedir filters
   manualSrcUnits <-
     if filterIsVSIOnly filters
@@ -394,8 +394,8 @@ analyze (BaseDir basedir) destination override unpackArchives jsonOutput include
         locator <- uploadSuccessfulAnalysis (BaseDir basedir) opts metadata jsonOutput override sourceUnits
         doAssertRevisionBinaries modeIATAssertion opts locator
 
-analyzeVSI :: (MonadIO m, Has Diag.Diagnostics sig m, Has Exec sig m, Has (Lift IO) sig m, Has Logger sig m) => VSIAnalysisMode -> Maybe ApiOpts -> Path Abs Dir -> AllFilters -> VSI.SkipResolution -> m (Maybe SourceUnit)
-analyzeVSI VSIAnalysisEnabled (Just apiOpts) dir filters skipResolving = do
+analyzeVSI :: (MonadIO m, Has Diag.Diagnostics sig m, Has Exec sig m, Has (Lift IO) sig m, Has Logger sig m, Has StickyLogger sig m, Has ReadFS sig m) => VSIAnalysisMode -> Maybe ApiOpts -> Path Abs Dir -> OverrideProject -> AllFilters -> VSI.SkipResolution -> m (Maybe SourceUnit)
+analyzeVSI VSIAnalysisEnabled (Just apiOpts) dir override filters skipResolving = do
   logInfo "Running VSI analysis"
 
   let skippedLocators = VSI.unVSISkipResolution skipResolving
@@ -405,9 +405,10 @@ analyzeVSI VSIAnalysisEnabled (Just apiOpts) dir filters skipResolving = do
       traverse_ (logInfo . pretty . VSI.renderLocator) skippedLocators
     else pure ()
 
-  results <- analyzeVSIDeps dir apiOpts filters skipResolving
+  revision <- inferProjectRevision dir override
+  results <- analyzeVSIDeps dir revision apiOpts filters skipResolving
   pure $ Just results
-analyzeVSI _ _ _ _ _ = pure Nothing
+analyzeVSI _ _ _ _ _ _ = pure Nothing
 
 analyzeDiscoverBinaries :: (MonadIO m, Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has Logger sig m, Has ReadFS sig m) => BinaryDiscoveryMode -> Path Abs Dir -> AllFilters -> m (Maybe SourceUnit)
 analyzeDiscoverBinaries BinaryDiscoveryEnabled dir filters = do
@@ -471,10 +472,7 @@ uploadSuccessfulAnalysis ::
   NE.NonEmpty SourceUnit ->
   m Locator
 uploadSuccessfulAnalysis (BaseDir basedir) apiOpts metadata jsonOutput override units = Diag.context "Uploading analysis" $ do
-  inferred <- Diag.context "Inferring project name/revision" (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
-  logDebug $ "Inferred revision: " <> viaShow inferred
-
-  let revision = mergeOverride override inferred
+  revision <- inferProjectRevision basedir override
   logDebug $ "Merged revision: " <> viaShow revision
 
   logInfo ""
@@ -511,6 +509,12 @@ uploadSuccessfulAnalysis (BaseDir basedir) apiOpts metadata jsonOutput override 
     else pure ()
 
   pure locator
+
+inferProjectRevision :: (Has (Lift IO) sig m, Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m, Has Logger sig m) => Path Abs Dir -> OverrideProject -> m ProjectRevision
+inferProjectRevision basedir override = do
+  inferred <- Diag.context "Inferring project name/revision" (inferProjectFromVCS basedir <||> inferProjectDefault basedir)
+  logDebug $ "Inferred revision: " <> viaShow inferred
+  pure $ mergeOverride override inferred
 
 data CountedResult
   = NoneDiscovered

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module App.Fossa.FossaAPIV1 (

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -654,9 +654,8 @@ vsiAddFilesToScan :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> 
 vsiAddFilesToScan apiOpts scanID files = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
-  let opts = baseOpts <> "sync" =: True
   let body = VSIAddFilesToScanRequestBody files
-  _ <- req POST (vsiAddFilesToScanEndpoint baseUrl scanID) (ReqBodyJsonCompat body) ignoreResponse opts
+  _ <- req POST (vsiAddFilesToScanEndpoint baseUrl scanID) (ReqBodyJsonCompat body) ignoreResponse baseOpts
 
   pure ()
 

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -30,11 +30,17 @@ module App.Fossa.FossaAPIV1 (
   assertRevisionBinaries,
   resolveUserDefinedBinary,
   resolveProjectDependencies,
+  vsiCreateScan,
+  vsiAddFilesToScan,
+  vsiCompleteScan,
+  vsiScanAnalysisStatus,
+  vsiDownloadInferences,
 ) where
 
 import App.Fossa.Container (ContainerScan (..))
 import App.Fossa.Report.Attribution qualified as Attr
 import App.Fossa.VSI.Fingerprint (Fingerprint, Raw)
+import App.Fossa.VSI.Fingerprint qualified as Fingerprint
 import App.Fossa.VSI.IAT.Types qualified as IAT
 import App.Fossa.VSI.Types qualified as VSI
 import App.Types
@@ -61,6 +67,7 @@ import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Req
 import Network.HTTP.Req.Extra (httpConfigRetryTimeouts)
 import Network.HTTP.Types qualified as HTTP
+import Path (File, Path, Rel)
 import Srclib.Types
 import Text.URI (URI)
 import Text.URI qualified as URI
@@ -580,3 +587,100 @@ resolveProjectDependencies apiOpts locator = fossaReq $ do
   (dependencies :: [ResolvedDependency]) <- responseBody <$> req GET (resolveProjectDependenciesEndpoint baseUrl locator) NoReqBody jsonResponse opts
 
   pure $ map unwrapResolvedDependency dependencies
+
+----------
+
+baseVsiUrl :: Url scheme -> Url scheme
+baseVsiUrl baseurl = baseurl /: "api" /: "proxy" /: "sherlock"
+
+data VSICreateScanRequestBody = VSICreateScanRequestBody
+  { vsiCreateScanRequestBodyOrgID :: Int
+  , vsiCreateScanRequestBodyProjectID :: Text
+  , vsiCreateScanRequestBodyRevisionID :: Text
+  }
+
+instance ToJSON VSICreateScanRequestBody where
+  toJSON VSICreateScanRequestBody{..} =
+    object
+      [ "OrganizationID" .= vsiCreateScanRequestBodyOrgID
+      , "ProjectID" .= vsiCreateScanRequestBodyProjectID
+      , "RevisionID" .= vsiCreateScanRequestBodyRevisionID
+      ]
+
+newtype VSICreateScanResponseBody = VSICreateScanResponseBody {unVSICreateScanResponseBody :: VSI.ScanID}
+
+instance FromJSON VSICreateScanResponseBody where
+  parseJSON = withObject "VSICreateScanResponseBody" $ \obj -> VSICreateScanResponseBody <$> obj .: "ScanID"
+
+vsiCreateScanEndpoint :: Url scheme -> Url scheme
+vsiCreateScanEndpoint baseurl = baseVsiUrl baseurl /: "scans"
+
+vsiCreateScan :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> ProjectRevision -> m VSI.ScanID
+vsiCreateScan apiOpts ProjectRevision{..} = fossaReq $ do
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+
+  Organization orgId _ <- getOrganization apiOpts
+  let projectID = renderLocator $ Locator "custom" projectName Nothing
+  let reqBody = VSICreateScanRequestBody orgId projectRevision projectID
+
+  (resBody :: VSICreateScanResponseBody) <- responseBody <$> req POST (vsiCreateScanEndpoint baseUrl) (ReqBodyJson reqBody) jsonResponse baseOpts
+  pure $ unVSICreateScanResponseBody resBody
+
+newtype VSIAddFilesToScanRequestBody = VSIAddFilesToScanRequestBody {vsiAddFilesToScanRequestBodyFiles :: Map (Path Rel File) Fingerprint.Combined}
+
+instance ToJSON VSIAddFilesToScanRequestBody where
+  toJSON VSIAddFilesToScanRequestBody{..} = object ["ScanData" .= vsiAddFilesToScanRequestBodyFiles]
+
+vsiAddFilesToScanEndpoint :: Url scheme -> VSI.ScanID -> Url scheme
+vsiAddFilesToScanEndpoint baseurl scanID = baseVsiUrl baseurl /: "scans" /: toText scanID /: "files"
+
+vsiAddFilesToScan :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> VSI.ScanID -> Map (Path Rel File) Fingerprint.Combined -> m ()
+vsiAddFilesToScan apiOpts scanID files = fossaReq $ do
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+
+  let opts = baseOpts <> "sync" =: True
+  let body = VSIAddFilesToScanRequestBody files
+  _ <- req POST (vsiAddFilesToScanEndpoint baseUrl scanID) (ReqBodyJson body) ignoreResponse opts
+
+  pure ()
+
+vsiCompleteScanEndpoint :: Url scheme -> VSI.ScanID -> Url scheme
+vsiCompleteScanEndpoint baseurl scanID = baseVsiUrl baseurl /: "scans" /: toText scanID /: "complete"
+
+vsiCompleteScan :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> VSI.ScanID -> m ()
+vsiCompleteScan apiOpts scanID = fossaReq $ do
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+  _ <- req POST (vsiCompleteScanEndpoint baseUrl scanID) NoReqBody ignoreResponse baseOpts
+  pure ()
+
+newtype VSIScanAnalysisStatusBody = VSIScanAnalysisStatusBody {unVSIScanAnalysisStatusBody :: VSI.AnalysisStatus}
+
+instance FromJSON VSIScanAnalysisStatusBody where
+  parseJSON = withObject "VSIScanAnalysisStatusBody" $ \obj -> do
+    (status :: Text) <- obj .: "Status"
+    pure . VSIScanAnalysisStatusBody $ VSI.parseAnalysisStatus status
+
+vsiScanAnalysisStatusEndpoint :: Url scheme -> VSI.ScanID -> Url scheme
+vsiScanAnalysisStatusEndpoint baseurl scanID = baseVsiUrl baseurl /: "scans" /: toText scanID /: "status" /: "analysis"
+
+vsiScanAnalysisStatus :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> VSI.ScanID -> m VSI.AnalysisStatus
+vsiScanAnalysisStatus apiOpts scanID = fossaReq $ do
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+  (resBody :: VSIScanAnalysisStatusBody) <- responseBody <$> req GET (vsiScanAnalysisStatusEndpoint baseUrl scanID) NoReqBody jsonResponse baseOpts
+  pure $ unVSIScanAnalysisStatusBody resBody
+
+newtype VSIExportedInferencesBody = VSIExportedInferencesBody {unVSIExportedInferencesBody :: [Locator]}
+
+instance FromJSON VSIExportedInferencesBody where
+  parseJSON = withObject "VSIExportedInferencesBody" $ \obj -> do
+    (plainLocators :: [Text]) <- obj .: "Locators"
+    pure . VSIExportedInferencesBody $ fmap parseLocator plainLocators
+
+vsiDownloadInferencesEndpoint :: Url scheme -> VSI.ScanID -> Url scheme
+vsiDownloadInferencesEndpoint baseurl scanID = baseVsiUrl baseurl /: "scans" /: toText scanID /: "inferences" /: "locator"
+
+vsiDownloadInferences :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> VSI.ScanID -> m [Locator]
+vsiDownloadInferences apiOpts scanID = fossaReq $ do
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+  (resBody :: VSIExportedInferencesBody) <- responseBody <$> req GET (vsiDownloadInferencesEndpoint baseUrl scanID) NoReqBody jsonResponse baseOpts
+  pure $ unVSIExportedInferencesBody resBody

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -59,7 +59,7 @@ runVsiAnalysis dir apiOpts projectRevision filters = context "VSI" $ do
   -- Split into 1000-fingerprint buckets for uploading.
   -- This number wasn't chosen for any specific reason, it's just what the current VSI plugin does.
   -- The goal is to ensure that we don't hit any upload size limits.
-  let chunks = map Map.fromList $ chunksOf 1000 $ Map.toList fingerprints
+  let chunks = map Map.fromList . chunksOf 1000 $ Map.toList fingerprints
   logDebug . pretty $
     "Adding "
       <> toText (show $ length fingerprints)
@@ -159,8 +159,8 @@ runVsiAnalysis dir apiOpts projectRevision filters = context "VSI" $ do
 -- >   , ("external/ffmpeg.zip!_fossa.virtual_!/ffmpeg.h", { <fingerprints> })
 -- >   ]
 --
--- The `!_fossa.virtual_!` suffix is expected by the server-side analysis implementation,
--- so this literal is significant and may not be changed without ensuring the server expects the change.
+-- The `!_fossa.virtual_!` suffix is a server-side invariant.
+-- Similarly, it is a server-side invariant that the `!_fossa.virtual_!`-suffixed directory is a sibling of the original archive.
 runFingerprint :: FingerprintEffs sig m => PathFilters -> Path Abs Dir -> m (Map (Path Rel File) Combined)
 runFingerprint filters root = flip walk' root $ \dir _ files -> do
   if filters `allow` dir

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -287,7 +287,6 @@ ancestryDerived parent dir file = do
 -- > "external/lib.zip!_fossa.virtual_!/" :: Path Rel Dir
 convertArchiveSuffix :: (Has Diagnostics sig m) => Path Rel File -> m (Path Rel Dir)
 convertArchiveSuffix file = do
-  -- Lifting this exception into IO is not exactly safe, but since it's coming directly from a filename this should never error.
   name <- fromEither . P.parseRelDir $ P.toFilePath (P.filename file) <> "!_fossa.virtual_!"
   pure $ P.parent file </> name
 

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -200,11 +200,12 @@ runFingerprint' filters root renderAncestry = context ("walk root: " <> toText r
           logDebug . pretty $ "Output file '" <> toText file <> "' as: " <> toText logicalPath
           output (logicalPath, fp)
 
-          -- If the file is an archive, fingerprint its contents.
-          withArchive' file $ \archiveRoot -> context ("expand archive: " <> toText file) . forkTask $ do
-            asLogicalParent <- context "convert parent to logical parent" $ convertArchiveSuffix logicalPath
-            logDebug . pretty $ "Walking into archive '" <> toText logicalPath <> "' as: " <> toText asLogicalParent
-            runFingerprint' filters archiveRoot $ ancestryDerived asLogicalParent
+        -- If the file is an archive, fingerprint its contents.
+        -- TODO(kit): Uncomment this. Commented for a baseline test compared with Basis.
+        -- withArchive' file $ \archiveRoot -> context ("expand archive: " <> toText file) . forkTask $ do
+        --   asLogicalParent <- context "convert parent to logical parent" $ convertArchiveSuffix logicalPath
+        --   logDebug . pretty $ "Walking into archive '" <> toText logicalPath <> "' as: " <> toText asLogicalParent
+        --   runFingerprint' filters archiveRoot $ ancestryDerived asLogicalParent
         pure WalkContinue
       else do
         logDebug "Skipped: filters do not match"

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -1,0 +1,120 @@
+module App.Fossa.VSI.Analyze (
+  runVsiAnalysis,
+) where
+
+import App.Fossa.FossaAPIV1 (vsiAddFilesToScan, vsiCompleteScan, vsiCreateScan, vsiDownloadInferences, vsiScanAnalysisStatus)
+import App.Fossa.VSI.Fingerprint (Combined, fingerprint)
+import App.Fossa.VSI.IAT.Types qualified as IAT
+import App.Fossa.VSI.Types qualified as VSI
+import App.Types (ProjectRevision)
+import Control.Algebra (Has)
+import Control.Concurrent (threadDelay)
+import Control.Effect.Diagnostics (Diagnostics, context, fatalText, fromEither)
+import Control.Effect.Lift (Lift, sendIO)
+import Control.Effect.StickyLogger (StickyLogger, logSticky)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe (catMaybes)
+import Data.String.Conversion (toText)
+import Discovery.Filters (AllFilters, combinedPaths, excludeFilters, includeFilters)
+import Discovery.Walk (WalkStep (WalkContinue, WalkSkipAll), walk')
+import Effect.Logger (Logger, logDebug, pretty)
+import Effect.ReadFS (ReadFS)
+import Fossa.API.Types (ApiOpts)
+import Path (Abs, Dir, File, Path, Rel, SomeBase (Abs, Rel), isProperPrefixOf, (</>))
+import Path.Extra (isChildOf, tryMakeRelative)
+
+runVsiAnalysis ::
+  ( Has (Lift IO) sig m
+  , Has ReadFS sig m
+  , Has Diagnostics sig m
+  , Has StickyLogger sig m
+  , Has Logger sig m
+  ) =>
+  Path Abs Dir ->
+  ApiOpts ->
+  ProjectRevision ->
+  AllFilters ->
+  m ([VSI.Locator], [IAT.UserDep])
+runVsiAnalysis dir apiOpts projectRevision filters = context "VSI" $ do
+  -- TODO(kit): Figure out how to parallelize fingerprinting
+  -- TODO(kit): Figure out how to walk expanded files
+  -- TODO(kit): Figure out how to filter walked files
+
+  scanID <- context "Create scan in backend" $ vsiCreateScan apiOpts projectRevision
+  logDebug . pretty $ "Created Scan ID: " <> toText scanID
+
+  -- TODO(kit): Make both walking and uploading streaming so we work on 1000 fingerprint chunks at a time.
+  fingerprints <- context "Fingerprint files" $ runFingerprint dir (toPathFilters dir filters)
+  context "Upload fingerprints" $ vsiAddFilesToScan apiOpts scanID fingerprints
+
+  context "Finalize scan files" $ vsiCompleteScan apiOpts scanID
+  context "Waiting for backend analysis to complete" $ waitForAnalysis apiOpts scanID
+
+  discoveredRawLocators <- context "Download analysis results" $ vsiDownloadInferences apiOpts scanID
+  parsedLocators <- context "Parse analysis results" . fromEither $ traverse VSI.parseLocator discoveredRawLocators
+
+  let userDefinedDeps = map IAT.toUserDep $ filter VSI.isUserDefined parsedLocators
+  let allOtherDeps = filter (not . VSI.isUserDefined) parsedLocators
+  pure (allOtherDeps, userDefinedDeps)
+
+-- | Walk the directory tree starting from the root directory, fingerprinting any files that are children of the root directory.
+runFingerprint :: (Has (Lift IO) sig m, Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> PathFilters -> m (Map (Path Rel File) Combined)
+runFingerprint root filters = flip walk' root $ \dir _ files ->
+  if shouldFingerprint dir
+    then do
+      fingerprints <- traverse (fingerprintRelativeFiles root) files
+      pure (Map.fromList $ catMaybes fingerprints, WalkContinue)
+    else pure (Map.empty, WalkSkipAll)
+  where
+    shouldFingerprint dir = filters `allow` dir && dir `isChildOf` root
+    fingerprintRelativeFiles dir file = case tryMakeRelative dir file of
+      Abs _ -> pure Nothing
+      Rel rel -> do
+        fp <- fingerprint file
+        pure $ Just (rel, fp)
+
+-- | Wait for analysis to complete
+waitForAnalysis ::
+  (Has (Lift IO) sig m, Has Diagnostics sig m, Has Logger sig m, Has StickyLogger sig m) =>
+  ApiOpts ->
+  VSI.ScanID ->
+  m ()
+waitForAnalysis apiOpts scanID = do
+  status <- vsiScanAnalysisStatus apiOpts scanID
+  case status of
+    VSI.AnalysisFailed -> fatalText "Backend analysis failed. If this persists, please contact FOSSA and provide debug logs (generated with --debug)"
+    VSI.AnalysisFinished -> do
+      logDebug "Backend analysis complete"
+      pure ()
+    VSI.AnalysisPending -> do
+      logSticky "Backend analysis is enqueued, waiting to start..."
+      waitForAnalysis apiOpts scanID
+    VSI.AnalysisInformational msg -> do
+      logDebug . pretty $ "Backend analysis status: '" <> msg <> "'"
+      logSticky "Backend analysis running"
+      sendIO $ threadDelay (pollDelaySeconds * 1_000_000)
+      waitForAnalysis apiOpts scanID
+  where
+    pollDelaySeconds = 8
+
+-- | PathFilters is a specialized filter mechanism that operates only on absolute directory paths.
+data PathFilters = PathFilters
+  { include :: [Path Abs Dir]
+  , exclude :: [Path Abs Dir]
+  }
+  deriving (Show)
+
+toPathFilters :: Path Abs Dir -> AllFilters -> PathFilters
+toPathFilters root filters =
+  PathFilters
+    { include = map (root </>) (combinedPaths $ includeFilters filters)
+    , exclude = map (root </>) (combinedPaths $ excludeFilters filters)
+    }
+
+allow :: PathFilters -> Path Abs Dir -> Bool
+allow filters dir = (not shouldExclude) && shouldInclude
+  where
+    shouldExclude = (isPrefixedOrEqual dir) `any` (exclude filters)
+    shouldInclude = null (include filters) || (isPrefixedOrEqual dir) `any` (include filters)
+    isPrefixedOrEqual a b = a == b || isProperPrefixOf b a -- swap order of isProperPrefixOf comparison because we want to know if dir is prefixed by any filter

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -61,7 +61,7 @@ runVsiAnalysis dir apiOpts projectRevision filters = context "VSI" $ do
   -- - newTBMChanIO also buffers up to uploadBufferSize
   files <- sendIO $ newTBMChanIO uploadBufferSize
   context "Fingerprint files"
-    . withTaskPool capabilities (updateProgress "Upload files")
+    . withTaskPool capabilities (updateProgress "Upload remaining files")
     . runAtomicCounter
     $ do
       context "Discover fingerprints" . forkTask $ runFingerprintDiscovery capabilities files dir filters

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -248,6 +248,8 @@ discover output filters root renderAncestry =
       logicalPath <- renderAncestry root file
 
       -- Fork an async task to walk the contents of the archive, if the file is an archive.
+      -- Note: if you're ever looking at the @TaskPool@ progress message and are like "why does it show 2x the files as are actually in the project?"
+      -- This is the reason. We fork a task for every file to process its fingerprint, then fork a second task to (maybe) extract it as an archive.
       forkTask . recover . fatalOnSomeException "extract archive" . withArchive' file $ \archiveRoot -> context "walking into child archive" $ do
         logDebug . pretty $ "walking into " <> toText file <> " as archive"
         logicalParent <- convertArchiveSuffix logicalPath

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -11,27 +11,35 @@ import App.Types (ProjectRevision)
 import Control.Algebra (Has)
 import Control.Concurrent (threadDelay)
 import Control.Effect.Diagnostics (Diagnostics, context, fatalText, fromEither)
+import Control.Effect.Finally (Finally)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.StickyLogger (StickyLogger, logSticky)
 import Control.Monad (when)
+import Data.Foldable (traverse_)
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (catMaybes)
 import Data.String.Conversion (toText)
+import Discovery.Archive (withArchive')
 import Discovery.Filters (AllFilters, combinedPaths, excludeFilters, includeFilters)
 import Discovery.Walk (WalkStep (WalkContinue, WalkSkipAll), walk')
 import Effect.Logger (Logger, logDebug, pretty)
 import Effect.ReadFS (ReadFS)
 import Fossa.API.Types (ApiOpts)
 import Path (Abs, Dir, File, Path, Rel, SomeBase (Abs, Rel), isProperPrefixOf, (</>))
-import Path.Extra (isChildOf, tryMakeRelative)
+import Path qualified as P
+import Path.Extra (tryMakeRelative)
 
-runVsiAnalysis ::
+type FingerprintEffs sig m =
   ( Has (Lift IO) sig m
+  , Has Finally sig m
+  , Has Logger sig m
   , Has ReadFS sig m
   , Has Diagnostics sig m
+  )
+
+runVsiAnalysis ::
+  ( FingerprintEffs sig m
   , Has StickyLogger sig m
-  , Has Logger sig m
   ) =>
   Path Abs Dir ->
   ApiOpts ->
@@ -40,16 +48,15 @@ runVsiAnalysis ::
   m ([VSI.Locator], [IAT.UserDep])
 runVsiAnalysis dir apiOpts projectRevision filters = context "VSI" $ do
   -- TODO(kit): Figure out how to parallelize fingerprinting
-  -- TODO(kit): Figure out how to walk expanded files
-  -- TODO(kit): Figure out how to filter walked files
   -- TODO(kit): Make both walking and uploading streaming so we work on 1000 fingerprint chunks at a time.
-  fingerprints <- context "Fingerprint files" $ runFingerprint dir (toPathFilters dir filters)
+  fingerprints <- context "Fingerprint files" $ runFingerprint (toPathFilters dir filters) dir
   when (Map.null fingerprints) $ fatalText "No files fingerprinted"
 
   scanID <- context "Create scan in backend" $ vsiCreateScan apiOpts projectRevision
   logDebug . pretty $ "Created Scan ID: " <> unScanID scanID
 
-  logDebug . pretty $ "Adding " <> toText (show $ length fingerprints) <> " files to scan " <> VSI.unScanID scanID
+  logDebug . pretty $ "Adding " <> toText (show $ length fingerprints) <> " files to scan " <> VSI.unScanID scanID <> ":"
+  traverse_ (logDebug . pretty . ("  " <>) . toText . P.toFilePath . fst) $ Map.toList fingerprints
   context "Upload fingerprints" $ vsiAddFilesToScan apiOpts scanID fingerprints
 
   context "Finalize scan files" $ vsiCompleteScan apiOpts scanID
@@ -63,27 +70,147 @@ runVsiAnalysis dir apiOpts projectRevision filters = context "VSI" $ do
   pure (allOtherDeps, userDefinedDeps)
 
 -- | Walk the directory tree starting from the root directory, fingerprinting any files that are children of the root directory.
-runFingerprint :: (Has (Lift IO) sig m, Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => Path Abs Dir -> PathFilters -> m (Map (Path Rel File) Combined)
-runFingerprint root filters = flip walk' root $ \dir _ files -> do
-  let willFingerprint = shouldFingerprint dir
-  logDebug . pretty $ "Should fingerprint " <> toText (show dir) <> ": " <> toText (show willFingerprint)
-  if willFingerprint
+--
+-- Results in a map of file paths to fingerprint values. The file paths are relative *to the directory being scanned*.
+-- This means that the following directory structure:
+--
+-- > ~/
+-- >   my_project/
+-- >     main.c
+-- >     main.h
+-- >     lib/
+-- >       lib.c
+-- >       lib.h
+--
+-- Is reported as:
+--
+-- > Map.fromList
+-- >   [ ("main.c", { <fingerprints> })
+-- >   , ("main.h", { <fingerprints> })
+-- >   , ("lib/lib.c", { <fingerprints> })
+-- >   , ("lib/lib.h", { <fingerprints> })
+-- >   ]
+--
+-- Also recursively unpacks archives and fingerprints their contents.
+--
+-- Files extracted from archives are *actually* extracted to a temporary directory,
+-- but are reported as though they come from a directory with the same path as the archive
+-- with the literal `!_fossa.virtual_!` appended.
+--
+-- The archive itself is also still fingerprinted and reported.
+--
+-- Specifically, given the following directory structure:
+--
+-- > ~/
+-- >  my_project/
+-- >    lib.zip
+-- >      other.tar
+-- >        README.md
+--
+-- The directory structure expands to the following "virtual" directory structure:
+--
+-- > ~/
+-- >  my_project/
+-- >    lib.zip  <-- Reported as a fingerprint
+-- >    lib.zip!_fossa.virtual_!/
+-- >      other.tar  <-- Reported as a fingerprint
+-- >      other.tar!_fossa.virtual_!/
+-- >        README.md  <-- Reported as a fingerprint
+--
+-- This means that the following directory structure:
+--
+-- > ~/
+-- >   my_project/
+-- >     main.c
+-- >     main.h
+-- >     lib/
+-- >       lib.c
+-- >       lib.h
+-- >     external/
+-- >       ffmpeg.zip
+-- >         ffmpeg.c
+-- >         ffmpeg.h
+--
+-- Is reported as:
+--
+-- > Map.fromList
+-- >   [ ("main.c", { <fingerprints> })
+-- >   , ("main.h", { <fingerprints> })
+-- >   , ("lib/lib.c", { <fingerprints> })
+-- >   , ("lib/lib.h", { <fingerprints> })
+-- >   , ("external/ffmpeg.zip", { <fingerprints> })
+-- >   , ("external/ffmpeg.zip!_fossa.virtual_!/ffmpeg.c", { <fingerprints> })
+-- >   , ("external/ffmpeg.zip!_fossa.virtual_!/ffmpeg.h", { <fingerprints> })
+-- >   ]
+--
+-- The `!_fossa.virtual_!` suffix is expected by the server-side analysis implementation,
+-- so this literal is significant and may not be changed without ensuring the server expects the change.
+runFingerprint :: FingerprintEffs sig m => PathFilters -> Path Abs Dir -> m (Map (Path Rel File) Combined)
+runFingerprint filters root = flip walk' root $ \dir _ files -> do
+  if filters `allow` dir
     then do
-      fingerprints <- traverse (fingerprintRelativeFiles root) files
-      pure (Map.fromList $ catMaybes fingerprints, WalkContinue)
-    else pure (Map.empty, WalkSkipAll)
+      logDebug . pretty $ "Fingerprint: " <> toText (show dir)
+      fingerprints <- traverse (fingerprintFile filters root) files
+      pure (Map.unions fingerprints, WalkContinue)
+    else do
+      logDebug . pretty $ "Excluded by filter: " <> toText (show dir)
+      pure (Map.empty, WalkSkipAll)
+
+-- | Fingerprints the file, and attempts to extract it as though it was an archive.
+--
+-- If the file is an archive, its contents are extracted and fingerprinted, resulting in a map
+-- of the fingerprint of the archive itself combined with the fingerprints of its contents
+-- (with remapped file paths, per the comment for @runFingerprint@).
+--
+-- If the file is not an archive, results in a singleton map of the fingerprints for this file.
+fingerprintFile :: FingerprintEffs sig m => PathFilters -> Path Abs Dir -> Path Abs File -> m (Map (Path Rel File) Combined)
+fingerprintFile filters root file = do
+  relFile <- mustMakeRelative root file
+  fp <- fingerprint file
+  let direct = Map.singleton relFile fp
+
+  contains <- withArchive' file (runFingerprint filters)
+  case contains of
+    -- In the most common case where this file was not an archive, evaluate to the singleton directly.
+    Nothing -> pure direct
+    -- In the case where `file` is an archive, we'll have a map of paths relative to the archive.
+    -- Remap the ancestry of all the contained files such that they are reported correctly.
+    Just contents -> do
+      withRemappedAncestry <- traverse (remapAncestry relFile) $ Map.toList contents
+      pure . Map.union direct $ Map.fromList withRemappedAncestry
   where
-    shouldFingerprint dir = filters `allow` dir && (dir == root || dir `isChildOf` root)
-    fingerprintRelativeFiles dir file = case tryMakeRelative dir file of
-      Abs _ -> pure Nothing
-      Rel rel -> do
-        logDebug . pretty $ "Fingerprint " <> toText (show file)
-        fp <- fingerprint file
-        pure $ Just (rel, fp)
+    remapAncestry archive (target, fp) = do
+      parent <- convertArchiveSuffix archive
+      pure (parent </> target, fp)
+
+-- | Converts a relative file path into a relative directory, where the passed in file path is suffixed by the archive suffix literal.
+-- In other words, this:
+--
+-- > "external/lib.zip" :: Path Rel File
+--
+-- Becomes this:
+--
+-- > "external/lib.zip!_fossa.virtual_!/" :: Path Rel Dir
+convertArchiveSuffix :: Has (Lift IO) sig m => Path Rel File -> m (Path Rel Dir)
+convertArchiveSuffix file = do
+  -- Lifting this exception into IO is not exactly safe, but since it's coming directly from a filename this should never error.
+  name <- sendIO . P.parseRelDir $ P.toFilePath (P.filename file) <> "!_fossa.virtual_!"
+  pure $ P.parent file </> name
+
+-- | Makes the passed file relative to the passed directory.
+-- If that's not possible, fatally exits via the Diagnostics effect.
+mustMakeRelative :: Has Diagnostics sig m => Path Abs Dir -> Path Abs File -> m (Path Rel File)
+mustMakeRelative root file = case tryMakeRelative root file of
+  Abs _ -> fatalText $ "cannot make " <> toText (show file) <> " relative to " <> toText (show root)
+  Rel rel -> pure rel
 
 -- | Wait for analysis to complete
 waitForAnalysis ::
-  (Has (Lift IO) sig m, Has Diagnostics sig m, Has Logger sig m, Has StickyLogger sig m) =>
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has Logger sig m
+  , Has StickyLogger sig m
+  ) =>
   ApiOpts ->
   VSI.ScanID ->
   m ()

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -5,6 +5,7 @@ module App.Fossa.VSI.Analyze (
 import App.Fossa.FossaAPIV1 (vsiAddFilesToScan, vsiCompleteScan, vsiCreateScan, vsiDownloadInferences, vsiScanAnalysisStatus)
 import App.Fossa.VSI.Fingerprint (Combined, fingerprint)
 import App.Fossa.VSI.IAT.Types qualified as IAT
+import App.Fossa.VSI.Types (ScanID (..))
 import App.Fossa.VSI.Types qualified as VSI
 import App.Types (ProjectRevision)
 import Control.Algebra (Has)
@@ -15,7 +16,6 @@ import Control.Effect.StickyLogger (StickyLogger, logSticky)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (catMaybes)
-import Data.String.Conversion (toText)
 import Discovery.Filters (AllFilters, combinedPaths, excludeFilters, includeFilters)
 import Discovery.Walk (WalkStep (WalkContinue, WalkSkipAll), walk')
 import Effect.Logger (Logger, logDebug, pretty)
@@ -42,7 +42,7 @@ runVsiAnalysis dir apiOpts projectRevision filters = context "VSI" $ do
   -- TODO(kit): Figure out how to filter walked files
 
   scanID <- context "Create scan in backend" $ vsiCreateScan apiOpts projectRevision
-  logDebug . pretty $ "Created Scan ID: " <> toText scanID
+  logDebug . pretty $ "Created Scan ID: " <> unScanID scanID
 
   -- TODO(kit): Make both walking and uploading streaming so we work on 1000 fingerprint chunks at a time.
   fingerprints <- context "Fingerprint files" $ runFingerprint dir (toPathFilters dir filters)

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -281,10 +281,10 @@ ancestryDerived parent dir file = do
 -- Becomes this:
 --
 -- > "external/lib.zip!_fossa.virtual_!/" :: Path Rel Dir
-convertArchiveSuffix :: Has (Lift IO) sig m => Path Rel File -> m (Path Rel Dir)
+convertArchiveSuffix :: (Has Diagnostics sig m) => Path Rel File -> m (Path Rel Dir)
 convertArchiveSuffix file = do
   -- Lifting this exception into IO is not exactly safe, but since it's coming directly from a filename this should never error.
-  name <- sendIO . P.parseRelDir $ P.toFilePath (P.filename file) <> "!_fossa.virtual_!"
+  name <- fromEither . P.parseRelDir $ P.toFilePath (P.filename file) <> "!_fossa.virtual_!"
   pure $ P.parent file </> name
 
 -- | Wait for analysis to complete

--- a/src/App/Fossa/VSI/Fingerprint.hs
+++ b/src/App/Fossa/VSI/Fingerprint.hs
@@ -69,20 +69,19 @@ encodeFingerprint = Fingerprint . toText . show
 -- | Hashes the whole contents of the given file in constant memory.
 hashBinaryFile :: (Has (Lift IO) sig m, Has Diagnostics sig m, HashAlgorithm hash) => FilePath -> m (Digest hash)
 hashBinaryFile fp =
-  context "hash binary file" $
+  context "as binary" $
     (fatalOnIOException "hash binary file") . sendIO . runConduitRes $ sourceFile fp .| sinkHash
 
 hashTextFileCommentStripped :: (Has (Lift IO) sig m, Has Diagnostics sig m, HashAlgorithm hash) => FilePath -> m (Digest hash)
 hashTextFileCommentStripped file =
-  context "hash text file comment stripped" $
-    (fatalOnIOException "hash text file comment stripped") . sendIO . runConduitRes $
-      sourceFile file -- Read from the file
-        .| basicCStyleCommentStripC -- Strip comments
-        .| sinkHash -- Hash the result
+  (fatalOnIOException "hash text file comment stripped") . sendIO . runConduitRes $
+    sourceFile file -- Read from the file
+      .| basicCStyleCommentStripC -- Strip comments
+      .| sinkHash -- Hash the result
 
 hashTextFile :: (Has (Lift IO) sig m, Has Diagnostics sig m, HashAlgorithm hash) => FilePath -> m (Digest hash)
 hashTextFile file =
-  context "hash text file" $
+  context "as text" $
     (fatalOnIOException "hash text file") . sendIO . runConduitRes $
       sourceFile file -- Read from the file
         .| linesUnboundedAsciiC -- Split into lines (for @stripCrLines@)

--- a/src/App/Fossa/VSI/Types.hs
+++ b/src/App/Fossa/VSI/Types.hs
@@ -33,17 +33,17 @@ newtype ScanID = ScanID {unScanID :: Text} deriving (ToJSON, FromJSON)
 -- | The VSI backend returns statuses for tracking which stage analysis is on.
 -- Programmatically we only care about some of these, the rest are informational and can be safely shown to a user to indicate activity.
 data AnalysisStatus
-  = Pending
-  | Finished
-  | Failed
-  | Informational Text
+  = AnalysisPending
+  | AnalysisFinished
+  | AnalysisFailed
+  | AnalysisInformational Text
 
 parseAnalysisStatus :: Text -> AnalysisStatus
 parseAnalysisStatus status = case status of
-  "NOT_STARTED" -> Pending
-  "DONE" -> Finished
-  "FAILED" -> Failed
-  other -> Informational other
+  "NOT_STARTED" -> AnalysisPending
+  "DONE" -> AnalysisFinished
+  "FAILED" -> AnalysisFailed
+  other -> AnalysisInformational other
 
 -- | VSI supports a subset of possible Locators.
 -- Specifically, all VSI locators must have a valid revision.

--- a/src/App/Fossa/VSI/Types.hs
+++ b/src/App/Fossa/VSI/Types.hs
@@ -36,17 +36,17 @@ instance ToText ScanID where
 -- | The VSI backend returns statuses for tracking which stage analysis is on.
 -- Programmatically we only care about some of these, the rest are informational and can be safely shown to a user to indicate activity.
 data AnalysisStatus
-  = Pending
-  | Finished
-  | Failed
-  | Informational Text
+  = AnalysisPending
+  | AnalysisFinished
+  | AnalysisFailed
+  | AnalysisInformational Text
 
 parseAnalysisStatus :: (ToText a) => a -> AnalysisStatus
 parseAnalysisStatus a = case toText a of
-  "NOT_STARTED" -> Pending
-  "DONE" -> Finished
-  "FAILED" -> Failed
-  other -> Informational other
+  "NOT_STARTED" -> AnalysisPending
+  "DONE" -> AnalysisFinished
+  "FAILED" -> AnalysisFailed
+  other -> AnalysisInformational other
 
 -- | VSI supports a subset of possible Locators.
 -- Specifically, all VSI locators must have a valid revision.
@@ -64,8 +64,8 @@ instance FromJSON Locator where
       <*> obj .: "package"
       <*> obj .: "revision"
 
-parseLocator :: Text -> Either LocatorParseError Locator
-parseLocator = validateLocator . Srclib.parseLocator
+parseLocator :: (ToText a) => a -> Either LocatorParseError Locator
+parseLocator = validateLocator . Srclib.parseLocator . toText
 
 renderLocator :: Locator -> Text
 renderLocator Locator{..} = locatorFetcher <> "+" <> locatorProject <> "$" <> locatorRevision

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -45,6 +45,7 @@ import Control.Algebra as X
 import Control.Effect.Exception (catch)
 import Control.Effect.Lift (Lift)
 import Control.Exception (IOException, SomeException (..))
+import Control.Exception.Extra (safeCatch)
 import Data.Aeson (ToJSON, object, toJSON, (.=))
 import Data.List (intersperse)
 import Data.List.NonEmpty qualified as NE
@@ -101,7 +102,7 @@ fatalOnIOException ctx go = context ctx $ catch go die'
 
 -- | Throw a generic error message on any exception, wrapped in a new 'context' using the provided @Text@.
 fatalOnSomeException :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Text -> m a -> m a
-fatalOnSomeException ctx go = context ctx $ catch go die'
+fatalOnSomeException ctx go = context ctx $ safeCatch go die'
   where
     die' (e :: SomeException) = fatalText ("caught exception: " <> toText (show e))
 

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -24,6 +24,7 @@ module Control.Effect.Diagnostics (
   -- * Diagnostic helpers
   fatalText,
   fatalOnIOException,
+  fatalOnSomeException,
   fromEither,
   fromEitherShow,
   fromMaybe,
@@ -97,6 +98,12 @@ fatalOnIOException :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Text -> m 
 fatalOnIOException ctx go = context ctx $ catch go die'
   where
     die' (e :: IOException) = fatalText ("io exception: " <> toText (show e))
+
+-- | Throw a generic error message on any exception, wrapped in a new 'context' using the provided @Text@.
+fatalOnSomeException :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Text -> m a -> m a
+fatalOnSomeException ctx go = context ctx $ catch go die'
+  where
+    die' (e :: SomeException) = fatalText ("caught exception: " <> toText (show e))
 
 -- | Recover from a fatal error. The error will be recorded as a warning instead.
 recover :: Has Diagnostics sig m => m a -> m (Maybe a)

--- a/src/Path/Extra.hs
+++ b/src/Path/Extra.hs
@@ -2,6 +2,7 @@ module Path.Extra (
   tryMakeRelative,
   renderRelative,
   extensionOf,
+  isChildOf,
 ) where
 
 import Data.String.Conversion (toText)
@@ -10,7 +11,7 @@ import Path (Abs, Dir, File, Path, SomeBase (..), fileExtension, stripProperPref
 
 -- tryMakeRelative returns the path of an absolute file (Path Abs File) relative to an absolute directory (Path Abs Dir).
 -- If the file is not within the directory, then the absolute file path will be returned
-tryMakeRelative :: Path Abs Dir -> Path Abs File -> SomeBase File
+tryMakeRelative :: Path Abs Dir -> Path Abs t -> SomeBase t
 tryMakeRelative absDir absFile =
   case stripProperPrefix absDir absFile of
     Left _ -> Abs absFile
@@ -23,3 +24,8 @@ renderRelative absDir absFile = toText $ tryMakeRelative absDir absFile
 
 extensionOf :: Path Abs File -> Maybe Text
 extensionOf absFile = toText <$> fileExtension absFile
+
+isChildOf :: Path Abs t -> Path Abs Dir -> Bool
+isChildOf target root = case tryMakeRelative root target of
+  Abs _ -> False
+  _ -> True

--- a/src/Path/Extra.hs
+++ b/src/Path/Extra.hs
@@ -19,7 +19,7 @@ tryMakeRelative absDir absFile =
 
 -- | Render the relative path between a Path Abs Dir and a Path Abs File that is supposed to be in that dir.
 -- Intended for convenience when displaying the newly relative path; to interact with it use `tryMakeRelative` instead.
-renderRelative :: Path Abs Dir -> Path Abs File -> Text
+renderRelative :: Path Abs Dir -> Path Abs t -> Text
 renderRelative absDir absFile = toText $ tryMakeRelative absDir absFile
 
 extensionOf :: Path Abs File -> Maybe Text

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -14,7 +14,7 @@ module Srclib.Types (
 
 import Data.Aeson
 import Data.Maybe (fromMaybe)
-import Data.String.Conversion (toText)
+import Data.String.Conversion (ToText, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Path (File, SomeBase)
@@ -80,6 +80,9 @@ data Locator = Locator
   , locatorRevision :: Maybe Text
   }
   deriving (Eq, Ord, Show)
+
+instance ToText Locator where
+  toText = renderLocator
 
 renderLocator :: Locator -> Text
 renderLocator Locator{..} =


### PR DESCRIPTION
# Overview

Finalizes the VSI rewrite, bring all VSI functionality into pure Haskell.

## Acceptance criteria

The goal of this project was:

* Better error reporting
* Better progress reporting for users
* Easier for other analysis team members to contribute or maintain this functionality
* Merge work streams (for example, archive expansion)

The one place this doesn't quite deliver is on performance: this version of VSI is about 6x slower at fingerprinting than the Go version. However, overall scan times remain roughly consistent with or better than what they were before:

* Most of the end-to-end scan performance bottleneck is in the forensics process, which hasn't changed.
* A substantial server side issue was fixed, improving ingestion speed 166x. This more than covers for the slower client.

## Testing plan

I have successfully scanned the following projects, which display the expected results:

- [x] VPS Demo: "standard" 
- [x] VPS Demo: "large"
- [x] VSI "example internal" demo projects
- [x] Chromium (can't actually complete in cloud analysis, but completed fingerprinting!)

## Risks

Not risky: VSI isn't in the critical path of any users yet.

## References

Closes https://github.com/fossas/team-analysis/issues/844

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
