### PR TITLE
VSI + Dynamic Linking: lookup linux packages

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -177,6 +177,7 @@ library
     App.Fossa.VPS.Types
     App.Fossa.VSI.Analyze
     App.Fossa.VSI.DynLinked.Internal.Binary
+    App.Fossa.VSI.DynLinked.Internal.Lookup
     App.Fossa.VSI.DynLinked.Internal.Lookup.APK
     App.Fossa.VSI.DynLinked.Internal.Lookup.DEB
     App.Fossa.VSI.DynLinked.Internal.Lookup.RPM

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -177,6 +177,7 @@ library
     App.Fossa.VPS.Types
     App.Fossa.VSI.Analyze
     App.Fossa.VSI.DynLinked.Internal.Binary
+    App.Fossa.VSI.DynLinked.Internal.Lookup.DEB
     App.Fossa.VSI.DynLinked.Internal.Lookup.RPM
     App.Fossa.VSI.DynLinked.Internal.Resolve
     App.Fossa.VSI.DynLinked.Types
@@ -375,6 +376,7 @@ test-suite unit-tests
     App.Fossa.Report.Log4jReportSpec
     App.Fossa.VPS.NinjaGraphSpec
     App.Fossa.VSI.DynLinked.Internal.BinarySpec
+    App.Fossa.VSI.DynLinked.Internal.Lookup.DEBSpec
     App.Fossa.VSI.DynLinked.Internal.Lookup.RPMSpec
     App.Fossa.VSI.DynLinked.Internal.ResolveSpec
     App.Fossa.VSI.DynLinked.UtilSpec

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -177,6 +177,7 @@ library
     App.Fossa.VPS.Types
     App.Fossa.VSI.Analyze
     App.Fossa.VSI.DynLinked.Internal.Binary
+    App.Fossa.VSI.DynLinked.Internal.Lookup.RPM
     App.Fossa.VSI.DynLinked.Internal.Resolve
     App.Fossa.VSI.DynLinked.Types
     App.Fossa.VSI.DynLinked.Util
@@ -374,6 +375,7 @@ test-suite unit-tests
     App.Fossa.Report.Log4jReportSpec
     App.Fossa.VPS.NinjaGraphSpec
     App.Fossa.VSI.DynLinked.Internal.BinarySpec
+    App.Fossa.VSI.DynLinked.Internal.Lookup.RPMSpec
     App.Fossa.VSI.DynLinked.Internal.ResolveSpec
     App.Fossa.VSI.DynLinked.UtilSpec
     App.Fossa.VSI.FingerprintSpec

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -177,6 +177,7 @@ library
     App.Fossa.VPS.Types
     App.Fossa.VSI.Analyze
     App.Fossa.VSI.DynLinked.Internal.Binary
+    App.Fossa.VSI.DynLinked.Internal.Lookup.APK
     App.Fossa.VSI.DynLinked.Internal.Lookup.DEB
     App.Fossa.VSI.DynLinked.Internal.Lookup.RPM
     App.Fossa.VSI.DynLinked.Internal.Resolve
@@ -376,6 +377,7 @@ test-suite unit-tests
     App.Fossa.Report.Log4jReportSpec
     App.Fossa.VPS.NinjaGraphSpec
     App.Fossa.VSI.DynLinked.Internal.BinarySpec
+    App.Fossa.VSI.DynLinked.Internal.Lookup.APKSpec
     App.Fossa.VSI.DynLinked.Internal.Lookup.DEBSpec
     App.Fossa.VSI.DynLinked.Internal.Lookup.RPMSpec
     App.Fossa.VSI.DynLinked.Internal.ResolveSpec

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup.hs
@@ -1,0 +1,11 @@
+module App.Fossa.VSI.DynLinked.Internal.Lookup (
+  dynamicDependencies,
+) where
+
+import App.Fossa.VSI.DynLinked.Types (DynamicDependency, ResolvedLinuxPackage)
+import Data.Set (Set, empty, toList)
+import Path (Abs, File, Path)
+import System.Info qualified as SysInfo
+
+dynamicDependencies :: Monad m => Set (Path Abs File) -> m (Set DynamicDependency)
+dynamicDependencies files = undefined

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup.hs
@@ -2,12 +2,13 @@ module App.Fossa.VSI.DynLinked.Internal.Lookup (
   dynamicDependencies,
 ) where
 
-import App.Fossa.VSI.DynLinked.Internal.Lookup.APK qualified as APK
-import App.Fossa.VSI.DynLinked.Internal.Lookup.DEB qualified as DEB
-import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM qualified as RPM
+import App.Fossa.VSI.DynLinked.Internal.Lookup.APK (APKLookupTable, apkTactic, buildLookupTable)
+import App.Fossa.VSI.DynLinked.Internal.Lookup.DEB (debTactic)
+import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM (rpmTactic)
 import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..))
 import Control.Algebra (Has)
-import Control.Effect.Diagnostics (Diagnostics)
+import Control.Applicative ((<|>))
+import Control.Effect.Diagnostics (Diagnostics, (<||>))
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Effect.Exec (Exec)
@@ -24,43 +25,17 @@ dynamicDependencies ::
   Set (Path Abs File) ->
   -- Resulting dependencies.
   m (Set DynamicDependency)
-dynamicDependencies root files = Set.fromList <$> resolveFiles root strategies (Set.toList files) []
+dynamicDependencies root files = do
+  apkLookupTable <- buildLookupTable root
+  resolved <- traverse (resolveFile apkLookupTable root) $ Set.toList files
+  pure $ Set.fromList resolved
 
--- | Resolve all the files into dynamic dependencies by recursively applying strategies until all files are resolved.
-resolveFiles ::
-  ( Has Diagnostics sig m
-  , Has Exec sig m
-  ) =>
-  -- The scan root.
-  Path Abs Dir ->
-  -- The list of strategies which resolve files.
-  [(Path Abs Dir -> [Path Abs File] -> m ([Path Abs File], [DynamicDependency]))] ->
-  -- The files to resolve.
-  [Path Abs File] ->
-  -- The working set of resolved dependencies by previous strategies.
-  [DynamicDependency] ->
-  -- Resulting dependencies.
-  m [DynamicDependency]
--- We're out of files to resolve.
--- They were reversed during the function for performance, so put them back in the correct order.
-resolveFiles _ _ [] resolved = pure $ reverse resolved
--- We're out of resolvers, but still have files since the above pattern didn't match.
--- Resolve remaining files with @strategyRawFingerprint@.
-resolveFiles root [] files resolved = resolveFiles root [] [] $ fmap strategyRawFingerprint files ++ resolved
--- We have a strategy! Resolve as many files as we can with it and move on.
-resolveFiles root (resolve : remainingStrategies) files resolved = do
-  (remainingFiles, newlyResolved) <- resolve root files
-  resolveFiles root remainingStrategies remainingFiles $ newlyResolved ++ resolved
+resolveFile :: (Has Diagnostics sig m, Has Exec sig m) => Maybe APKLookupTable -> Path Abs Dir -> Path Abs File -> m DynamicDependency
+resolveFile table root file = do
+  resolved <- rpmTactic root file <||> debTactic root file
+  case resolved <|> apkTactic table file of
+    Nothing -> pure $ fallbackTactic file
+    Just result -> pure result
 
--- | Functions which may be able to resolve a binary to a dependency.
-strategies :: (Has Diagnostics sig m, Has Exec sig m) => [(Path Abs Dir -> [Path Abs File] -> m ([Path Abs File], [DynamicDependency]))]
-strategies =
-  [ RPM.lookupDependencies
-  , DEB.lookupDependencies
-  , APK.lookupDependencies
-  ]
-
--- | Fallback strategy: resolve to a binary dependency for the binary.
--- This strategy is used if no other strategy succeeds at resolving the path.
-strategyRawFingerprint :: Path Abs File -> DynamicDependency
-strategyRawFingerprint file = DynamicDependency file Nothing
+fallbackTactic :: Path Abs File -> DynamicDependency
+fallbackTactic file = DynamicDependency file Nothing

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup.hs
@@ -2,10 +2,65 @@ module App.Fossa.VSI.DynLinked.Internal.Lookup (
   dynamicDependencies,
 ) where
 
-import App.Fossa.VSI.DynLinked.Types (DynamicDependency, ResolvedLinuxPackage)
-import Data.Set (Set, empty, toList)
-import Path (Abs, File, Path)
-import System.Info qualified as SysInfo
+import App.Fossa.VSI.DynLinked.Internal.Lookup.APK qualified as APK
+import App.Fossa.VSI.DynLinked.Internal.Lookup.DEB qualified as DEB
+import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM qualified as RPM
+import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..))
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Effect.Exec (Exec)
+import Path (Abs, Dir, File, Path)
 
