### PR TITLE
Fix tests

### DIFF
--- a/test/App/Fossa/VSI/DynLinked/Internal/BinarySpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/BinarySpec.hs
@@ -21,19 +21,11 @@ spec = pure ()
 import App.Fossa.VSI.DynLinked.Internal.Binary qualified as Binary
 import Data.Text (Text)
 import Data.Void (Void)
-import Path (Path, Abs, File, mkAbsFile)
+import Path (mkAbsFile)
 import Test.Hspec.Megaparsec (shouldParse)
 import Text.Megaparsec (Parsec, parse)
 import Data.Maybe (catMaybes)
-import Path.IO qualified as PIO
-import Data.Set (Set)
-import Data.Set qualified as Set
-import Control.Carrier.Diagnostics (runDiagnostics)
-import Effect.Exec (runExecIO)
-import qualified System.Info as SysInfo
 import Text.RawString.QQ (r)
-import Diag.Result (Result(Failure, Success), renderFailure)
-import Control.Carrier.Stack (runStack)
 
 spec :: Hspec.Spec
 spec = do

--- a/test/App/Fossa/VSI/DynLinked/Internal/BinarySpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/BinarySpec.hs
@@ -55,14 +55,6 @@ spec = do
       realOutputUbuntu `shouldParseOutputInto` realOutputUbuntuExpected
       realOutputAlpine `shouldParseOutputInto` realOutputAlpineExpected
 
-  Hspec.describe "parse ldd output" $ do
-    executableTarget <- Hspec.runIO localExecutable
-    targetDependencies <- Hspec.runIO . runStack . runDiagnostics . runExecIO $ Binary.dynamicLinkedDependencies executableTarget
-
-    Hspec.it "should parse actual ldd output" $ case targetDependencies of
-      Failure ws eg -> Hspec.expectationFailure ("could not check file: ensure you've run `make build-test-data` locally. Error: " <> show (renderFailure ws eg))
-      Success _ result -> result `Hspec.shouldBe` localExecutableExpected
-
 parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Hspec.Expectation
 parseMatch parser input expected = parse parser "" input `shouldParse` expected
 
@@ -80,9 +72,6 @@ singleLineMoreSpaces = "    libc.so.6   =>    /lib/x86_64-linux-gnu/libc.so.6   
 
 singleLineExpected :: Maybe Binary.LocalDependency
 singleLineExpected = Just $ Binary.LocalDependency "libc.so.6" $(mkAbsFile "/lib/x86_64-linux-gnu/libc.so.6")
-
--- multipleLine :: Text
--- multipleLine = "libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fbea9a88000)\n\tlibc2.so.6 => /lib/x86_64-linux-gnu/libc2.so.6 (0x00007fbea9a88000)"
 
 multipleLine :: Text
 multipleLine =
@@ -134,14 +123,5 @@ realOutputUbuntuExpected = [Binary.LocalDependency "libc.so.6" $(mkAbsFile "/lib
 
 realOutputAlpineExpected :: [Binary.LocalDependency]
 realOutputAlpineExpected = [Binary.LocalDependency "libc.musl-x86_64.so.1" $(mkAbsFile "/lib/ld-musl-x86_64.so.1")]
-
-localExecutable :: IO (Path Abs File)
-localExecutable = PIO.resolveFile' "test/App/Fossa/VSI/DynLinked/testdata/hello_standard"
-
--- While parsing ldd-shaped output works on every platform, only Linux can actually run ldd.
-localExecutableExpected :: Set (Path Abs File)
-localExecutableExpected = if SysInfo.os == "linux"
-  then Set.singleton $(mkAbsFile "/lib/ld-musl-x86_64.so.1")
-  else Set.empty
 
 #endif

--- a/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/Lookup/APKSpec.hs
@@ -8,19 +8,21 @@ import App.Fossa.VSI.DynLinked.Internal.Lookup.APK (APKLookupTable (..), SyftArt
 import App.Fossa.VSI.DynLinked.Types (LinuxPackageMetadata (..))
 import App.Fossa.VSI.DynLinked.Util (fsRoot)
 import Control.Carrier.Diagnostics (runDiagnostics)
+import Control.Carrier.Stack (runStack)
 import Data.Aeson (toJSON)
 import Data.Map qualified as Map
+import Diag.Result (Result (..))
 import Path (mkRelFile, (</>))
 import Test.Hspec (Spec, describe, expectationFailure, it, runIO, shouldBe)
 
 spec :: Spec
 spec = do
   describe "lookup table" $ do
-    result <- runIO . runDiagnostics $ compileSyftOutput syntheticData
+    result <- runIO . runStack . runDiagnostics $ compileSyftOutput syntheticData
 
     it "correctly builds lookup table" $ case result of
-      Left e -> expectationFailure ("could not construct lookup table: " <> show e)
-      Right table -> table `shouldBe` expectedLookupTable
+      Failure _ e -> expectationFailure ("could not construct lookup table: " <> show e)
+      Success _ table -> table `shouldBe` expectedLookupTable
 
 syntheticData :: SyftData
 syntheticData =


### PR DESCRIPTION
# Overview

Fix the testing errors in `master`.

* 6ecd9c7: remove an overzealous `ldd` test that prevents tests from passing on non-alpine linux.
* f640b80: Update `APKSpec` to use `Result`.