### PR TITLE
Refractor discovered project type's datatype

### DIFF
--- a/integration-test/Analysis/CarthageSpec.hs
+++ b/integration-test/Analysis/CarthageSpec.hs
@@ -8,7 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Carthage qualified as Carthage
 import Test.Hspec
-import Types (GraphBreadth (Complete))
+import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 swiftQueue :: AnalysisTestFixture (Carthage.CarthageProject)
 swiftQueue =
@@ -24,4 +24,4 @@ swiftQueue =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary swiftQueue "carthage" (DependencyResultsSummary 1 1 0 1 Complete)
+  testSuiteDepResultSummary swiftQueue CarthageProjectType (DependencyResultsSummary 1 1 0 1 Complete)

--- a/integration-test/Analysis/ClojureSpec.hs
+++ b/integration-test/Analysis/ClojureSpec.hs
@@ -8,7 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Leiningen qualified as Leiningen
 import Test.Hspec
-import Types (GraphBreadth (Complete))
+import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 clojureEnv :: FixtureEnvironment
 clojureEnv = NixEnv ["openjdk11", "clojure", "leiningen"]
@@ -39,5 +39,5 @@ ring =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary eastwood "leiningen" (DependencyResultsSummary 10 7 3 1 Complete)
-  testSuiteDepResultSummary ring "leiningen" (DependencyResultsSummary 23 6 17 1 Complete)
+  testSuiteDepResultSummary eastwood LeiningenProjectType (DependencyResultsSummary 10 7 3 1 Complete)
+  testSuiteDepResultSummary ring LeiningenProjectType (DependencyResultsSummary 23 6 17 1 Complete)

--- a/integration-test/Analysis/CocoapodsSpec.hs
+++ b/integration-test/Analysis/CocoapodsSpec.hs
@@ -8,7 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Cocoapods qualified as Cocoapods
 import Test.Hspec
-import Types (GraphBreadth (..))
+import Types (DiscoveredProjectType (..), GraphBreadth (..))
 
 shadowsocksXNG :: AnalysisTestFixture (Cocoapods.CocoapodsProject)
 shadowsocksXNG =
@@ -36,5 +36,5 @@ sDWebImage =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary shadowsocksXNG "cocoapods" (DependencyResultsSummary 6 6 0 1 Partial)
-  testSuiteDepResultSummary sDWebImage "cocoapods" (DependencyResultsSummary 4 4 0 1 Partial)
+  testSuiteDepResultSummary shadowsocksXNG CocoapodsProjectType (DependencyResultsSummary 6 6 0 1 Partial)
+  testSuiteDepResultSummary sDWebImage CocoapodsProjectType (DependencyResultsSummary 4 4 0 1 Partial)

--- a/integration-test/Analysis/ElixirSpec.hs
+++ b/integration-test/Analysis/ElixirSpec.hs
@@ -9,7 +9,7 @@ import Effect.Exec (AllowErr (Never), Command (Command))
 import Path
 import Strategy.Mix qualified as Mix
 import Test.Hspec
-import Types (GraphBreadth (Complete))
+import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 elixirEnv :: FixtureEnvironment
 elixirEnv = NixEnv ["elixir"]
@@ -31,4 +31,4 @@ absinthe =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary absinthe "mix" (DependencyResultsSummary 4 4 1 1 Complete)
+  testSuiteDepResultSummary absinthe MixProjectType (DependencyResultsSummary 4 4 1 1 Complete)

--- a/integration-test/Analysis/ErlangSpec.hs
+++ b/integration-test/Analysis/ErlangSpec.hs
@@ -8,7 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Rebar3 qualified as Rebar3
 import Test.Hspec
-import Types (GraphBreadth (Complete))
+import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 erlangEnv :: FixtureEnvironment
 erlangEnv = NixEnv ["erlang", "rebar3"]
@@ -39,5 +39,5 @@ emqx =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary cowboy "rebar3" (DependencyResultsSummary 2 2 0 1 Complete)
-  testSuiteDepResultSummary emqx "rebar3" (DependencyResultsSummary 0 0 0 1 Complete)
+  testSuiteDepResultSummary cowboy Rebar3ProjectType (DependencyResultsSummary 2 2 0 1 Complete)
+  testSuiteDepResultSummary emqx Rebar3ProjectType (DependencyResultsSummary 0 0 0 1 Complete)

--- a/integration-test/Analysis/FixtureExpectationUtils.hs
+++ b/integration-test/Analysis/FixtureExpectationUtils.hs
@@ -18,7 +18,7 @@ import App.Fossa.Analyze.Types (AnalyzeProject)
 import Control.Algebra (Has)
 import Control.Effect.Lift (Lift, sendIO)
 import Data.List (find)
-import Data.String.Conversion (toString, toText)
+import Data.String.Conversion (toString)
 import Graphing
 import Path
 import Path.IO qualified as PIO
@@ -86,7 +86,7 @@ withProjectOfType ::
   (DiscoveredProjectType, Path Abs Dir) ->
   Maybe (DiscoveredProject a, DependencyResults)
 withProjectOfType result (projType, projPath) =
-  find (\(dr, _) -> (toText . show $ projectType dr) == toText (show projType) && projectPath dr == projPath) result
+  find (\(dr, _) -> projectType dr == projType && projectPath dr == projPath) result
 
 testSuiteDepResultSummary :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> DiscoveredProjectType -> DependencyResultsSummary -> Spec
 testSuiteDepResultSummary fixture projType depResultSummary =

--- a/integration-test/Analysis/FixtureExpectationUtils.hs
+++ b/integration-test/Analysis/FixtureExpectationUtils.hs
@@ -18,13 +18,12 @@ import App.Fossa.Analyze.Types (AnalyzeProject)
 import Control.Algebra (Has)
 import Control.Effect.Lift (Lift, sendIO)
 import Data.List (find)
-import Data.String.Conversion (toString)
-import Data.Text (Text)
+import Data.String.Conversion (toString, toText)
 import Graphing
 import Path
 import Path.IO qualified as PIO
 import Test.Hspec (Expectation, Spec, aroundAll, describe, expectationFailure, it, shouldBe, shouldNotBe)