-dynamicDependencies :: Monad m => Set (Path Abs File) -> m (Set DynamicDependency)
-dynamicDependencies files = undefined
+-- | Resolve the provided file paths, which represent dynamic dependencies of a binary, into a set of @DynamicDependency@.
+dynamicDependencies ::
+  ( Has Diagnostics sig m
+  , Has Exec sig m
+  ) =>
+  -- The scan root.
+  Path Abs Dir ->
+  -- The files to resolve.
+  Set (Path Abs File) ->
+  -- Resulting dependencies.
+  m (Set DynamicDependency)
+dynamicDependencies root files = Set.fromList <$> resolveFiles root strategies (Set.toList files) []
+
+-- | Resolve all the files into dynamic dependencies by recursively applying strategies until all files are resolved.
+resolveFiles ::
+  ( Has Diagnostics sig m
+  , Has Exec sig m
+  ) =>
+  -- The scan root.
+  Path Abs Dir ->
+  -- The list of strategies which resolve files.
+  [(Path Abs Dir -> [Path Abs File] -> m ([Path Abs File], [DynamicDependency]))] ->
+  -- The files to resolve.
+  [Path Abs File] ->
+  -- The working set of resolved dependencies by previous strategies.
+  [DynamicDependency] ->
+  -- Resulting dependencies.
+  m [DynamicDependency]
+-- We're out of files to resolve.
+-- They were reversed during the function for performance, so put them back in the correct order.
+resolveFiles _ _ [] resolved = pure $ reverse resolved
+-- We're out of resolvers, but still have files since the above pattern didn't match.
+-- Resolve remaining files with @strategyRawFingerprint@.
+resolveFiles root [] files resolved = resolveFiles root [] [] $ fmap strategyRawFingerprint files ++ resolved
+-- We have a strategy! Resolve as many files as we can with it and move on.
+resolveFiles root (resolve : remainingStrategies) files resolved = do
+  (remainingFiles, newlyResolved) <- resolve root files
+  resolveFiles root remainingStrategies remainingFiles $ newlyResolved ++ resolved
+
+-- | Functions which may be able to resolve a binary to a dependency.
+strategies :: (Has Diagnostics sig m, Has Exec sig m) => [(Path Abs Dir -> [Path Abs File] -> m ([Path Abs File], [DynamicDependency]))]
+strategies =
+  [ RPM.lookupDependencies
+  , DEB.lookupDependencies
+  , APK.lookupDependencies
+  ]
+
+-- | Fallback strategy: resolve to a binary dependency for the binary.
+-- This strategy is used if no other strategy succeeds at resolving the path.
+strategyRawFingerprint :: Path Abs File -> DynamicDependency
+strategyRawFingerprint file = DynamicDependency file Nothing

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup/APK.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup/APK.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
+
+module App.Fossa.VSI.DynLinked.Internal.Lookup.APK (
+  lookupDependencies,
+  constructLookupTables,
+  tryLookup,
+  SyftData (..),
+  SyftArtifact (..),
+  SyftArtifactMetadata (..),
+  SyftArtifactMetadataFile (..),
+  SyftLookupTable (..),
+) where
+
+import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxDistro, LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
+import App.Fossa.VSI.DynLinked.Util (runningLinux)
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics, fatalText)
+import Control.Monad (join)
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT), runMaybeT)
+import Data.Aeson (FromJSON, Result (Error, Success), ToJSON, Value, fromJSON, object, parseJSON, toJSON, withObject, (.:), (.=))
+import Data.Either (partitionEithers)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.String.Conversion (toText)
+import Data.Text (Text)
+import Effect.Exec (AllowErr (Never), Command (..), Exec, execJson)
+import Path (Abs, Dir, File, Path)
+
+-- | The idea here is that we look up what paths we can with apt and turn them into @DynamicDependency@.
+-- We then hand back leftovers and lookup results for the next resolution function.
+lookupDependencies :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> LinuxDistro -> [Path Abs File] -> m ([Path Abs File], [DynamicDependency])
+lookupDependencies _ _ files | not runningLinux = pure (files, [])
+lookupDependencies root distro files = do
+  syft <- runSyft root
+  table <- constructLookupTables syft
+  partitionEithers <$> traverse (tryLookup table distro) files
+
+tryLookup :: (Has Diagnostics sig m) => SyftLookupTable -> LinuxDistro -> Path Abs File -> m (Either (Path Abs File) DynamicDependency)
+tryLookup SyftLookupTable{..} distro file = fmap (maybeToRight file) . runMaybeT $ do
+  index <- MaybeT . pure $ Map.lookup file pathToIndex
+  meta <- MaybeT . pure $ Map.lookup index indexToMeta
+  pure . DynamicDependency file . Just $ ResolvedLinuxPackage LinuxPackageManagerRPM distro meta
+
+-- | The output of the syft binary
+newtype SyftData = SyftData
+  { syftArtifacts :: [SyftArtifact]
+  }
+  deriving (Eq, Show)
+
+instance FromJSON SyftData where
+  parseJSON = withObject "SyftData" $ \obj ->
+    SyftData . filter artifactIsOk <$> obj .: "artifacts"
+
+data SyftArtifact = SyftArtifact
+  { artifactName :: Text
+  , artifactVersion :: Text
+  , artifactType :: Text
+  , artifactMetadataType :: Text
+  , -- We may run this on systems containing packages whose type we don't handle.
+    -- Delay parsing the metadata until it is required.
+    artifactMetadata :: Value
+  }
+  deriving (Eq, Show)
+
+instance FromJSON SyftArtifact where
+  parseJSON = withObject "SyftArtifact" $ \obj ->
+    SyftArtifact <$> obj .: "name"
+      <*> obj .: "version"
+      <*> obj .: "type"
+      <*> obj .: "metadataType"
+      <*> obj .: "metadata"
+
+data SyftArtifactMetadata = SyftArtifactMetadata
+  { metadataArchitecture :: Text
+  , metadataFiles :: [SyftArtifactMetadataFile]
+  }
+  deriving (Eq, Show)
+
+instance FromJSON SyftArtifactMetadata where
+  parseJSON = withObject "SyftArtifactMetadata" $ \obj ->
+    SyftArtifactMetadata <$> obj .: "architecture"
+      <*> obj .: "files"
+
+instance ToJSON SyftArtifactMetadata where
+  toJSON SyftArtifactMetadata{..} =
+    object
+      [ "architecture" .= metadataArchitecture
+      , "files" .= metadataFiles
+      ]
+
+newtype SyftArtifactMetadataFile = SyftArtifactMetadataFile
+  { metadataFilePath :: Path Abs File
+  }
+  deriving (Eq, Show)
+
+instance FromJSON SyftArtifactMetadataFile where
+  parseJSON = withObject "SyftArtifactMetadataFile" $ \obj ->
+    SyftArtifactMetadataFile <$> obj .: "path"
+
+instance ToJSON SyftArtifactMetadataFile where
+  toJSON SyftArtifactMetadataFile{..} = object ["path" .= metadataFilePath]
+
+artifactIsOk :: SyftArtifact -> Bool
+artifactIsOk SyftArtifact{..} = artifactType == "apk" && artifactMetadataType == "ApkMetadata"
+
+runSyft :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> m SyftData
+runSyft root = execJson root syftCommand
+
+syftCommand :: Command
+syftCommand =
+  Command
+    { cmdName = "syft"
+    , cmdArgs = ["/", "-o", "json"]
+    , cmdAllowErr = Never
+    }
+
+-- | Multiple file paths can point to the same metadata.
+data SyftLookupTable = SyftLookupTable
+  { pathToIndex :: Map (Path Abs File) Word
+  , indexToMeta :: Map Word LinuxPackageMetadata
+  }
+  deriving (Eq, Show)
+
+constructLookupTables :: (Has Diagnostics sig m) => SyftData -> m SyftLookupTable
+constructLookupTables SyftData{syftArtifacts} = do
+  tables <- traverse construct $ zip [0 ..] syftArtifacts
+  let (lookupTable, metadataTable) = flattenConstructed tables
+  pure $ SyftLookupTable (Map.fromList lookupTable) (Map.fromList metadataTable)
+  where
+    construct :: (Has Diagnostics sig m) => (Word, SyftArtifact) -> m ([(Path Abs File, Word)], (Word, LinuxPackageMetadata))
+    construct (index, artifact@SyftArtifact{artifactMetadata}) = do
+      syftMeta <- fatalParse $ fromJSON artifactMetadata
+      pure (lookupTableEntries index syftMeta, fromSyft index artifact syftMeta)
+
+    lookupTableEntries :: Word -> SyftArtifactMetadata -> [(Path Abs File, Word)]
+    lookupTableEntries index = fmap ((,index) . metadataFilePath) . metadataFiles
+
+    fromSyft :: Word -> SyftArtifact -> SyftArtifactMetadata -> (Word, LinuxPackageMetadata)
+    fromSyft index artifact metadata =
+      ( index
+      , LinuxPackageMetadata
+          { linuxPackageID = artifactName artifact
+          , linuxPackageRevision = artifactVersion artifact
+          , linuxPackageArch = metadataArchitecture metadata
+          , linuxPackageDistroEpoch = Nothing
+          }
+      )
+
+    flattenConstructed :: [([(a, b)], (b, c))] -> ([(a, b)], [(b, c)])
+    flattenConstructed input = do
+      let (left, right) = unzip input
+      (join left, right)
+
+fatalParse :: (Has Diagnostics sig m) => Result a -> m a
+fatalParse r = case r of
+  Error s -> fatalText $ toText s
+  Success v -> pure v
+
+maybeToRight :: a -> Maybe b -> Either a b
+maybeToRight df right = case right of
+  Just a -> Right a
+  Nothing -> Left df

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup/APK.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup/APK.hs
@@ -17,7 +17,6 @@ import App.Fossa.VSI.DynLinked.Util (runningLinux)
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, fatalText, recover)
 import Control.Monad (join)
-import Control.Monad.Trans.Maybe (MaybeT (MaybeT), runMaybeT)
 import Data.Aeson (FromJSON, Result (Error, Success), ToJSON, Value, fromJSON, object, parseJSON, toJSON, withObject, (.:), (.=))
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -114,9 +113,9 @@ data APKLookupTable = APKLookupTable
   deriving (Eq, Show)
 
 buildLookupTable :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> m (Maybe APKLookupTable)
-buildLookupTable root | runningLinux = runMaybeT $ do
-  syft <- MaybeT . recover $ runSyft root
-  compileSyftOutput syft
+buildLookupTable root | runningLinux = do
+  syft <- recover $ runSyft root
+  traverse compileSyftOutput syft
 buildLookupTable _ = pure Nothing
 
 compileSyftOutput :: (Has Diagnostics sig m) => SyftData -> m APKLookupTable

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup/APK.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup/APK.hs
@@ -50,7 +50,7 @@ newtype SyftData = SyftData
 
 instance FromJSON SyftData where
   parseJSON = withObject "SyftData" $ \obj ->
-    SyftData . filter artifactIsOk <$> obj .: "artifacts"
+    SyftData . filter isAPKArtifact <$> obj .: "artifacts"
 
 data SyftArtifact = SyftArtifact
   { artifactName :: Text
@@ -101,8 +101,8 @@ instance FromJSON SyftArtifactMetadataFile where
 instance ToJSON SyftArtifactMetadataFile where
   toJSON SyftArtifactMetadataFile{..} = object ["path" .= metadataFilePath]
 
-artifactIsOk :: SyftArtifact -> Bool
-artifactIsOk SyftArtifact{..} = artifactType == "apk" && artifactMetadataType == "ApkMetadata"
+isAPKArtifact :: SyftArtifact -> Bool
+isAPKArtifact SyftArtifact{..} = artifactType == "apk" && artifactMetadataType == "ApkMetadata"
 
 runSyft :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> m SyftData
 runSyft root = execJson root syftCommand

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup/DEB.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup/DEB.hs
@@ -37,10 +37,10 @@ tryLookup root file = fmap (maybeToRight file) . runMaybeT $ do
 
 packageForFile :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> Path Abs File -> m (Maybe Text)
 packageForFile _ _ | not runningLinux = pure Nothing
-packageForFile root file = recover . execParser parsePackageForFileOutput root $ packageForFileCommand file
+packageForFile root file = recover . execParser parsePackageForFileOutput root $ dpkgQueryFileCommand file
 
-packageForFileCommand :: Path Abs File -> Command
-packageForFileCommand file =
+dpkgQueryFileCommand :: Path Abs File -> Command
+dpkgQueryFileCommand file =
   Command
     { cmdName = "dpkg"
     , cmdArgs = ["-S", toText file]
@@ -58,10 +58,10 @@ parsePackageForFileOutput = ident <* symbol ": "
 
 packageMeta :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> Text -> m (Maybe LinuxPackageMetadata)
 packageMeta _ _ | not runningLinux = pure Nothing
-packageMeta root name = recover . execParser parseMetaOutput root $ packageMetaCommand name
+packageMeta root name = recover . execParser parseMetaOutput root $ dpkgQueryPackageInfoCommand name
 
-packageMetaCommand :: Text -> Command
-packageMetaCommand packageName =
+dpkgQueryPackageInfoCommand :: Text -> Command
+dpkgQueryPackageInfoCommand packageName =
   Command
     { cmdName = "dpkg"
     , cmdArgs = ["-s", packageName]

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup/DEB.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup/DEB.hs
@@ -1,0 +1,143 @@
+module App.Fossa.VSI.DynLinked.Internal.Lookup.DEB (
+  lookupDependencies,
+  parseMetaOutput,
+) where
+
+import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxDistro, LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
+import App.Fossa.VSI.DynLinked.Util (runningLinux)
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics, recover)
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT), runMaybeT)
+import Data.Char (isSpace)
+import Data.Either (partitionEithers)
+import Data.Foldable (traverse_)
+import Data.String.Conversion (toText)
+import Data.Text (Text)
+import Data.Void (Void)
+import Effect.Exec (AllowErr (Never), Command (..), Exec, execParser)
+import Path (Abs, Dir, File, Path)
+import Text.Megaparsec (Parsec, empty, takeWhile1P)
+import Text.Megaparsec.Char (space1)
+import Text.Megaparsec.Char.Lexer qualified as L
+
+type Parser = Parsec Void Text
+
+-- | The idea here is that we look up what paths we can with apt and turn them into @DynamicDependency@.
+-- We then hand back leftovers and lookup results for the next resolution function.
+lookupDependencies :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> LinuxDistro -> [Path Abs File] -> m ([Path Abs File], [DynamicDependency])
+lookupDependencies _ _ files | not runningLinux = pure (files, [])
+lookupDependencies root distro files = partitionEithers <$> traverse (tryLookup root distro) files
+
+tryLookup :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> LinuxDistro -> Path Abs File -> m (Either (Path Abs File) DynamicDependency)
+tryLookup root distro file = fmap (maybeToRight file) . runMaybeT $ do
+  name <- MaybeT $ packageForFile root file
+  meta <- MaybeT $ packageMeta root name
+  pure . DynamicDependency file . Just $ ResolvedLinuxPackage LinuxPackageManagerRPM distro meta
+
+packageForFile :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> Path Abs File -> m (Maybe Text)
+packageForFile _ _ | not runningLinux = pure Nothing
+packageForFile root file = recover . execParser parsePackageForFileOutput root $ packageForFileCommand file
+
+packageForFileCommand :: Path Abs File -> Command
+packageForFileCommand file =
+  Command
+    { cmdName = "dpkg"
+    , cmdArgs = ["-S", toText file]
+    , cmdAllowErr = Never
+    }
+
+-- | Parse @dpkg -S@ output.
+-- Example:
+--
+-- > dpkg -S /lib/x86_64-linux-gnu/libc.so.6
+-- > libc6:amd64: /lib/x86_64-linux-gnu/libc.so.6
+-- > ^^^^^^^^^^^ we want this part
+parsePackageForFileOutput :: Parser Text
+parsePackageForFileOutput = ident <* symbol ": "
+
+packageMeta :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> Text -> m (Maybe LinuxPackageMetadata)
+packageMeta _ _ | not runningLinux = pure Nothing
+packageMeta root name = recover . execParser parseMetaOutput root $ packageMetaCommand name
+
+packageMetaCommand :: Text -> Command
+packageMetaCommand packageName =
+  Command
+    { cmdName = "dpkg"
+    , cmdArgs = ["-s", packageName]
+    , cmdAllowErr = Never
+    }
+
+-- | Parse @dpkg -s@ output.
+--
+-- To keep things simple for now, assume fields always appear in predictable order.
+-- if this turns out to be incorrect, we should parse the db directly like syft does.
+--
+-- Example output:
+-- > dpkg -s libc6:amd64
+-- > Package: libc6
+-- > Status: install ok installed
+-- > Priority: optional
+-- > Section: libs
+-- > Installed-Size: 13246
+-- > Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+-- > Architecture: amd64
+-- > Multi-Arch: same
+-- > Source: glibc
+-- > Version: 2.31-0ubuntu9.2
+-- > Replaces: libc6-amd64
+-- > Depends: libgcc-s1, libcrypt1 (>= 1:4.4.10-10ubuntu4)
+-- > Recommends: libidn2-0 (>= 2.0.5~)
+-- > Suggests: glibc-doc, debconf | debconf-2.0, locales
+-- > Breaks: hurd (<< 1:0.9.git20170910-1), iraf-fitsutil (<< 2018.07.06-4), libtirpc1 (<< 0.2.3), locales (<< 2.31), locales-all (<< 2.31), nocache (<< 1.1-1~), nscd (<< 2.31), r-cran-later (<< 0.7.5+dfsg-2), wcc (<< 0.0.2+dfsg-3)
+-- > Conflicts: openrc (<< 0.27-2~)
+-- > Conffiles:
+-- >  /etc/ld.so.conf.d/x86_64-linux-gnu.conf d4e7a7b88a71b5ffd9e2644e71a0cfab
+-- > Description: GNU C Library: Shared libraries
+-- >  Contains the standard libraries that are used by nearly all programs on
+-- >  the system. This package includes shared versions of the standard C library
+-- >  and the standard math library, as well as many others.
+-- > Homepage: https://www.gnu.org/software/libc/libc.html
+-- > Original-Maintainer: GNU Libc Maintainers <debian-glibc@lists.debian.org>
+-- > Original-Vcs-Browser: https://salsa.debian.org/glibc-team/glibc
+-- > Original-Vcs-Git: https://salsa.debian.org/glibc-team/glibc.git
+parseMetaOutput :: Parser LinuxPackageMetadata
+parseMetaOutput = do
+  name <- parseField "Package"
+  repeatM consumeLine 5
+  arch <- parseField "Architecture"
+  repeatM consumeLine 2
+  version <- parseField "Version"
+  pure $ LinuxPackageMetadata name version arch Nothing
+
+consumeLine :: Parser ()
+consumeLine = do
+  _ <- lexeme $ takeWhile1P Nothing (/= '\n')
+  pure ()
+
+parseField :: Text -> Parser Text
+parseField field = symbol field *> symbol ":" *> ident
+
+-- | Consume spaces.
+sc :: Parser ()
+sc = L.space space1 empty empty
+
+-- | Run the provided parser, then consume any trailing spaces.
+lexeme :: Parser a -> Parser a
+lexeme = L.lexeme sc
+
+-- | Parse for the provided symbol, then consume any trailing spaces.
+symbol :: Text -> Parser Text
+symbol = L.symbol sc
+
+-- | Collect a contiguous list of non-space characters into a @Text@, then consume any trailing spaces.
+-- Requires that a space trails the identifier.
+ident :: Parser Text
+ident = lexeme $ toText <$> takeWhile1P Nothing (not . isSpace)
+
+maybeToRight :: a -> Maybe b -> Either a b
+maybeToRight df right = case right of
+  Just a -> Right a
+  Nothing -> Left df
+
+repeatM :: Monad m => m () -> Word -> m ()
+repeatM f n = traverse_ (const f) [1 .. n]

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup/DEB.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup/DEB.hs
@@ -7,8 +7,7 @@ import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxPackageManage
 import App.Fossa.VSI.DynLinked.Util (runningLinux)
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, recover)
-import Control.Monad (void)
-import Control.Monad.Trans.Maybe (MaybeT (MaybeT), runMaybeT)
+import Control.Monad (join, void)
 import Data.Char (isSpace)
 import Data.Foldable (traverse_)
 import Data.String.Conversion (toText)
