### PR TITLE
Ruby: Improve error/warnings (1 of Many)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## Yet to be released
+
+- Ruby: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/800))
+
 ## v3.1.0 
 
 - Fossa API: Uses `SSL_CERT_FILE`, and `SSL_CERT_DIR` environment variable for certificates when provided. ([#760](https://github.com/fossas/fossa-cli/pull/760)) 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -354,6 +354,7 @@ library
     Strategy.Rebar3
     Strategy.RPM
     Strategy.Ruby.BundleShow
+    Strategy.Ruby.Errors
     Strategy.Ruby.GemfileLock
     Strategy.Scala
     Strategy.Swift.PackageResolved

--- a/src/App/Docs.hs
+++ b/src/App/Docs.hs
@@ -2,6 +2,7 @@ module App.Docs (
   userGuideUrl,
   newIssueUrl,
   fossaYmlDocUrl,
+  strategyLangDocUrl,
 ) where
 
 import App.Version (currentBranch, versionNumber)
@@ -21,3 +22,6 @@ fossaYmlDocUrl = guidePathOf (maybe currentBranch ("v" <>) versionNumber) "/docs
 
 newIssueUrl :: Text
 newIssueUrl = sourceCodeUrl <> "/issues/new"
+
+strategyLangDocUrl :: Text -> Text
+strategyLangDocUrl path = guidePathOf (maybe currentBranch ("v" <>) versionNumber) ("/docs/references/strategies/languages/" <> path)

--- a/src/Strategy/Ruby/Errors.hs
+++ b/src/Strategy/Ruby/Errors.hs
@@ -45,4 +45,4 @@ instance ToDiagnostic RubyMissingEdges where
 data RubyMissingDepClassification = RubyMissingDepClassification
 instance ToDiagnostic RubyMissingDepClassification where
   renderDiagnostic (RubyMissingDepClassification) =
-    "Could not classify dependencies between direct or deep. All dependencies will be classified as direct."
+    "Could not differentiate between direct and deep dependencies. All dependencies will be classified as direct."

--- a/src/Strategy/Ruby/Errors.hs
+++ b/src/Strategy/Ruby/Errors.hs
@@ -24,10 +24,13 @@ newtype BundlerMissingLockFile = BundlerMissingLockFile (Path Abs File)
 instance ToDiagnostic BundlerMissingLockFile where
   renderDiagnostic (BundlerMissingLockFile path) =
     vsep
-      [ "We could not find or parse Gemfile.lock corresponding to Gemfile: " <> viaShow path
+      [ "We could not perform Gemfile.lock analysis for Gemfile: " <> viaShow path
       , ""
-      , "Ensure your ruby project is built, and has lockfile prior to running fossa."
-      , "If you are using bundler, you can perform: `bundler install` to generate Gemfile.lock."
+      , indent 2 $
+          vsep
+            [ "Ensure valid Gemfile.lock exists, and is readable by user."
+            , "If you are using bundler, you can perform: `bundler install` to generate Gemfile.lock."
+            ]
       , ""
       , "Refer to:"
       , indent 2 $ pretty $ "- " <> bundlerLockFileRationaleUrl

--- a/src/Strategy/Ruby/Errors.hs
+++ b/src/Strategy/Ruby/Errors.hs
@@ -1,0 +1,45 @@
+module Strategy.Ruby.Errors (
+  BundlerMissingLockFile (..),
+  RubyMissingEdges (..),
+  RubyMissingDepClassification (..),
+
+  -- * Reference docs
+  bundlerLockFileRationaleUrl,
+  rubyFossaDocUrl,
+) where
+
+import App.Docs (strategyLangDocUrl)
+import Data.Text (Text)
+import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
+import Path
+import Prettyprinter (indent, viaShow, vsep)
+
+bundlerLockFileRationaleUrl :: Text
+bundlerLockFileRationaleUrl = "https://bundler.io/rationale.html#sharing-your-application-with-other-developers"
+
+rubyFossaDocUrl :: Text
+rubyFossaDocUrl = strategyLangDocUrl "ruby/ruby.md"
+
+newtype BundlerMissingLockFile = BundlerMissingLockFile (Path Abs File)
+instance ToDiagnostic BundlerMissingLockFile where
+  renderDiagnostic (BundlerMissingLockFile path) =
+    vsep
+      [ "We could not corresponding Gemfile.lock for Gemfile: " <> viaShow path
+      , ""
+      , "Ensure your ruby project is built, and has lockfile prior to running fossa."
+      , "If you are using bundler, you can perform: bundler install."
+      , ""
+      , "Refer to:"
+      , indent 4 $ viaShow bundlerLockFileRationaleUrl
+      , indent 4 $ viaShow rubyFossaDocUrl
+      ]
+
+data RubyMissingEdges = RubyMissingEdges
+instance ToDiagnostic RubyMissingEdges where
+  renderDiagnostic (RubyMissingEdges) =
+    "Could not infer edges between dependencies."
+
+data RubyMissingDepClassification = RubyMissingDepClassification
+instance ToDiagnostic RubyMissingDepClassification where
+  renderDiagnostic (RubyMissingDepClassification) =
+    "Could not classify dependencies between direct or deep. All dependencies will be classified as direct."

--- a/src/Strategy/Ruby/Errors.hs
+++ b/src/Strategy/Ruby/Errors.hs
@@ -12,7 +12,7 @@ import App.Docs (strategyLangDocUrl)
 import Data.Text (Text)
 import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
 import Path
-import Prettyprinter (indent, viaShow, vsep)
+import Prettyprinter (Pretty (pretty), indent, viaShow, vsep)
 
 bundlerLockFileRationaleUrl :: Text
 bundlerLockFileRationaleUrl = "https://bundler.io/rationale.html#sharing-your-application-with-other-developers"
@@ -24,14 +24,14 @@ newtype BundlerMissingLockFile = BundlerMissingLockFile (Path Abs File)
 instance ToDiagnostic BundlerMissingLockFile where
   renderDiagnostic (BundlerMissingLockFile path) =
     vsep
-      [ "We could not corresponding Gemfile.lock for Gemfile: " <> viaShow path
+      [ "We could not find or parse Gemfile.lock corresponding to Gemfile: " <> viaShow path
       , ""
       , "Ensure your ruby project is built, and has lockfile prior to running fossa."
-      , "If you are using bundler, you can perform: bundler install."
+      , "If you are using bundler, you can perform: `bundler install` to generate Gemfile.lock."
       , ""
       , "Refer to:"
-      , indent 4 $ viaShow bundlerLockFileRationaleUrl
-      , indent 4 $ viaShow rubyFossaDocUrl
+      , indent 2 $ pretty $ "- " <> bundlerLockFileRationaleUrl
+      , indent 2 $ pretty $ "- " <> rubyFossaDocUrl
       ]
 
 data RubyMissingEdges = RubyMissingEdges

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -3,7 +3,9 @@ module App.DocsSpec (
 ) where
 
 import App.Docs (fossaYmlDocUrl, newIssueUrl, userGuideUrl)
+import Data.Foldable (for_)
 import Data.Maybe (fromJust)
+import Data.String.Conversion (toString)
 import Data.Text (Text)
 import Network.HTTP.Req (
   GET (GET),
@@ -15,7 +17,8 @@ import Network.HTTP.Req (
   runReq,
   useHttpsURI,
  )
-import Test.Hspec (Expectation, Spec, describe, shouldBe, xit)
+import Strategy.Ruby.Errors (bundlerLockFileRationaleUrl, rubyFossaDocUrl)
+import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 import Text.URI (mkURI)
 
 shouldRespondToGETWithHttpCode :: Text -> Int -> Expectation
@@ -24,16 +27,18 @@ shouldRespondToGETWithHttpCode uri expected = do
   r <- runReq defaultHttpConfig $ req GET url NoReqBody bsResponse mempty
   responseStatusCode r `shouldBe` expected
 
+urlsToCheck :: [Text]
+urlsToCheck =
+  [ userGuideUrl
+  , newIssueUrl
+  , fossaYmlDocUrl
+  , bundlerLockFileRationaleUrl
+  , rubyFossaDocUrl
+  ]
+
 spec :: Spec
 spec = do
-  describe "userGuideUrl" $
-    xit "should be reachable" $
-      userGuideUrl `shouldRespondToGETWithHttpCode` 200
-
-  describe "newIssueUrl" $
-    xit "should be reachable" $
-      newIssueUrl `shouldRespondToGETWithHttpCode` 200
-
-  describe "fossaYmlDocUrl" $
-    xit "should be reachable" $
-      fossaYmlDocUrl `shouldRespondToGETWithHttpCode` 200
+  describe "Documentation links provided in application are reachable" $
+    for_ urlsToCheck $ \url ->
+      it (toString url <> " should be reachable") $
+        url `shouldRespondToGETWithHttpCode` 200


### PR DESCRIPTION
# Overview

- Adds contextual warn/error for Ruby.
- Prefers lock analysis over bundler show.

## Acceptance criteria

- Shows warning when bundler tactic is selected.

## Screenshot

<img width="880" alt="CleanShot 2022-02-11 at 16 42 58@2x" src="https://user-images.githubusercontent.com/86321858/153685229-246c8e70-f552-427a-b8e7-1a11b4c204ae.png">

## Testing plan

When Gemfile.lock does not exist - warning is rendered showing limitations. 

```
make install-dev
echo '' > example/Gemfile
fossa-dev analyze ./example/ -o 
```

## Risks

N/A

## References

Works on: https://github.com/fossas/team-analysis/issues/854

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
