### PR TITLE
Remove fdescribe.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -43,8 +43,8 @@
   - {name: "Data.Map.!", within: []}
     # TODO: remove the need to special-case this test module.
   - {name: fromJust, within: [App.DocsSpec]}
-  - {name: fdescribe, within: []}
-  - {name: fit, within: []}
-  - {name: focus, within: []}
-  - {name: fspecify, within: []}
-  - {name: fcontext, within: []}
+  - {name: Test.Hspec.fdescribe, within: []}
+  - {name: Test.Hspec.fit, within: []}
+  - {name: Test.Hspec.focus, within: []}
+  - {name: Test.Hspec.fspecify, within: []}
+  - {name: Test.Hspec.fcontext, within: []}

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -43,3 +43,8 @@
   - {name: "Data.Map.!", within: []}
     # TODO: remove the need to special-case this test module.
   - {name: fromJust, within: [App.DocsSpec]}
+  - {name: fdescribe, within: []}
+  - {name: fit, within: []}
+  - {name: focus, within: []}
+  - {name: fspecify, within: []}
+  - {name: fcontext, within: []}

--- a/test/Erlang/ConfigParserSpec.hs
+++ b/test/Erlang/ConfigParserSpec.hs
@@ -16,7 +16,7 @@ parseMatch parser input expected = parse parser "" input `shouldParse` expected
 
 spec :: Spec
 spec = do
-  fdescribe "Erlang config parser" $ do
+  describe "Erlang config parser" $ do
     rawText <- runIO $ TIO.readFile "test/Erlang/testdata/rebar.config"
     oneWithEverything <- runIO $ TIO.readFile "test/Erlang/testdata/stresstest.config"
     it "should succeed on a real input file" $
@@ -116,14 +116,14 @@ spec = do
               ]
           ]
 
-  fdescribe "radix parser" $
+  describe "radix parser" $
     it "should parse number strings correctly" $ do
       intLiteralInBase 2 "11001" `shouldBe` 25
       intLiteralInBase 8 "1234" `shouldBe` 0o1234
       intLiteralInBase 10 "1234" `shouldBe` 1234
       intLiteralInBase 16 "abcd" `shouldBe` 0xabcd
       intLiteralInBase 36 "1z" `shouldBe` 71 -- (36 * 2 - 1)
-  fdescribe "alphaNumToInt" $
+  describe "alphaNumToInt" $
     it "should provide the correct value for chars" $ do
       alphaNumToInt 'a' `shouldBe` 10
       alphaNumToInt 'B' `shouldBe` 11


### PR DESCRIPTION
# Overview

A number of our unit tests weren't running because of an `fdescribe` which focuses the test runner on a specific set of tests and ignores the others. This PR puts them back to `describe`.

## Acceptance criteria

Remove `fdescribe` in unit tests.

## Testing plan

When running unit tests I found that only some of them were running. I tested this by removing fdescribe then running again. 

## Risks

None

## References

None

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