-import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth)
+import Types (DependencyResults (..), DiscoveredProject (..), DiscoveredProjectType (..), GraphBreadth)
 
 -- | Tabulated property of the DependencyResult.
 data DependencyResultsSummary = DependencyResultsSummary
@@ -62,7 +61,7 @@ withAnalysisOf a runTest = do
 -- | Retrieves a dependency result from discovered project of a given type and path.
 getDepResultsOf ::
   [(DiscoveredProject a, DependencyResults)] ->
-  (Text, Path Abs Dir) ->
+  (DiscoveredProjectType, Path Abs Dir) ->
   Maybe DependencyResults
 getDepResultsOf result (projType, projPath) =
   snd <$> withProjectOfType result (projType, projPath)
@@ -70,7 +69,7 @@ getDepResultsOf result (projType, projPath) =
 -- | Expects a discovered project of type at given path.
 expectProject ::
   (Show a, Eq a) =>
-  (Text, Path Abs Dir) ->
+  (DiscoveredProjectType, Path Abs Dir) ->
   [(DiscoveredProject a, DependencyResults)] ->
   Expectation
 expectProject (projType, projPath) result =
@@ -84,12 +83,12 @@ expectDepResultsSummary depResultSummary depResult = case depResult of
 
 withProjectOfType ::
   [(DiscoveredProject a, DependencyResults)] ->
-  (Text, Path Abs Dir) ->
+  (DiscoveredProjectType, Path Abs Dir) ->
   Maybe (DiscoveredProject a, DependencyResults)
 withProjectOfType result (projType, projPath) =
-  find (\(dr, _) -> projectType dr == projType && projectPath dr == projPath) result
+  find (\(dr, _) -> (toText . show $ projectType dr) == toText (show projType) && projectPath dr == projPath) result
 
-testSuiteDepResultSummary :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> Text -> DependencyResultsSummary -> Spec
+testSuiteDepResultSummary :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> DiscoveredProjectType -> DependencyResultsSummary -> Spec
 testSuiteDepResultSummary fixture projType depResultSummary =
   aroundAll (withAnalysisOf fixture) $
     describe (toString $ testName fixture) $ do

--- a/integration-test/Analysis/GoSpec.hs
+++ b/integration-test/Analysis/GoSpec.hs
@@ -8,6 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Gomodules qualified as Gomodules
 import Test.Hspec
+import Types (DiscoveredProjectType (..))
 
 goEnv :: FixtureEnvironment
 goEnv = NixEnv ["go"]
@@ -29,7 +30,7 @@ testVault =
   aroundAll (withAnalysisOf vault) $ do
     describe "vault" $ do
       it "should find targets" $ \(result, extractedDir) -> do
-        expectProject ("gomod", extractedDir) result
+        expectProject (GomodProjectType, extractedDir) result
         length result `shouldBe` 7
 
 spec :: Spec

--- a/integration-test/Analysis/MavenSpec.hs
+++ b/integration-test/Analysis/MavenSpec.hs
@@ -8,6 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Maven qualified as Maven
 import Test.Hspec
+import Types
 
 mavenEnv :: FixtureEnvironment
 mavenEnv = NixEnv ["maven", "jdk11"]
@@ -29,7 +30,7 @@ testKeycloak =
   aroundAll (withAnalysisOf keycloak) $ do
     describe "keycloak" $ do
       it "should find targets" $ \(result, extractedDir) ->
-        expectProject ("maven", extractedDir) result
+        expectProject (MavenProjectType, extractedDir) result
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/Python/PipenvSpec.hs
+++ b/integration-test/Analysis/Python/PipenvSpec.hs
@@ -8,7 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Python.Pipenv qualified as Pipenv
 import Test.Hspec
-import Types (GraphBreadth (Complete))
+import Types (DiscoveredProjectType (PipenvProjectType), GraphBreadth (Complete))
 
 pipenv :: AnalysisTestFixture (Pipenv.PipenvProject)
 pipenv =
@@ -24,4 +24,4 @@ pipenv =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary pipenv "pipenv" (DependencyResultsSummary 90 90 0 1 Complete)
+  testSuiteDepResultSummary pipenv PipenvProjectType (DependencyResultsSummary 90 90 0 1 Complete)

--- a/integration-test/Analysis/Python/PoetrySpec.hs
+++ b/integration-test/Analysis/Python/PoetrySpec.hs
@@ -8,7 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Python.Poetry qualified as Poetry
 import Test.Hspec
-import Types (GraphBreadth (Complete))
+import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 poetry :: AnalysisTestFixture (Poetry.PoetryProject)
 poetry =
@@ -24,4 +24,4 @@ poetry =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary poetry "poetry" (DependencyResultsSummary 66 29 69 1 Complete)
+  testSuiteDepResultSummary poetry PoetryProjectType (DependencyResultsSummary 66 29 69 1 Complete)

--- a/integration-test/Analysis/Python/SetuptoolsSpec.hs
+++ b/integration-test/Analysis/Python/SetuptoolsSpec.hs
@@ -8,7 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Python.Setuptools qualified as Setuptools
 import Test.Hspec
-import Types (GraphBreadth (..))
+import Types (DiscoveredProjectType (..), GraphBreadth (..))
 
 theFuck :: AnalysisTestFixture (Setuptools.SetuptoolsProject)
 theFuck =
@@ -36,5 +36,5 @@ flask =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary theFuck "setuptools" (DependencyResultsSummary 16 16 0 2 Partial)
-  testSuiteDepResultSummary flask "setuptools" (DependencyResultsSummary 4 4 0 1 Partial)
+  testSuiteDepResultSummary theFuck SetuptoolsProjectType (DependencyResultsSummary 16 16 0 2 Partial)
+  testSuiteDepResultSummary flask SetuptoolsProjectType (DependencyResultsSummary 4 4 0 1 Partial)

--- a/integration-test/Analysis/RubySpec.hs
+++ b/integration-test/Analysis/RubySpec.hs
@@ -8,7 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Bundler qualified as Bundler
 import Test.Hspec
