### PR TITLE
Packagelock json bool resolved

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## Unreleased
+
+- Npm: Fixes an issue where a package-lock.json dep with a boolean 'resolved' key wouldn't parse. ([#718](https://github.com/fossas/fossa-cli/issues/718))
+
 ## v3.0.16
 
 - Monorepo: Upload file data and licenses together during monorepo scans, speed up issue scans. ([#772](https://github.com/fossas/fossa-cli/pull/772))

--- a/test/Node/NpmLockSpec.hs
+++ b/test/Node/NpmLockSpec.hs
@@ -19,7 +19,7 @@ mockInput =
             , NpmDep
                 { depVersion = "1.0.0"
                 , depDev = False
-                , depResolved = Just "https://example.com/one.tgz"
+                , depResolved = NpmResolved $ Just "https://example.com/one.tgz"
                 , depRequires = Map.fromList [("packageTwo", "2.0.0"), ("packageSeven", "7.0.0")]
                 , depDependencies =
                     Map.fromList
@@ -28,7 +28,7 @@ mockInput =
                         , NpmDep
                             { depVersion = "2.0.0"
                             , depDev = True
-                            , depResolved = Just "https://example.com/two.tgz"
+                            , depResolved = NpmResolved $ Just "https://example.com/two.tgz"
                             , depRequires = Map.fromList [("packageThree", "3.0.0")]
                             , depDependencies = mempty
                             }
@@ -41,7 +41,7 @@ mockInput =
             , NpmDep
                 { depVersion = "3.0.0"
                 , depDev = True
-                , depResolved = Just "https://example.com/three.tgz"
+                , depResolved = NpmResolved $ Just "https://example.com/three.tgz"
                 , depRequires = Map.fromList [("packageOne", "1.0.0")]
                 , depDependencies = mempty
                 }
@@ -51,7 +51,7 @@ mockInput =
             , NpmDep
                 { depVersion = "7.0.0"
                 , depDev = False
-                , depResolved = Just "https://example.com/seven.tgz"
+                , depResolved = NpmResolved $ Just "https://example.com/seven.tgz"
                 , depRequires = mempty
                 , depDependencies = mempty
                 }
@@ -61,7 +61,7 @@ mockInput =
             , NpmDep
                 { depVersion = "file:abc/def"
                 , depDev = False
-                , depResolved = Nothing
+                , depResolved = NpmResolved Nothing
                 , depRequires = mempty
                 , depDependencies = mempty
                 }
@@ -71,7 +71,7 @@ mockInput =
             , NpmDep
                 { depVersion = "5.0.0"
                 , depDev = True
-                , depResolved = Just "https://example.com/five.tgz"
+                , depResolved = NpmResolved $ Just "https://example.com/five.tgz"
                 , depRequires = Map.fromList [("packageSix", "6.0.0")]
                 , depDependencies = mempty
                 }
@@ -81,7 +81,7 @@ mockInput =
             , NpmDep
                 { depVersion = "6.0.0"
                 , depDev = True
-                , depResolved = Just "https://example.com/six.tgz"
+                , depResolved = NpmResolved $ Just "https://example.com/six.tgz"
                 , depRequires = mempty
                 , depDependencies = mempty
                 }

--- a/test/Node/NpmLockSpec.hs
+++ b/test/Node/NpmLockSpec.hs
@@ -200,17 +200,17 @@ spec = do
     it' "Should ignore \"resolved\": <bool> in package-lock.json" $ do
       let packageLock = testDir </> $(mkRelFile "boolean-resolved-package-lock.json")
       NpmPackageJson{packageDependencies = packageDependencies} <- readContentsJson packageLock
-      let foo = Map.lookup "foo" packageDependencies >>= unNpmResolved . depResolved
+      let foo = unNpmResolved . depResolved =<< Map.lookup "foo" packageDependencies
       foo `shouldBe'` Nothing
 
     it' "Should parse \"resolved\": <string> in package-lock.json" $ do
       let packageLock = testDir </> $(mkRelFile "string-resolved-package-lock.json")
       NpmPackageJson{packageDependencies = packageDependencies} <- readContentsJson packageLock
-      let foo = Map.lookup "foo" packageDependencies >>= unNpmResolved . depResolved
+      let foo = unNpmResolved . depResolved =<< Map.lookup "foo" packageDependencies
       foo `shouldBe'` Just "https://bar.npmjs.org/foo/-/foo-1.0.0.tgz"
 
     it' "Should parse dependency with no \"resolved\" key in package-lock.json" $ do
       let packageLock = testDir </> $(mkRelFile "absent-resolved-package-lock.json")
       NpmPackageJson{packageDependencies = packageDependencies} <- readContentsJson packageLock
-      let foo = Map.lookup "foo" packageDependencies >>= unNpmResolved . depResolved
+      let foo = unNpmResolved . depResolved =<< Map.lookup "foo" packageDependencies
       foo `shouldBe'` Nothing

--- a/test/Node/testdata/absent-resolved-package-lock.json
+++ b/test/Node/testdata/absent-resolved-package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "packagelock-test",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "packagelock-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+          "foo": "^1.0.0"
+      }
+    },
+      "node_modules/foo": {
+          "version": "1.0.0",
+          "resolved": "https://bar.npmjs.org/foo/-/foo-1.0.0.tgz",
+          "integrity": "sha512-bar"
+      }
+  },
+  "dependencies": {
+      "foo": {
+          "version": "1.0.0",
+          "integrity": "sha512-bar"
+      }
+  }
+}

