### PR TITLE
Adds contextual error/warn -  FileParserError, CommandParserError and few analyzers (Part 1)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,11 @@
 # Fossa CLI Changelog
 
 ## Unreleased
+- Improves error for parsing failure when parsing file or command output's content.
 - Gradle: improves error message when gradle, gradlew, gradlew.bat is not found, or fails.
+- Elixir: warns when packages are not analyzed because of not supported scm.
+- Dart: warns when suboptimal analysis is performed.
+- Go: warns when transitives are not retrieved as part of analysis.
 
 ## v3.0.18
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Fossa CLI Changelog
 
+## Unreleased
+- Gradle: improves error message when gradle, gradlew, gradlew.bat is not found, or fails.
+
 ## v3.0.18
 
 - Fully percent-encode sub-paths in generated URLs. ([#789](https://github.com/fossas/fossa-cli/pull/789))

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -281,6 +281,7 @@ library
     Strategy.Fortran.FpmToml
     Strategy.Fpm
     Strategy.Glide
+    Strategy.Go.Errors
     Strategy.Go.GlideLock
     Strategy.Go.GoList
     Strategy.Go.Gomod

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -293,6 +293,7 @@ library
     Strategy.Googlesource.RepoManifest
     Strategy.Gradle
     Strategy.Gradle.Common
+    Strategy.Gradle.Errors
     Strategy.Gradle.ResolutionApi
     Strategy.Haskell.Cabal
     Strategy.Haskell.Stack

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -271,6 +271,7 @@ library
     Strategy.Conda
     Strategy.Conda.CondaList
     Strategy.Conda.EnvironmentYml
+    Strategy.Dart.Errors
     Strategy.Dart.PubDeps
     Strategy.Dart.PubSpec
     Strategy.Dart.PubSpecLock

--- a/src/App/Docs.hs
+++ b/src/App/Docs.hs
@@ -2,6 +2,9 @@ module App.Docs (
   userGuideUrl,
   newIssueUrl,
   fossaYmlDocUrl,
+
+  -- * Reference documentations
+  strategyLangDocUrl,
 ) where
 
 import App.Version (currentBranch, versionNumber)
@@ -21,3 +24,6 @@ fossaYmlDocUrl = guidePathOf (maybe currentBranch ("v" <>) versionNumber) "/docs
 
 newIssueUrl :: Text
 newIssueUrl = sourceCodeUrl <> "/issues/new"
+
+strategyLangDocUrl :: Text -> Text
+strategyLangDocUrl path = guidePathOf (maybe currentBranch ("v" <>) versionNumber) ("/docs/references/strategies/languages/" <> path)

--- a/src/Control/Carrier/Diagnostics.hs
+++ b/src/Control/Carrier/Diagnostics.hs
@@ -66,6 +66,8 @@ instance Has Stack sig m => Algebra (Diag :+: sig) (DiagnosticsC m) where
       (<$ ctx) <$> ResultT.warnT (Result.SomeWarn w)
     L (WarnOnErr w act) ->
       ResultT.warnOnErrT (Result.SomeWarn w) $ runDiagnosticsC $ hdl (act <$ ctx)
+    L (WarnOnSuccess w act) ->
+      ResultT.warnOnSuccessT (Result.SomeWarn w) $ runDiagnosticsC $ hdl (act <$ ctx)
     L (ErrCtx c act) ->
       ResultT.errCtxT (Result.ErrCtx c) $ runDiagnosticsC $ hdl (act <$ ctx)
     L (Fatal diag) -> do

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -19,6 +19,7 @@ module Control.Effect.Diagnostics (
   rethrow,
   warn,
   warnOnErr,
+  warnOnSuccess,
   (<||>),
 
   -- * Diagnostic helpers
@@ -76,6 +77,7 @@ data Diag m k where
   Rethrow :: Result a -> Diag m a
   Warn :: ToDiagnostic warn => warn -> Diag m ()
   WarnOnErr :: ToDiagnostic warn => warn -> m a -> Diag m a
+  WarnOnSuccess :: ToDiagnostic warn => warn -> m a -> Diag m a
   FirstToSucceed :: m a -> m a -> Diag m a
 
 -- | Throw an error
@@ -110,6 +112,10 @@ warn = send . Warn
 -- | When the provided action fails, emit a warning
 warnOnErr :: (ToDiagnostic warn, Has Diagnostics sig m) => warn -> m a -> m a
 warnOnErr w m = send (WarnOnErr w m)
+
+-- | When the provided action fails, emit a warning
+warnOnSuccess :: (ToDiagnostic warn, Has Diagnostics sig m) => warn -> m a -> m a
+warnOnSuccess w m = send (WarnOnSuccess w m)
 
 -- | Analagous to @Alternative@'s @<|>@. Try the provided actions, returning the
 -- value of the first to succeed

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -145,7 +145,16 @@ instance ToDiagnostic ExecErr where
               , "stderr: " <> line <> indent 2 (pretty @Text (decodeUtf8 (cmdFailureStderr err)))
               ]
           )
-    CommandParseError cmd err -> "Failed to parse command output. command: " <> viaShow cmd <> " . error: " <> pretty err
+    CommandParseError cmd err ->
+      vsep
+        [ "Failed to parse command output. command: " <> viaShow cmd <> "."
+        , ""
+        , "Details:"
+        , indent 4 (pretty err)
+        , ""
+        , "If you believe this to be a defect, please report bug to"
+        , "FOSSA support at: https://support.fossa.com/hc/en-us."
+        ]
 
 -- | Execute a command and return its @(exitcode, stdout, stderr)@
 exec :: Has Exec sig m => Path Abs Dir -> Command -> m (Either CmdFailure Stdout)

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -36,7 +36,7 @@ module Effect.ReadFS (
   readContentsToml,
   readContentsYaml,
   readContentsXML,
-  ParsingFileType(..),
+  ParsingFileType (..),
 
   -- * File identity information
   contentIsBinary,
@@ -72,7 +72,6 @@ import Text.Megaparsec (Parsec, runParser)
 import Text.Megaparsec.Error (errorBundlePretty)
 import Toml qualified
 
-
 data ReadFSF a where
   ReadContentsBS' :: SomeBase File -> ReadFSF (Either ReadFSErr ByteString)
   ReadContentsBSLimit' :: SomeBase File -> Int -> ReadFSF (Either ReadFSErr ByteString)
@@ -85,8 +84,8 @@ data ReadFSF a where
 
 type ReadFS = Simple ReadFSF
 
-data ParsingFileType = 
-  PythonRequirementFiletype
+data ParsingFileType
+  = PythonRequirementFiletype
   | OtherFiletype
   deriving (Show, Eq, Ord, Generic)
 
@@ -133,7 +132,6 @@ instance ToDiagnostic ReadFSErr where
         , "If you believe this to be a defect - please report bug with copy of the file"
         , "to FOSSA support: https://support.fossa.com/hc/en-us."
         ]
-
     FileParseError path err OtherFiletype ->
       vsep
         [ "Error parsing file: " <> pretty path <> "."

--- a/src/Strategy/Dart/Errors.hs
+++ b/src/Strategy/Dart/Errors.hs
@@ -1,6 +1,6 @@
 module Strategy.Dart.Errors (
-    PubspecLimitation(..),
-    refPubDocUrl,
+  PubspecLimitation (..),
+  refPubDocUrl,
 ) where
 
 import App.Docs (strategyLangDocUrl)

--- a/src/Strategy/Dart/Errors.hs
+++ b/src/Strategy/Dart/Errors.hs
@@ -1,0 +1,28 @@
+module Strategy.Dart.Errors (
+    PubspecLimitation(..),
+    refPubDocUrl,
+) where
+
+import App.Docs (strategyLangDocUrl)
+import Data.List.NonEmpty (fromList)
+import Data.Text (Text)
+import Diag.Diagnostic (ActionableDiagCtx (..), ToDiagnostic (..), renderActionable)
+
+refPubDocUrl :: Text
+refPubDocUrl = strategyLangDocUrl "dart/dart.md"
+
+data PubspecLimitation = PubspecLimitation
+
+instance ToDiagnostic PubspecLimitation where
+  renderDiagnostic (PubspecLimitation) =
+    renderActionable $
+      ActionableDiagCtx
+        { description = "Suboptimal pubspec.yaml analysis performed - Edges and deep dependencies will not be reported."
+        , documentationLinks = fromList [refPubDocUrl]
+        , troubleshootingSteps =
+            Just $
+              fromList
+                [ "Build your project and ensure pubspec.lock file exists prior to using fossa-cli."
+                , "Ensure dart or flutter executables are in PATH."
+                ]
+        }

--- a/src/Strategy/Go/Errors.hs
+++ b/src/Strategy/Go/Errors.hs
@@ -1,0 +1,46 @@
+module Strategy.Go.Errors (
+  GoModStaticAnalysisLimitation (..),
+  GoModTransitivesNotFilled (..),
+  refGoModDocUrl,
+) where
+
+import App.Docs (strategyLangDocUrl)
+import Data.List.NonEmpty (fromList)
+import Data.Text (Text)
+import Diag.Diagnostic (ActionableDiagCtx (..), ToDiagnostic (..), renderActionable)
+
+refGoModDocUrl :: Text
+refGoModDocUrl = strategyLangDocUrl "golang/gomodules.md"
+
+data GoModStaticAnalysisLimitation = GoModStaticAnalysisLimitation
+data GoModTransitivesNotFilled = GoModTransitivesNotFilled
+
+instance ToDiagnostic GoModTransitivesNotFilled where
+  renderDiagnostic (GoModTransitivesNotFilled) =
+    renderActionable $
+      ActionableDiagCtx
+        { description = "Deep dependencies and edges between them will not be reported."
+        , documentationLinks = fromList [refGoModDocUrl]
+        , troubleshootingSteps =
+            Just $
+              fromList
+                [ "Ensure go executable is in your PATH."
+                , "Ensure go project is built."
+                , "Ensure go mod graph, go list -m -json all command can be performed for your project."
+                ]
+        }
+
+instance ToDiagnostic GoModStaticAnalysisLimitation where
+  renderDiagnostic (GoModStaticAnalysisLimitation) =
+    renderActionable $
+      ActionableDiagCtx
+        { description = "Suboptimal static analyzer used for golang module analysis. Deep dependencies and edges will not be reported."
+        , documentationLinks = fromList [refGoModDocUrl]
+        , troubleshootingSteps =
+            Just $
+              fromList
+                [ "Ensure go executable is in your PATH."
+                , "Ensure go project is built."
+                , "Ensure go mod graph, go list -m -json all command can be performed for your project."
+                ]
+        }

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -25,6 +25,9 @@ import Effect.Exec (
 import Effect.Grapher (deep, direct, label)
 import Graphing (Graphing)
 import Path
+import Strategy.Go.Errors (
+  GoModTransitivesNotFilled (..),
+ )
 import Strategy.Go.Transitive (decodeMany, fillInTransitive)
 import Strategy.Go.Types (
   GolangGrapher,
@@ -80,7 +83,7 @@ analyze' dir = do
       Left (path, err) -> fatal (CommandParseError goListJsonCmd (toText (formatError path err)))
       Right (mods :: [GoListModule]) -> do
         context "Adding direct dependencies" $ buildGraph (toRequires mods)
-        _ <- recover (fillInTransitive dir)
+        _ <- recover $ warnOnErr GoModTransitivesNotFilled (fillInTransitive dir)
         pure ()
   pure (graph, Complete)
   where

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -17,7 +17,7 @@ module Strategy.Go.Gomod (
 ) where
 
 import Control.Algebra (Has)
-import Control.Effect.Diagnostics (Diagnostics, context, recover)
+import Control.Effect.Diagnostics (Diagnostics, context, recover, warnOnErr)
 import Data.Char (isSpace)
 import Data.Foldable (traverse_)
 import Data.Functor (void)
@@ -35,6 +35,9 @@ import Effect.Grapher (direct, label)
 import Effect.ReadFS (ReadFS, readContentsParser)
 import Graphing (Graphing)
 import Path (Abs, File, Path, parent)
+import Strategy.Go.Errors (
+  GoModTransitivesNotFilled (..),
+ )
 import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types (
   GolangGrapher,
@@ -343,7 +346,7 @@ analyze' file = do
 
     context "Building dependency graph" $ buildGraph gomod
 
-    _ <- recover (fillInTransitive (parent file))
+    _ <- recover $ warnOnErr GoModTransitivesNotFilled $ (fillInTransitive (parent file))
     pure ()
   pure (graph, Partial)
 

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -345,8 +345,7 @@ analyze' file = do
     gomod <- readContentsParser gomodParser file
 
     context "Building dependency graph" $ buildGraph gomod
-
-    _ <- recover $ warnOnErr GoModTransitivesNotFilled $ (fillInTransitive (parent file))
+    _ <- recover $ warnOnErr GoModTransitivesNotFilled (fillInTransitive (parent file))
     pure ()
   pure (graph, Partial)
 

--- a/src/Strategy/Go/GopkgLock.hs
+++ b/src/Strategy/Go/GopkgLock.hs
@@ -18,6 +18,9 @@ import Effect.Grapher
 import Effect.ReadFS
 import Graphing (Graphing)
 import Path
+import Strategy.Go.Errors (
+  GoModTransitivesNotFilled (..),
+ )
 import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types
 import Toml (TomlCodec, (.=))
@@ -57,7 +60,7 @@ analyze' ::
 analyze' file = graphingGolang $ do
   golock <- readContentsToml golockCodec file
   context "Building dependency graph" $ buildGraph (lockProjects golock)
-  _ <- recover (fillInTransitive (parent file))
+  _ <- recover $ warnOnErr GoModTransitivesNotFilled (fillInTransitive (parent file))
   pure ()
 
 buildGraph :: Has GolangGrapher sig m => [Project] -> m ()

--- a/src/Strategy/Go/GopkgToml.hs
+++ b/src/Strategy/Go/GopkgToml.hs
@@ -21,6 +21,9 @@ import Effect.Grapher
 import Effect.ReadFS
 import Graphing (Graphing)
 import Path
+import Strategy.Go.Errors (
+  GoModTransitivesNotFilled (..),
+ )
 import Strategy.Go.Transitive (fillInTransitive)
 import Strategy.Go.Types
 import Toml (TomlCodec, (.=))
@@ -67,7 +70,7 @@ analyze' file = graphingGolang $ do
   gopkg <- readContentsToml gopkgCodec file
   context "Building dependency graph" $ buildGraph gopkg
 
-  _ <- recover (fillInTransitive (parent file))
+  _ <- recover $ warnOnErr GoModTransitivesNotFilled (fillInTransitive (parent file))
   pure ()
 
 buildGraph :: Has GolangGrapher sig m => Gopkg -> m ()

--- a/src/Strategy/Gradle/Errors.hs
+++ b/src/Strategy/Gradle/Errors.hs
@@ -1,5 +1,6 @@
 module Strategy.Gradle.Errors (
   GradleCmdErrCtx (..),
+  FailedToListProjects (..),
   refGradleDocUrl,
 ) where
 
@@ -8,14 +9,28 @@ import Data.List.NonEmpty (fromList)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Diag.Diagnostic (ActionableDiagCtx (..), ToDiagnostic (..), renderActionable)
+import Effect.Logger (viaShow)
 import Path
 import Prettyprinter (Pretty (pretty), vsep)
 
 refGradleDocUrl :: Text
 refGradleDocUrl = strategyLangDocUrl "gradle/gradle.md"
 
-newtype GradleCmdErrCtx = GradleCmdErrCtx (Path Abs Dir)
+newtype FailedToListProjects = FailedToListProjects (Path Abs Dir) deriving (Eq, Ord, Show)
+instance ToDiagnostic FailedToListProjects where
+  renderDiagnostic (FailedToListProjects dir) =
+    renderActionable $
+      ActionableDiagCtx
+        { description = "Found a gradle build manifest in " <> viaShow dir <> " but, could not list projects."
+        , documentationLinks = fromList [refGradleDocUrl]
+        , troubleshootingSteps =
+            Just $
+              fromList
+                [ "Ensure gradle, gradlew or gradlew.bat can execute projects subcommand."
+                ]
+        }
 
+newtype GradleCmdErrCtx = GradleCmdErrCtx (Path Abs Dir) deriving (Eq, Ord, Show)
 instance ToDiagnostic GradleCmdErrCtx where
   renderDiagnostic (GradleCmdErrCtx path) =
     renderActionable $
@@ -32,7 +47,6 @@ instance ToDiagnostic GradleCmdErrCtx where
                 map
                   toText
                   [ "Ensure gradlew or gradlew.bat exists in or any parent directory of: " <> show path <> "."
-                  , "Ensure gradlew or gradlew.bat exists can be executed for following commands: projects."
                   , "If not using gradle wrapper, ensure gradle executable is in your PATH."
                   ]
         }

--- a/src/Strategy/Gradle/Errors.hs
+++ b/src/Strategy/Gradle/Errors.hs
@@ -7,7 +7,7 @@ import App.Docs (strategyLangDocUrl)
 import Data.List.NonEmpty (fromList)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Diag.Diagnostic (ActionableErrCtx (..), ToDiagnostic (..), renderActionable)
+import Diag.Diagnostic (ActionableDiagCtx (..), ToDiagnostic (..), renderActionable)
 import Path
 import Prettyprinter (Pretty (pretty), vsep)
 
@@ -19,7 +19,7 @@ newtype GradleCmdErrCtx = GradleCmdErrCtx (Path Abs Dir)
 instance ToDiagnostic GradleCmdErrCtx where
   renderDiagnostic (GradleCmdErrCtx path) =
     renderActionable $
-      ActionableErrCtx
+      ActionableDiagCtx
         { description =
             vsep
               [ "Failed to run gradle, gradlew, or gradlew.bat for gradle analysis in directory:"

--- a/src/Strategy/Gradle/Errors.hs
+++ b/src/Strategy/Gradle/Errors.hs
@@ -1,0 +1,38 @@
+module Strategy.Gradle.Errors (
+  GradleCmdErrCtx (..),
+  refGradleDocUrl,
+) where
+
+import App.Docs (strategyLangDocUrl)
+import Data.List.NonEmpty (fromList)
+import Data.String.Conversion (toText)
+import Data.Text (Text)
+import Diag.Diagnostic (ActionableErrCtx (..), ToDiagnostic (..), renderActionable)
+import Path
+import Prettyprinter (Pretty (pretty), vsep)
+
+refGradleDocUrl :: Text
+refGradleDocUrl = strategyLangDocUrl "gradle/gradle.md"
+
+newtype GradleCmdErrCtx = GradleCmdErrCtx (Path Abs Dir)
+
+instance ToDiagnostic GradleCmdErrCtx where
+  renderDiagnostic (GradleCmdErrCtx path) =
+    renderActionable $
+      ActionableErrCtx
+        { description =
+            vsep
+              [ "Failed to run gradle, gradlew, or gradlew.bat for gradle analysis in directory:"
+              , pretty $ "  " <> show path
+              ]
+        , documentationLinks = fromList [refGradleDocUrl]
+        , troubleshootingSteps =
+            Just $
+              fromList $
+                map
+                  toText
+                  [ "Ensure gradlew or gradlew.bat exists in or any parent directory of: " <> show path <> "."
+                  , "Ensure gradlew or gradlew.bat exists can be executed for following commands: projects."
+                  , "If not using gradle wrapper, ensure gradle executable is in your PATH."
+                  ]
+        }

--- a/src/Strategy/Node/YarnV1/YarnLock.hs
+++ b/src/Strategy/Node/YarnV1/YarnLock.hs
@@ -38,7 +38,7 @@ import Effect.Logger (
   hsep,
   pretty,
  )
-import Effect.ReadFS (ReadFS, ReadFSErr (FileParseError), readContentsText)
+import Effect.ReadFS (ParsingFileType (..), ReadFS, ReadFSErr (FileParseError), readContentsText)
 import Graphing (Graphing)
 import Path (Abs, File, Path)
 import Strategy.Node.PackageJson (Development, FlatDeps (..), NodePackage (..), Production)
@@ -60,7 +60,7 @@ analyze yarnFile flatdeps = do
   context "Building yarn.lock package graph" $ buildGraph parsed flatdeps
 
 mangleParseErr :: FilePath -> YL.LockfileError -> ReadFSErr
-mangleParseErr path = FileParseError path . YL.prettyLockfileError
+mangleParseErr path lockError = FileParseError path (YL.prettyLockfileError lockError) OtherFiletype
 
 data YarnV1Label
   = NodeEnvironment DepEnvironment

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
 {-# HLINT ignore "Move brackets to avoid $" #-}
 module Strategy.Pub (discover) where
 
@@ -12,11 +13,11 @@ import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
 import Path
+import Strategy.Dart.Errors (PubspecLimitation (PubspecLimitation))
 import Strategy.Dart.PubDeps (analyzeDepsCmd)
 import Strategy.Dart.PubSpec (analyzePubSpecFile)
 import Strategy.Dart.PubSpecLock (analyzePubLockFile)
 import Types (DependencyResults (..), DiscoveredProject (..), DiscoveredProjectType (PubProjectType))
-import Strategy.Dart.Errors (PubspecLimitation(PubspecLimitation))
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject PubProject]
 discover dir = context "Pub" $ do

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -6,7 +6,6 @@ module Strategy.Pub (discover) where
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context, warnOnSuccess, (<||>))
 import Data.Aeson (ToJSON)
-import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
 import Discovery.Walk (WalkStep (WalkContinue), findFileNamed, walk')
 import Effect.Exec (Exec, Has)
 import Effect.Logger (Logger)

--- a/src/Strategy/Python/ReqTxt.hs
+++ b/src/Strategy/Python/ReqTxt.hs
@@ -18,7 +18,7 @@ import Types
 
 analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = do
-  reqs <- readContentsParser requirementsTxtParser file
+  reqs <- readContentsParserOf PythonRequirementFiletype requirementsTxtParser file
   context "Building dependency graph" $ pure (buildGraph reqs)
 
 type Parser = Parsec Void Text

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -16,6 +16,7 @@ import Network.HTTP.Req (
   useHttpsURI,
  )
 import Strategy.Gradle.Errors (refGradleDocUrl)
+import Strategy.Dart.Errors (refPubDocUrl)
 import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 import Text.URI (mkURI)
 
@@ -42,3 +43,7 @@ spec = do
   describe "refGradleDocUrl" $
     it "should be reachable" $
       refGradleDocUrl `shouldRespondToGETWithHttpCode` 200
+
+  describe "refPubDocUrl" $ 
+    it "should be reachable" $
+      refPubDocUrl `shouldRespondToGETWithHttpCode` 200

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -15,8 +15,10 @@ import Network.HTTP.Req (
   runReq,
   useHttpsURI,
  )
-import Strategy.Gradle.Errors (refGradleDocUrl)
 import Strategy.Dart.Errors (refPubDocUrl)
+import Strategy.Elixir.MixTree (refMixDocUrl)
+import Strategy.Go.Errors (refGoModDocUrl)
+import Strategy.Gradle.Errors (refGradleDocUrl)
 import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 import Text.URI (mkURI)
 
@@ -44,6 +46,14 @@ spec = do
     it "should be reachable" $
       refGradleDocUrl `shouldRespondToGETWithHttpCode` 200
 
-  describe "refPubDocUrl" $ 
+  describe "refPubDocUrl" $
     it "should be reachable" $
       refPubDocUrl `shouldRespondToGETWithHttpCode` 200
+
+  describe "refMixDocUrl" $
+    it "should be reachable" $
+      refMixDocUrl `shouldRespondToGETWithHttpCode` 200
+
+  describe "refGoModDocUrl" $
+    it "should be reachable" $
+      refGoModDocUrl `shouldRespondToGETWithHttpCode` 200

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -15,7 +15,8 @@ import Network.HTTP.Req (
   runReq,
   useHttpsURI,
  )
-import Test.Hspec (Expectation, Spec, describe, shouldBe, xit)
+import Strategy.Gradle.Errors (refGradleDocUrl)
+import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 import Text.URI (mkURI)
 
 shouldRespondToGETWithHttpCode :: Text -> Int -> Expectation
@@ -27,13 +28,17 @@ shouldRespondToGETWithHttpCode uri expected = do
 spec :: Spec
 spec = do
   describe "userGuideUrl" $
-    xit "should be reachable" $
+    it "should be reachable" $
       userGuideUrl `shouldRespondToGETWithHttpCode` 200
 
   describe "newIssueUrl" $
-    xit "should be reachable" $
+    it "should be reachable" $
       newIssueUrl `shouldRespondToGETWithHttpCode` 200
 
   describe "fossaYmlDocUrl" $
-    xit "should be reachable" $
+    it "should be reachable" $
       fossaYmlDocUrl `shouldRespondToGETWithHttpCode` 200
+
+  describe "refGradleDocUrl" $
+    it "should be reachable" $
+      refGradleDocUrl `shouldRespondToGETWithHttpCode` 200


### PR DESCRIPTION
# Overview

This PR: 

Modifies generated diagnostics message for:
- FileParserError
- CommandParserError

<img width="643" alt="CleanShot 2022-02-11 at 11 45 57@2x" src="https://user-images.githubusercontent.com/86321858/153651169-062ee676-6f4f-4828-952a-f8f474b65387.png">

Adds warning for suboptimal analysis:
- Dart
- Golang

<img width="848" alt="CleanShot 2022-02-11 at 11 44 58@2x" src="https://user-images.githubusercontent.com/86321858/153651047-d88f110e-396d-4fbe-a19f-283824dbf7dd.png">

Adds error context for:
- Gradle command failure
- Mix dependencies not analyzed because of not supported source code manager (anything except hex, and git)


## Acceptance criteria

- Any file parser error shows, where user can report a bug
- Any command parser failure error shows, where user can report a bug
- When gradle analysis fails due to not having (gradle, gradlew, or gradlew.bat), error context is shown
- When gradle analysis fails to list projects, warning is shown
- When mix analysis uses local dependency, warning is shown indicating given dependency is not reported
- When go analysis's attempt to fill transitive fails, warning is shown with troubleshooting steps.  


## Testing plan

1) For any strategy that involves parsing, provide incorrect file, ensure error shows where user can file a bug request. 

```
make install-dev
echo '' > example/pubspec.yaml
fossa-dev analyze example -o 
```

2) For req.txt parsing, warning indicates that user can avoid reporting this bug if it's not really python req.txt

```
make install-dev
echo '[ a b ] > 2.90000abv' > example/reqs.txt
fossa-dev analyze example -o 
``` 

3) For Dart, analyze project which only has pubspec.yaml.

Valid `pubspec.yaml` example:
```
name: newtify
description: >-
  Have you been turned into a newt?  Would you like to be?
  This package can help. It has all of the
  newt-transmogrification functionality you have been looking
  for.
version: 1.2.3
homepage: https://example-pet-store.com/newtify
documentation: https://example-pet-store.com/newtify/docs

environment:
  sdk: '>=2.10.0 <3.0.0'
  
dependencies:
  efts: ^2.0.4
  transmogrify: ^0.4.0
  
dev_dependencies:
  test: '>=1.15.0 <2.0.0'
```
4) For Gradle, ensure you do not have `gradle` in PATH, and execute:
```
make install-dev
echo '' > example/gradle/settings.gradle
fossa-dev analyze example/gradle -o 
```

5) For Go, analyze go module project which without having `go` in you PATH. 
TODO - Add example

6) For Elixir, analyze elixir/mix project which has path dependency. 
TODO - Add example

## Risks

N/A

## References

Works on https://github.com/fossas/team-analysis/issues/854
Closes: https://github.com/fossas/team-analysis/issues/853 

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
