### PR TITLE
use new filters, kill timeout

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -34,10 +34,10 @@ jobs:
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: |
-          fossa analyze --filter cabal@.
+          fossa analyze --only-target cabal
 
       - name: Check for scan results
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: |
-          fossa test --timeout 1800
+          fossa test


### PR DESCRIPTION
# Overview

Update `dependency_scan` workflow to use the new filter method, and to use the default timeout (we really don't need a special timeout).

## Acceptance criteria

- CI works.
- No warning for deprecated filters during `fossa-test`

## Testing plan

Monitoring GH actions logs
