### PR TITLE
Adds analysis scan summary

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Fossa API: Uses `SSL_CERT_FILE`, and `SSL_CERT_DIR` environment variable for certificates when provided. ([#760](https://github.com/fossas/fossa-cli/pull/760)) 
 - UX: Uses error messages received from FOSSA api, when reporting API related errors. ([#792](https://github.com/fossas/fossa-cli/pull/792))
+- UX: Adds scan summary tabulating errors, warnings, project directory, and skipped projects. ([#790](https://github.com/fossas/fossa-cli/pull/790))   
 
 ## v3.0.18
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -149,6 +149,7 @@ library
     App.Fossa.Analyze.Log4jReport
     App.Fossa.Analyze.Project
     App.Fossa.Analyze.Record
+    App.Fossa.Analyze.ScanSummary
     App.Fossa.Analyze.Types
     App.Fossa.Analyze.Upload
     App.Fossa.API.BuildLink

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -278,7 +278,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   let projectResults = mapMaybe toProjectResult projectScans
   let filteredProjects = mapMaybe toProjectResult projectScansWithSkippedProdPath
 
-  _ <- renderScanSummary projectScansWithSkippedProdPath vsiResults binarySearchResults manualSrcUnits
+  renderScanSummary projectScansWithSkippedProdPath vsiResults binarySearchResults manualSrcUnits
 
   -- Need to check if vendored is empty as well, even if its a boolean that vendoredDeps exist
   case checkForEmptyUpload includeAll projectResults filteredProjects additionalSourceUnits of

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -1,0 +1,244 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.Analyze.ScanSummary (
+  renderScanSummary,
+) where
+
+import App.Fossa.Analyze.Project (
+  ProjectResult (projectResultPath),
+  projectResultType,
+ )
+import App.Fossa.Analyze.Types (
+  DiscoveredProjectIdentifier (dpiProjectPath, dpiProjectType),
+  DiscoveredProjectScan (..),
+ )
+import App.Version (currentBranch, versionNumber)
+import Control.Effect.Diagnostics qualified as Diag (Diagnostics)
+import Control.Monad (when)
+import Data.Foldable (traverse_)
+import Data.List (sortBy)
+import Data.String.Conversion (toText)
+import Data.Text (Text)
+import Diag.Result (EmittedWarn (IgnoredErrGroup), Result (Failure, Success))
+import Effect.Logger (
+  AnsiStyle,
+  Has,
+  Logger,
+  Pretty (pretty),
+  hsep,
+  logInfo,
+ )
+import Path
+import Prettyprinter (Doc, annotate)
+import Prettyprinter.Render.Terminal (Color (Green, Red, Yellow), bold, color)
+import Srclib.Types (
+  AdditionalDepData (userDefinedDeps),
+  SourceUnit (additionalData),
+  SourceUserDefDep (srcUserDepName),
+ )
+import Types (DiscoveredProjectType, projectTypeToText)
+
+data ScanCount = ScanCount
+  { numProjects :: Int
+  , numSkipped :: Int
+  , numSucceeded :: Int
+  , numFailed :: Int
+  , numWarnings :: Int
+  }
+  deriving (Show, Eq, Ord)
+
+(|+|) :: ScanCount -> ScanCount -> ScanCount
+ScanCount l1 l2 l3 l4 l5 |+| ScanCount r1 r2 r3 r4 r5 =
+  ScanCount (l1 + r1) (l2 + r2) (l3 + r3) (l4 + r4) (l5 + r5)
+
+getScanCount :: [DiscoveredProjectScan] -> ScanCount
+getScanCount = foldl countOf (ScanCount 0 0 0 0 0)
+  where
+    countOf :: ScanCount -> DiscoveredProjectScan -> ScanCount
+    countOf tsc (SkippedDueToProvidedFilter _) =
+      tsc
+        { numProjects = numProjects tsc + 1
+        , numSkipped = numSkipped tsc + 1
+        }
+    countOf tsc (SkippedDueToDefaultProductionFilter _) =
+      tsc
+        { numProjects = numProjects tsc + 1
+        , numSkipped = numSkipped tsc + 1
+        }
+    countOf tsc (Scanned _ (Failure _ _)) =
+      tsc
+        { numProjects = numProjects tsc + 1
+        , numFailed = numFailed tsc + 1
+        }
+    countOf tsc (Scanned _ (Success wg _)) =
+      tsc
+        { numProjects = numProjects tsc + 1
+        , numSucceeded = numSucceeded tsc + 1
+        , numWarnings = numWarnings tsc + countWarnings wg
+        }
+
+instance Pretty ScanCount where
+  pretty ScanCount{..} =
+    hsep
+      [ pretty numProjects <> " projects scanned; "
+      , pretty numSkipped <> " skipped, "
+      , pretty numSucceeded <> " succeeded, "
+      , pretty numFailed <> " failed, "
+      , pretty numWarnings <> " analysis warnings"
+      ]
+
+-- | Renders Analysis Scan Summary with `ServInfo` severity.
+--
+-- It renders summary of all scanned projects (including skipped projects due to filters),
+-- and it's status - failed, successful, successful with warning count,
+-- if project count is greater than 0, otherwise it does nothing.
+--
+-- ### Example
+--
+-- Scan Summary
+-- - - - - - - -
+-- Using fossa-cli: `v3.0.0`
+--
+-- 4 projects scanned;  2 skipped,  2 succeeded,  0 failed,  0 analysis warnings
+--
+-- * __poetry__ project in path: succeeded
+-- * __poetry__ project in path: succeeded
+-- * __fpm__ project in path: skipped
+-- * __setuptools__ project in path: skipped
+renderScanSummary ::
+  (Has Diag.Diagnostics sig m, Has Logger sig m) =>
+  [DiscoveredProjectScan] ->
+  -- | Resulted source unit from @analyzeVSI@
+  Result (Maybe SourceUnit) ->
+  -- | Resulted source unit from @analyzeDiscoverBinaries@
+  Result (Maybe SourceUnit) ->
+  -- | Resulted source unit from @manualSrcUnits@
+  Result (Maybe SourceUnit) ->
+  m ()
+renderScanSummary dps vsi binary manualDeps = do
+  -- Ensure consistent order for serialization
+  -- or repeated analysis
+
+  let projects = sortBy orderByScanStatusAndType dps
+  let totalScanCount =
+        getScanCount projects
+          |+| srcUnitToScanCount vsi
+          |+| srcUnitToScanCount binary
+          |+| srcUnitToScanCount manualDeps
+
+  when (numProjects totalScanCount > 0) $ do
+    logInfoVsep
+      [ ""
+      , "Scan Summary"
+      , "------------"
+      , pretty $ "Using fossa-cli: `" <> maybe currentBranch ("v" <>) versionNumber <> "`"
+      , ""
+      , pretty totalScanCount
+      ]
+    logInfo ""
+    logInfoVsep $ itemize listSymbol summarizeProjectScan projects
+
+    -- Additional analysis done outside of standard strategy flow
+    summarizeSrcUnit "vsi analysis" Nothing vsi
+    summarizeSrcUnit "binary-deps analysis" (Just getBinaryIdentifier) binary
+    summarizeSrcUnit "manual and vendor dependencies" Nothing manualDeps
+
+listSymbol :: Text
+listSymbol = "* "
+
+itemize :: Text -> (a -> Doc ann) -> [a] -> [Doc ann]
+itemize symbol f = map ((pretty symbol <>) . f)
+
+getBinaryIdentifier :: SourceUnit -> [Text]
+getBinaryIdentifier srcUnit = maybe [] (srcUserDepName <$>) (userDefinedDeps =<< additionalData srcUnit)
+
+srcUnitToScanCount :: Result (Maybe SourceUnit) -> ScanCount
+srcUnitToScanCount (Failure _ _) = ScanCount 1 0 0 1 0
+srcUnitToScanCount (Success _ Nothing) = ScanCount 0 0 0 0 0
+srcUnitToScanCount (Success wg (Just _)) = ScanCount 1 0 1 0 (countWarnings wg)
+
+summarizeSrcUnit ::
+  (Has Diag.Diagnostics sig m, Has Logger sig m) =>
+  Text ->
+  (Maybe (SourceUnit -> [Text])) ->
+  Result (Maybe SourceUnit) ->
+  m ()
+summarizeSrcUnit analysisHeader maybeGetter (Success wg (Just unit)) = do
+  logInfo $ successColorCoded wg $ pretty (listSymbol <> analysisHeader) <> renderSucceeded wg
+  case maybeGetter <*> (Just unit) of
+    Just txts -> logInfoVsep $ itemize ("  *" <> listSymbol) pretty txts
+    Nothing -> pure ()
+summarizeSrcUnit analysisHeader _ (Failure _ _) =
+  logInfo . failColorCoded $
+    (annotate bold . pretty $ analysisHeader)
+      <> renderFailed
+summarizeSrcUnit _ _ _ = pure ()
+
+summarizeProjectScan :: DiscoveredProjectScan -> Doc AnsiStyle
+summarizeProjectScan (Scanned dpi (Failure _ _)) = failColorCoded $ renderDiscoveredProjectIdentifier dpi <> renderFailed
+summarizeProjectScan (Scanned _ (Success wg pr)) = successColorCoded wg $ renderProjectResult pr <> renderSucceeded wg
+summarizeProjectScan (SkippedDueToProvidedFilter dpi) = renderDiscoveredProjectIdentifier dpi <> renderSkipped
+summarizeProjectScan (SkippedDueToDefaultProductionFilter dpi) = renderDiscoveredProjectIdentifier dpi <> renderSkipped
+
+---------- Rendering Helpers
+
+logInfoVsep :: (Has Logger sig m) => [Doc AnsiStyle] -> m ()
+logInfoVsep = traverse_ logInfo
+
+renderDiscoveredProjectIdentifier :: DiscoveredProjectIdentifier -> Doc AnsiStyle
+renderDiscoveredProjectIdentifier dpi = renderProjectPathAndType (dpiProjectType dpi) (dpiProjectPath dpi)
+
+renderProjectResult :: ProjectResult -> Doc AnsiStyle
+renderProjectResult pr = renderProjectPathAndType (projectResultType pr) (projectResultPath pr)
+
+renderProjectPathAndType :: DiscoveredProjectType -> Path Abs Dir -> Doc AnsiStyle
+renderProjectPathAndType pt path =
+  (annotate bold . pretty $ projectTypeToText pt)
+    <> pretty (" project in " :: Text)
+    <> pretty (toText path)
+
+successColorCoded :: [EmittedWarn] -> Doc AnsiStyle -> Doc AnsiStyle
+successColorCoded ew = if countWarnings ew == 0 then annotate (color Green) else annotate (color Yellow)
+
+failColorCoded :: Doc AnsiStyle -> Doc AnsiStyle
+failColorCoded = annotate (color Red)
+
+renderSkipped :: Doc ann
+renderSkipped = pretty (": skipped" :: Text)
+
+renderSucceeded :: [EmittedWarn] -> Doc ann
+renderSucceeded ew =
+  if countWarnings ew == 0
+    then pretty (": succeeded" :: Text)
+    else pretty (": succeeded with " :: Text) <> pretty (show $ countWarnings ew) <> pretty (": warning" :: Text)
+
+renderFailed :: Doc ann
+renderFailed = pretty (": failed" :: Text)
+
+orderByScanStatusAndType :: DiscoveredProjectScan -> DiscoveredProjectScan -> Ordering
+orderByScanStatusAndType (SkippedDueToProvidedFilter lhs) (SkippedDueToProvidedFilter rhs) = compare lhs rhs
+orderByScanStatusAndType (SkippedDueToProvidedFilter lhs) (SkippedDueToDefaultProductionFilter rhs) = compare lhs rhs
+orderByScanStatusAndType (SkippedDueToDefaultProductionFilter lhs) (SkippedDueToProvidedFilter rhs) = compare lhs rhs
+orderByScanStatusAndType (SkippedDueToDefaultProductionFilter lhs) (SkippedDueToDefaultProductionFilter rhs) = compare lhs rhs
+orderByScanStatusAndType (SkippedDueToDefaultProductionFilter _) (Scanned _ _) = GT
+orderByScanStatusAndType (SkippedDueToProvidedFilter _) (Scanned _ _) = GT
+orderByScanStatusAndType (Scanned _ (Success _ lhs)) (Scanned _ (Success _ rhs)) = compare (projectResultType lhs) (projectResultType rhs)
+orderByScanStatusAndType (Scanned lhs (Failure _ _)) (Scanned rhs (Failure _ _)) = compare lhs rhs
+orderByScanStatusAndType (Scanned _ (Success _ _)) (Scanned _ (Failure _ _)) = LT
+orderByScanStatusAndType (Scanned _ _) _ = LT
+
+-- | Counts number of displayed warning.
+-- It ignores warning aggregated under @IgnoredErrGroup@.
+-- We do this to ensure warning count is consistent with rendered warnings.
+countWarnings :: [EmittedWarn] -> Int
+countWarnings ws =
+  case notIgnoredErrs of
+    [] -> 0
+    ws' -> length ws'
+  where
+    notIgnoredErrs :: [EmittedWarn]
+    notIgnoredErrs = filter (not . isIgnoredErrGroup) ws
+
+    isIgnoredErrGroup :: EmittedWarn -> Bool
+    isIgnoredErrGroup IgnoredErrGroup{} = True
+    isIgnoredErrGroup _ = False

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -12,7 +12,7 @@ import App.Fossa.Analyze.Types (
   DiscoveredProjectIdentifier (dpiProjectPath, dpiProjectType),
   DiscoveredProjectScan (..),
  )
-import App.Version (currentBranch, versionNumber)
+import App.Version (currentBranch, fullVersionDescription, versionNumber)
 import Control.Effect.Diagnostics qualified as Diag (Diagnostics)
 import Control.Monad (when)
 import Data.Foldable (traverse_)
@@ -117,7 +117,6 @@ renderScanSummary ::
   Result (Maybe SourceUnit) ->
   m ()
 renderScanSummary dps vsi binary manualDeps = do
-  let cliVersion = maybe currentBranch ("v" <>) versionNumber
   let projects = sort dps -- consistent ordering for repeated analysis
   let totalScanCount =
         mconcat
@@ -132,7 +131,7 @@ renderScanSummary dps vsi binary manualDeps = do
       [ ""
       , "Scan Summary"
       , "------------"
-      , pretty $ "Using fossa-cli: " <> cliVersion
+      , fullVersionDescription
       , ""
       , pretty totalScanCount
       ]

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -12,7 +12,7 @@ import App.Fossa.Analyze.Types (
   DiscoveredProjectIdentifier (dpiProjectPath, dpiProjectType),
   DiscoveredProjectScan (..),
  )
-import App.Version (currentBranch, fullVersionDescription, versionNumber)
+import App.Version (fullVersionDescription)
 import Control.Effect.Diagnostics qualified as Diag (Diagnostics)
 import Control.Monad (when)
 import Data.Foldable (traverse_)
@@ -131,7 +131,7 @@ renderScanSummary dps vsi binary manualDeps = do
       [ ""
       , "Scan Summary"
       , "------------"
-      , fullVersionDescription
+      , pretty fullVersionDescription
       , ""
       , pretty totalScanCount
       ]

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -2,8 +2,11 @@ module App.Fossa.Analyze.Types (
   AnalyzeProject (..),
   AnalyzeTaskEffs,
   AnalyzeExperimentalPreferences (..),
+  DiscoveredProjectScan (..),
+  DiscoveredProjectIdentifier (..),
 ) where
 
+import App.Fossa.Analyze.Project (ProjectResult)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig)
 import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics, Has)
@@ -11,10 +14,12 @@ import Control.Effect.Lift (Lift)
 import Control.Effect.Reader (Reader)
 import Data.Set (Set)
 import Data.Text (Text)
+import Diag.Result (Result)
 import Effect.Exec (Exec)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
-import Types (DependencyResults, FoundTargets)
+import Path
+import Types (DependencyResults, DiscoveredProjectType, FoundTargets)
 
 newtype AnalyzeExperimentalPreferences = AnalyzeExperimentalPreferences
   {gradleOnlyConfigsAllowed :: Maybe (Set Text)}
@@ -29,6 +34,17 @@ type AnalyzeTaskEffs sig m =
   , Has Debug sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
   )
+
+data DiscoveredProjectScan
+  = SkippedDueToProvidedFilter DiscoveredProjectIdentifier
+  | SkippedDueToDefaultProductionFilter DiscoveredProjectIdentifier
+  | Scanned DiscoveredProjectIdentifier (Result ProjectResult)
+
+data DiscoveredProjectIdentifier = DiscoveredProjectIdentifier
+  { dpiProjectPath :: Path Abs Dir
+  , dpiProjectType :: DiscoveredProjectType
+  }
+  deriving (Eq, Ord)
 
 class AnalyzeProject a where
   analyzeProject :: AnalyzeTaskEffs sig m => FoundTargets -> a -> m DependencyResults

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -55,7 +55,7 @@ orderByScanStatusAndType (SkippedDueToDefaultProductionFilter _) (Scanned _ _) =
 orderByScanStatusAndType (SkippedDueToProvidedFilter _) (Scanned _ _) = GT
 orderByScanStatusAndType (Scanned _ (Success lhsEw lhs)) (Scanned _ (Success rhsEw rhs)) =
   if (projectResultType lhs) /= (projectResultType rhs)
-    then compare (length lhsEw) (length rhsEw)
+    then compare (length rhsEw) (length lhsEw)
     else EQ
 orderByScanStatusAndType (Scanned lhs (Failure _ _)) (Scanned rhs (Failure _ _)) = compare lhs rhs
 orderByScanStatusAndType (Scanned _ (Success _ _)) (Scanned _ (Failure _ _)) = GT

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -44,7 +44,7 @@ instance Ord DiscoveredProjectScan where
   a `compare` b = orderByScanStatusAndType a b
 
 instance Eq DiscoveredProjectScan where
-  a == b = orderByScanStatusAndType a b == EQ
+  a == b = compare a b == EQ
 
 orderByScanStatusAndType :: DiscoveredProjectScan -> DiscoveredProjectScan -> Ordering
 orderByScanStatusAndType (SkippedDueToProvidedFilter lhs) (SkippedDueToProvidedFilter rhs) = compare lhs rhs
@@ -55,7 +55,7 @@ orderByScanStatusAndType (SkippedDueToDefaultProductionFilter _) (Scanned _ _) =
 orderByScanStatusAndType (SkippedDueToProvidedFilter _) (Scanned _ _) = GT
 orderByScanStatusAndType (Scanned _ (Success lhsEw lhs)) (Scanned _ (Success rhsEw rhs)) =
   if (projectResultType lhs) /= (projectResultType rhs)
-    then compare (length rhsEw) (length lhsEw)
+    then compare (length lhsEw) (length rhsEw)
     else EQ
 orderByScanStatusAndType (Scanned lhs (Failure _ _)) (Scanned rhs (Failure _ _)) = compare lhs rhs
 orderByScanStatusAndType (Scanned _ (Success _ _)) (Scanned _ (Failure _ _)) = GT

--- a/src/App/Fossa/Analyze/Upload.hs
+++ b/src/App/Fossa/Analyze/Upload.hs
@@ -42,7 +42,6 @@ import Effect.Logger (
   logInfo,
   logStdout,
   viaShow,
-  vsep,
  )
 import Fossa.API.Types (ApiOpts)
 import Path (Abs, Dir, Path)
@@ -77,15 +76,15 @@ uploadSuccessfulAnalysis (BaseDir basedir) apiOpts metadata jsonOutput revision 
   uploadResult <- uploadAnalysis apiOpts revision metadata units
   let locator = parseLocator $ uploadLocator uploadResult
   buildUrl <- getFossaBuildUrl revision apiOpts locator
-  logInfo $
-    vsep
-      [ "============================================================"
-      , ""
-      , "    View FOSSA Report:"
-      , "    " <> pretty buildUrl
-      , ""
-      , "============================================================"
-      ]
+  traverse_
+    logInfo
+    [ "============================================================"
+    , ""
+    , "    View FOSSA Report:"
+    , "    " <> pretty buildUrl
+    , ""
+    , "============================================================"
+    ]
   traverse_ (\err -> logError $ "FOSSA error: " <> viaShow err) (uploadError uploadResult)
   -- Warn on contributor errors, never fail
   void . recover . runExecIO $ tryUploadContributors basedir apiOpts (uploadLocator uploadResult)

--- a/src/Diag/Result.hs
+++ b/src/Diag/Result.hs
@@ -26,6 +26,7 @@ module Diag.Result (
 
   -- * Helpers
   resultToMaybe,
+  flushLogs,
 
   -- * Rendering
   renderFailure,
@@ -36,6 +37,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
 import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
+import Effect.Logger (Has, Logger, Severity, log)
 import GHC.Show (showLitString)
 import Prettyprinter
 import Prettyprinter.Render.Terminal
@@ -275,3 +277,16 @@ section name content =
 
 subsection :: Doc AnsiStyle -> [Doc AnsiStyle] -> Doc AnsiStyle
 subsection name = vsep . map (\single -> annotate (color Yellow) name <> line <> line <> indent 2 single <> line)
+
+-- | Log all encountered errors and warnings associated with 'Result a'
+--
+-- - On failure, the failure is logged with the provided @sevOnErr@ severity
+--
+-- - On success, the associated warnings are logged with the provided
+--   @sevOnSuccess@ severity
+flushLogs :: Has Logger sig m => Severity -> Severity -> Result a -> m ()
+flushLogs sevOnErr _ (Failure ws eg) = Effect.Logger.log sevOnErr (renderFailure ws eg)
+flushLogs _ sevOnSuccess (Success ws _) = do
+  case renderSuccess ws of
+    Nothing -> pure ()
+    Just rendered -> Effect.Logger.log sevOnSuccess rendered

--- a/src/Diag/Result.hs
+++ b/src/Diag/Result.hs
@@ -26,7 +26,6 @@ module Diag.Result (
 
   -- * Helpers
   resultToMaybe,
-  flushLogs,
 
   -- * Rendering
   renderFailure,
@@ -37,7 +36,6 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
 import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
-import Effect.Logger (Has, Logger, Severity, log)
 import GHC.Show (showLitString)
 import Prettyprinter
 import Prettyprinter.Render.Terminal
@@ -277,16 +275,3 @@ section name content =
 
 subsection :: Doc AnsiStyle -> [Doc AnsiStyle] -> Doc AnsiStyle
 subsection name = vsep . map (\single -> annotate (color Yellow) name <> line <> line <> indent 2 single <> line)
-
--- | Log all encountered errors and warnings associated with 'Result a'
---
--- - On failure, the failure is logged with the provided @sevOnErr@ severity
---
--- - On success, the associated warnings are logged with the provided
---   @sevOnSuccess@ severity
-flushLogs :: Has Logger sig m => Severity -> Severity -> Result a -> m ()
-flushLogs sevOnErr _ (Failure ws eg) = Effect.Logger.log sevOnErr (renderFailure ws eg)
-flushLogs _ sevOnSuccess (Success ws _) = do
-  case renderSuccess ws of
-    Nothing -> pure ()
-    Just rendered -> Effect.Logger.log sevOnSuccess rendered


### PR DESCRIPTION
# Overview

With these changes, when `fossa analyze` is performed, scan summary is rendered. It provide visibility on "what" was analyzed to user at glance, and whether they were successful, failed or succeeded with warnings. 

- CLI version (`v3.0.0`)
- The number of projects scanned (+ success, failure, analysis warning totals)
- For each project, whether it succeeded (`succeeded`/`failed`)
- For each project, the strategy type of that project (`yarn`, `maven`, ...)
- For each project, the relative directory of the project (`foo/javaproj`)
- For each project, the number of warnings (if > 0)

#### Out of Scope

It largely leaves the existing logging and warning rendering as is. As such following are not implemented:
 
- Logger messages from analysis tasks are no longer emitted to stderr
- Discovery/analysis errors are no longer emitted to stderr
- Logged analysis errors are not emitted at the end only.

These will be addressed in subsequent PRs when error context primitive are used which has actionable errors and warnings context.  

## Acceptance criteria

- When fossa analyze is performed scan summary is always rendered unless no targets are discovered. 
- Rendered scan summary includes project type, project path, and whether it was successful or failed. 
- Analysis task status is emitted as before (i.e., [N waiting / running / finished] + [TASK N] Context > Stack messages

## UX Screenshots 

- Note that CLI version rendered will be replaced with tag value, when released. 

#### `fossa analyze` successful

![CleanShot 2022-02-02 at 10 26 38@2x](https://user-images.githubusercontent.com/86321858/152205694-284eeff2-7f6c-48b9-a60f-41596b5c4760.png)

#### `fossa analyze`, when no targets are discovered

![CleanShot 2022-02-02 at 10 17 58@2x](https://user-images.githubusercontent.com/86321858/152204103-5fecc468-1af6-4f67-a737-d6eeedda67b0.png)

#### `fossa analyze`, when all targets are filtered

![CleanShot 2022-02-02 at 10 21 43@2x](https://user-images.githubusercontent.com/86321858/152204708-8fc5f60c-ef59-4233-bb16-f89b93e4d394.png)

#### `fossa analyze -o`

![CleanShot 2022-02-02 at 10 13 07@2x](https://user-images.githubusercontent.com/86321858/152203410-932ef1a2-1b49-4045-9e48-9533bcf3e89b.png)

#### `fossa analyze --json`

![CleanShot 2022-02-02 at 10 28 50@2x](https://user-images.githubusercontent.com/86321858/152205982-5409f8d0-1c05-47ee-bf2b-acc47a63c30e.png)

## Testing plan

This largely compromises of manual testing of following example cases:

- [x] Analyzing with use of exclusion filters
- [x] Analyzing with projects when they fall under non production path (e.g. `node_modules`)
- [x] Analyzing with vsi, binary discovery
- [x] Analyzing with manual dependencies provided
- [x] Analyzing directory which has projects which lead to success with some warnings, success, and failure. 

```
git checkout feat/analysis-summary
make install-dev
fossa-dev analyze .../ example cases
``` 
## Risks

Users relying on formatting of the `fossa analyze` workflow may break. For this reason I have left the formatting of Fossa Report section as is. 

## References

- https://github.com/fossas/team-analysis/issues/857

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
