### PR TITLE
Pkglock nested deps

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -44,7 +44,8 @@
     # TODO: remove the need to special-case this test module.
   - {name: fromJust, within: [App.DocsSpec]}
   - {name: Test.Hspec.fdescribe, within: []}
-  - {name: Test.Hspec.fit, within: []}
+    # We define fit' in terms of fit,so this is necessary
+  - {name: Test.Hspec.fit, within: [Test.Effect]}
   - {name: Test.Hspec.focus, within: []}
   - {name: Test.Hspec.fspecify, within: []}
   - {name: Test.Hspec.fcontext, within: []}

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Npm: Fixes an issue where a package-lock.json dep with a boolean 'resolved' key wouldn't parse. ([#718](https://github.com/fossas/fossa-cli/issues/718))
+- Npm: Fixes an issue where analyzing `package-lock.json` would miss duplicate packages with different versions. ([#779](https://github.com/fossas/fossa-cli/pull/779))
 
 ## v3.0.16
 

--- a/src/Strategy/Node/Npm/PackageLock.hs
+++ b/src/Strategy/Node/Npm/PackageLock.hs
@@ -23,7 +23,7 @@ import Data.Aeson (
   (.:),
   (.:?),
  )
-import Data.Foldable (traverse_)
+import Data.Foldable (traverse_, asum)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -111,39 +111,56 @@ data NpmPackageLabel = NpmPackageEnv DepEnvironment | NpmPackageLocation Text
 buildGraph :: NpmPackageJson -> Set Text -> Graphing Dependency
 buildGraph packageJson directSet =
   run . withLabeling toDependency $
-    void $ Map.traverseWithKey (maybeAddDep False) (packageDependencies packageJson)
+    void $ Map.traverseWithKey (maybeAddDep False Nothing) (packageDependencies packageJson)
   where
     -- Skip adding deps if we think it's a workspace package.
-    maybeAddDep isRecursive name dep@NpmDep{..} =
+    maybeAddDep isRecursive parent name dep@NpmDep{..} =
       if isNothing (unNpmResolved depResolved) || "file:" `Text.isPrefixOf` depVersion
         then pure ()
-        else addDep isRecursive name dep
+        else addDep isRecursive parent name dep
 
     -- If not resolved, then likely a workspace dep, should be ignored.
     -- isRecursive lets us know if we are parsing a top-level or nested dep.
-    addDep :: Has NpmGrapher sig m => Bool -> Text -> NpmDep -> m ()
-    addDep isRecursive name NpmDep{..} = do
+    addDep :: Has NpmGrapher sig m => Bool -> Maybe NpmPackage -> Text -> NpmDep -> m ()
+    addDep isRecursive parent name NpmDep{..} = do
       let pkg = NpmPackage name depVersion
 
+      -- DEEP/DIRECT
       -- Allow entry of orphan deps.  We may prune these later.
       deep pkg
-
       -- Try marking non-recursively-discovered deps as direct
       when (not isRecursive && Set.member name directSet) $
         direct pkg
 
+      -- LOCATION/ENVIRONMENT
+      -- Mark prod/dev
       label pkg $ NpmPackageEnv $ if depDev then EnvDevelopment else EnvProduction
-
+      -- Add locations from "resolved"
       traverse_ (label pkg . NpmPackageLocation) (unNpmResolved depResolved)
 
-      -- add edges to required packages
-      void $ Map.traverseWithKey (\reqName reqVer -> edge pkg $ NpmPackage reqName $ getResolvedVersion reqName reqVer) depRequires
+      -- EDGES
+      -- Add edges to packages in "requires"
+      void $
+        Map.traverseWithKey
+          ( \reqName reqVer ->
+              edge pkg $
+                NpmPackage reqName $
+                  getResolvedVersion [depDependencies, packageDependencies packageJson] reqName reqVer
+          )
+          depRequires
+      -- Add edge from parent
+      case parent of
+        Nothing -> pure ()
+        Just parentPkg -> edge parentPkg pkg
 
-      -- add dependency nodes
-      void $ Map.traverseWithKey (maybeAddDep True) depDependencies
+      -- RECURSION
+      -- Recurse to dep nodes
+      void $ Map.traverseWithKey (maybeAddDep True (Just pkg)) depDependencies
 
-    getResolvedVersion :: Text -> Text -> Text
-    getResolvedVersion reqName reqVersion = maybe reqVersion depVersion (Map.lookup reqName $ packageDependencies packageJson)
+    getResolvedVersion :: [Map Text NpmDep] -> Text -> Text -> Text
+    getResolvedVersion lookups reqName reqVersion = maybe reqVersion depVersion foundVersion
+      where
+        foundVersion = asum $ map (Map.lookup reqName) lookups
 
     toDependency :: NpmPackage -> Set NpmPackageLabel -> Dependency
     toDependency pkg = foldr addLabel (start pkg)

--- a/src/Strategy/Node/Npm/PackageLock.hs
+++ b/src/Strategy/Node/Npm/PackageLock.hs
@@ -23,7 +23,7 @@ import Data.Aeson (
   (.:),
   (.:?),
  )
-import Data.Foldable (traverse_, asum)
+import Data.Foldable (asum, traverse_)
 import Data.Functor (void)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map

--- a/test/Node/testdata/nested-deps.json
+++ b/test/Node/testdata/nested-deps.json
@@ -1,0 +1,36 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    }
+  }
+}

