### PR TITLE
Settings gradle detection

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Npm: Fixes an issue where a package-lock.json dep with a boolean 'resolved' key wouldn't parse. ([#775](https://github.com/fossas/fossa-cli/pull/775))
 - Npm: Fixes an issue where analyzing `package-lock.json` would miss duplicate packages with different versions. ([#779](https://github.com/fossas/fossa-cli/pull/779))
+- Gradle: Projects with only a top-level `settings.gradle` file will now be detected. ([#785](https://github.com/fossas/fossa-cli/pull/785))
 
 ## v3.0.16
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Fossa CLI Changelog
 
-## Unreleased
+## v3.0.17
 
 - Npm: Fixes an issue where a package-lock.json dep with a boolean 'resolved' key wouldn't parse. ([#775](https://github.com/fossas/fossa-cli/pull/775))
 - Npm: Fixes an issue where analyzing `package-lock.json` would miss duplicate packages with different versions. ([#779](https://github.com/fossas/fossa-cli/pull/779))

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Npm: Fixes an issue where a package-lock.json dep with a boolean 'resolved' key wouldn't parse. ([#718](https://github.com/fossas/fossa-cli/issues/718))
+- Npm: Fixes an issue where a package-lock.json dep with a boolean 'resolved' key wouldn't parse. ([#775](https://github.com/fossas/fossa-cli/pull/775))
 - Npm: Fixes an issue where analyzing `package-lock.json` would miss duplicate packages with different versions. ([#779](https://github.com/fossas/fossa-cli/pull/779))
 
 ## v3.0.16

--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -2,7 +2,7 @@
 
 [Gradle](https://gradle.org/) is a polyglot tool mostly used by JVM projects. It's popular with Java and Android projects.
 
-Gradle users generally specify their builds using a `build.gradle` file (written in Groovy) or a `build.gradle.kts` file (written in Kotlin). These builds are specified as programs that must be dynamically evaluated.
+Gradle users generally specify their builds using a `build.gradle`/`settings.gradle` file (written in Groovy) or a `build.gradle.kts`/`settings.gradle.kts` file (written in Kotlin). These builds are specified as programs that must be dynamically evaluated. Examples of many different kinds of `gradle` projects are distributed on Gradle's website or for older versions of Gradle in the "complete" release archive in the `examples/` directory.
 
 |           |                                                                           |
 | --------- | ------------------------------------------------------------------------- |
@@ -41,7 +41,7 @@ Most sizable Gradle builds organize their dependencies with two concepts: subpro
 
 #### Subprojects
 
-_Subprojects_ are used when you have multiple "projects" in a single Gradle build (e.g. having multiple projects in a single repository managed by with single `settings.gradle` and one or more `build.gradle` files). Gradle calls these "multi-projects". Gradle multi-projects have one root project, and one or more subprojects.
+_Subprojects_ are used when you have multiple "projects" in a single Gradle build (e.g. having multiple projects in a single repository managed by with single `settings.gradle` and zero or more `build.gradle` files). Gradle calls these "multi-projects". Gradle multi-projects have one root project, and one or more subprojects.
 
 A single subproject roughly corresponds to a single set of outputs. Hence, we treat subprojects as separate analysis targets.
 
@@ -73,7 +73,7 @@ Because of this, the Gradle analyzer has logic for selecting which `gradle` exec
 
 ## Running Gradle
 
-This strategy requires dynamic analysis in its discovery phase (not just in the analysis phase). This is because we need to execute Gradle in order to list subprojects and evaluate `build.gradle` files.
+This strategy requires dynamic analysis in its discovery phase (not just in the analysis phase). This is because we need to execute Gradle in order to list subprojects and evaluate `build.gradle` or `settings.gradle` files.
 
 When executing Gradle for an analysis target at directory `ANALYSIS_TARGET_DIR`, the CLI will prefer (in order):
 
@@ -87,7 +87,7 @@ In this documentation below, for brevity, we'll always refer to the selected too
 
 ## Discovery
 
-This strategy discovers analysis targets by looking for files in the folder being analyzed whose names start with `build.gradle`. This matches both `build.gradle` as well as `build.gradle.kts` and Gradle build scripts in other Gradle-supported languages (`build.gradle.*`).
+This strategy discovers analysis targets by looking for files in the folder being analyzed whose names start with `build.gradle` or `settings.gradle`. This matches any of `build.gradle`, or `settings.gradle` and Gradle build scripts in other Gradle-supported languages (`build.gradle.*`, `settings.gradle.*`).
 
 It then executes `gradle projects` in the directory where the build file is found to get a list of subprojects for this Gradle build. These subprojects are used to create the analysis targets for this Gradle build.
 

--- a/hie.yaml
+++ b/hie.yaml
@@ -6,3 +6,5 @@ cradle:
       component: "lib:spectrometer"
     - path: "./test"
       component: "test:unit-tests"
+    - path: "./integration-test"
+      component: "test:integration-tests"

--- a/integration-test/Analysis/FixtureUtils.hs
+++ b/integration-test/Analysis/FixtureUtils.hs
@@ -25,7 +25,7 @@ import Data.Conduit (runConduitRes, (.|))
 import Data.Conduit.Binary qualified as CB
 import Data.Function ((&))
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Discovery.Archive (selectUnarchiver)
 import Effect.Exec (
   Command (..),

--- a/integration-test/Analysis/FixtureUtils.hs
+++ b/integration-test/Analysis/FixtureUtils.hs
@@ -25,8 +25,8 @@ import Data.Conduit (runConduitRes, (.|))
 import Data.Conduit.Binary qualified as CB
 import Data.Function ((&))
 import Data.Text (Text)
-import Data.Text qualified as Text
-import Discovery.Archive (extractTarGz)
+import qualified Data.Text as Text
+import Discovery.Archive (selectUnarchiver)
 import Effect.Exec (
   Command (..),
   ExecF (Exec),
@@ -42,16 +42,29 @@ import Network.HTTP.Req (
   NoReqBody (NoReqBody),
   Url,
   defaultHttpConfig,
+  renderUrl,
   reqBr,
   runReq,
   useHttpsURI,
  )
 import Network.HTTP.Req.Conduit (responseBodySource)
-import Path
+import Path (
+  Abs,
+  Dir,
+  File,
+  Path,
+  Rel,
+  reldir,
+  toFilePath,
+  (</>),
+ )
 import Path.IO qualified as PIO
 import System.Directory.Internal.Prelude (Handle, hClose)
 import Text.URI (mkURI)
-import Types
+import Types (
+  DependencyResults,
+  DiscoveredProject (projectBuildTargets, projectData),
+ )
 
 analysisIntegrationCaseFixtureDir :: Path Rel Dir
 analysisIntegrationCaseFixtureDir = [reldir|integration-test/artifacts/|]
@@ -140,7 +153,6 @@ getArtifact :: Has (Lift IO) sig m => FixtureArtifact -> m (Path Abs Dir)
 getArtifact target = sendIO $ do
   -- Ensure parent directory for fixture exists
   PIO.ensureDir analysisIntegrationCaseFixtureDir
-  let artifactUrl = tarGzFileUrl target
   let archiveExtractionDir = analysisIntegrationCaseFixtureDir </> extractAt target
 
   PIO.ensureDir archiveExtractionDir
@@ -149,9 +161,12 @@ getArtifact target = sendIO $ do
   case resolvedUrl of
     Nothing -> fail ("could not be resolved, artifact's download url: " <> show artifactUrl)
     Just (url, _) -> do
-      PIO.withTempFile (analysisIntegrationCaseFixtureDir) "artifact" (downloadAndExtractArtifact url archiveExtractionDir)
+      res <- PIO.withTempFile (analysisIntegrationCaseFixtureDir) "artifact" (downloadAndExtractArtifact url archiveExtractionDir)
+      either fail pure res
   where
-    downloadAndExtractArtifact :: Url a -> Path Rel Dir -> Path Abs File -> Handle -> IO (Path Abs Dir)
+    artifactUrl = tarGzFileUrl target
+
+    downloadAndExtractArtifact :: Url a -> Path Rel Dir -> Path Abs File -> Handle -> IO (Either String (Path Abs Dir))
     downloadAndExtractArtifact url extractionTarget tempFile tempFileHandle = do
       _ <- runReq defaultHttpConfig $
         reqBr GET url NoReqBody mempty $
@@ -161,7 +176,10 @@ getArtifact target = sendIO $ do
 
       sendIO $ PIO.ensureDir extractionTarget
       archiveExtractFolder <- sendIO $ PIO.makeAbsolute extractionTarget
-      sendIO $ extractTarGz archiveExtractFolder tempFile
 
-      PIO.removeFile tempFile
-      pure archiveExtractFolder
+      let urlStr = Text.unpack . renderUrl $ url
+      case selectUnarchiver urlStr of
+        Nothing -> pure . Left $ "Failed to extract file from " <> urlStr
+        Just extractor -> do
+          sendIO $ extractor archiveExtractFolder tempFile
+          pure . Right $ archiveExtractFolder

--- a/integration-test/Analysis/GradleSpec.hs
+++ b/integration-test/Analysis/GradleSpec.hs
@@ -13,7 +13,7 @@ import Analysis.FixtureUtils (
   FixtureArtifact (FixtureArtifact),
   FixtureEnvironment (NixEnv),
  )
-import Path (mkRelDir, reldir)
+import Path (reldir)
 import Strategy.Gradle qualified as Gradle
 import Test.Hspec (Spec, aroundAll, describe, it, shouldBe)
 import Types (DiscoveredProjectType (..))
@@ -31,7 +31,7 @@ springBoot =
     $ FixtureArtifact
       "https://github.com/spring-projects/spring-boot/archive/refs/tags/v3.0.0-M1.tar.gz"
       [reldir|gradle/sample/|]
-      $(mkRelDir "spring-boot-3.0.0-M1")
+      [reldir|spring-boot-3.0.0-M1|]
 
 gradleSettingsOnly :: AnalysisTestFixture (Gradle.GradleProject)
 gradleSettingsOnly =

--- a/integration-test/Analysis/GradleSpec.hs
+++ b/integration-test/Analysis/GradleSpec.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Analysis.GradleSpec (spec) where
+
+import Analysis.FixtureExpectationUtils (
+  expectProject,
+  withAnalysisOf,
+ )
+import Analysis.FixtureUtils (
+  AnalysisTestFixture (AnalysisTestFixture),
+  FixtureArtifact (FixtureArtifact),
+  FixtureEnvironment (NixEnv),
+ )
+import Path (mkRelDir, reldir)
+import Strategy.Gradle qualified as Gradle
+import Test.Hspec (Spec, aroundAll, describe, it, shouldBe)
+import Types (DiscoveredProjectType (..))
+
+goEnv :: FixtureEnvironment
+goEnv = NixEnv ["gradle"]
+
+springBoot :: AnalysisTestFixture (Gradle.GradleProject)
+springBoot =
+  AnalysisTestFixture
+    "gradle-java"
+    Gradle.discover
+    goEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/spring-projects/spring-boot/archive/refs/tags/v3.0.0-M1.tar.gz"
+      [reldir|gradle/sample/|]
+      $(mkRelDir "spring-boot-3.0.0-M1")
+
+gradleSettingsOnly :: AnalysisTestFixture (Gradle.GradleProject)
+gradleSettingsOnly =
+  AnalysisTestFixture
+    "gradle-java"
+    Gradle.discover
+    goEnv
+    Nothing
+    $ FixtureArtifact
+      "https://docs.gradle.org/current/samples/zips/sample_building_java_applications-groovy-dsl.zip"
+      [reldir|gradle/sample/|]
+      [reldir|.|]
+
+testSpringBoot :: Spec
+testSpringBoot =
+  aroundAll (withAnalysisOf springBoot) $ do
+    describe "gradle-java" $ do
+      it "should find targets" $ \(result, extractedDir) -> do
+        expectProject (GradleProjectType, extractedDir) result
+        length result `shouldBe` 1
+
+testGradleSettingsOnly :: Spec
+testGradleSettingsOnly =
+  aroundAll (withAnalysisOf gradleSettingsOnly) $ do
+    describe "gradle-java" $ do
+      it "should find targets" $ \(result, extractedDir) -> do
+        expectProject (GradleProjectType, extractedDir) result
+        length result `shouldBe` 1
+
+spec :: Spec
+spec = do
+  testSpringBoot
+  testGradleSettingsOnly

--- a/integration-test/Analysis/GradleSpec.hs
+++ b/integration-test/Analysis/GradleSpec.hs
@@ -17,15 +17,15 @@ import Strategy.Gradle qualified as Gradle
 import Test.Hspec (Spec, aroundAll, describe, it, shouldBe)
 import Types (DiscoveredProjectType (..))
 
-goEnv :: FixtureEnvironment
-goEnv = NixEnv ["gradle"]
+gradleEnv :: FixtureEnvironment
+gradleEnv = NixEnv ["gradle"]
 
 springBoot :: AnalysisTestFixture (Gradle.GradleProject)
 springBoot =
   AnalysisTestFixture
     "gradle-java"
     Gradle.discover
-    goEnv
+    gradleEnv
     Nothing
     $ FixtureArtifact
       "https://github.com/spring-projects/spring-boot/archive/refs/tags/v3.0.0-M1.tar.gz"
@@ -37,10 +37,10 @@ gradleSettingsOnly =
   AnalysisTestFixture
     "gradle-java"
     Gradle.discover
-    goEnv
+    gradleEnv
     Nothing
     $ FixtureArtifact
-      "https://docs.gradle.org/current/samples/zips/sample_building_java_applications-groovy-dsl.zip"
+      "https://docs.gradle.org/7.3.3/samples/zips/sample_building_java_applications-groovy-dsl.zip"
       [reldir|gradle/sample/|]
       [reldir|.|]
 

--- a/integration-test/Analysis/GradleSpec.hs
+++ b/integration-test/Analysis/GradleSpec.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Analysis.GradleSpec (spec) where
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -474,6 +474,7 @@ test-suite integration-tests
     Analysis.FixtureExpectationUtils
     Analysis.FixtureUtils
     Analysis.GoSpec
+    Analysis.GradleSpec
     Analysis.MavenSpec
     Analysis.NugetSpec
     Analysis.Python.PipenvSpec

--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -58,7 +58,7 @@ walk f = walkDir $ \dir subdirs files -> do
     WalkSkipAll -> pure $ WalkExclude subdirs
     WalkStop -> pure WalkFinish
 
--- Like @walk@, but collects the output of @f@ in a monoid.
+-- |Like @walk@, but collects the output of @f@ in a monoid.
 walk' ::
   forall o sig m.
   (Has ReadFS sig m, Has Diagnostics sig m, Monoid o) =>

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -15,6 +15,7 @@
 -- - Gradle init scripts: https://docs.gradle.org/current/userguide/init_scripts.html
 module Strategy.Gradle (
   discover,
+  GradleProject,
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeExperimentalPreferences (..), AnalyzeProject, analyzeProject)


### PR DESCRIPTION
# Overview

In newer versions of gradle, there may only be a `settings.gradle` file in a project root directory. We would not be able to discover subprojects in this case and would report no dependencies. 

## Acceptance criteria

Detect when a project has a top-level file starting with `settings.gradle` without a `build.gradle` and also run discovery.

## Testing plan

I tested with some sample repositories that had `settings.gradle` only in their root directories. These included projects in Java/Kotlin. I also wrote an integration test which tests both a real repository (spring-boot) with both files in its root and one of the samples with only `settings.gradle`.

[This](https://docs.gradle.org/7.3.3/samples/zips/sample_building_java_applications-groovy-dsl.zip) project will fail currently on master. On this branch it succeeds and reports dependencies.

## Risks

_Highlight any areas that you're unsure of, or want reviewers to pay particular attention to._

As part of the integration testing I extended some code in `TestFixtureUtils.hs` to support more archive formats than just `.tar.gz`. Please look at how it detects which extraction function to use and also how it reports errors.

## References

Closes fossas/team-analysis#846

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