-import Types (GraphBreadth (Complete))
+import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 rails :: AnalysisTestFixture (Bundler.BundlerProject)
 rails =
@@ -24,4 +24,4 @@ rails =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary rails "bundler" (DependencyResultsSummary 210 70 293 1 Complete)
+  testSuiteDepResultSummary rails BundlerProjectType (DependencyResultsSummary 210 70 293 1 Complete)

--- a/integration-test/Analysis/RustSpec.hs
+++ b/integration-test/Analysis/RustSpec.hs
@@ -8,7 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Cargo qualified as Cargo
 import Test.Hspec
-import Types (GraphBreadth (Complete))
+import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 rustEnv :: FixtureEnvironment
 rustEnv = NixEnv ["rustc", "cargo"]
@@ -39,5 +39,5 @@ fd =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary bat "cargo" (DependencyResultsSummary 146 29 269 1 Complete)
-  testSuiteDepResultSummary fd "cargo" (DependencyResultsSummary 71 25 137 1 Complete)
+  testSuiteDepResultSummary bat CargoProjectType (DependencyResultsSummary 146 29 269 1 Complete)
+  testSuiteDepResultSummary fd CargoProjectType (DependencyResultsSummary 71 25 137 1 Complete)

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -71,7 +71,7 @@ import Data.Functor (void)
 import Data.List (isInfixOf, stripPrefix)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes, fromMaybe)
-import Data.String.Conversion (decodeUtf8)
+import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text (Text)
 import Discovery.Archive qualified as Archive
 import Discovery.Filters (AllFilters, applyFilters, filterIsVSIOnly)
@@ -248,7 +248,7 @@ applyFiltersToProject basedir filters DiscoveredProject{..} =
     -- will always fail
     Nothing -> Just projectBuildTargets
     Just rel -> do
