### PR TITLE
VSI + Dynamic Linking: lookup linux distro

### DIFF
--- a/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
@@ -13,7 +13,7 @@ import App.Fossa.BinaryDeps (analyzeSingleBinary)
 import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..), LinuxDistro (..), LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
 import App.Fossa.VSI.DynLinked.Util (fsRoot, runningLinux)
 import Control.Algebra (Has)
-import Control.Effect.Diagnostics (Diagnostics, recover, (<||>))
+import Control.Effect.Diagnostics (Diagnostics, (<||>))
 import Control.Effect.Lift (Lift)
 import Data.Either (partitionEithers)
 import Data.Map qualified as Map
@@ -123,7 +123,7 @@ sortResolvedUnresolved = partitionEithers . map forkEither . toList
 -- Exits via @Diagnostics@ on parse errors.
 environmentDistro :: (Has Diagnostics sig m, Has ReadFS sig m) => m (Maybe LinuxDistro)
 environmentDistro
-  | runningLinux = recover $ readOsReleaseAt primaryPath <||> readOsReleaseAt fallbackPath
+  | runningLinux = Just <$> (readOsReleaseAt primaryPath <||> readOsReleaseAt fallbackPath)
   | otherwise = pure Nothing
   where
     primaryPath :: Path Abs File

--- a/src/App/Fossa/VSI/DynLinked/Util.hs
+++ b/src/App/Fossa/VSI/DynLinked/Util.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module App.Fossa.VSI.DynLinked.Util (
   hasSetUID,
   runningLinux,
+  fsRoot,
 ) where
 
-import Path (File, Path)
+import Path (Abs, Dir, File, Path, mkAbsDir)
 import System.Info qualified as SysInfo
 
 -- Have to use CPP pragmas here so we can import @System.Posix.Files@.
@@ -15,6 +17,10 @@ import System.Info qualified as SysInfo
 -- Windows doesn't have the concept of a "set uid bit", so always eval to false.
 hasSetUID :: Monad m => Path t File -> m Bool
 hasSetUID _ = pure False
+
+-- | The root of the primary file system.
+fsRoot :: Path Abs Dir
+fsRoot = $(mkAbsDir "C:/")
 
 #else
 
@@ -30,6 +36,10 @@ hasSetUID :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path t File -> m Bo
 hasSetUID file = do
   stat <- fatalOnSomeException "get file status" . sendIO . getFileStatus $ P.toFilePath file
   pure $ fileMode stat .&. setUserIDMode /= 0
+
+-- | The root of the primary file system.
+fsRoot :: Path Abs Dir
+fsRoot = $(mkAbsDir "/")
 
 #endif
 

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -7,10 +6,11 @@ module App.Fossa.VSI.DynLinked.Internal.Lookup.APKSpec (spec) where
 
 import App.Fossa.VSI.DynLinked.Internal.Lookup.APK (SyftArtifact (..), SyftArtifactMetadata (..), SyftArtifactMetadataFile (..), SyftData (..), SyftLookupTable (..), constructLookupTables)
 import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
+import App.Fossa.VSI.DynLinked.Util (fsRoot)
 import Control.Carrier.Diagnostics (runDiagnostics)
 import Data.Aeson (toJSON)
 import Data.Map qualified as Map
-import Path (Abs, Dir, Path, mkAbsDir, mkRelFile, (</>))
+import Path (mkRelFile, (</>))
 import Test.Hspec (Spec, describe, expectationFailure, it, runIO, shouldBe)
 
 spec :: Spec
@@ -35,9 +35,9 @@ syntheticData =
               SyftArtifactMetadata
                 { metadataArchitecture = "arch_1"
                 , metadataFiles =
-                    [ SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file1_1")
-                    , SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file1_2")
-                    , SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file1_3")
+                    [ SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file1_1")
+                    , SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file1_2")
+                    , SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file1_3")
                     ]
                 }
         }
@@ -51,9 +51,9 @@ syntheticData =
               SyftArtifactMetadata
                 { metadataArchitecture = "arch_2"
                 , metadataFiles =
-                    [ SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file2_1")
-                    , SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file2_2")
-                    , SyftArtifactMetadataFile $ safeAbsRoot </> $(mkRelFile "file2_3")
+                    [ SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file2_1")
+                    , SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file2_2")
+                    , SyftArtifactMetadataFile $ fsRoot </> $(mkRelFile "file2_3")
                     ]
                 }
         }