@@ -23,10 +22,10 @@ import Text.Megaparsec.Char.Lexer qualified as L
 type Parser = Parsec Void Text
 
 debTactic :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> Path Abs File -> m (Maybe DynamicDependency)
-debTactic root file | runningLinux = runMaybeT $ do
-  name <- MaybeT $ packageForFile root file
-  meta <- MaybeT $ packageMeta root name
-  pure . DynamicDependency file . Just $ ResolvedLinuxPackage LinuxPackageManagerRPM meta
+debTactic root file | runningLinux = do
+  name <- packageForFile root file
+  meta <- join <$> traverse (packageMeta root) name
+  pure (DynamicDependency file . Just . ResolvedLinuxPackage LinuxPackageManagerDEB <$> meta)
 debTactic _ _ = pure Nothing
 
 packageForFile :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> Path Abs File -> m (Maybe Text)

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup/DEB.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup/DEB.hs
@@ -7,6 +7,7 @@ import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxPackageManage
 import App.Fossa.VSI.DynLinked.Util (runningLinux)
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, recover)
+import Control.Monad (void)
 import Control.Monad.Trans.Maybe (MaybeT (MaybeT), runMaybeT)
 import Data.Char (isSpace)
 import Data.Either (partitionEithers)
@@ -111,7 +112,7 @@ parseMetaOutput = do
 
 consumeLine :: Parser ()
 consumeLine = do
-  _ <- lexeme $ takeWhile1P Nothing (/= '\n')
+  void . lexeme $ takeWhile1P Nothing (/= '\n')
   pure ()
 
 parseField :: Text -> Parser Text

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup/DEB.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup/DEB.hs
@@ -3,7 +3,7 @@ module App.Fossa.VSI.DynLinked.Internal.Lookup.DEB (
   parseMetaOutput,
 ) where
 
-import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxDistro, LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
+import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
 import App.Fossa.VSI.DynLinked.Util (runningLinux)
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, recover)
@@ -24,15 +24,15 @@ type Parser = Parsec Void Text
 
 -- | The idea here is that we look up what paths we can with apt and turn them into @DynamicDependency@.
 -- We then hand back leftovers and lookup results for the next resolution function.
-lookupDependencies :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> LinuxDistro -> [Path Abs File] -> m ([Path Abs File], [DynamicDependency])
-lookupDependencies _ _ files | not runningLinux = pure (files, [])
-lookupDependencies root distro files = partitionEithers <$> traverse (tryLookup root distro) files
+lookupDependencies :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> [Path Abs File] -> m ([Path Abs File], [DynamicDependency])
+lookupDependencies _ files | not runningLinux = pure (files, [])
+lookupDependencies root files = partitionEithers <$> traverse (tryLookup root) files
 
-tryLookup :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> LinuxDistro -> Path Abs File -> m (Either (Path Abs File) DynamicDependency)
-tryLookup root distro file = fmap (maybeToRight file) . runMaybeT $ do
+tryLookup :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> Path Abs File -> m (Either (Path Abs File) DynamicDependency)
+tryLookup root file = fmap (maybeToRight file) . runMaybeT $ do
   name <- MaybeT $ packageForFile root file
   meta <- MaybeT $ packageMeta root name
-  pure . DynamicDependency file . Just $ ResolvedLinuxPackage LinuxPackageManagerRPM distro meta
+  pure . DynamicDependency file . Just $ ResolvedLinuxPackage LinuxPackageManagerRPM meta
 
 packageForFile :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> Path Abs File -> m (Maybe Text)
 packageForFile _ _ | not runningLinux = pure Nothing

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup/RPM.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup/RPM.hs
@@ -1,0 +1,104 @@
+module App.Fossa.VSI.DynLinked.Internal.Lookup.RPM (
+  lookupDependencies,
+  parseCommand,
+  LinuxPackageSubset (..),
+) where
+
+import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxPackageManager (LinuxPackageManagerRPM), ResolvedLinuxPackage (..))
+import App.Fossa.VSI.DynLinked.Util (runningLinux)
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT), runMaybeT)
+import Data.ByteString.Lazy qualified as BL
+import Data.Char (isSpace)
+import Data.Either (partitionEithers)
+import Data.String.Conversion (decodeUtf8, toText)
+import Data.Text (Text, isInfixOf, strip)
+import Data.Void (Void)
+import Effect.Exec (AllowErr (Never), Command (..), Exec, execParser, execThrow)
+import Path (Abs, Dir, File, Path, toFilePath)
+import Text.Megaparsec (Parsec, empty, many, option, satisfy, try, (<|>))
+import Text.Megaparsec.Char (space1)
+import Text.Megaparsec.Char.Lexer qualified as L
+
+type Parser = Parsec Void Text
+
+data LinuxPackageSubset = LinuxPackageSubset
+  { linuxPackageID :: Text
+  , linuxPackageRevision :: Text
+  , linuxPackageArch :: Text
+  , linuxPackageDistroEpoch :: Maybe Text
+  }
+  deriving (Show, Eq)
+
+-- | The idea here is that we look up what paths we can with RPM and turn them into @DynamicDependency@.
+-- We then hand back leftovers and lookup results for the next resolution function.
+lookupDependencies :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> [Path Abs File] -> m ([Path Abs File], [DynamicDependency])
+lookupDependencies _ files | not runningLinux = pure (files, [])
+lookupDependencies root files = partitionEithers <$> traverse (tryLookup root) files
+
+tryLookup :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> Path Abs File -> m (Either (Path Abs File) DynamicDependency)
+tryLookup root file = fmap (maybeToRight file) . runMaybeT $ do
+  pkgName <- MaybeT $ rpmqf root file
+  meta <- MaybeT $ rpmqi root pkgName
+
+  -- TODO: I need to refactor the types to remove distro name & version from packages.
+  -- for now, leave this undefined until I've merged in flight PRs so I don't have to deal with conflicts.
+
+  pure . DynamicDependency file . Just $ ResolvedLinuxPackage LinuxPackageManagerRPM undefined
+
+maybeToRight :: a -> Maybe b -> Either a b
+maybeToRight df right = case right of
+  Just a -> Right a
+  Nothing -> Left df
+
+rpmqf :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> Path Abs File -> m (Maybe Text)
+rpmqf _ _ | not runningLinux = pure Nothing
+rpmqf root file = do
+  content <- decodeUtf8 . BL.toStrict <$> execThrow root (Command "rpm" ["-qf", toText $ toFilePath file] Never)
+  if "not owned by any package" `isInfixOf` content
+    then pure Nothing
+    else pure . Just $ strip content
+
+rpmqi :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> Text -> m (Maybe LinuxPackageSubset)
+rpmqi _ _ | not runningLinux = pure Nothing
+rpmqi root name = execParser parseCommand root $ Command "rpm" ["-qi", name] Never
+
+parseCommand :: Parser (Maybe LinuxPackageSubset)
+parseCommand = try consumePackageNotFound <|> fmap Just parseMeta
+
+consumePackageNotFound :: Parser (Maybe LinuxPackageSubset)
+consumePackageNotFound = do
+  _ <- symbol "package" <* ident <* symbol "is" <* symbol "not" <* symbol "installed"
+  pure Nothing
+
+-- | To keep things simple for now, assume fields always appear in predictable order.
+-- if this turns out to be incorrect, we should parse the rpm db directly, like syft does.
+parseMeta :: Parser LinuxPackageSubset
+parseMeta = do
+  name <- parseField "Name"
+  epoch <- try . option Nothing $ Just <$> parseField "Epoch"
+  version <- parseField "Version"
+  release <- parseField "Release"
+  arch <- parseField "Architecture"
+  pure $ LinuxPackageSubset name (version <> "-" <> release) arch epoch
+
+parseField :: Text -> Parser Text
+parseField field = symbol field *> symbol ":" *> ident
+
+-- | Consume spaces.
+sc :: Parser ()
+sc = L.space space1 empty empty
+
+-- | Run the provided parser, then consume any trailing spaces.
+lexeme :: Parser a -> Parser a
+lexeme = L.lexeme sc
+
+-- | Parse for the provided symbol, then consume any trailing spaces.
+symbol :: Text -> Parser Text
+symbol = L.symbol sc
+
+-- | Collect a contiguous list of non-space characters into a @Text@, then consume any trailing spaces.
+-- Requires that a space trails the identifier.
+ident :: Parser Text
+ident = lexeme $ toText <$> many (satisfy $ not . isSpace)

