### PR TITLE
Small doc improvements

### DIFF
--- a/docs/references/files/fossa-deps.md
+++ b/docs/references/files/fossa-deps.md
@@ -2,6 +2,8 @@
 
 Fossa-deps file is a file named `fossa-deps.{yaml, yml, json}` at the root of the project. It can be used to provide manual and vendor dependencies. 
 
+You can use [this configuration generator tool](https://wirechunk.com/topics/c4f67ee8-29f4-4fd3-8b87-76b80da015f6) to easily create a fossa-deps file.
+
 ## Fields
 
 ### `referenced-dependencies:`
@@ -29,7 +31,7 @@ Denotes listing of dependencies, which can't be automatically discovered or iden
 
 - `name`: Name of the dependency. (Required)
 - `version`: Revision of the dependency. (Required)
-- `license`: Licence of the dependency. (Required)
+- `license`: License of the dependency. (Required)
 - `metadata.homepage`: Homepage of the dependency. This metadata is used to enrich reporting provided in FOSSA's web interface.
 - `metadata.description`: Description of the dependency. This metadata is used to enrich reporting provided in FOSSA's web interface.
 

--- a/docs/references/files/fossa-deps.schema.json
+++ b/docs/references/files/fossa-deps.schema.json
@@ -56,9 +56,9 @@
                     "description": "Version of the dependency. This will be the version used in FOSSA's dashboard.",
                     "minLength": 1
                 },
-                "licence": {
+                "license": {
                     "type": "string",
-                    "description": "Licence of the dependency. This string will be used to infer licence type.",
+                    "description": "License of the dependency. This string will be used to infer license type.",
                     "minLength": 1
                 },
                 "metadata": {
@@ -78,7 +78,7 @@
             "required": [
                 "name",
                 "version",
-                "licence"
+                "license"
             ],
             "additionalProperties": false
         },
@@ -91,7 +91,7 @@
                 },
                 "path": {
                     "type": "string",
-                    "description": "Path to directory, which will be archived and upload to provided endpoint for licence scanning.",
+                    "description": "Path to directory, which will be archived and upload to provided endpoint for license scanning.",
                     "minLength": 1
                 },
                 "version": {
@@ -150,28 +150,28 @@
         },
         "referenced-dependencies": {
             "type": "array",
-            "description": "Reference dependency to locate from registry and include it project's dependency and licence scanning.",
+            "description": "Reference dependency to locate from registry and include it project's dependency and license scanning.",
             "items": {
                 "$ref": "#/$defs/referenced-dependency"
             }
         },
         "custom-dependencies": {
             "type": "array",
-            "description": "Custom dependency and their licence for project",
+            "description": "Custom dependency and their license for project",
             "items": {
                 "$ref": "#/$defs/custom-dependency"
             }
         },
         "vendored-dependencies": {
             "type": "array",
-            "description": "Local dependencies upload to server for licence scanning",
+            "description": "Local dependencies upload to server for license scanning",
             "items": {
                 "$ref": "#/$defs/vendored-dependency"
             }
         },
         "remote-dependencies": {
             "type": "array",
-            "description": "Remote dependencies to licence scanning",
+            "description": "Remote dependencies to license scanning",
             "items": {
                 "$ref": "#/$defs/remote-dependency"
             }


### PR DESCRIPTION
# Overview
Various improvements to the documentation on configuration files.

## Acceptance criteria
- Add links to configuration file generators for the fossa-deps.yml file.
- Fix a few misspellings of "license".

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
