### PR TITLE
VSI + Dynamic Linking: Resolve dynamic deps to `SourceUnit`

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -176,6 +176,7 @@ library
     App.Fossa.VPS.Test
     App.Fossa.VPS.Types
     App.Fossa.VSI.Analyze
+    App.Fossa.VSI.DynLinked.Internal.Resolve
     App.Fossa.VSI.DynLinked.Types
     App.Fossa.VSI.DynLinked.Util
     App.Fossa.VSI.Fingerprint
@@ -371,6 +372,7 @@ test-suite unit-tests
     App.Fossa.Report.AttributionSpec
     App.Fossa.Report.Log4jReportSpec
     App.Fossa.VPS.NinjaGraphSpec
+    App.Fossa.VSI.DynLinked.Internal.ResolveSpec
     App.Fossa.VSI.DynLinked.UtilSpec
     App.Fossa.VSI.FingerprintSpec
     Cargo.MetadataSpec

--- a/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
@@ -37,7 +37,7 @@ toSourceUnit root dependencies = do
   let (resolved, unresolved) = sortResolvedUnresolved dependencies
   binaries <- traverse (analyzeSingleBinary root) unresolved
 
-  let project = toProject root $ Graphing.fromList (map toDependency resolved)
+  let project = toProject root $ Graphing.directs (map toDependency resolved)
   let unit = Srclib.toSourceUnit False project
   pure $ unit{additionalData = fmap toDepData (Just binaries)}
   where

--- a/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
@@ -24,7 +24,15 @@ import Types (DiscoveredProjectType (VsiProjectType), GraphBreadth (Complete))
 
 -- | Resolves a set of dynamic dependencies into a @SourceUnit@.
 -- Any @DynamicDependency@ that isn't resolved to a Linux package dependency is converted to an unknown binary dependency.