--- a/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
@@ -7,7 +7,7 @@ module App.Fossa.VSI.DynLinked.Internal.Resolve (
 
 import App.Fossa.Analyze.Project (ProjectResult (..))
 import App.Fossa.BinaryDeps (analyzeSingleBinary)
-import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
+import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxDistro (..), LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Lift)
@@ -50,9 +50,9 @@ toSourceUnit root dependencies = do
 
 toDependency :: ResolvedLinuxPackage -> Dependency
 toDependency ResolvedLinuxPackage{..} = case resolvedLinuxPackageManager of
-  LinuxPackageManagerDEB -> renderDEB resolvedLinuxPackageMetadata
-  LinuxPackageManagerRPM -> renderRPM resolvedLinuxPackageMetadata
-  LinuxPackageManagerAPK -> renderAPK resolvedLinuxPackageMetadata
+  LinuxPackageManagerDEB -> renderDEB resolvedLinuxPackageMetadata resolvedLinuxDistro
+  LinuxPackageManagerRPM -> renderRPM resolvedLinuxPackageMetadata resolvedLinuxDistro
+  LinuxPackageManagerAPK -> renderAPK resolvedLinuxPackageMetadata resolvedLinuxDistro
   where
     render :: DepType -> [Text] -> [Text] -> Dependency
     render fetcher projectParts revisionParts =
@@ -68,25 +68,25 @@ toDependency ResolvedLinuxPackage{..} = case resolvedLinuxPackageManager of
     fromParts :: [Text] -> Text
     fromParts = intercalate "#"
 
-    renderDEB :: LinuxPackageMetadata -> Dependency
-    renderDEB LinuxPackageMetadata{..} =
+    renderDEB :: LinuxPackageMetadata -> LinuxDistro -> Dependency
+    renderDEB LinuxPackageMetadata{..} LinuxDistro{..} =
       render
         LinuxDEB
-        [linuxPackageID, linuxPackageDistro, linuxPackageDistroRelease]
+        [linuxPackageID, linuxDistroName, linuxDistroRelease]
         [linuxPackageArch, linuxPackageRevision]
 
-    renderRPM :: LinuxPackageMetadata -> Dependency
-    renderRPM LinuxPackageMetadata{..} =
+    renderRPM :: LinuxPackageMetadata -> LinuxDistro -> Dependency
+    renderRPM LinuxPackageMetadata{..} LinuxDistro{..} =
       render
         LinuxRPM
-        [linuxPackageID, linuxPackageDistro, linuxPackageDistroRelease]
+        [linuxPackageID, linuxDistroName, linuxDistroRelease]
         [linuxPackageArch, epoch <> linuxPackageRevision]
 
-    renderAPK :: LinuxPackageMetadata -> Dependency
-    renderAPK LinuxPackageMetadata{..} =
+    renderAPK :: LinuxPackageMetadata -> LinuxDistro -> Dependency
+    renderAPK LinuxPackageMetadata{..} LinuxDistro{..} =
       render
         LinuxAPK
-        [linuxPackageID, linuxPackageDistro, linuxPackageDistroRelease]
+        [linuxPackageID, linuxDistroName, linuxDistroRelease]
         [linuxPackageArch, linuxPackageRevision]
 
     epoch :: Text

--- a/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
@@ -1,27 +1,38 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module App.Fossa.VSI.DynLinked.Internal.Resolve (
   toSourceUnit,
   toDependency,
+  environmentDistro,
+  parseLinuxDistro,
 ) where
 
 import App.Fossa.Analyze.Project (ProjectResult (..))
 import App.Fossa.BinaryDeps (analyzeSingleBinary)
 import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxDistro (..), LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
+import App.Fossa.VSI.DynLinked.Util (fsRoot, runningLinux)
 import Control.Algebra (Has)
-import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Diagnostics (Diagnostics, (<||>))
 import Control.Effect.Lift (Lift)
 import Data.Either (partitionEithers)
+import Data.Map qualified as Map
 import Data.Set (Set, toList)
+import Data.String.Conversion (toText)
 import Data.Text (Text, intercalate)
+import Data.Text qualified as Text
+import Data.Void (Void)
 import DepTypes (DepType (LinuxAPK, LinuxDEB, LinuxRPM), Dependency (..), VerConstraint (CEq))
 import Effect.Logger (Logger)
-import Effect.ReadFS (ReadFS)
+import Effect.ReadFS (ReadFS, readContentsParser)
 import Graphing (Graphing)
 import Graphing qualified
-import Path (Abs, Dir, File, Path)
+import Path (Abs, Dir, File, Path, mkRelFile, (</>))
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
+import Text.Megaparsec (Parsec, empty, eof, many, takeWhile1P)
+import Text.Megaparsec.Char (char, space1)
+import Text.Megaparsec.Char.Lexer qualified as L
 import Types (DiscoveredProjectType (VsiProjectType), GraphBreadth (Complete))
 
 -- | Resolves a set of dynamic dependencies into a @SourceUnit@.
@@ -105,3 +116,46 @@ sortResolvedUnresolved = partitionEithers . map forkEither . toList
     forkEither dep = case dynamicDependencyResolved dep of
       Nothing -> Right $ dynamicDependencyDiskPath dep
       Just linuxPackage -> Left linuxPackage
+
+-- | Discover the linux distro under which we are currently executing.
+--
+-- Evaluates to @Nothing@ on non-Linux environments.
+-- Exits via @Diagnostics@ on parse errors.
+environmentDistro :: (Has Diagnostics sig m, Has ReadFS sig m) => m (Maybe LinuxDistro)
+environmentDistro
+  | runningLinux = Just <$> (readOsReleaseAt primaryPath <||> readOsReleaseAt fallbackPath)
+  | otherwise = pure Nothing
+  where
+    primaryPath :: Path Abs File
+    primaryPath = fsRoot </> $(mkRelFile "etc/os-release")
+
+    fallbackPath :: Path Abs File
+    fallbackPath = fsRoot </> $(mkRelFile "usr/lib/os-release")
+
+    readOsReleaseAt :: (Has Diagnostics sig m, Has ReadFS sig m) => Path Abs File -> m LinuxDistro
+    readOsReleaseAt = readContentsParser parseLinuxDistro
+
+type Parser = Parsec Void Text
+
+parseLinuxDistro :: Parser LinuxDistro
+parseLinuxDistro = do
+  keys <- Map.fromList <$> many parseField <* eof
+  case (Map.lookup "ID" keys, Map.lookup "VERSION_ID" keys) of
+    (Just distro, Just version) -> pure $ LinuxDistro distro version
+    (Just _, Nothing) -> fail "missing required key: VERSION_ID"
+    (Nothing, Just _) -> fail "missing required key: ID"
+    (Nothing, Nothing) -> fail "missing required keys: ID, VERSION_ID"
+
+parseField :: Parser (Text, Text)
+parseField = do
+  name <- lexeme $ takeWhile1P Nothing (/= '=') <* char '='
+  value <- lexeme $ toText <$> takeWhile1P Nothing (/= '\n')
+  pure (Text.strip name, Text.strip value)
+
+-- | Consume spaces.
+sc :: Parser ()
+sc = L.space space1 empty empty
+
+-- | Run the provided parser, then consume any trailing spaces.
+lexeme :: Parser a -> Parser a
+lexeme = L.lexeme sc

--- a/src/App/Fossa/VSI/DynLinked/Types.hs
+++ b/src/App/Fossa/VSI/DynLinked/Types.hs
@@ -1,6 +1,7 @@
 module App.Fossa.VSI.DynLinked.Types (
   LinuxPackageManager (..),
   LinuxPackageMetadata (..),
+  LinuxDistro (..),
   DynamicDependency (..),
   ResolvedLinuxPackage (..),
 ) where
@@ -18,14 +19,19 @@ data LinuxPackageManager
 data LinuxPackageMetadata = LinuxPackageMetadata
   { linuxPackageID :: Text
   , linuxPackageRevision :: Text
-  , linuxPackageDistro :: Text
-  , linuxPackageDistroRelease :: Text
   , linuxPackageArch :: Text
   , linuxPackageDistroEpoch :: Maybe Text
+  }
+  deriving (Eq, Show)
+
+data LinuxDistro = LinuxDistro
+  { linuxDistroName :: Text
+  , linuxDistroRelease :: Text
   }
 
 data ResolvedLinuxPackage = ResolvedLinuxPackage
   { resolvedLinuxPackageManager :: LinuxPackageManager
+  , resolvedLinuxDistro :: LinuxDistro
   , resolvedLinuxPackageMetadata :: LinuxPackageMetadata
   }
 

--- a/src/App/Fossa/VSI/DynLinked/Types.hs
+++ b/src/App/Fossa/VSI/DynLinked/Types.hs
@@ -10,9 +10,10 @@ import Data.Text (Text)
 import Path (Abs, File, Path)
 
 data LinuxPackageManager
-  = LinuxPackageManagerDEB
-  | LinuxPackageManagerRPM
+  = LinuxPackageManagerRPM
+  | LinuxPackageManagerDEB
   | LinuxPackageManagerAPK
+  deriving (Eq, Ord, Show)
 
 -- | These are all opaque blobs, we're not doing any processing on them other than rendering into a @Locator@.
 -- For that reason, stick to @Text@.
@@ -22,20 +23,22 @@ data LinuxPackageMetadata = LinuxPackageMetadata
   , linuxPackageArch :: Text
   , linuxPackageDistroEpoch :: Maybe Text
   }
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 data LinuxDistro = LinuxDistro
   { linuxDistroName :: Text
   , linuxDistroRelease :: Text
   }
+  deriving (Eq, Ord, Show)
 
 data ResolvedLinuxPackage = ResolvedLinuxPackage
   { resolvedLinuxPackageManager :: LinuxPackageManager
-  , resolvedLinuxDistro :: LinuxDistro
   , resolvedLinuxPackageMetadata :: LinuxPackageMetadata
   }
+  deriving (Eq, Ord, Show)
 
 data DynamicDependency = DynamicDependency
   { dynamicDependencyDiskPath :: Path Abs File
   , dynamicDependencyResolved :: Maybe ResolvedLinuxPackage
   }
+  deriving (Eq, Ord, Show)

--- a/src/App/Fossa/VSI/DynLinked/Util.hs
+++ b/src/App/Fossa/VSI/DynLinked/Util.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module App.Fossa.VSI.DynLinked.Util (
   hasSetUID,
   runningLinux,
+  fsRoot,
 ) where
 
-import Path (File, Path)
+import Path (Abs, Dir, File, Path, mkAbsDir)
 import System.Info qualified as SysInfo
 
 -- Have to use CPP pragmas here so we can import @System.Posix.Files@.
@@ -15,6 +17,10 @@ import System.Info qualified as SysInfo
 -- Windows doesn't have the concept of a "set uid bit", so always eval to false.
 hasSetUID :: Monad m => Path t File -> m Bool
 hasSetUID _ = pure False
+
+-- | The root of the primary file system.
+fsRoot :: Path Abs Dir
+fsRoot = $(mkAbsDir "C:/")
 
 #else
 
@@ -30,6 +36,10 @@ hasSetUID :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path t File -> m Bo
 hasSetUID file = do
   stat <- fatalOnSomeException "get file status" . sendIO . getFileStatus $ P.toFilePath file
   pure $ fileMode stat .&. setUserIDMode /= 0
+
+-- | The root of the primary file system.
+fsRoot :: Path Abs Dir
+fsRoot = $(mkAbsDir "/")
 
 #endif
 

--- a/src/App/Fossa/VSI/DynLinked/Util.hs
+++ b/src/App/Fossa/VSI/DynLinked/Util.hs
@@ -2,6 +2,7 @@
 
 module App.Fossa.VSI.DynLinked.Util (
   hasSetUID,
+  runningLinux,
 ) where
 
 import Path (File, Path)
@@ -21,6 +22,7 @@ import Control.Effect.Lift (Lift, sendIO)
 import Data.Bits ((.&.))
 import Path qualified as P
 import System.Posix.Files (fileMode, getFileStatus, setUserIDMode)