-      applyFilters filters projectType rel projectBuildTargets
+      applyFilters filters (toText projectType) rel projectBuildTargets
 
 runAnalyzers ::
   ( AnalyzeTaskEffs sig m

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -3,7 +3,6 @@ module App.Fossa.Analyze.Project (
   mkResult,
 ) where
 
-import Data.Text (Text)
 import DepTypes
 import Graphing (Graphing)
 import Graphing qualified
@@ -33,14 +32,14 @@ mkResult basedir project dependencyResults =
     relativeManifestFiles = map (tryMakeRelative basedir) $ dependencyManifestFiles dependencyResults
 
 data ProjectResult = ProjectResult
-  { projectResultType :: Text
+  { projectResultType :: DiscoveredProjectType
   , projectResultPath :: Path Abs Dir
   , projectResultGraph :: Graphing Dependency
   , projectResultGraphBreadth :: GraphBreadth
   , projectResultManifestFiles :: [SomeBase File]
   }
 
-shouldKeepUnreachableDeps :: Text -> Bool
-shouldKeepUnreachableDeps "swift" = True
-shouldKeepUnreachableDeps "gomod" = True
+shouldKeepUnreachableDeps :: DiscoveredProjectType -> Bool
+shouldKeepUnreachableDeps SwiftProjectType = True
+shouldKeepUnreachableDeps GomodProjectType = True
 shouldKeepUnreachableDeps _ = False

--- a/src/App/Fossa/BinaryDeps.hs
+++ b/src/App/Fossa/BinaryDeps.hs
@@ -18,7 +18,7 @@ import Path (Abs, Dir, File, Path, isProperPrefixOf, (</>))
 import Path.Extra (tryMakeRelative)
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep (..))
-import Types (GraphBreadth (Complete))
+import Types (DiscoveredProjectType (BinaryDepsProjectType), GraphBreadth (Complete))
 
 -- | Binary detection is sufficiently different from other analysis types that it cannot be just another strategy.
 -- Instead, binary detection is run separately over the entire scan directory, outputting its own source unit.
@@ -63,7 +63,7 @@ shouldFingerprintDir dir filters = (not shouldExclude) && shouldInclude
     isPrefixedOrEqual a b = a == b || isProperPrefixOf b a -- swap order of isProperPrefixOf comparison because we want to know if dir is prefixed by any filter
 
 toProject :: Path Abs Dir -> ProjectResult
-toProject dir = ProjectResult "binary-deps" dir mempty Complete []
+toProject dir = ProjectResult BinaryDepsProjectType dir mempty Complete []
 
 toSourceUnit :: ProjectResult -> [SourceUserDefDep] -> SourceUnit
 toSourceUnit project deps = do

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -22,7 +22,7 @@ import Graphing qualified
 import Path (Abs, Dir, Path)
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
-import Types (GraphBreadth (Complete))
+import Types (DiscoveredProjectType (VsiProjectType), GraphBreadth (Complete))
 
 -- | VSI analysis is sufficiently different from other analysis types that it cannot be just another strategy.
 -- Instead, VSI analysis is run separately over the entire scan directory, outputting its own source unit.
@@ -47,7 +47,7 @@ pluginAnalyze opts = context "VSI" $ do
   pure (allOtherDeps, userDefinedDeps)
 
 toProject :: Path Abs Dir -> Graphing Dependency -> ProjectResult
-toProject dir graph = ProjectResult "vsi" dir graph Complete []
+toProject dir graph = ProjectResult VsiProjectType dir graph Complete []
 
 toSourceUnit :: ProjectResult -> Maybe [SourceUserDefDep] -> SourceUnit
 toSourceUnit project deps = do

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -22,6 +22,7 @@ import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson
 import Data.Bool (bool)
 import Data.ByteString.Lazy qualified as BL
+import Data.String.Conversion (ToText (toText))
 import Data.Text (Text)
 import Discovery.Projects (withDiscoveredProjects)
 import Effect.Exec
@@ -133,8 +134,8 @@ instance ToJSON CompletedLicenseScan where
 mkLicenseScan :: DiscoveredProject n -> [LicenseResult] -> ProjectLicenseScan
 mkLicenseScan project licenses =
   ProjectLicenseScan
-    { licenseStrategyType = projectType project
-    , licenseStrategyName = projectType project
+    { licenseStrategyType = toText (show $ projectType project)
+    , licenseStrategyName = toText (show $ projectType project)
     , discoveredLicenses = licenses
     }
 

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -134,8 +134,8 @@ instance ToJSON CompletedLicenseScan where
 mkLicenseScan :: DiscoveredProject n -> [LicenseResult] -> ProjectLicenseScan
 mkLicenseScan project licenses =
   ProjectLicenseScan
-    { licenseStrategyType = toText (show $ projectType project)
-    , licenseStrategyName = toText (show $ projectType project)
+    { licenseStrategyType = toText (projectType project)
+    , licenseStrategyName = toText (projectType project)
     , discoveredLicenses = licenses
     }
 

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -47,7 +47,7 @@ toSourceUnit :: Bool -> ProjectResult -> SourceUnit
 toSourceUnit leaveUnfiltered ProjectResult{..} =
   SourceUnit
     { sourceUnitName = renderedPath
-    , sourceUnitType = projectResultType
+    , sourceUnitType = toText projectResultType
     , sourceUnitManifest = renderedPath
     , sourceUnitBuild =
         Just $

--- a/src/Strategy/Bundler.hs
+++ b/src/Strategy/Bundler.hs
@@ -56,7 +56,7 @@ instance AnalyzeProject BundlerProject where
 mkProject :: BundlerProject -> DiscoveredProject BundlerProject
 mkProject project =
   DiscoveredProject
-    { projectType = "bundler"
+    { projectType = BundlerProjectType
     , projectBuildTargets = mempty
     , projectPath = bundlerDir project
     , projectData = project

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -159,7 +159,7 @@ instance AnalyzeProject CargoProject where
 mkProject :: CargoProject -> DiscoveredProject CargoProject
 mkProject project =
   DiscoveredProject
-    { projectType = "cargo"
+    { projectType = CargoProjectType
     , projectBuildTargets = mempty
     , projectPath = cargoDir project
     , projectData = project

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -66,7 +66,7 @@ instance AnalyzeProject CarthageProject where
 mkProject :: CarthageProject -> DiscoveredProject CarthageProject
 mkProject project =
   DiscoveredProject
-    { projectType = "carthage"
+    { projectType = CarthageProjectType
     , projectBuildTargets = mempty
     , projectPath = carthageDir project
     , projectData = project

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -55,7 +55,7 @@ instance AnalyzeProject CocoapodsProject where
 mkProject :: CocoapodsProject -> DiscoveredProject CocoapodsProject
 mkProject project =
   DiscoveredProject
-    { projectType = "cocoapods"
+    { projectType = CocoapodsProjectType
     , projectBuildTargets = mempty
     , projectPath = cocoapodsDir project
     , projectData = project

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -44,7 +44,7 @@ findProjects = walk' $ \dir _ files -> do
 mkProject :: ComposerProject -> DiscoveredProject ComposerProject
 mkProject project =
   DiscoveredProject
-    { projectType = "composer"
+    { projectType = ComposerProjectType
     , projectBuildTargets = mempty
     , projectPath = composerDir project
     , projectData = project

--- a/src/Strategy/Conda.hs
+++ b/src/Strategy/Conda.hs
@@ -43,7 +43,7 @@ instance AnalyzeProject CondaProject where
 mkProject :: CondaProject -> DiscoveredProject CondaProject
 mkProject project =
   DiscoveredProject
-    { projectType = "conda"
+    { projectType = CondaProjectType
     , projectBuildTargets = mempty
     , projectPath = condaDir project
     , projectData = project

--- a/src/Strategy/Fpm.hs
+++ b/src/Strategy/Fpm.hs
@@ -8,7 +8,7 @@ import Effect.ReadFS (Has, ReadFS)
 import GHC.Generics (Generic)
 import Path
 import Strategy.Fortran.FpmToml (analyzeFpmToml)
-import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (Partial))
+import Types (DependencyResults (..), DiscoveredProject (..), DiscoveredProjectType (FpmProjectType), GraphBreadth (Partial))
 
 discover ::
   ( Has ReadFS sig m
@@ -41,7 +41,7 @@ instance AnalyzeProject FpmProject where
 mkProject :: FpmProject -> DiscoveredProject FpmProject
 mkProject project =
   DiscoveredProject
-    { projectType = "fpm"
+    { projectType = FpmProjectType
     , projectBuildTargets = mempty
     , projectPath = fpmSpecDir project
     , projectData = project

--- a/src/Strategy/Glide.hs
+++ b/src/Strategy/Glide.hs
@@ -37,7 +37,7 @@ instance AnalyzeProject GlideProject where
 mkProject :: GlideProject -> DiscoveredProject GlideProject
 mkProject project =
   DiscoveredProject
-    { projectType = "glide"
+    { projectType = GlideProjectType
     , projectBuildTargets = mempty
     , projectPath = glideDir project
     , projectData = project

--- a/src/Strategy/Godep.hs
+++ b/src/Strategy/Godep.hs
@@ -50,7 +50,7 @@ instance AnalyzeProject GodepProject where
 mkProject :: GodepProject -> DiscoveredProject GodepProject
 mkProject project =
   DiscoveredProject
-    { projectType = "godep"
+    { projectType = GodepProjectType
     , projectBuildTargets = mempty
     , projectPath = godepDir project
     , projectData = project

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -44,7 +44,7 @@ instance AnalyzeProject GomodulesProject where
 mkProject :: GomodulesProject -> DiscoveredProject GomodulesProject
 mkProject project =
   DiscoveredProject
-    { projectType = "gomod"
+    { projectType = GomodProjectType
     , projectBuildTargets = mempty
     , projectPath = gomodulesDir project
     , projectData = project

--- a/src/Strategy/Googlesource/RepoManifest.hs
+++ b/src/Strategy/Googlesource/RepoManifest.hs
@@ -69,7 +69,7 @@ instance ToJSON RepoManifestProject
 mkProject :: RepoManifestProject -> DiscoveredProject RepoManifestProject
 mkProject project =
   DiscoveredProject
-    { projectType = "repomanifest"
+    { projectType = RepoManifestProjectType
     , projectBuildTargets = mempty
     , projectData = project
     , projectPath = parent $ repoManifestXml project

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -61,7 +61,7 @@ import Strategy.Gradle.Common (
  )
 import Strategy.Gradle.ResolutionApi qualified as ResolutionApi
 import System.FilePath qualified as FilePath
-import Types (BuildTarget (..), DependencyResults (..), DiscoveredProject (..), FoundTargets (..), GraphBreadth (..))
+import Types (BuildTarget (..), DependencyResults (..), DiscoveredProject (..), DiscoveredProjectType (GradleProjectType), FoundTargets (..), GraphBreadth (..))
 
 -- Run the init script on a set of subprojects. Note that this runs the
 -- `:jsonDeps` task on every subproject in one command. This is helpful for
@@ -222,7 +222,7 @@ parseSubproject line =
 mkProject :: GradleProject -> DiscoveredProject GradleProject
 mkProject project =
   DiscoveredProject
-    { projectType = "gradle"
+    { projectType = GradleProjectType
     , projectBuildTargets = maybe ProjectWithoutTargets FoundTargets $ nonEmpty $ Set.map BuildTarget $ gradleProjects project
     , projectPath = gradleDir project
     , projectData = project

--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -137,7 +137,7 @@ findProjects = walk' $ \dir _ files -> do
 mkProject :: CabalProject -> DiscoveredProject CabalProject
 mkProject project =
   DiscoveredProject
-    { projectType = "cabal"
+    { projectType = CabalProjectType
     , projectBuildTargets = mempty
     , projectPath = cabalDir project
     , projectData = project

--- a/src/Strategy/Haskell/Stack.hs
+++ b/src/Strategy/Haskell/Stack.hs
@@ -74,7 +74,7 @@ findProjects = walk' $ \dir _ files -> do
 mkProject :: StackProject -> DiscoveredProject StackProject
 mkProject project =
   DiscoveredProject
-    { projectType = "stack"
+    { projectType = StackProjectType
     , projectBuildTargets = mempty
     , projectPath = stackDir project
     , projectData = project

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -82,7 +82,7 @@ findProjects = walk' $ \dir _ files -> do
 mkProject :: LeiningenProject -> DiscoveredProject LeiningenProject
 mkProject project =
   DiscoveredProject
-    { projectType = "leiningen"
+    { projectType = LeiningenProjectType
     , projectBuildTargets = mempty
     , projectPath = leinDir project
     , projectData = project

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -20,7 +20,7 @@ import Strategy.Maven.DepTree qualified as DepTreeCmd
 import Strategy.Maven.PluginStrategy qualified as Plugin
 import Strategy.Maven.Pom qualified as Pom
 import Strategy.Maven.Pom.Closure qualified as PomClosure
-import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (..))
+import Types (DependencyResults (..), DiscoveredProject (..), DiscoveredProjectType (MavenProjectType), GraphBreadth (..))
 
 discover ::
   ( MonadIO m
@@ -39,7 +39,7 @@ mkProject ::
   DiscoveredProject MavenProject
 mkProject closure =
   DiscoveredProject
-    { projectType = "maven"
+    { projectType = MavenProjectType
     , projectPath = parent $ PomClosure.closurePath closure
     , projectBuildTargets = mempty
     , projectData = MavenProject closure

--- a/src/Strategy/Mix.hs
+++ b/src/Strategy/Mix.hs
@@ -14,7 +14,7 @@ import Discovery.Walk (
 import Effect.ReadFS (Has, ReadFS)
 import Path
 import Strategy.Elixir.MixTree (MixProject (..))
-import Types (DiscoveredProject (..))
+import Types (DiscoveredProject (..), DiscoveredProjectType (MixProjectType))
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject MixProject]
 discover dir = context "Mix" $ do
@@ -30,7 +30,7 @@ findProjects = walk' $ \dir _ files -> do
 mkProject :: MixProject -> DiscoveredProject MixProject
 mkProject project =
   DiscoveredProject
-    { projectType = "mix"
+    { projectType = MixProjectType
     , projectBuildTargets = mempty
     , projectPath = mixDir project
     , projectData = project

--- a/src/Strategy/Nim.hs
+++ b/src/Strategy/Nim.hs
@@ -17,7 +17,7 @@ import Effect.ReadFS (Has, ReadFS)
 import GHC.Generics (Generic)
 import Path
 import Strategy.Nim.NimbleLock (analyze)
-import Types (DependencyResults (..), DiscoveredProject (..))
+import Types (DependencyResults (..), DiscoveredProject (..), DiscoveredProjectType (NimbleProjectType))
 
 data NimbleProject = NimbleProject
   { nimDir :: Path Abs Dir
@@ -44,7 +44,7 @@ findProjects = walk' $ \dir _ files -> do
 mkProject :: NimbleProject -> DiscoveredProject NimbleProject
 mkProject project =
   DiscoveredProject
-    { projectType = "nimble"
+    { projectType = NimbleProjectType
     , projectBuildTargets = mempty
     , projectPath = nimDir project
     , projectData = project

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -69,6 +69,7 @@ import Strategy.Node.YarnV2.YarnLock qualified as V2
 import Types (
   DependencyResults (DependencyResults),
   DiscoveredProject (..),
+  DiscoveredProjectType (NpmProjectType, YarnProjectType),
   FoundTargets (ProjectWithoutTargets),
   GraphBreadth (Complete, Partial),
  )
@@ -108,9 +109,9 @@ mkProject ::
   m (DiscoveredProject NodeProject)
 mkProject project = do
   let (graph, typename) = case project of
-        Yarn _ g -> (g, "yarn")
-        NPMLock _ g -> (g, "npm")
-        NPM g -> (g, "npm")
+        Yarn _ g -> (g, YarnProjectType)
+        NPMLock _ g -> (g, NpmProjectType)
+        NPM g -> (g, NpmProjectType)
   result <- errorBoundary $ fromEitherShow $ findWorkspaceRootManifest graph
   Manifest rootManifest <- case result of
     Left bundle -> do

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -33,6 +33,7 @@ import Path
 import Types (
   DependencyResults (..),
   DiscoveredProject (..),
+  DiscoveredProjectType (NuspecProjectType),
   GraphBreadth (Partial),
   License (License),
   LicenseResult (LicenseResult),
@@ -60,7 +61,7 @@ instance ToJSON NuspecProject
 mkProject :: NuspecProject -> DiscoveredProject NuspecProject
 mkProject project =
   DiscoveredProject
-    { projectType = "nuspec"
+    { projectType = NuspecProjectType
     , projectBuildTargets = mempty
     , projectData = project
     , projectPath = parent $ nuspecFile project

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -57,7 +57,7 @@ instance AnalyzeProject PackageReferenceProject where
 mkProject :: PackageReferenceProject -> DiscoveredProject PackageReferenceProject
 mkProject project =
   DiscoveredProject
-    { projectType = "packagereference"
+    { projectType = PackageReferenceProjectType
     , projectBuildTargets = mempty
     , projectPath = parent $ packageReferenceFile project
     , projectData = project

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -50,7 +50,7 @@ instance AnalyzeProject PackagesConfigProject where
 mkProject :: PackagesConfigProject -> DiscoveredProject PackagesConfigProject
 mkProject project =
   DiscoveredProject
-    { projectType = "packagesconfig"
+    { projectType = PackagesConfigProjectType
     , projectBuildTargets = mempty
     , projectPath = parent $ packagesConfigFile project
     , projectData = project

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -60,7 +60,7 @@ instance AnalyzeProject PaketProject where
 mkProject :: PaketProject -> DiscoveredProject PaketProject
 mkProject project =
   DiscoveredProject
-    { projectType = "paket"
+    { projectType = PaketProjectType
     , projectBuildTargets = mempty
     , projectPath = parent $ paketLock project
     , projectData = project

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -64,7 +64,7 @@ instance AnalyzeProject ProjectAssetsJsonProject where
 mkProject :: ProjectAssetsJsonProject -> DiscoveredProject ProjectAssetsJsonProject
 mkProject project =
   DiscoveredProject
-    { projectType = "projectassetsjson"
+    { projectType = ProjectAssetsJsonProjectType
     , projectBuildTargets = mempty
     , projectPath = parent $ projectAssetsJsonFile project
     , projectData = project

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -48,7 +48,7 @@ instance AnalyzeProject ProjectJsonProject where
 mkProject :: ProjectJsonProject -> DiscoveredProject ProjectJsonProject
 mkProject project =
   DiscoveredProject
-    { projectType = "projectjson"
+    { projectType = ProjectJsonProjectType
     , projectBuildTargets = mempty
     , projectPath = parent $ projectJsonFile project
     , projectData = project

--- a/src/Strategy/Perl.hs
+++ b/src/Strategy/Perl.hs
@@ -40,6 +40,7 @@ import Text.Read (readMaybe)
 import Types (
   DependencyResults (..),
   DiscoveredProject (..),
+  DiscoveredProjectType (PerlProjectType),
   GraphBreadth (Partial),
  )
 
@@ -69,7 +70,7 @@ instance AnalyzeProject PerlProject where
 mkProject :: PerlProject -> DiscoveredProject PerlProject
 mkProject project =
   DiscoveredProject
-    { projectType = "perl"
+    { projectType = PerlProjectType
     , projectBuildTargets = mempty
     , projectPath = perlDir project
     , projectData = project

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -12,7 +12,7 @@ import Path
 import Strategy.Dart.PubDeps (analyzeDepsCmd)
 import Strategy.Dart.PubSpec (analyzePubSpecFile)
 import Strategy.Dart.PubSpecLock (analyzePubLockFile)
-import Types (DependencyResults (..), DiscoveredProject (..))
+import Types (DependencyResults (..), DiscoveredProject (..), DiscoveredProjectType (PubProjectType))
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject PubProject]
 discover dir = context "Pub" $ do
@@ -48,7 +48,7 @@ instance AnalyzeProject PubProject where
 mkProject :: PubProject -> DiscoveredProject PubProject
 mkProject project =
   DiscoveredProject
-    { projectType = "pub"
+    { projectType = PubProjectType
     , projectBuildTargets = mempty
     , projectPath = pubSpecDir project
     , projectData = project

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -66,7 +66,7 @@ getDeps project = context "Pipenv" $ do
 mkProject :: PipenvProject -> DiscoveredProject PipenvProject
 mkProject project =
   DiscoveredProject
-    { projectType = "pipenv"
+    { projectType = PipenvProjectType
     , projectBuildTargets = mempty
     , projectPath = parent $ pipenvLockfile project
     , projectData = project

--- a/src/Strategy/Python/Poetry.hs
+++ b/src/Strategy/Python/Poetry.hs
@@ -31,7 +31,7 @@ import Path (Abs, Dir, File, Path)
 import Strategy.Python.Poetry.Common (getPoetryBuildBackend, logIgnoredDeps, pyProjectDeps, toCanonicalName, toMap)
 import Strategy.Python.Poetry.PoetryLock (PackageName (..), PoetryLock (..), PoetryLockPackage (..), poetryLockCodec)
 import Strategy.Python.Poetry.PyProject (PyProject (..), pyProjectCodec)
-import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (..))
+import Types (DependencyResults (..), DiscoveredProject (..), DiscoveredProjectType (PoetryProjectType), GraphBreadth (..))
 
 newtype PyProjectTomlFile = PyProjectTomlFile {pyProjectTomlPath :: Path Abs File} deriving (Eq, Ord, Show, Generic)
 newtype PoetryLockFile = PoetryLockFile {poetryLockPath :: Path Abs File} deriving (Eq, Ord, Show, Generic)
@@ -105,7 +105,7 @@ findProjects = walk' $ \dir _ files -> do
 mkProject :: PoetryProject -> DiscoveredProject PoetryProject
 mkProject project =
   DiscoveredProject
-    { projectType = "poetry"
+    { projectType = PoetryProjectType
     , projectBuildTargets = mempty
     , projectPath = pyProjectPath $ projectDir project
     , projectData = project

--- a/src/Strategy/Python/Setuptools.hs
+++ b/src/Strategy/Python/Setuptools.hs
@@ -84,7 +84,7 @@ instance AnalyzeProject SetuptoolsProject where
 mkProject :: SetuptoolsProject -> DiscoveredProject SetuptoolsProject
 mkProject project =
   DiscoveredProject
-    { projectType = "setuptools"
+    { projectType = SetuptoolsProjectType
     , projectBuildTargets = mempty
     , projectPath = setuptoolsDir project
     , projectData = project

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -78,7 +78,7 @@ instance AnalyzeProject RpmProject where
 mkProject :: RpmProject -> DiscoveredProject RpmProject
 mkProject project =
   DiscoveredProject
-    { projectType = "rpm"
+    { projectType = RpmProjectType
     , projectBuildTargets = mempty
     , projectPath = rpmDir project
     , projectData = project

--- a/src/Strategy/Rebar3.hs
+++ b/src/Strategy/Rebar3.hs
@@ -42,7 +42,7 @@ instance AnalyzeProject RebarProject where
 mkProject :: RebarProject -> DiscoveredProject RebarProject
 mkProject project =
   DiscoveredProject
-    { projectType = "rebar3"
+    { projectType = Rebar3ProjectType
     , projectBuildTargets = mempty
     , projectPath = rebarDir project
     , projectData = project

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -54,7 +54,7 @@ instance AnalyzeProject ScalaProject where
 mkProject :: MavenProjectClosure -> DiscoveredProject ScalaProject
 mkProject closure =
   DiscoveredProject
-    { projectType = "scala"
+    { projectType = ScalaProjectType
     , projectPath = parent $ PomClosure.closurePath closure
     , projectBuildTargets = mempty
     , projectData = ScalaProject closure

--- a/src/Strategy/SwiftPM.hs
+++ b/src/Strategy/SwiftPM.hs
@@ -22,7 +22,7 @@ import GHC.Generics (Generic)
 import Path
 import Strategy.Swift.PackageSwift (analyzePackageSwift)
 import Strategy.Swift.Xcode.Pbxproj (analyzeXcodeProjForSwiftPkg, hasSomeSwiftDeps)
-import Types (DependencyResults (..), DiscoveredProject (..), GraphBreadth (..))
+import Types (DependencyResults (..), DiscoveredProject (..), DiscoveredProjectType (SwiftProjectType), GraphBreadth (..))
 
 data SwiftProject
   = PackageProject SwiftPackageProject
@@ -106,7 +106,7 @@ debugXCodeWithoutSwiftDeps projFile =
 mkProject :: SwiftProject -> DiscoveredProject SwiftProject
 mkProject project =
   DiscoveredProject
-    { projectType = "swift"
+    { projectType = SwiftProjectType
     , projectBuildTargets = mempty
     , projectPath = case project of
         PackageProject p -> swiftPkgProjectDir p

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -11,6 +11,7 @@ module Types (
   LicenseType (..),
   module DepTypes,
   TargetFilter (..),
+  DiscoveredProjectType (..),
 ) where
 
 import Data.Aeson (
@@ -24,8 +25,9 @@ import Data.Aeson (
  )
 import Data.Aeson.Types (Parser)
 import Data.Set.NonEmpty (NonEmptySet)
-import Data.String.Conversion (toString)
+import Data.String.Conversion (ToText (toText), toString)
 import Data.Text (Text)
+import Data.Text qualified as Text
 import DepTypes (
   DepEnvironment (..),
   DepType (..),
@@ -38,6 +40,7 @@ import DepTypes (
 import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Path (Abs, Dir, File, Path, Rel, parseRelDir)
+import Prettyprinter (Pretty (pretty))
 
 -- TODO: results should be within a graph of build targets && eliminate SubprojectType
 data FoundTargets = ProjectWithoutTargets | FoundTargets (NonEmptySet BuildTarget)
@@ -53,10 +56,98 @@ instance Semigroup FoundTargets where
 instance Monoid FoundTargets where
   mempty = ProjectWithoutTargets
 
+data DiscoveredProjectType
+  = BinaryDepsProjectType
+  | BundlerProjectType
+  | CabalProjectType
+  | CargoProjectType
+  | CarthageProjectType
+  | CocoapodsProjectType
+  | ComposerProjectType
+  | CondaProjectType
+  | FpmProjectType
+  | GlideProjectType
+  | GodepProjectType
+  | GomodProjectType
+  | GradleProjectType
+  | LeiningenProjectType
+  | MavenProjectType
+  | MixProjectType
+  | NimbleProjectType
+  | NpmProjectType
+  | NuspecProjectType
+  | PackageReferenceProjectType
+  | PackagesConfigProjectType
+  | PaketProjectType
+  | PerlProjectType
+  | PipenvProjectType
+  | PoetryProjectType
+  | ProjectAssetsJsonProjectType
+  | ProjectJsonProjectType
+  | PubProjectType
+  | Rebar3ProjectType
+  | RepoManifestProjectType
+  | RpmProjectType
+  | ScalaProjectType
+  | SetuptoolsProjectType
+  | StackProjectType
+  | SwiftProjectType
+  | VsiProjectType
+  | YarnProjectType
+  deriving (Eq, Ord)
+
+instance Show DiscoveredProjectType where
+  show BinaryDepsProjectType = "binary-deps"
+  show BundlerProjectType = "bundler"
+  show CabalProjectType = "stack"
+  show CargoProjectType = "cargo"
+  show CarthageProjectType = "carthage"
+  show CocoapodsProjectType = "cocoapods"
+  show ComposerProjectType = "composer"
+  show CondaProjectType = "conda"
+  show FpmProjectType = "fpm"
+  show GlideProjectType = "glide"
+  show GodepProjectType = "godep"
+  show GomodProjectType = "gomod"
+  show GradleProjectType = "gradle"
+  show LeiningenProjectType = "leiningen"
+  show MavenProjectType = "maven"
+  show MixProjectType = "mix"
+  show NimbleProjectType = "nimble"
+  show NpmProjectType = "npm"
+  show NuspecProjectType = "nuspec"
+  show PackageReferenceProjectType = "packagereference"
+  show PackagesConfigProjectType = "packagesconfig"
+  show PaketProjectType = "packet"
+  show PerlProjectType = "perl"
+  show PipenvProjectType = "pipenv"
+  show PoetryProjectType = "poetry"
+  show ProjectAssetsJsonProjectType = "projectassetsjson"
+  show ProjectJsonProjectType = "projectjson"
+  show PubProjectType = "pub"
+  show Rebar3ProjectType = "rebar3"
+  show RepoManifestProjectType = "repomanifest"
+  show RpmProjectType = "rpm"
+  show ScalaProjectType = "scala"
+  show SetuptoolsProjectType = "setuptools"
+  show StackProjectType = "stack"
+  show SwiftProjectType = "swift"
+  show VsiProjectType = "vsi"
+  show YarnProjectType = "yarn"
+
+instance ToJSON DiscoveredProjectType where
+  toJSON = toJSON . show
+
+instance ToText DiscoveredProjectType where
+  toText = Text.pack . show
+
+instance Pretty DiscoveredProjectType where
+  pretty = pretty . toText
+
 -- | A project found during project discovery, parameterized by the monad
 -- used to perform dependency analysis
 data DiscoveredProject a = DiscoveredProject
-  { projectType :: Text
+  { projectType :: DiscoveredProjectType
   , projectPath :: Path Abs Dir
   , projectBuildTargets :: FoundTargets
   , projectData :: a

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -27,7 +27,6 @@ import Data.Aeson.Types (Parser)
 import Data.Set.NonEmpty (NonEmptySet)
 import Data.String.Conversion (ToText (toText), toString)
 import Data.Text (Text)
-import Data.Text qualified as Text
 import DepTypes (
   DepEnvironment (..),
   DepType (..),
@@ -97,49 +96,50 @@ data DiscoveredProjectType
   deriving (Eq, Ord)
 
 instance Show DiscoveredProjectType where
-  show BinaryDepsProjectType = "binary-deps"
-  show BundlerProjectType = "bundler"
-  show CabalProjectType = "stack"
-  show CargoProjectType = "cargo"
-  show CarthageProjectType = "carthage"
-  show CocoapodsProjectType = "cocoapods"
-  show ComposerProjectType = "composer"
-  show CondaProjectType = "conda"
-  show FpmProjectType = "fpm"
-  show GlideProjectType = "glide"
-  show GodepProjectType = "godep"
-  show GomodProjectType = "gomod"
-  show GradleProjectType = "gradle"
-  show LeiningenProjectType = "leiningen"
-  show MavenProjectType = "maven"
-  show MixProjectType = "mix"
-  show NimbleProjectType = "nimble"
-  show NpmProjectType = "npm"
-  show NuspecProjectType = "nuspec"
-  show PackageReferenceProjectType = "packagereference"
-  show PackagesConfigProjectType = "packagesconfig"
-  show PaketProjectType = "packet"
-  show PerlProjectType = "perl"
-  show PipenvProjectType = "pipenv"
-  show PoetryProjectType = "poetry"
-  show ProjectAssetsJsonProjectType = "projectassetsjson"
-  show ProjectJsonProjectType = "projectjson"
-  show PubProjectType = "pub"
-  show Rebar3ProjectType = "rebar3"
-  show RepoManifestProjectType = "repomanifest"
-  show RpmProjectType = "rpm"
-  show ScalaProjectType = "scala"
-  show SetuptoolsProjectType = "setuptools"
-  show StackProjectType = "stack"
-  show SwiftProjectType = "swift"
-  show VsiProjectType = "vsi"
-  show YarnProjectType = "yarn"
+  show = \case
+    BinaryDepsProjectType -> "binary-deps"
+    BundlerProjectType -> "bundler"
+    CabalProjectType -> "stack"
+    CargoProjectType -> "cargo"
+    CarthageProjectType -> "carthage"
+    CocoapodsProjectType -> "cocoapods"
+    ComposerProjectType -> "composer"
+    CondaProjectType -> "conda"
+    FpmProjectType -> "fpm"
+    GlideProjectType -> "glide"
+    GodepProjectType -> "godep"
+    GomodProjectType -> "gomod"
+    GradleProjectType -> "gradle"
+    LeiningenProjectType -> "leiningen"
+    MavenProjectType -> "maven"
+    MixProjectType -> "mix"
+    NimbleProjectType -> "nimble"
+    NpmProjectType -> "npm"
+    NuspecProjectType -> "nuspec"
+    PackageReferenceProjectType -> "packagereference"
+    PackagesConfigProjectType -> "packagesconfig"
+    PaketProjectType -> "packet"
+    PerlProjectType -> "perl"
+    PipenvProjectType -> "pipenv"
+    PoetryProjectType -> "poetry"
+    ProjectAssetsJsonProjectType -> "projectassetsjson"
+    ProjectJsonProjectType -> "projectjson"
+    PubProjectType -> "pub"
+    Rebar3ProjectType -> "rebar3"
+    RepoManifestProjectType -> "repomanifest"
+    RpmProjectType -> "rpm"
+    ScalaProjectType -> "scala"
+    SetuptoolsProjectType -> "setuptools"
+    StackProjectType -> "stack"
+    SwiftProjectType -> "swift"
+    VsiProjectType -> "vsi"
+    YarnProjectType -> "yarn"
 
 instance ToJSON DiscoveredProjectType where
   toJSON = toJSON . show
 
 instance ToText DiscoveredProjectType where
-  toText = Text.pack . show
+  toText = toText . show
 
 instance Pretty DiscoveredProjectType where
   pretty = pretty . toText


### PR DESCRIPTION
# Overview

This PR modifies,  Discovered projectType's datatype. It changes types from string to sum type. 

## Testing plan

N/A

## Risks

N/A

## References

N/A

## Checklist

- [ ] ~I added tests for this PR's change (or confirmed tests are not viable).~
- [ ] ~If this PR introduced a user-visible change, I added documentation into `docs/`.~
- [ ] ~I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.~
- [ ] ~I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).~
- [ ] ~I linked this PR to any referenced GitHub issues, if they exist.~