-toSourceUnit :: (Has (Lift IO) sig m, Has Logger sig m, Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> Set DynamicDependency -> m SourceUnit
+toSourceUnit ::
+  ( Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has ReadFS sig m
+  , Has Diagnostics sig m
+  ) =>
+  Path Abs Dir ->
+  Set DynamicDependency ->
+  m SourceUnit
 toSourceUnit root dependencies = do
   let (resolved, unresolved) = sortResolvedUnresolved dependencies
   binaries <- traverse (analyzeSingleBinary root) unresolved

--- a/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
@@ -97,9 +97,6 @@ toDependency ResolvedLinuxPackage{..} = case resolvedLinuxPackageManager of
 -- Whether a dependency is "resolved" is predicated on whether its @dynamicDependencyResolved@ is not @Nothing@.
 -- Dependencies thus sorted are unwrapped into more specific types based on the needs of downstream functions
 -- converting this set of dependencies into a @SourceUnit@.
---
--- This function reverses the order of dependencies for performance reasons,
--- but dependency order isn't significant so we don't reverse it back.
 sortResolvedUnresolved :: Set DynamicDependency -> ([ResolvedLinuxPackage], [Path Abs File])
 sortResolvedUnresolved = partitionEithers . map forkEither . toList
   where

--- a/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.VSI.DynLinked.Internal.Resolve (
+  toSourceUnit,
+  toDependency,
+) where
+
+import App.Fossa.Analyze.Project (ProjectResult (..))
+import App.Fossa.BinaryDeps (analyzeSingleBinary)
+import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Lift)
+import Data.Set (Set, toList)
+import Data.Text (intercalate)
+import DepTypes (DepType (LinuxAPK, LinuxDEB, LinuxRPM), Dependency (..), VerConstraint (CEq))
+import Effect.Logger (Logger)
+import Effect.ReadFS (ReadFS)
+import Graphing qualified
+import Path (Abs, Dir, File, Path)
+import Srclib.Converter qualified as Srclib
+import Srclib.Types (AdditionalDepData (..), SourceUnit (..))
+import Types (DiscoveredProjectType (VsiProjectType), GraphBreadth (Complete))
+
+-- | Resolves a set of dynamic dependencies into a @SourceUnit@.
+-- Any @DynamicDependency@ that isn't resolved to a Linux package dependency is converted to an unknown binary dependency.
+toSourceUnit :: (Has (Lift IO) sig m, Has Logger sig m, Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> Set DynamicDependency -> m SourceUnit
+toSourceUnit root dependencies = do
+  let (resolved, unresolved) = sortResolvedUnresolved dependencies
+  binaries <- traverse (analyzeSingleBinary root) unresolved
+
+  let project = toProject root $ Graphing.fromList (map toDependency resolved)
+  let unit = Srclib.toSourceUnit False project
+  pure $ unit{additionalData = fmap toDepData (Just binaries)}
+  where
+    toDepData d = AdditionalDepData (Just d) Nothing
+    toProject dir graph = ProjectResult VsiProjectType dir graph Complete []
+
+toDependency :: ResolvedLinuxPackage -> Dependency
+toDependency ResolvedLinuxPackage{..} = case resolvedLinuxPackageManager of
+  LinuxPackageManagerDEB -> renderDEB resolvedLinuxPackageMetadata
+  LinuxPackageManagerRPM -> renderRPM resolvedLinuxPackageMetadata
+  LinuxPackageManagerAPK -> renderAPK resolvedLinuxPackageMetadata
+  where
+    render fetcher projectParts revisionParts =
+      Dependency
+        { dependencyType = fetcher
+        , dependencyName = fromParts projectParts
+        , dependencyVersion = Just . CEq $ fromParts revisionParts
+        , dependencyLocations = []
+        , dependencyEnvironments = mempty
+        , dependencyTags = mempty
+        }
+    fromParts = intercalate "#"
+    renderDEB LinuxPackageMetadata{..} =
+      render
+        LinuxDEB
+        [linuxPackageID, linuxPackageDistro, linuxPackageDistroRelease]
+        [linuxPackageArch, linuxPackageRevision]
+    renderRPM LinuxPackageMetadata{..} =
+      render
+        LinuxRPM
+        [linuxPackageID, linuxPackageDistro, linuxPackageDistroRelease]
+        [linuxPackageArch, epoch <> linuxPackageRevision]
+    renderAPK LinuxPackageMetadata{..} =
+      render
+        LinuxAPK
+        [linuxPackageID, linuxPackageDistro, linuxPackageDistroRelease]
+        [linuxPackageArch, linuxPackageRevision]
+    epoch = maybe "" (<> ":") $ linuxPackageDistroEpoch resolvedLinuxPackageMetadata
+
+-- | Sort @Set DynamicDependency@ into two lists: "resolved", and "unresolved", in a single pass.
+--
+-- Whether a dependency is "resolved" is predicated on whether its @dynamicDependencyResolved@ is not @Nothing@.
+-- Dependencies thus sorted are unwrapped into more specific types based on the needs of downstream functions
+-- converting this set of dependencies into a @SourceUnit@.
+--
+-- This function reverses the order of dependencies for performance reasons,
+-- but dependency order isn't significant so we don't reverse it back.
+sortResolvedUnresolved :: Set DynamicDependency -> ([ResolvedLinuxPackage], [Path Abs File])
+sortResolvedUnresolved = buckets [] [] . toList
+  where
+    buckets resolved unresolved [] = (resolved, unresolved)
+    buckets resolved unresolved (dep : remaining) = case dynamicDependencyResolved dep of
+      Nothing -> buckets resolved (dynamicDependencyDiskPath dep : unresolved) remaining
+      Just linuxPackage -> buckets (linuxPackage : resolved) unresolved remaining

--- a/src/App/Fossa/VSI/DynLinked/Types.hs
+++ b/src/App/Fossa/VSI/DynLinked/Types.hs
@@ -2,6 +2,7 @@ module App.Fossa.VSI.DynLinked.Types (
   LinuxPackageManager (..),
   LinuxPackageMetadata (..),
   DynamicDependency (..),
+  ResolvedLinuxPackage (..),
 ) where
 
 import Data.Text (Text)
@@ -15,8 +16,7 @@ data LinuxPackageManager
 -- | These are all opaque blobs, we're not doing any processing on them other than rendering into a @Locator@.
 -- For that reason, stick to @Text@.
 data LinuxPackageMetadata = LinuxPackageMetadata
-  { linuxPackageFetcher :: Text
-  , linuxPackageID :: Text
+  { linuxPackageID :: Text
   , linuxPackageRevision :: Text
   , linuxPackageDistro :: Text
   , linuxPackageDistroRelease :: Text
@@ -24,7 +24,12 @@ data LinuxPackageMetadata = LinuxPackageMetadata
   , linuxPackageDistroEpoch :: Maybe Text
   }
 
+data ResolvedLinuxPackage = ResolvedLinuxPackage
+  { resolvedLinuxPackageManager :: LinuxPackageManager
+  , resolvedLinuxPackageMetadata :: LinuxPackageMetadata
+  }
+
 data DynamicDependency = DynamicDependency
   { dynamicDependencyDiskPath :: Path Abs File
-  , dynamicDependencyResolved :: Maybe (LinuxPackageManager, LinuxPackageMetadata)
+  , dynamicDependencyResolved :: Maybe ResolvedLinuxPackage
   }

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -85,6 +85,12 @@ data DepType
     GooglesourceType
   | -- | Hex registry
     HexType
+  | -- | Linux "apk" registry
+    LinuxAPK
+  | -- | Linux "debian" registry
+    LinuxDEB
+  | -- | Linux "rpm" registry
+    LinuxRPM
   | -- | Maven registry
     MavenType
   | -- | NPM registry (or similar)

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -140,6 +140,9 @@ depTypeToFetcher = \case
   GoType -> "go"
   HackageType -> "hackage"
   HexType -> "hex"
+  LinuxAPK -> "apk"
+  LinuxDEB -> "deb"
+  LinuxRPM -> "rpm-generic"
   MavenType -> "mvn"
   NodeJSType -> "npm"
   NuGetType -> "nuget"
@@ -167,6 +170,9 @@ fetcherToDepType fetcher | depTypeToFetcher GitType == fetcher = Just GitType
 fetcherToDepType fetcher | depTypeToFetcher GoType == fetcher = Just GoType
 fetcherToDepType fetcher | depTypeToFetcher HackageType == fetcher = Just HackageType
 fetcherToDepType fetcher | depTypeToFetcher HexType == fetcher = Just HexType
+fetcherToDepType fetcher | depTypeToFetcher LinuxAPK == fetcher = Just LinuxAPK
+fetcherToDepType fetcher | depTypeToFetcher LinuxDEB == fetcher = Just LinuxDEB
+fetcherToDepType fetcher | depTypeToFetcher LinuxRPM == fetcher = Just LinuxRPM
 fetcherToDepType fetcher | depTypeToFetcher MavenType == fetcher = Just MavenType
 fetcherToDepType fetcher | depTypeToFetcher NodeJSType == fetcher = Just NodeJSType
 fetcherToDepType fetcher | depTypeToFetcher NuGetType == fetcher = Just NuGetType

--- a/test/App/Fossa/VSI/DynLinked/Internal/ResolveSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/ResolveSpec.hs
@@ -1,0 +1,36 @@
+module App.Fossa.VSI.DynLinked.Internal.ResolveSpec (spec) where
+
+import App.Fossa.VSI.DynLinked.Internal.Resolve (toDependency)
+import App.Fossa.VSI.DynLinked.Types (LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
+import Data.Text (Text)
+import DepTypes (DepType (..), Dependency (..), VerConstraint (CEq))
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = do
+  describe "resolves linux dependencies to srclib dependencies" $ do
+    it "resolves apk" $ do
+      let original = ResolvedLinuxPackage LinuxPackageManagerAPK placeholderMeta
+      let expected = Dependency LinuxAPK "id#distro#release" (Just $ CEq "arch#revision") [] mempty mempty
+      toDependency original `shouldBe` expected
+
+    it "resolves debian" $ do
+      let original = ResolvedLinuxPackage LinuxPackageManagerDEB placeholderMeta
+      let expected = Dependency LinuxDEB "id#distro#release" (Just $ CEq "arch#revision") [] mempty mempty
+      toDependency original `shouldBe` expected
+
+    it "resolves rpm with epoch" $ do
+      let original = ResolvedLinuxPackage LinuxPackageManagerRPM placeholderMeta
+      let expected = Dependency LinuxRPM "id#distro#release" (Just $ CEq "arch#epoch:revision") [] mempty mempty
+      toDependency original `shouldBe` expected
+
+    it "resolves rpm without epoch" $ do
+      let original = ResolvedLinuxPackage LinuxPackageManagerRPM $ baseMeta Nothing
+      let expected = Dependency LinuxRPM "id#distro#release" (Just $ CEq "arch#revision") [] mempty mempty
+      toDependency original `shouldBe` expected
+
+placeholderMeta :: LinuxPackageMetadata
+placeholderMeta = baseMeta (Just "epoch")
+
+baseMeta :: Maybe Text -> LinuxPackageMetadata
+baseMeta = LinuxPackageMetadata "id" "revision" "distro" "release" "arch"


### PR DESCRIPTION
# Overview

Provides the ability to resolve dynamic dependencies into a `SourceUnit`.

_I'm leaving this PR out of the changelog as it's literally irrelevant for users; I'll include this PR in a merged changelog message when I'm done (if anyone disagrees let me know!)_

## Acceptance criteria

We now have the ability to resolve dynamic dependencies obtained by inspecting the local package manager into a `SourceUnit` that'll be reported to FOSSA.

## Testing plan

I relied on automated testing.

## Risks

None

## References

Closes https://github.com/fossas/team-analysis/issues/882

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