+import qualified System.Info as SysInfo
 
 -- | Test whether the file has a `setuid` bit.
 hasSetUID :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path t File -> m Bool
@@ -29,3 +31,6 @@ hasSetUID file = do
   pure $ fileMode stat .&. setUserIDMode /= 0
 
 #endif
+
+runningLinux :: Bool
+runningLinux = SysInfo.os == "linux"

--- a/src/App/Fossa/VSI/DynLinked/Util.hs
+++ b/src/App/Fossa/VSI/DynLinked/Util.hs
@@ -6,7 +6,9 @@ module App.Fossa.VSI.DynLinked.Util (
 ) where
 
 import Path (File, Path)
+import System.Info qualified as SysInfo
 
+-- Have to use CPP pragmas here so we can import @System.Posix.Files@.
 #ifdef mingw32_HOST_OS
 
 -- | Test whether the file has a `setuid` bit.
@@ -22,7 +24,6 @@ import Control.Effect.Lift (Lift, sendIO)
 import Data.Bits ((.&.))
 import Path qualified as P
 import System.Posix.Files (fileMode, getFileStatus, setUserIDMode)
-import qualified System.Info as SysInfo
 
 -- | Test whether the file has a `setuid` bit.
 hasSetUID :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path t File -> m Bool

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
@@ -6,10 +6,11 @@ module App.Fossa.VSI.DynLinked.Internal.Lookup.APKSpec (spec) where
 
 import App.Fossa.VSI.DynLinked.Internal.Lookup.APK (APKLookupTable (..), SyftArtifact (..), SyftArtifactMetadata (..), SyftArtifactMetadataFile (..), SyftData (..), compileSyftOutput)
 import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
+import App.Fossa.VSI.DynLinked.Util (fsRoot)
 import Control.Carrier.Diagnostics (runDiagnostics)
 import Data.Aeson (toJSON)
 import Data.Map qualified as Map
-import Path (Abs, Dir, Path, mkAbsDir, mkRelFile, (</>))
+import Path (mkRelFile, (</>))
 import Test.Hspec (Spec, describe, expectationFailure, it, runIO, shouldBe)
 
 spec :: Spec
@@ -34,9 +35,9 @@ syntheticData =
               SyftArtifactMetadata
                 { metadataArchitecture = "arch_1"
                 , metadataFiles =
-                    [ SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file1_1")
-                    , SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file1_2")
-                    , SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file1_3")
+                    [ SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file1_1")
+                    , SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file1_2")
+                    , SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file1_3")
                     ]
                 }
         }
@@ -50,9 +51,9 @@ syntheticData =
               SyftArtifactMetadata
                 { metadataArchitecture = "arch_2"
                 , metadataFiles =
-                    [ SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file2_1")
-                    , SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file2_2")
-                    , SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file2_3")
+                    [ SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file2_1")
+                    , SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file2_2")
+                    , SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file2_3")
                     ]
                 }
         }
@@ -63,12 +64,12 @@ expectedLookupTable =
   APKLookupTable
     { pathToIndex =
         Map.fromList
-          [ (safeAbsRoot </> $(mkRelFile "file1_1"), 0)
-          , (safeAbsRoot </> $(mkRelFile "file1_2"), 0)
-          , (safeAbsRoot </> $(mkRelFile "file1_3"), 0)
-          , (safeAbsRoot </> $(mkRelFile "file2_1"), 1)
-          , (safeAbsRoot </> $(mkRelFile "file2_2"), 1)
-          , (safeAbsRoot </> $(mkRelFile "file2_3"), 1)
+          [ (fsRoot </> $(mkRelFile "file1_1"), 0)
+          , (fsRoot </> $(mkRelFile "file1_2"), 0)
+          , (fsRoot </> $(mkRelFile "file1_3"), 0)
+          , (fsRoot </> $(mkRelFile "file2_1"), 1)
+          , (fsRoot </> $(mkRelFile "file2_2"), 1)
+          , (fsRoot </> $(mkRelFile "file2_3"), 1)
           ]
     , indexToMeta =
         Map.fromList
@@ -92,12 +93,3 @@ expectedLookupTable =
             )
           ]
     }
-
--- We have to use CPP pragmas here, because we can't compile abs paths for other platforms.
-#ifdef mingw32_HOST_OS
-safeAbsRoot :: Path Abs Dir
-safeAbsRoot = $(mkAbsDir "C:/")
-#else
-safeAbsRoot :: Path Abs Dir
-safeAbsRoot = $(mkAbsDir "/")
-#endif

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
@@ -4,7 +4,7 @@
 
 module App.Fossa.VSI.DynLinked.Internal.Lookup.APKSpec (spec) where
 
-import App.Fossa.VSI.DynLinked.Internal.Lookup.APK (SyftArtifact (..), SyftArtifactMetadata (..), SyftArtifactMetadataFile (..), SyftData (..), SyftLookupTable (..), constructLookupTables)
+import App.Fossa.VSI.DynLinked.Internal.Lookup.APK (APKLookupTable (..), SyftArtifact (..), SyftArtifactMetadata (..), SyftArtifactMetadataFile (..), SyftData (..), compileSyftOutput)
 import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
 import Control.Carrier.Diagnostics (runDiagnostics)
 import Data.Aeson (toJSON)
@@ -15,7 +15,7 @@ import Test.Hspec (Spec, describe, expectationFailure, it, runIO, shouldBe)
 spec :: Spec
 spec = do
   describe "lookup table" $ do
-    result <- runIO . runDiagnostics $ constructLookupTables syntheticData
+    result <- runIO . runDiagnostics $ compileSyftOutput syntheticData
 
     it "correctly builds lookup table" $ case result of
       Left e -> expectationFailure ("could not construct lookup table: " <> show e)
@@ -58,9 +58,9 @@ syntheticData =
         }
     ]
 
-expectedLookupTable :: SyftLookupTable
+expectedLookupTable :: APKLookupTable
 expectedLookupTable =