@@ -64,12 +64,12 @@ expectedLookupTable =
   SyftLookupTable
     { pathToIndex =
         Map.fromList
-          [ (safeAbsRoot </> $(mkRelFile "file1_1"), 0)
-          , (safeAbsRoot </> $(mkRelFile "file1_2"), 0)
-          , (safeAbsRoot </> $(mkRelFile "file1_3"), 0)
-          , (safeAbsRoot </> $(mkRelFile "file2_1"), 1)
-          , (safeAbsRoot </> $(mkRelFile "file2_2"), 1)
-          , (safeAbsRoot </> $(mkRelFile "file2_3"), 1)
+          [ (fsRoot </> $(mkRelFile "file1_1"), 0)
+          , (fsRoot </> $(mkRelFile "file1_2"), 0)
+          , (fsRoot </> $(mkRelFile "file1_3"), 0)
+          , (fsRoot </> $(mkRelFile "file2_1"), 1)
+          , (fsRoot </> $(mkRelFile "file2_2"), 1)
+          , (fsRoot </> $(mkRelFile "file2_3"), 1)
           ]
     , indexToMeta =
         Map.fromList
@@ -93,12 +93,3 @@ expectedLookupTable =
             )
           ]
     }
-
--- We have to use CPP pragmas here, because we can't compile abs paths for other platforms.
-#ifdef mingw32_HOST_OS
-safeAbsRoot :: Path Abs Dir
-safeAbsRoot = $(mkAbsDir "C:/")
-#else
-safeAbsRoot :: Path Abs Dir
-safeAbsRoot = $(mkAbsDir "/")
-#endif

--- a/test/App/Fossa/VSI/DynLinked/Internal/ResolveSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/ResolveSpec.hs
@@ -1,10 +1,14 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module App.Fossa.VSI.DynLinked.Internal.ResolveSpec (spec) where
 
-import App.Fossa.VSI.DynLinked.Internal.Resolve (toDependency)
+import App.Fossa.VSI.DynLinked.Internal.Resolve (readLinuxDistro, toDependency)
 import App.Fossa.VSI.DynLinked.Types (LinuxDistro (..), LinuxPackageManager (..), LinuxPackageMetadata (..), ResolvedLinuxPackage (..))
+import Control.Carrier.Diagnostics (runDiagnostics)
 import Data.Text (Text)
 import DepTypes (DepType (..), Dependency (..), VerConstraint (CEq))
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (Spec, describe, expectationFailure, it, runIO, shouldBe)
+import Text.RawString.QQ (r)
 
 spec :: Spec
 spec = do
@@ -29,6 +33,18 @@ spec = do
       let expected = Dependency LinuxRPM "id#distro#release" (Just $ CEq "arch#revision") [] mempty mempty
       toDependency placeholderDistro original `shouldBe` expected
 
+  describe "parses linux distro" $ do
+    simpleResult <- runIO . runDiagnostics $ readLinuxDistro simpleDistro
+    complexResult <- runIO . runDiagnostics $ readLinuxDistro complexDistro
+
+    it "parses simple distro" $ case simpleResult of
+      Left e -> expectationFailure ("could not parse: " <> show e)
+      Right result -> result `shouldBe` expectedSimpleDistro
+
+    it "parses complex distro" $ case complexResult of
+      Left e -> expectationFailure ("could not parse: " <> show e)
+      Right result -> result `shouldBe` expectedComplexDistro
+
 placeholderMeta :: LinuxPackageMetadata
 placeholderMeta = baseMeta (Just "epoch")
 
@@ -37,3 +53,28 @@ baseMeta = LinuxPackageMetadata "id" "revision" "arch"
 
 placeholderDistro :: LinuxDistro
 placeholderDistro = LinuxDistro "distro" "release"
+
+simpleDistro :: Text
+simpleDistro =
+  [r| ID=distro
+      VERSION_ID=release
+  |]
+
+expectedSimpleDistro :: LinuxDistro
+expectedSimpleDistro = LinuxDistro "distro" "release"
+
+complexDistro :: Text
+complexDistro =
+  [r| NAME=Fedora
+      VERSION="17 (Beefy Miracle)"
+      ID=fedora
+      VERSION_ID=17
+      PRETTY_NAME="Fedora 17 (Beefy Miracle)"
+      ANSI_COLOR="0;34"
+      CPE_NAME="cpe:/o:fedoraproject:fedora:17"
+      HOME_URL="https://fedoraproject.org/"
+      BUG_REPORT_URL="https://bugzilla.redhat.com/"
+  |]
+
+expectedComplexDistro :: LinuxDistro
+expectedComplexDistro = LinuxDistro "fedora" "17"


### PR DESCRIPTION
# Overview

Provides the ability to look up the linux distro.

## Acceptance criteria

We need to be able to identify the linux distro in which we are running in order to report linux locators.

## Testing plan

I relied on automated testing.

## Risks

No risk, this code is unreachable.

## References

Related to https://github.com/fossas/team-analysis/issues/883

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
