### PR TITLE
Swift: Improves errors (4 of many)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 - Poetry: Improves error and warning messages. ([#803](https://github.com/fossas/fossa-cli/pull/803))
 - Maven: Improves error and warning messages. ([#808](https://github.com/fossas/fossa-cli/pull/808))
 - Nodejs: Improves error and warning messages. ([#805](https://github.com/fossas/fossa-cli/pull/805))
+- Swift: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/802))
 
 ## v3.1.0 
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -362,6 +362,7 @@ library
     Strategy.Ruby.Errors
     Strategy.Ruby.GemfileLock
     Strategy.Scala
+    Strategy.Swift.Errors
     Strategy.Swift.PackageResolved
     Strategy.Swift.PackageSwift
     Strategy.Swift.Xcode.Pbxproj

--- a/src/App/Docs.hs
+++ b/src/App/Docs.hs
@@ -3,6 +3,7 @@ module App.Docs (
   newIssueUrl,
   fossaYmlDocUrl,
   strategyLangDocUrl,
+  platformDocUrl,
 ) where
 
 import App.Version (versionOrBranch)
@@ -25,3 +26,6 @@ newIssueUrl = sourceCodeUrl <> "/issues/new"
 
 strategyLangDocUrl :: Text -> Text
 strategyLangDocUrl path = guidePathOf versionOrBranch ("/docs/references/strategies/languages/" <> path)
+
+platformDocUrl :: Text -> Text
+platformDocUrl path = guidePathOf versionOrBranch ("/docs/references/strategies/platforms/" <> path)

--- a/src/Strategy/Swift/Errors.hs
+++ b/src/Strategy/Swift/Errors.hs
@@ -1,0 +1,47 @@
+module Strategy.Swift.Errors (
+  MissingPackageResolvedFile (..),
+  SwiftAnalysisDeepDeps (..),
+
+  -- * docs
+  swiftFossaDocUrl,
+  swiftPackageResolvedRef,
+  xcodeCoordinatePkgVersion,
+) where
+
+import App.Docs (platformDocUrl)
+import Data.Text (Text)
+import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
+import Path
+import Prettyprinter (Pretty (pretty), indent, viaShow, vsep)
+
+swiftFossaDocUrl :: Text
+swiftFossaDocUrl = platformDocUrl "ios/swift.md"
+
+swiftPackageResolvedRef :: Text
+swiftPackageResolvedRef = "https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#resolving-versions-packageresolved-file"
+
+xcodeCoordinatePkgVersion :: Text
+xcodeCoordinatePkgVersion = "https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app"
+
+data SwiftAnalysisDeepDeps = SwiftAnalysisDeepDeps
+instance ToDiagnostic SwiftAnalysisDeepDeps where
+  renderDiagnostic (SwiftAnalysisDeepDeps) =
+    "Could not analyze deep dependencies."
+
+newtype MissingPackageResolvedFile = MissingPackageResolvedFile (Path Abs File)
+
+instance ToDiagnostic MissingPackageResolvedFile where
+  renderDiagnostic (MissingPackageResolvedFile path) =
+    vsep
+      [ "We could not perform Package.resolved analysis for: " <> viaShow path
+      , ""
+      , indent 2 $
+          vsep
+            [ "Ensure valid Package.resolved exists, and is readable by user."
+            ]
+      , ""
+      , "Refer to:"
+      , indent 2 $ pretty $ "- " <> swiftPackageResolvedRef
+      , indent 2 $ pretty $ "- " <> xcodeCoordinatePkgVersion
+      , indent 2 $ pretty $ "- " <> swiftFossaDocUrl
+      ]

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -26,6 +26,11 @@ import Strategy.Node.Errors (
  )
 import Strategy.Python.Errors (commitPoetryLockToVCS)
 import Strategy.Ruby.Errors (bundlerLockFileRationaleUrl, rubyFossaDocUrl)
+import Strategy.Swift.Errors (
+  swiftFossaDocUrl,
+  swiftPackageResolvedRef,
+  xcodeCoordinatePkgVersion,
+ )
 import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 import Text.URI (mkURI)
 
@@ -48,6 +53,9 @@ urlsToCheck =
   , yarnLockfileDocUrl
   , fossaNodeDocUrl
   , yarnV2LockfileDocUrl
+  , swiftFossaDocUrl
+  , swiftPackageResolvedRef
+  , xcodeCoordinatePkgVersion
   ]
 
 spec :: Spec


### PR DESCRIPTION
# Overview

This PR improves error/warn messages for swift.

## Out of Scope
- ParserError and CommandParserError are not covered (this is covered by https://github.com/fossas/fossa-cli/pull/801)

## Acceptance criteria

- When suboptimal strategy is used, warning with limitation is rendered. 

## Testing plan

- Create swift package project without Package.Resolved file.
- Create xCode project using swiftPM, deliberately delete generated Package.Resolved file.

## Risks

N/A

## References

Works on: https://github.com/fossas/team-analysis/issues/854

## Notes

I intend to have one refactor PR, once all error/warn diag are merged to have common actionable diagnostic format. 

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