-  SyftLookupTable
+  APKLookupTable
     { pathToIndex =
         Map.fromList
           [ (safeAbsRoot </> $(mkRelFile "file1_1"), 0)

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.Fossa.VSI.DynLinked.Internal.Lookup.APKSpec (spec) where
+
+import App.Fossa.VSI.DynLinked.Internal.Lookup.APK (SyftArtifact (..), SyftArtifactMetadata (..), SyftArtifactMetadataFile (..), SyftData (..), SyftLookupTable (..), constructLookupTables)
+import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
+import Control.Carrier.Diagnostics (runDiagnostics)
+import Data.Aeson (toJSON)
+import Data.Map qualified as Map
+import Path (mkAbsFile)
+import Test.Hspec (Spec, describe, expectationFailure, it, runIO, shouldBe)
+
+spec :: Spec
+spec = do
+  describe "lookup table" $ do
+    result <- runIO . runDiagnostics $ constructLookupTables syntheticData
+
+    it "correctly builds lookup table" $ case result of
+      Left e -> expectationFailure ("could not construct lookup table: " <> show e)
+      Right table -> table `shouldBe` expectedLookupTable
+
+syntheticData :: SyftData
+syntheticData =
+  SyftData
+    [ SyftArtifact
+        { artifactName = "name_1"
+        , artifactVersion = "version_1"
+        , artifactType = "apk"
+        , artifactMetadataType = "ApkMetadata"
+        , artifactMetadata =
+            toJSON $
+              SyftArtifactMetadata
+                { metadataArchitecture = "arch_1"
+                , metadataFiles =
+                    [ SyftArtifactMetadataFile $(mkAbsFile "/file1_1")
+                    , SyftArtifactMetadataFile $(mkAbsFile "/file1_2")
+                    , SyftArtifactMetadataFile $(mkAbsFile "/file1_3")
+                    ]
+                }
+        }
+    , SyftArtifact
+        { artifactName = "name_2"
+        , artifactVersion = "version_2"
+        , artifactType = "apk"
+        , artifactMetadataType = "ApkMetadata"
+        , artifactMetadata =
+            toJSON $
+              SyftArtifactMetadata
+                { metadataArchitecture = "arch_2"
+                , metadataFiles =
+                    [ SyftArtifactMetadataFile $(mkAbsFile "/file2_1")
+                    , SyftArtifactMetadataFile $(mkAbsFile "/file2_2")
+                    , SyftArtifactMetadataFile $(mkAbsFile "/file2_3")
+                    ]
+                }
+        }
+    ]
+
+expectedLookupTable :: SyftLookupTable
+expectedLookupTable =
+  SyftLookupTable
+    { pathToIndex =
+        Map.fromList
+          [ ($(mkAbsFile "/file1_1"), 0)
+          , ($(mkAbsFile "/file1_2"), 0)
+          , ($(mkAbsFile "/file1_3"), 0)
+          , ($(mkAbsFile "/file2_1"), 1)
+          , ($(mkAbsFile "/file2_2"), 1)
+          , ($(mkAbsFile "/file2_3"), 1)
+          ]
+    , indexToMeta =
+        Map.fromList
+          [
+            ( 0
+            , LinuxPackageMetadata
+                { linuxPackageID = "name_1"
+                , linuxPackageRevision = "version_1"
+                , linuxPackageArch = "arch_1"
+                , linuxPackageDistroEpoch = Nothing
+                }
+            )
+          ,
+            ( 1
+            , LinuxPackageMetadata
+                { linuxPackageID = "name_2"
+                , linuxPackageRevision = "version_2"
+                , linuxPackageArch = "arch_2"
+                , linuxPackageDistroEpoch = Nothing
+                }
+            )
+          ]
+    }

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/DEBSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/DEBSpec.hs
@@ -2,7 +2,7 @@
 
 module App.Fossa.VSI.DynLinked.Internal.Lookup.DEBSpec (spec) where
 
-import App.Fossa.VSI.DynLinked.Internal.Lookup.DEB (parseMetaOutput)
+import App.Fossa.VSI.DynLinked.Internal.Lookup.DEB (dpkgParseQueryPackageInfo)
 import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
 import Data.Text (Text)
 import Data.Void (Void)
@@ -15,7 +15,7 @@ parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
 parseMatch parser input expected = parse parser "" input `shouldParse` expected
 
 shouldParseInto :: Text -> LinuxPackageMetadata -> Expectation
-shouldParseInto = parseMatch parseMetaOutput
+shouldParseInto = parseMatch dpkgParseQueryPackageInfo
 
 spec :: Spec
 spec = do

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/DEBSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/DEBSpec.hs
@@ -1,0 +1,57 @@
+module App.Fossa.VSI.DynLinked.Internal.Lookup.DEBSpec (spec) where
+
+import App.Fossa.VSI.DynLinked.Internal.Lookup.DEB (parseMetaOutput)
+import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Void (Void)
+import Test.Hspec (Expectation, Spec, describe, it)
+import Test.Hspec.Megaparsec (shouldParse)
+import Text.Megaparsec (Parsec, parse)
+
+parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
+parseMatch parser input expected = parse parser "" input `shouldParse` expected
+
+shouldParseInto :: Text -> LinuxPackageMetadata -> Expectation
+shouldParseInto = parseMatch parseMetaOutput
+
+spec :: Spec
+spec = do
+  describe "parse dpkg output" $ do
+    it "parses dpkg output" $ do
+      dpkgOutput `shouldParseInto` dpkgOutputExpected
+
+dpkgOutputExpected :: LinuxPackageMetadata
+dpkgOutputExpected = LinuxPackageMetadata "libc6" "2.31-0ubuntu9.2" "amd64" Nothing
+
+dpkgOutput :: Text
+dpkgOutput =
+  Text.intercalate
+    "\n"
+    [ "Package: libc6"
+    , "Status: install ok installed"
+    , "Priority: optional"
+    , "Section: libs"
+    , "Installed-Size: 13246"
+    , "Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>"
+    , "Architecture: amd64"
+    , "Multi-Arch: same"
+    , "Source: glibc"
+    , "Version: 2.31-0ubuntu9.2"
+    , "Replaces: libc6-amd64"
+    , "Depends: libgcc-s1, libcrypt1 (>= 1:4.4.10-10ubuntu4)"
+    , "Recommends: libidn2-0 (>= 2.0.5~)"
+    , "Suggests: glibc-doc, debconf | debconf-2.0, locales"
+    , "Breaks: hurd (<< 1:0.9.git20170910-1), iraf-fitsutil (<< 2018.07.06-4), libtirpc1 (<< 0.2.3), locales (<< 2.31), locales-all (<< 2.31), nocache (<< 1.1-1~), nscd (<< 2.31), r-cran-later (<< 0.7.5+dfsg-2), wcc (<< 0.0.2+dfsg-3)"
+    , "Conflicts: openrc (<< 0.27-2~)"
+    , "Conffiles:"
+    , " /etc/ld.so.conf.d/x86_64-linux-gnu.conf d4e7a7b88a71b5ffd9e2644e71a0cfab"
+    , "Description: GNU C Library: Shared libraries"
+    , " Contains the standard libraries that are used by nearly all programs on"
+    , " the system. This package includes shared versions of the standard C library"
+    , " and the standard math library, as well as many others."
+    , "Homepage: https://www.gnu.org/software/libc/libc.html"
+    , "Original-Maintainer: GNU Libc Maintainers <debian-glibc@lists.debian.org>"
+    , "Original-Vcs-Browser: https://salsa.debian.org/glibc-team/glibc"
+    , "Original-Vcs-Git: https://salsa.debian.org/glibc-team/glibc.git"
+    ]

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/DEBSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/DEBSpec.hs
@@ -28,30 +28,30 @@ dpkgOutputExpected = LinuxPackageMetadata "libc6" "2.31-0ubuntu9.2" "amd64" Noth
 
 dpkgOutput :: Text
 dpkgOutput =
-  [r| Package: libc6
-      Status: install ok installed
-      Priority: optional
-      Section: libs
-      Installed-Size: 13246
-      Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-      Architecture: amd64
-      Multi-Arch: same
-      Source: glibc
-      Version: 2.31-0ubuntu9.2
-      Replaces: libc6-amd64
-      Depends: libgcc-s1, libcrypt1 (>= 1:4.4.10-10ubuntu4)
-      Recommends: libidn2-0 (>= 2.0.5~)
-      Suggests: glibc-doc, debconf | debconf-2.0, locales
-      Breaks: hurd (<< 1:0.9.git20170910-1), iraf-fitsutil (<< 2018.07.06-4), libtirpc1 (<< 0.2.3), locales (<< 2.31), locales-all (<< 2.31), nocache (<< 1.1-1~), nscd (<< 2.31), r-cran-later (<< 0.7.5+dfsg-2), wcc (<< 0.0.2+dfsg-3)
-      Conflicts: openrc (<< 0.27-2~)
-      Conffiles:
-       /etc/ld.so.conf.d/x86_64-linux-gnu.conf d4e7a7b88a71b5ffd9e2644e71a0cfab
-      Description: GNU C Library: Shared libraries
-       Contains the standard libraries that are used by nearly all programs on
-       the system. This package includes shared versions of the standard C library
-       and the standard math library, as well as many others.
-      Homepage: https://www.gnu.org/software/libc/libc.html
-      Original-Maintainer: GNU Libc Maintainers <debian-glibc@lists.debian.org>
-      Original-Vcs-Browser: https://salsa.debian.org/glibc-team/glibc
-      Original-Vcs-Git: https://salsa.debian.org/glibc-team/glibc.git  
+  [r|Package: libc6
+Status: install ok installed
+Priority: optional
+Section: libs
+Installed-Size: 13246
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Architecture: amd64
+Multi-Arch: same
+Source: glibc
+Version: 2.31-0ubuntu9.2
+Replaces: libc6-amd64
+Depends: libgcc-s1, libcrypt1 (>= 1:4.4.10-10ubuntu4)
+Recommends: libidn2-0 (>= 2.0.5~)
+Suggests: glibc-doc, debconf | debconf-2.0, locales
+Breaks: hurd (<< 1:0.9.git20170910-1), iraf-fitsutil (<< 2018.07.06-4), libtirpc1 (<< 0.2.3), locales (<< 2.31), locales-all (<< 2.31), nocache (<< 1.1-1~), nscd (<< 2.31), r-cran-later (<< 0.7.5+dfsg-2), wcc (<< 0.0.2+dfsg-3)
+Conflicts: openrc (<< 0.27-2~)
+Conffiles:
+/etc/ld.so.conf.d/x86_64-linux-gnu.conf d4e7a7b88a71b5ffd9e2644e71a0cfab
+Description: GNU C Library: Shared libraries
+Contains the standard libraries that are used by nearly all programs on
+the system. This package includes shared versions of the standard C library
+and the standard math library, as well as many others.
+Homepage: https://www.gnu.org/software/libc/libc.html
+Original-Maintainer: GNU Libc Maintainers <debian-glibc@lists.debian.org>
+Original-Vcs-Browser: https://salsa.debian.org/glibc-team/glibc
+Original-Vcs-Git: https://salsa.debian.org/glibc-team/glibc.git  
   |]

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/DEBSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/DEBSpec.hs
@@ -1,13 +1,15 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module App.Fossa.VSI.DynLinked.Internal.Lookup.DEBSpec (spec) where
 
 import App.Fossa.VSI.DynLinked.Internal.Lookup.DEB (parseMetaOutput)
 import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
 import Data.Text (Text)
-import Data.Text qualified as Text
 import Data.Void (Void)
 import Test.Hspec (Expectation, Spec, describe, it)
 import Test.Hspec.Megaparsec (shouldParse)
 import Text.Megaparsec (Parsec, parse)
+import Text.RawString.QQ (r)
 
 parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
 parseMatch parser input expected = parse parser "" input `shouldParse` expected
@@ -26,32 +28,30 @@ dpkgOutputExpected = LinuxPackageMetadata "libc6" "2.31-0ubuntu9.2" "amd64" Noth
 
 dpkgOutput :: Text
 dpkgOutput =
-  Text.intercalate
-    "\n"
-    [ "Package: libc6"
-    , "Status: install ok installed"
-    , "Priority: optional"
-    , "Section: libs"
-    , "Installed-Size: 13246"
-    , "Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>"
-    , "Architecture: amd64"
-    , "Multi-Arch: same"
-    , "Source: glibc"
-    , "Version: 2.31-0ubuntu9.2"
-    , "Replaces: libc6-amd64"
-    , "Depends: libgcc-s1, libcrypt1 (>= 1:4.4.10-10ubuntu4)"
-    , "Recommends: libidn2-0 (>= 2.0.5~)"
-    , "Suggests: glibc-doc, debconf | debconf-2.0, locales"
-    , "Breaks: hurd (<< 1:0.9.git20170910-1), iraf-fitsutil (<< 2018.07.06-4), libtirpc1 (<< 0.2.3), locales (<< 2.31), locales-all (<< 2.31), nocache (<< 1.1-1~), nscd (<< 2.31), r-cran-later (<< 0.7.5+dfsg-2), wcc (<< 0.0.2+dfsg-3)"
-    , "Conflicts: openrc (<< 0.27-2~)"
-    , "Conffiles:"
-    , " /etc/ld.so.conf.d/x86_64-linux-gnu.conf d4e7a7b88a71b5ffd9e2644e71a0cfab"
-    , "Description: GNU C Library: Shared libraries"
-    , " Contains the standard libraries that are used by nearly all programs on"
-    , " the system. This package includes shared versions of the standard C library"
-    , " and the standard math library, as well as many others."
-    , "Homepage: https://www.gnu.org/software/libc/libc.html"
-    , "Original-Maintainer: GNU Libc Maintainers <debian-glibc@lists.debian.org>"
-    , "Original-Vcs-Browser: https://salsa.debian.org/glibc-team/glibc"
-    , "Original-Vcs-Git: https://salsa.debian.org/glibc-team/glibc.git"
-    ]
+  [r| Package: libc6
+      Status: install ok installed
+      Priority: optional
+      Section: libs
+      Installed-Size: 13246
+      Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+      Architecture: amd64
+      Multi-Arch: same
+      Source: glibc
+      Version: 2.31-0ubuntu9.2
+      Replaces: libc6-amd64
+      Depends: libgcc-s1, libcrypt1 (>= 1:4.4.10-10ubuntu4)
+      Recommends: libidn2-0 (>= 2.0.5~)
+      Suggests: glibc-doc, debconf | debconf-2.0, locales
+      Breaks: hurd (<< 1:0.9.git20170910-1), iraf-fitsutil (<< 2018.07.06-4), libtirpc1 (<< 0.2.3), locales (<< 2.31), locales-all (<< 2.31), nocache (<< 1.1-1~), nscd (<< 2.31), r-cran-later (<< 0.7.5+dfsg-2), wcc (<< 0.0.2+dfsg-3)
+      Conflicts: openrc (<< 0.27-2~)
+      Conffiles:
+       /etc/ld.so.conf.d/x86_64-linux-gnu.conf d4e7a7b88a71b5ffd9e2644e71a0cfab
+      Description: GNU C Library: Shared libraries
+       Contains the standard libraries that are used by nearly all programs on
+       the system. This package includes shared versions of the standard C library
+       and the standard math library, as well as many others.
+      Homepage: https://www.gnu.org/software/libc/libc.html
+      Original-Maintainer: GNU Libc Maintainers <debian-glibc@lists.debian.org>
+      Original-Vcs-Browser: https://salsa.debian.org/glibc-team/glibc
+      Original-Vcs-Git: https://salsa.debian.org/glibc-team/glibc.git  
+  |]

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
@@ -2,7 +2,7 @@
 
 module App.Fossa.VSI.DynLinked.Internal.Lookup.RPMSpec (spec) where
 
-import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM (parseMetaOutput)
+import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM (rpmParseQueryPackageInfo)
 import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
 import Data.Text (Text)
 import Data.Void (Void)
@@ -15,7 +15,7 @@ parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
 parseMatch parser input expected = parse parser "" input `shouldParse` expected
 
 shouldParseInto :: Text -> LinuxPackageMetadata -> Expectation
-shouldParseInto = parseMatch parseMetaOutput
+shouldParseInto = parseMatch rpmParseQueryPackageInfo
 
 spec :: Spec
 spec = do

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
@@ -1,6 +1,6 @@
 module App.Fossa.VSI.DynLinked.Internal.Lookup.RPMSpec (spec) where
 
-import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM (parseCommand)
+import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM (parseMetaOutput)
 import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -12,8 +12,8 @@ import Text.Megaparsec (Parsec, parse)
 parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
 parseMatch parser input expected = parse parser "" input `shouldParse` expected
 
-shouldParseInto :: Text -> (Maybe LinuxPackageMetadata) -> Expectation
-shouldParseInto = parseMatch parseCommand
+shouldParseInto :: Text -> LinuxPackageMetadata -> Expectation
+shouldParseInto = parseMatch parseMetaOutput
 
 spec :: Spec
 spec = do
@@ -24,14 +24,8 @@ spec = do
     it "parses rpm output with epoch" $ do
       rpmOutputEpoch `shouldParseInto` rpmOutputEpochExpected
 
-    it "parses noting on package not found" $ do
-      notFoundOutput `shouldParseInto` Nothing
-
-notFoundOutput :: Text
-notFoundOutput = "package glibc-2.28-151.el8.x86_64 is not installed"
-
-rpmOutputExpected :: Maybe LinuxPackageMetadata
-rpmOutputExpected = Just $ LinuxPackageMetadata "glibc" "2.28-151.el8" "x86_64" Nothing
+rpmOutputExpected :: LinuxPackageMetadata
+rpmOutputExpected = LinuxPackageMetadata "glibc" "2.28-151.el8" "x86_64" Nothing
 
 rpmOutput :: Text
 rpmOutput =
@@ -64,8 +58,8 @@ rpmOutput =
     , "Linux system will not function."
     ]
 
-rpmOutputEpochExpected :: Maybe LinuxPackageMetadata
-rpmOutputEpochExpected = Just $ LinuxPackageMetadata "device-mapper-libs" "1.02.175-5.el8" "x86_64" (Just "8")
+rpmOutputEpochExpected :: LinuxPackageMetadata
+rpmOutputEpochExpected = LinuxPackageMetadata "device-mapper-libs" "1.02.175-5.el8" "x86_64" (Just "8")
 
 rpmOutputEpoch :: Text
 rpmOutputEpoch =

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
@@ -1,0 +1,93 @@
+module App.Fossa.VSI.DynLinked.Internal.Lookup.RPMSpec (spec) where
+
+import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM (LinuxPackageSubset (..), parseCommand)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Void (Void)
+import Test.Hspec (Expectation, Spec, describe, it)
+import Test.Hspec.Megaparsec (shouldParse)
+import Text.Megaparsec (Parsec, parse)
+
+parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
+parseMatch parser input expected = parse parser "" input `shouldParse` expected
+
+shouldParseInto :: Text -> (Maybe LinuxPackageSubset) -> Expectation
+shouldParseInto = parseMatch parseCommand
+
+spec :: Spec
+spec = do
+  describe "parse rpm output" $ do
+    it "parses rpm output without epoch" $ do
+      rpmOutput `shouldParseInto` rpmOutputExpected
+
+    it "parses rpm output with epoch" $ do
+      rpmOutputEpoch `shouldParseInto` rpmOutputEpochExpected
+
+    it "parses noting on package not found" $ do
+      notFoundOutput `shouldParseInto` Nothing
+
+notFoundOutput :: Text
+notFoundOutput = "package glibc-2.28-151.el8.x86_64 is not installed"
+
+rpmOutputExpected :: Maybe LinuxPackageSubset
+rpmOutputExpected = Just $ LinuxPackageSubset "glibc" "2.28-151.el8" "x86_64" Nothing
+
+rpmOutput :: Text
+rpmOutput =
+  Text.intercalate
+    "\n"
+    [ "Name        : glibc"
+    , "Version     : 2.28"
+    , "Release     : 151.el8"
+    , "Architecture: x86_64"
+    , "Install Date: Wed Sep 15 14:17:28 2021"
+    , "Group       : Unspecified"
+    , "Size        : 15646740"
+    , "License     : LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
+    , "Signature   : RSA/SHA256, Thu Mar 11 21:46:42 2021, Key ID 05b555b38483c65d"
+    , "Source RPM  : glibc-2.28-151.el8.src.rpm"
+    , "Build Date  : Thu Mar 11 20:16:40 2021"
+    , "Build Host  : x86-01.mbox.centos.org"
+    , "Relocations : (not relocatable)"
+    , "Packager    : CentOS Buildsys <bugs@centos.org>"
+    , "Vendor      : CentOS"
+    , "URL         : http://www.gnu.org/software/glibc/"
+    , "Summary     : The GNU libc libraries"
+    , "Description :"
+    , "The glibc package contains standard libraries which are used by"
+    , "multiple programs on the system. In order to save disk space and"
+    , "memory, as well as to make upgrading easier, common system code is"
+    , "kept in one place and shared between programs. This particular package"
+    , "contains the most important sets of shared libraries: the standard C"
+    , "library and the standard math library. Without these two libraries, a"
+    , "Linux system will not function."
+    ]
+
+rpmOutputEpochExpected :: Maybe LinuxPackageSubset
+rpmOutputEpochExpected = Just $ LinuxPackageSubset "device-mapper-libs" "1.02.175-5.el8" "x86_64" (Just "8")
+
+rpmOutputEpoch :: Text
+rpmOutputEpoch =
+  Text.intercalate
+    "\n"
+    [ "Name        : device-mapper-libs"
+    , "Epoch       : 8"
+    , "Version     : 1.02.175"
+    , "Release     : 5.el8"
+    , "Architecture: x86_64"
+    , "Install Date: Wed Sep 15 14:17:37 2021"
+    , "Group       : Unspecified"
+    , "Size        : 415655"
+    , "License     : LGPLv2"
+    , "Signature   : RSA/SHA256, Wed Mar 10 22:00:57 2021, Key ID 05b555b38483c65d"
+    , "Source RPM  : lvm2-2.03.11-5.el8.src.rpm"
+    , "Build Date  : Wed Mar 10 21:50:25 2021"
+    , "Build Host  : x86-02.mbox.centos.org"
+    , "Relocations : (not relocatable)"
+    , "Packager    : CentOS Buildsys <bugs@centos.org>"
+    , "Vendor      : CentOS"
+    , "URL         : http://sourceware.org/lvm2"
+    , "Summary     : Device-mapper shared library"
+    , "Description :"
+    , "This package contains the device-mapper shared library, libdevmapper."
+    ]

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
@@ -31,31 +31,31 @@ rpmOutputExpected = LinuxPackageMetadata "glibc" "2.28-151.el8" "x86_64" Nothing
 
 rpmOutput :: Text
 rpmOutput =
-  [r| Name        : glibc
-      Version     : 2.28
-      Release     : 151.el8
-      Architecture: x86_64
-      Install Date: Wed Sep 15 14:17:28 2021
-      Group       : Unspecified
-      Size        : 15646740
-      License     : LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
-      Signature   : RSA/SHA256, Thu Mar 11 21:46:42 2021, Key ID 05b555b38483c65d
-      Source RPM  : glibc-2.28-151.el8.src.rpm
-      Build Date  : Thu Mar 11 20:16:40 2021
-      Build Host  : x86-01.mbox.centos.org
-      Relocations : (not relocatable)
-      Packager    : CentOS Buildsys <bugs@centos.org>
-      Vendor      : CentOS
-      URL         : http://www.gnu.org/software/glibc/
-      Summary     : The GNU libc libraries
-      Description :
-      The glibc package contains standard libraries which are used by
-      multiple programs on the system. In order to save disk space and
-      memory, as well as to make upgrading easier, common system code is
-      kept in one place and shared between programs. This particular package
-      contains the most important sets of shared libraries: the standard C
-      library and the standard math library. Without these two libraries, a
-      Linux system will not function.
+  [r|Name        : glibc
+Version     : 2.28
+Release     : 151.el8
+Architecture: x86_64
+Install Date: Wed Sep 15 14:17:28 2021
+Group       : Unspecified
+Size        : 15646740
+License     : LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
+Signature   : RSA/SHA256, Thu Mar 11 21:46:42 2021, Key ID 05b555b38483c65d
+Source RPM  : glibc-2.28-151.el8.src.rpm
+Build Date  : Thu Mar 11 20:16:40 2021
+Build Host  : x86-01.mbox.centos.org
+Relocations : (not relocatable)
+Packager    : CentOS Buildsys <bugs@centos.org>
+Vendor      : CentOS
+URL         : http://www.gnu.org/software/glibc/
+Summary     : The GNU libc libraries
+Description :
+The glibc package contains standard libraries which are used by
+multiple programs on the system. In order to save disk space and
+memory, as well as to make upgrading easier, common system code is
+kept in one place and shared between programs. This particular package
+contains the most important sets of shared libraries: the standard C
+library and the standard math library. Without these two libraries, a
+Linux system will not function.
   |]
 
 rpmOutputEpochExpected :: LinuxPackageMetadata
@@ -63,24 +63,24 @@ rpmOutputEpochExpected = LinuxPackageMetadata "device-mapper-libs" "1.02.175-5.e
 
 rpmOutputEpoch :: Text
 rpmOutputEpoch =
-  [r| Name        : device-mapper-libs
-      Epoch       : 8
-      Version     : 1.02.175
-      Release     : 5.el8
-      Architecture: x86_64
-      Install Date: Wed Sep 15 14:17:37 2021
-      Group       : Unspecified
-      Size        : 415655
-      License     : LGPLv2
-      Signature   : RSA/SHA256, Wed Mar 10 22:00:57 2021, Key ID 05b555b38483c65d
-      Source RPM  : lvm2-2.03.11-5.el8.src.rpm
-      Build Date  : Wed Mar 10 21:50:25 2021
-      Build Host  : x86-02.mbox.centos.org
-      Relocations : (not relocatable)
-      Packager    : CentOS Buildsys <bugs@centos.org>
-      Vendor      : CentOS
-      URL         : http://sourceware.org/lvm2
-      Summary     : Device-mapper shared library
-      Description :
-      This package contains the device-mapper shared library, libdevmapper.
+  [r|Name        : device-mapper-libs
+Epoch       : 8
+Version     : 1.02.175
+Release     : 5.el8
+Architecture: x86_64
+Install Date: Wed Sep 15 14:17:37 2021
+Group       : Unspecified
+Size        : 415655
+License     : LGPLv2
+Signature   : RSA/SHA256, Wed Mar 10 22:00:57 2021, Key ID 05b555b38483c65d
+Source RPM  : lvm2-2.03.11-5.el8.src.rpm
+Build Date  : Wed Mar 10 21:50:25 2021
+Build Host  : x86-02.mbox.centos.org
+Relocations : (not relocatable)
+Packager    : CentOS Buildsys <bugs@centos.org>
+Vendor      : CentOS
+URL         : http://sourceware.org/lvm2
+Summary     : Device-mapper shared library
+Description :
+This package contains the device-mapper shared library, libdevmapper.
   |]

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
@@ -1,13 +1,15 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module App.Fossa.VSI.DynLinked.Internal.Lookup.RPMSpec (spec) where
 
 import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM (parseMetaOutput)
 import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
 import Data.Text (Text)
-import Data.Text qualified as Text
 import Data.Void (Void)
 import Test.Hspec (Expectation, Spec, describe, it)
 import Test.Hspec.Megaparsec (shouldParse)
 import Text.Megaparsec (Parsec, parse)
+import Text.RawString.QQ (r)
 
 parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
 parseMatch parser input expected = parse parser "" input `shouldParse` expected
@@ -29,60 +31,56 @@ rpmOutputExpected = LinuxPackageMetadata "glibc" "2.28-151.el8" "x86_64" Nothing
 
 rpmOutput :: Text
 rpmOutput =
-  Text.intercalate
-    "\n"
-    [ "Name        : glibc"
-    , "Version     : 2.28"
-    , "Release     : 151.el8"
-    , "Architecture: x86_64"
-    , "Install Date: Wed Sep 15 14:17:28 2021"
-    , "Group       : Unspecified"
-    , "Size        : 15646740"
-    , "License     : LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL"
-    , "Signature   : RSA/SHA256, Thu Mar 11 21:46:42 2021, Key ID 05b555b38483c65d"
-    , "Source RPM  : glibc-2.28-151.el8.src.rpm"
-    , "Build Date  : Thu Mar 11 20:16:40 2021"
-    , "Build Host  : x86-01.mbox.centos.org"
-    , "Relocations : (not relocatable)"
-    , "Packager    : CentOS Buildsys <bugs@centos.org>"
-    , "Vendor      : CentOS"
-    , "URL         : http://www.gnu.org/software/glibc/"
-    , "Summary     : The GNU libc libraries"
-    , "Description :"
-    , "The glibc package contains standard libraries which are used by"
-    , "multiple programs on the system. In order to save disk space and"
-    , "memory, as well as to make upgrading easier, common system code is"
-    , "kept in one place and shared between programs. This particular package"
-    , "contains the most important sets of shared libraries: the standard C"
-    , "library and the standard math library. Without these two libraries, a"
-    , "Linux system will not function."
-    ]
+  [r| Name        : glibc
+      Version     : 2.28
+      Release     : 151.el8
+      Architecture: x86_64
+      Install Date: Wed Sep 15 14:17:28 2021
+      Group       : Unspecified
+      Size        : 15646740
+      License     : LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
+      Signature   : RSA/SHA256, Thu Mar 11 21:46:42 2021, Key ID 05b555b38483c65d
+      Source RPM  : glibc-2.28-151.el8.src.rpm
+      Build Date  : Thu Mar 11 20:16:40 2021
+      Build Host  : x86-01.mbox.centos.org
+      Relocations : (not relocatable)
+      Packager    : CentOS Buildsys <bugs@centos.org>
+      Vendor      : CentOS
+      URL         : http://www.gnu.org/software/glibc/
+      Summary     : The GNU libc libraries
+      Description :
+      The glibc package contains standard libraries which are used by
+      multiple programs on the system. In order to save disk space and
+      memory, as well as to make upgrading easier, common system code is
+      kept in one place and shared between programs. This particular package
+      contains the most important sets of shared libraries: the standard C
+      library and the standard math library. Without these two libraries, a
+      Linux system will not function.
+  |]
 
 rpmOutputEpochExpected :: LinuxPackageMetadata
 rpmOutputEpochExpected = LinuxPackageMetadata "device-mapper-libs" "1.02.175-5.el8" "x86_64" (Just "8")
 
 rpmOutputEpoch :: Text
 rpmOutputEpoch =
-  Text.intercalate
-    "\n"
-    [ "Name        : device-mapper-libs"
-    , "Epoch       : 8"
-    , "Version     : 1.02.175"
-    , "Release     : 5.el8"
-    , "Architecture: x86_64"
-    , "Install Date: Wed Sep 15 14:17:37 2021"
-    , "Group       : Unspecified"
-    , "Size        : 415655"
-    , "License     : LGPLv2"
-    , "Signature   : RSA/SHA256, Wed Mar 10 22:00:57 2021, Key ID 05b555b38483c65d"
-    , "Source RPM  : lvm2-2.03.11-5.el8.src.rpm"
-    , "Build Date  : Wed Mar 10 21:50:25 2021"
-    , "Build Host  : x86-02.mbox.centos.org"
-    , "Relocations : (not relocatable)"
-    , "Packager    : CentOS Buildsys <bugs@centos.org>"
-    , "Vendor      : CentOS"
-    , "URL         : http://sourceware.org/lvm2"
-    , "Summary     : Device-mapper shared library"
-    , "Description :"
-    , "This package contains the device-mapper shared library, libdevmapper."
-    ]
+  [r| Name        : device-mapper-libs
+      Epoch       : 8
+      Version     : 1.02.175
+      Release     : 5.el8
+      Architecture: x86_64
+      Install Date: Wed Sep 15 14:17:37 2021
+      Group       : Unspecified
+      Size        : 415655
+      License     : LGPLv2
+      Signature   : RSA/SHA256, Wed Mar 10 22:00:57 2021, Key ID 05b555b38483c65d
+      Source RPM  : lvm2-2.03.11-5.el8.src.rpm
+      Build Date  : Wed Mar 10 21:50:25 2021
+      Build Host  : x86-02.mbox.centos.org
+      Relocations : (not relocatable)
+      Packager    : CentOS Buildsys <bugs@centos.org>
+      Vendor      : CentOS
+      URL         : http://sourceware.org/lvm2
+      Summary     : Device-mapper shared library
+      Description :
+      This package contains the device-mapper shared library, libdevmapper.
+  |]

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/RPMSpec.hs
@@ -1,6 +1,7 @@
 module App.Fossa.VSI.DynLinked.Internal.Lookup.RPMSpec (spec) where
 
-import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM (LinuxPackageSubset (..), parseCommand)
+import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM (parseCommand)
+import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Void (Void)
@@ -11,7 +12,7 @@ import Text.Megaparsec (Parsec, parse)
 parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
 parseMatch parser input expected = parse parser "" input `shouldParse` expected
 
-shouldParseInto :: Text -> (Maybe LinuxPackageSubset) -> Expectation
+shouldParseInto :: Text -> (Maybe LinuxPackageMetadata) -> Expectation
 shouldParseInto = parseMatch parseCommand
 
 spec :: Spec
@@ -29,8 +30,8 @@ spec = do
 notFoundOutput :: Text
 notFoundOutput = "package glibc-2.28-151.el8.x86_64 is not installed"
 
-rpmOutputExpected :: Maybe LinuxPackageSubset
-rpmOutputExpected = Just $ LinuxPackageSubset "glibc" "2.28-151.el8" "x86_64" Nothing
+rpmOutputExpected :: Maybe LinuxPackageMetadata
+rpmOutputExpected = Just $ LinuxPackageMetadata "glibc" "2.28-151.el8" "x86_64" Nothing
 
 rpmOutput :: Text
 rpmOutput =
@@ -63,8 +64,8 @@ rpmOutput =
     , "Linux system will not function."
     ]
 
-rpmOutputEpochExpected :: Maybe LinuxPackageSubset
-rpmOutputEpochExpected = Just $ LinuxPackageSubset "device-mapper-libs" "1.02.175-5.el8" "x86_64" (Just "8")
+rpmOutputEpochExpected :: Maybe LinuxPackageMetadata
+rpmOutputEpochExpected = Just $ LinuxPackageMetadata "device-mapper-libs" "1.02.175-5.el8" "x86_64" (Just "8")
 
 rpmOutputEpoch :: Text
 rpmOutputEpoch =

--- a/test/App/Fossa/VSI/DynLinked/Internal/ResolveSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/ResolveSpec.hs
@@ -1,7 +1,7 @@
 module App.Fossa.VSI.DynLinked.Internal.ResolveSpec (spec) where
 
 import App.Fossa.VSI.DynLinked.Internal.Resolve (toDependency)
-import App.Fossa.VSI.DynLinked.Types (LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
+import App.Fossa.VSI.DynLinked.Types (LinuxDistro (..), LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
 import Data.Text (Text)
 import DepTypes (DepType (..), Dependency (..), VerConstraint (CEq))
 import Test.Hspec (Spec, describe, it, shouldBe)
@@ -10,22 +10,22 @@ spec :: Spec
 spec = do
   describe "resolves linux dependencies to srclib dependencies" $ do
     it "resolves apk" $ do
-      let original = ResolvedLinuxPackage LinuxPackageManagerAPK placeholderMeta
+      let original = ResolvedLinuxPackage LinuxPackageManagerAPK placeholderDistro placeholderMeta
       let expected = Dependency LinuxAPK "id#distro#release" (Just $ CEq "arch#revision") [] mempty mempty
       toDependency original `shouldBe` expected
 
     it "resolves debian" $ do
-      let original = ResolvedLinuxPackage LinuxPackageManagerDEB placeholderMeta
+      let original = ResolvedLinuxPackage LinuxPackageManagerDEB placeholderDistro placeholderMeta
       let expected = Dependency LinuxDEB "id#distro#release" (Just $ CEq "arch#revision") [] mempty mempty
       toDependency original `shouldBe` expected
 
     it "resolves rpm with epoch" $ do
-      let original = ResolvedLinuxPackage LinuxPackageManagerRPM placeholderMeta
+      let original = ResolvedLinuxPackage LinuxPackageManagerRPM placeholderDistro placeholderMeta
       let expected = Dependency LinuxRPM "id#distro#release" (Just $ CEq "arch#epoch:revision") [] mempty mempty
       toDependency original `shouldBe` expected
 
     it "resolves rpm without epoch" $ do
-      let original = ResolvedLinuxPackage LinuxPackageManagerRPM $ baseMeta Nothing
+      let original = ResolvedLinuxPackage LinuxPackageManagerRPM placeholderDistro $ baseMeta Nothing
       let expected = Dependency LinuxRPM "id#distro#release" (Just $ CEq "arch#revision") [] mempty mempty
       toDependency original `shouldBe` expected
 
@@ -33,4 +33,7 @@ placeholderMeta :: LinuxPackageMetadata
 placeholderMeta = baseMeta (Just "epoch")
 
 baseMeta :: Maybe Text -> LinuxPackageMetadata
-baseMeta = LinuxPackageMetadata "id" "revision" "distro" "release" "arch"
+baseMeta = LinuxPackageMetadata "id" "revision" "arch"
+
+placeholderDistro :: LinuxDistro
+placeholderDistro = LinuxDistro "distro" "release"

--- a/test/App/Fossa/VSI/DynLinked/Internal/ResolveSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/ResolveSpec.hs
@@ -10,24 +10,24 @@ spec :: Spec
 spec = do
   describe "resolves linux dependencies to srclib dependencies" $ do
     it "resolves apk" $ do
-      let original = ResolvedLinuxPackage LinuxPackageManagerAPK placeholderDistro placeholderMeta
+      let original = ResolvedLinuxPackage LinuxPackageManagerAPK placeholderMeta
       let expected = Dependency LinuxAPK "id#distro#release" (Just $ CEq "arch#revision") [] mempty mempty
-      toDependency original `shouldBe` expected
+      toDependency placeholderDistro original `shouldBe` expected
 
     it "resolves debian" $ do
-      let original = ResolvedLinuxPackage LinuxPackageManagerDEB placeholderDistro placeholderMeta
+      let original = ResolvedLinuxPackage LinuxPackageManagerDEB placeholderMeta
       let expected = Dependency LinuxDEB "id#distro#release" (Just $ CEq "arch#revision") [] mempty mempty
-      toDependency original `shouldBe` expected
+      toDependency placeholderDistro original `shouldBe` expected
 
     it "resolves rpm with epoch" $ do
-      let original = ResolvedLinuxPackage LinuxPackageManagerRPM placeholderDistro placeholderMeta
+      let original = ResolvedLinuxPackage LinuxPackageManagerRPM placeholderMeta
       let expected = Dependency LinuxRPM "id#distro#release" (Just $ CEq "arch#epoch:revision") [] mempty mempty
-      toDependency original `shouldBe` expected
+      toDependency placeholderDistro original `shouldBe` expected
 
     it "resolves rpm without epoch" $ do
-      let original = ResolvedLinuxPackage LinuxPackageManagerRPM placeholderDistro $ baseMeta Nothing
+      let original = ResolvedLinuxPackage LinuxPackageManagerRPM $ baseMeta Nothing
       let expected = Dependency LinuxRPM "id#distro#release" (Just $ CEq "arch#revision") [] mempty mempty
-      toDependency original `shouldBe` expected
+      toDependency placeholderDistro original `shouldBe` expected
 
 placeholderMeta :: LinuxPackageMetadata
 placeholderMeta = baseMeta (Just "epoch")

--- a/test/App/Fossa/VSI/DynLinked/Internal/ResolveSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/ResolveSpec.hs
@@ -1,10 +1,25 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module App.Fossa.VSI.DynLinked.Internal.ResolveSpec (spec) where
 
-import App.Fossa.VSI.DynLinked.Internal.Resolve (toDependency)
+import App.Fossa.VSI.DynLinked.Internal.Resolve (parseLinuxDistro, toDependency)
 import App.Fossa.VSI.DynLinked.Types (LinuxDistro (..), LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
 import Data.Text (Text)
+import Data.Void (Void)
 import DepTypes (DepType (..), Dependency (..), VerConstraint (CEq))
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
+import Test.Hspec.Megaparsec (shouldFailOn, shouldParse)
+import Text.Megaparsec (Parsec, parse)
+import Text.RawString.QQ (r)
+
+parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
+parseMatch parser input expected = parse parser "" input `shouldParse` expected
+
+shouldParseInto :: Text -> LinuxDistro -> Expectation
+shouldParseInto = parseMatch parseLinuxDistro
+
+shouldFailParsing :: Text -> Expectation
+shouldFailParsing input = parse parseLinuxDistro "" `shouldFailOn` input
 
 spec :: Spec
 spec = do
@@ -29,6 +44,16 @@ spec = do
       let expected = Dependency LinuxRPM "id#distro#release" (Just $ CEq "arch#revision") [] mempty mempty
       toDependency placeholderDistro original `shouldBe` expected
 
+  describe "parses linux distro" $ do
+    it "parses simple distro" $ do
+      simpleDistro `shouldParseInto` expectedSimpleDistro
+
+    it "parses complex distro" $ do
+      complexDistro `shouldParseInto` expectedComplexDistro
+
+    it "fails missing pieces distro" $ do
+      shouldFailParsing malformedDistro
+
 placeholderMeta :: LinuxPackageMetadata
 placeholderMeta = baseMeta (Just "epoch")
 
@@ -37,3 +62,31 @@ baseMeta = LinuxPackageMetadata "id" "revision" "arch"
 
 placeholderDistro :: LinuxDistro
 placeholderDistro = LinuxDistro "distro" "release"
+
+simpleDistro :: Text
+simpleDistro =
+  [r| ID=distro
+      VERSION_ID=release
+  |]
+
+malformedDistro :: Text
+malformedDistro = "ID=distro"
+
+expectedSimpleDistro :: LinuxDistro
+expectedSimpleDistro = LinuxDistro "distro" "release"
+
+complexDistro :: Text
+complexDistro =
+  [r| NAME=Fedora
+      VERSION="17 (Beefy Miracle)"
+      ID=fedora
+      VERSION_ID=17
+      PRETTY_NAME="Fedora 17 (Beefy Miracle)"
+      ANSI_COLOR="0;34"
+      CPE_NAME="cpe:/o:fedoraproject:fedora:17"
+      HOME_URL="https://fedoraproject.org/"
+      BUG_REPORT_URL="https://bugzilla.redhat.com/"
+  |]
+
+expectedComplexDistro :: LinuxDistro
+expectedComplexDistro = LinuxDistro "fedora" "17"


### PR DESCRIPTION
# Overview

Looks up linux packages discovered from other dynamic linking steps.

_Still not adding to changelog yet as this code is unreachable._

## Acceptance criteria

* Given a file path that has been determined to be a dynamically linked dependency of an executable, we need to be able to determine which linux package brought in the file (or fallback to a binary dependency).

## Testing plan

I relied on automated testing.

## Risks

Not risky.

## References

Closes https://github.com/fossas/team-analysis/issues/883

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