--- a/test/Test/Effect.hs
+++ b/test/Test/Effect.hs
@@ -6,8 +6,10 @@ module Test.Effect (
   shouldEndWith',
   shouldContain',
   shouldMatchList',
-  it',
   runTestEffects',
+  it',
+  fit',
+  xit',
 ) where
 
 import Control.Effect.Lift (Has, Lift, sendIO)
@@ -15,6 +17,7 @@ import Test.Hspec (
   Spec,
   SpecWith,
   expectationFailure,
+  fit,
   it,
   runIO,
   shouldBe,
@@ -23,6 +26,7 @@ import Test.Hspec (
   shouldMatchList,
   shouldSatisfy,
   shouldStartWith,
+  xit,
  )
 
 import Control.Carrier.Diagnostics (DiagnosticsC, renderFailureBundle, runDiagnostics)
@@ -37,6 +41,12 @@ type EffectStack a = ExecIOC (ReadFSIOC (DiagnosticsC (IgnoreLoggerC IO))) a
 
 it' :: String -> EffectStack () -> SpecWith ()
 it' msg = it msg . runTestEffects
+
+fit' :: String -> EffectStack () -> SpecWith ()
+fit' msg = fit msg . runTestEffects
+
+xit' :: String -> EffectStack () -> SpecWith ()
+xit' msg = xit msg . runTestEffects
 
 runTestEffects' :: EffectStack () -> Spec
 runTestEffects' = runIO . runTestEffects


### PR DESCRIPTION
# Overview

When a `package-lock.json` has the following structure (simplified for clarity), we were not reporting the edge between `js-yaml` and `argparse 2.0.1`:

```json
{
  "dependencies": {
    "argparse": {
      "version": "1.0.10",
      "requires": {
        "sprintf-js": "~1.0.2"
      }
    },
    "js-yaml": {
      "version": "4.1.0",
      "requires": {
        "argparse": "^2.0.1"
      },
      "dependencies": {
        "argparse": {
          "version": "2.0.1",
        }
      }
    },
    "sprintf-js": {
      "version": "1.0.3",
    }
  }
}
```

This was causing `argparse 2.0.1` to not be reported, since it was then pruned in the `SourceUnit` conversion (it was an orphan node in the graph without that edge).

To resolve this, we carry the parent into the recursive dep analysis, and add an edge when analyzing the child.
When implementing, another oversight was revealed: When adding edges from packages under the `requires` key, we try to detect the package's version from the top-level deps.  Now, we look at the local `dependecies` block first (at the same level of the `requires` that we're currently working on), before falling back to the top-level `dependencies` package list.

## Acceptance criteria

- Tests cover the failing case described in the linked issue
  - Specifically, we test that an edge is created between `js-yaml` and `argparse 2.0.1` in the example above.  This causes `pruneUnreachable` to not delete `argparse 2.0.1`, which would otherwise be an orphan node.
- Tests pass

## Testing plan

Unit testing should be sufficient

## References

Fixes fossas/team-analysis#874

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] ~If this PR introduced a user-visible change, I added documentation into `docs/`.~
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] ~I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).~
- [x] I linked this PR to any referenced GitHub issues, if they exist.
