### PR TITLE
Use modern-uri version that renders '+' and '@' in path components

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## Unreleased
+
+- Fully percent-encode sub-paths in generated URLs. ([#789](https://github.com/fossas/fossa-cli/pull/789))
+
 ## v3.0.17
 
 - Npm: Fixes an issue where a package-lock.json dep with a boolean 'resolved' key wouldn't parse. ([#775](https://github.com/fossas/fossa-cli/pull/775))

--- a/cabal.project
+++ b/cabal.project
@@ -46,14 +46,7 @@ source-repository-package
   tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
 
--- Current version of modern-uri does not render '+' or '@' characters in percent encoding.
--- TODO: Remove once version 0.3.4.3 is released to hackage
-source-repository-package
-  type: git
-  location: https://github.com/fossas/modern-uri
-  tag: 127c1f069f88c63f236c8f62d59a1c0984a3ed47
-
-index-state: hackage.haskell.org 2021-11-03T16:17:20Z
+index-state: hackage.haskell.org 2022-02-02T15:17:53Z
 
 package *
   extra-include-dirs: /opt/homebrew/include

--- a/cabal.project
+++ b/cabal.project
@@ -46,7 +46,7 @@ source-repository-package
   tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
 
--- Current version of modern-uri does not render '+' or '@' characters in percent encoding. 
+-- Current version of modern-uri does not render '+' or '@' characters in percent encoding.
 -- TODO: Remove once version 0.3.4.3 is released to hackage
 source-repository-package
   type: git

--- a/cabal.project
+++ b/cabal.project
@@ -46,6 +46,13 @@ source-repository-package
   tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
 
+-- Current version of modern-uri does not render '+' or '@' characters in percent encoding. 
+-- TODO: Remove once version 0.3.4.3 is released to hackage
+source-repository-package
+  type: git
+  location: https://github.com/fossas/modern-uri
+  tag: 127c1f069f88c63f236c8f62d59a1c0984a3ed47
+
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z
 
 package *

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -46,11 +46,18 @@ source-repository-package
 -- Current implementation of yarn-lock throws runtime error, as described by patches:
 -- (a) https://github.com/Profpatsch/yarn2nix/pull/73
 -- (b) https://github.com/Profpatsch/yarn2nix/pull/72
--- TODO: Remove once, both PRs are merged. 
+-- TODO: Remove once, both PRs are merged.
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
   tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
+
+-- Current version of modern-uri does not render '+' or '@' characters in percent encoding.
+-- TODO: Remove once version 0.3.4.3 is released to hackage
+source-repository-package
+  type: git
+  location: https://github.com/fossas/modern-uri
+  tag: 127c1f069f88c63f236c8f62d59a1c0984a3ed47
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -46,18 +46,11 @@ source-repository-package
 -- Current implementation of yarn-lock throws runtime error, as described by patches:
 -- (a) https://github.com/Profpatsch/yarn2nix/pull/73
 -- (b) https://github.com/Profpatsch/yarn2nix/pull/72
--- TODO: Remove once, both PRs are merged.
+-- TODO: Remove once, both PRs are merged. 
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
   tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
 
--- Current version of modern-uri does not render '+' or '@' characters in percent encoding.
--- TODO: Remove once version 0.3.4.3 is released to hackage
-source-repository-package
-  type: git
-  location: https://github.com/fossas/modern-uri
-  tag: 127c1f069f88c63f236c8f62d59a1c0984a3ed47
-
-index-state: hackage.haskell.org 2021-11-03T16:17:20Z
+index-state: hackage.haskell.org 2022-02-02T15:17:53Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -44,11 +44,18 @@ source-repository-package
 -- Current implementation of yarn-lock throws runtime error, as described by patches:
 -- (a) https://github.com/Profpatsch/yarn2nix/pull/73
 -- (b) https://github.com/Profpatsch/yarn2nix/pull/72
--- TODO: Remove once, both PRs are merged. 
+-- TODO: Remove once, both PRs are merged.
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
   tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
+
+-- Current version of modern-uri does not render '+' or '@' characters in percent encoding.
+-- TODO: Remove once version 0.3.4.3 is released to hackage
+source-repository-package
+  type: git
+  location: https://github.com/fossas/modern-uri
+  tag: 127c1f069f88c63f236c8f62d59a1c0984a3ed47
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -44,18 +44,11 @@ source-repository-package
 -- Current implementation of yarn-lock throws runtime error, as described by patches:
 -- (a) https://github.com/Profpatsch/yarn2nix/pull/73
 -- (b) https://github.com/Profpatsch/yarn2nix/pull/72
--- TODO: Remove once, both PRs are merged.
+-- TODO: Remove once, both PRs are merged. 
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
   tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
 
--- Current version of modern-uri does not render '+' or '@' characters in percent encoding.
--- TODO: Remove once version 0.3.4.3 is released to hackage
-source-repository-package
-  type: git
-  location: https://github.com/fossas/modern-uri
-  tag: 127c1f069f88c63f236c8f62d59a1c0984a3ed47
-
-index-state: hackage.haskell.org 2021-11-03T16:17:20Z
+index-state: hackage.haskell.org 2022-02-02T15:17:53Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -46,11 +46,18 @@ source-repository-package
 -- Current implementation of yarn-lock throws runtime error, as described by patches:
 -- (a) https://github.com/Profpatsch/yarn2nix/pull/73
 -- (b) https://github.com/Profpatsch/yarn2nix/pull/72
--- TODO: Remove once, both PRs are merged. 
+-- TODO: Remove once, both PRs are merged.
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
   tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
+
+-- Current version of modern-uri does not render '+' or '@' characters in percent encoding.
+-- TODO: Remove once version 0.3.4.3 is released to hackage
+source-repository-package
+  type: git
+  location: https://github.com/fossas/modern-uri
+  tag: 127c1f069f88c63f236c8f62d59a1c0984a3ed47
 
 index-state: hackage.haskell.org 2021-11-03T16:17:20Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -46,18 +46,11 @@ source-repository-package
 -- Current implementation of yarn-lock throws runtime error, as described by patches:
 -- (a) https://github.com/Profpatsch/yarn2nix/pull/73
 -- (b) https://github.com/Profpatsch/yarn2nix/pull/72
--- TODO: Remove once, both PRs are merged.
+-- TODO: Remove once, both PRs are merged. 
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
   tag: 7d9f505b35750e54bf9d73e5a996df4a1c5ab117
   subdir: yarn-lock
 
--- Current version of modern-uri does not render '+' or '@' characters in percent encoding.
--- TODO: Remove once version 0.3.4.3 is released to hackage
-source-repository-package
-  type: git
-  location: https://github.com/fossas/modern-uri
-  tag: 127c1f069f88c63f236c8f62d59a1c0984a3ed47
-
-index-state: hackage.haskell.org 2021-11-03T16:17:20Z
+index-state: hackage.haskell.org 2022-02-02T15:17:53Z

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -2,7 +2,7 @@
 
 module App.Fossa.API.BuildLinkSpec (spec) where
 
-import App.Fossa.API.BuildLink
+import App.Fossa.API.BuildLink (getBuildURLWithOrg)
 import App.Fossa.FossaAPIV1 (Organization (Organization))
 import App.Types (ProjectRevision (ProjectRevision))
 import Control.Carrier.Diagnostics (DiagnosticsC, runDiagnostics)
@@ -12,21 +12,21 @@ import Data.Text (Text)
 import Diag.Result (resultToMaybe)
 import Fossa.API.Types
 import Srclib.Types (Locator (Locator))
-import Test.Hspec
-import Text.URI.QQ
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Text.URI.QQ (uri)
 
 simpleSamlPath :: Text
-simpleSamlPath = "https://app.fossa.com/account/saml/1?next=/projects/fetcher123%2bproject123/refs/branch/master123/revision123"
+simpleSamlPath = "https://app.fossa.com/account/saml/1?next=/projects/fetcher123%252bproject123/refs/branch/master123/revision123"
 
 -- | Note the differences here between '%2F' and '%252F'.  The percent sign is re-encoded so that it's properly handled on the next redirect.
 gitSamlPath :: Text
-gitSamlPath = "https://app.fossa.com/account/saml/103?next=/projects/fetcher@123%252fabc%2bgit@github.com%252fuser%252frepo/refs/branch/weird--branch/revision@123%252fabc"
+gitSamlPath = "https://app.fossa.com/account/saml/103?next=/projects/fetcher%2540123%252fabc%252bgit%2540github.com%252fuser%252frepo/refs/branch/weird--branch/revision%2540123%252fabc"
 
 fullSamlURL :: Text
-fullSamlURL = "https://app.fossa.com/account/saml/33?next=/projects/a%2bb/refs/branch/master/c"
+fullSamlURL = "https://app.fossa.com/account/saml/33?next=/projects/a%252bb/refs/branch/master/c"
 
 simpleStandardURL :: Text
-simpleStandardURL = "https://app.fossa.com/projects/haskell+89%2fspectrometer/refs/branch/master/revision123"
+simpleStandardURL = "https://app.fossa.com/projects/haskell%2b89%2fspectrometer/refs/branch/master/revision123"
 
 stripDiag :: DiagnosticsC (StackC Identity) a -> Maybe a
 stripDiag = resultToMaybe . runIdentity . runStack . runDiagnostics

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -18,7 +18,10 @@ import Text.URI.QQ (uri)
 simpleSamlPath :: Text
 simpleSamlPath = "https://app.fossa.com/account/saml/1?next=/projects/fetcher123%252bproject123/refs/branch/master123/revision123"
 
--- | Note the differences here between '%2F' and '%252F'.  The percent sign is re-encoded so that it's properly handled on the next redirect.
+-- All reserved characters in the 'next' URI get encoded once during render of
+-- the query value. Then the resulting '%' symbols are themselves
+-- percent-encoded during final rendering of the URI.  For example, the process
+-- for '@' works this way: '@' -> '%40' -> '%2540'
 gitSamlPath :: Text
 gitSamlPath = "https://app.fossa.com/account/saml/103?next=/projects/fetcher%2540123%252fabc%252bgit%2540github.com%252fuser%252frepo/refs/branch/weird--branch/revision%2540123%252fabc"
 


### PR DESCRIPTION
# Overview

This change switches us to use a version of modern-uri. 

## Acceptance criteria

The current version of modern-uri inconsistently percent-encodes characters in path components.

## Testing plan

I edited our existing test cases to work where needed. I also manually checked that the links we generate at the end of a run of fossa-cli go to the correct place in our web ui. 

## Risks

Some of our tests needed to be changed to accommodate two passes of percent encoding. Please pay special attention to that. 

## References

Closes fossas/team-analysis#633

Modern-uri PR: mrkkrp/modern-uri#47

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
