### PR TITLE
Uses Fossa API's error messages for api related errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ## Unreleased 
 
-- Fossa API: Uses `SSL_CERT_FILE`, and `SSL_CERT_DIR` environment variable for certificates when provided. 
+- Fossa API: Uses `SSL_CERT_FILE`, and `SSL_CERT_DIR` environment variable for certificates when provided. ([#760](https://github.com/fossas/fossa-cli/pull/760)) 
+- UX: Uses error messages received from FOSSA api, when reporting API related errors. ([#792](https://github.com/fossas/fossa-cli/pull/792))
 
 ## v3.0.18
 


### PR DESCRIPTION
# Overview

This PR uses provided FOSSA API error messages, instead of mangling error (and presuming) intent. This keeps the error messages consistent across API, UI, and CLI related to FOSSA API.  

#### Example Screenshot Change

![CleanShot 2022-02-03 at 13 56 07@2x](https://user-images.githubusercontent.com/86321858/152427451-8d280a0b-06cf-4e79-92dd-a98084a3651e.png)

## Acceptance criteria

You agree that, CLI should use provided error message from API instead of performing interpretation of them. This means the error messages related to API will always have to be updated upstream. Likewise, we forego coupling between CLI version and rendered API related error messages. 

- Fossa API errors messages are consistent across CLI. 
- CLI error messages provide ERROR uuid (provided via API) for faster support resolution. 
- CLI error messages are reflective, when team is not found.
- CLI error messages are reflective, when release group is not found.

## Backend work in progress

Improve error message wording to include potential corrective actions in following: 

- ~[ ] Improve NotFoundError message for project~
- ~[ ] Improve NotFoundError message for revision~
- ~[ ] Improve NotFoundError message for team~
- ~[ ] Improve NotFoundError message for Release Group~

I intent to have sibling PR on backend for these. 
Sibling PR: https://github.com/fossas/FOSSA/pull/7065

## Testing plan

```
make install-dev
fossa-dev analyze ../some-project/ --fossa-api-key incorrect-key
fossa-dev analyze ../some-project/ --team team-that-does-not-exist
fossa-dev test --project project-that-does-not-exist
fossa-dev test --project some-project --revision revision-that-does-not-exist
fossa-dev analyze --link --fossa-api-key push-only-api-key
```

## Risks

Not risky. 

## References

- Closes https://github.com/fossas/team-analysis/issues/754
- Works on https://github.com/fossas/team-analysis/issues/854

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