--- a/test/Node/testdata/boolean-resolved-package-lock.json
+++ b/test/Node/testdata/boolean-resolved-package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "packagelock-test",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "packagelock-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+          "foo": "^1.0.0"
+      }
+    },
+      "node_modules/foo": {
+          "version": "1.0.0",
+          "resolved": "https://bar.npmjs.org/foo/-/foo-1.0.0.tgz",
+          "integrity": "sha512-bar"
+      }
+  },
+  "dependencies": {
+      "foo": {
+          "version": "1.0.0",
+          "resolved": true,
+          "integrity": "sha512-bar"
+    }
+  }
+}

--- a/test/Node/testdata/no-resolved-package-lock.json
+++ b/test/Node/testdata/no-resolved-package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "packagelock-test",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "packagelock-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+          "foo": "^1.0.0"
+      }
+    },
+      "node_modules/foo": {
+          "version": "1.0.0",
+          "resolved": "https://bar.npmjs.org/foo/-/foo-1.0.0.tgz",
+          "integrity": "sha512-bar"
+      }
+  },
+  "dependencies": {
+      "foo": {
+          "version": "1.0.0",
+          "integrity": "sha512-bar"
+      }
+  }
+}

--- a/test/Node/testdata/string-resolved-package-lock.json
+++ b/test/Node/testdata/string-resolved-package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "packagelock-test",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "packagelock-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+          "foo": "^1.0.0"
+      }
+    },
+      "node_modules/foo": {
+          "version": "1.0.0",
+          "resolved": "https://bar.npmjs.org/foo/-/foo-1.0.0.tgz",
+          "integrity": "sha512-bar"
+      }
+  },
+  "dependencies": {
+      "foo": {
+          "version": "1.0.0",
+          "resolved": "https://bar.npmjs.org/foo/-/foo-1.0.0.tgz",
+          "integrity": "sha512-bar"
+    }
+  }
+}


### PR DESCRIPTION
# Overview

This fixes a parser error when a `package-lock.json` dependency's `resolved` key is a boolean rather than a string.

## Acceptance criteria

The parser for `package-lock.json` dependencies should ignore a boolean `resolved` key.

## Testing plan

I added unit tests for the dependency parser. I also manually ran `fossa analyze` against the repo referenced in #718 and verified that it now parses successfully.

To reproduce you can run the master branch's `fossa analyze` against the repo in the above issue.

## Risks



## References

Closes fossas/team-analysis#849
Closes #718 

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
