### PR TITLE
Pipenv and Poetry: Improve errors (3 of Many)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 - UX: Parser error messages include call to action. ([#801](https://github.com/fossas/fossa-cli/pull/801))
 - Python: `setup.py` error messages are _less_ noisy. ([#801](https://github.com/fossas/fossa-cli/pull/801))
 - Dart: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/806))
+- Pipenv: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/803))
+- Poetry: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/803))
 
 ## v3.1.0 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,8 +6,8 @@
 - UX: Parser error messages include call to action. ([#801](https://github.com/fossas/fossa-cli/pull/801))
 - Python: `setup.py` error messages are _less_ noisy. ([#801](https://github.com/fossas/fossa-cli/pull/801))
 - Dart: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/806))
-- Pipenv: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/803))
-- Poetry: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/803))
+- Pipenv: Improves error and warning messages. ([#803](https://github.com/fossas/fossa-cli/pull/803))
+- Poetry: Improves error and warning messages. ([#803](https://github.com/fossas/fossa-cli/pull/803))
 
 ## v3.1.0 
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -345,6 +345,7 @@ library
     Strategy.NuGet.ProjectJson
     Strategy.Perl
     Strategy.Pub
+    Strategy.Python.Errors
     Strategy.Python.Pipenv
     Strategy.Python.Poetry
     Strategy.Python.Poetry.Common

--- a/src/Diag/Common.hs
+++ b/src/Diag/Common.hs
@@ -1,6 +1,7 @@
 module Diag.Common (
   MissingDeepDeps (..),
   MissingEdges (..),
+  AllDirectDeps (..),
 ) where
 
 import Diag.Diagnostic (ToDiagnostic (renderDiagnostic))
@@ -14,3 +15,8 @@ data MissingEdges = MissingEdges
 instance ToDiagnostic MissingEdges where
   renderDiagnostic (MissingEdges) =
     "Could not analyze edges between dependencies."
+
+data AllDirectDeps = AllDirectDeps
+instance ToDiagnostic AllDirectDeps where
+  renderDiagnostic (AllDirectDeps) =
+    "Could not differentiate between direct and deep dependencies, all dependencies will be reported as direct."

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -34,8 +34,9 @@ import Data.Aeson
 import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as BL
 import Data.String (fromString)
-import Data.String.Conversion (decodeUtf8, toString, toText)
+import Data.String.Conversion (ToText, decodeUtf8, toString, toText)
 import Data.Text (Text)
+import Data.Text qualified as Text
 import Data.Void (Void)
 import GHC.Generics (Generic)
 import Path
@@ -60,6 +61,9 @@ instance ToJSON Command
 instance RecordableValue Command
 instance FromJSON Command
 instance ReplayableValue Command
+
+instance ToText Command where
+  toText (Command name args _) = Text.intercalate " " $ [name] <> args
 
 data CmdFailure = CmdFailure
   { cmdFailureCmd :: Command

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -16,6 +16,7 @@ module Effect.Exec (
   execJson,
   ExecIOC,
   runExecIO,
+  renderCommand,
   module System.Exit,
   module X,
 ) where
@@ -34,7 +35,7 @@ import Data.Aeson
 import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as BL
 import Data.String (fromString)
-import Data.String.Conversion (ToText, decodeUtf8, toString, toText)
+import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Void (Void)
@@ -62,8 +63,8 @@ instance RecordableValue Command
 instance FromJSON Command
 instance ReplayableValue Command
 
-instance ToText Command where
-  toText (Command name args _) = Text.intercalate " " $ [name] <> args
+renderCommand :: Command -> Text
+renderCommand (Command name args _) = Text.intercalate " " $ [name] <> args
 
 data CmdFailure = CmdFailure
   { cmdFailureCmd :: Command

--- a/src/Strategy/Python/Errors.hs
+++ b/src/Strategy/Python/Errors.hs
@@ -1,0 +1,44 @@
+module Strategy.Python.Errors (
+  MissingPoetryLockFile (..),
+  PipenvCmdFailed (..),
+
+  -- * docs
+  commitPoetryLockToVCS,
+) where
+
+import Data.String.Conversion (toText)
+import Data.Text (Text)
+import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
+import Effect.Exec (Command)
+import Path (Abs, File, Path)
+import Prettyprinter (Pretty (pretty), indent, viaShow, vsep)
+
+commitPoetryLockToVCS :: Text
+commitPoetryLockToVCS = "https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control"
+
+newtype PipenvCmdFailed = PipenvCmdFailed Command
+instance ToDiagnostic PipenvCmdFailed where
+  renderDiagnostic (PipenvCmdFailed cmd) =
+    vsep
+      [ pretty $ "We could not perform pipenv graph analysis using, command:" <> toText cmd
+      , ""
+      , indent 2 $
+          vsep
+            [ "Ensure pipenv executable is in your PATH."
+            ]
+      ]
+
+newtype MissingPoetryLockFile = MissingPoetryLockFile (Path Abs File)
+instance ToDiagnostic MissingPoetryLockFile where
+  renderDiagnostic (MissingPoetryLockFile path) =
+    vsep
+      [ "We could not perform poetry.lock analysis for: " <> viaShow path
+      , ""
+      , indent 2 $
+          vsep
+            [ "Ensure valid poetry.lock exists and is readable."
+            ]
+      , ""
+      , "Refer to:"
+      , indent 2 $ pretty $ "- " <> commitPoetryLockToVCS
+      ]

--- a/src/Strategy/Python/Errors.hs
+++ b/src/Strategy/Python/Errors.hs
@@ -9,7 +9,7 @@ module Strategy.Python.Errors (
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
-import Effect.Exec (Command)
+import Effect.Exec (Command, renderCommand)
 import Path (Abs, File, Path)
 import Prettyprinter (Pretty (pretty), indent, viaShow, vsep)
 
@@ -20,7 +20,7 @@ newtype PipenvCmdFailed = PipenvCmdFailed Command
 instance ToDiagnostic PipenvCmdFailed where
   renderDiagnostic (PipenvCmdFailed cmd) =
     vsep
-      [ pretty $ "We could not perform pipenv graph analysis using, command:" <> toText cmd
+      [ pretty $ "We could not perform pipenv graph analysis using, command:" <> renderCommand cmd
       , ""
       , indent 2 $
           vsep

--- a/src/Strategy/Python/Errors.hs
+++ b/src/Strategy/Python/Errors.hs
@@ -6,7 +6,6 @@ module Strategy.Python.Errors (
   commitPoetryLockToVCS,
 ) where
 
-import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
 import Effect.Exec (Command, renderCommand)

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -15,25 +15,64 @@ module Strategy.Python.Pipenv (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Effect.Diagnostics
-import Data.Aeson
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  context,
+  errCtx,
+  recover,
+  run,
+  warnOnErr,
+ )
+import Data.Aeson (
+  FromJSON (parseJSON),
+  ToJSON,
+  withObject,
+  (.:),
+  (.:?),
+ )
 import Data.Foldable (for_, traverse_)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import DepTypes
-import Diag.Common
-import Discovery.Walk
-import Effect.Exec
-import Effect.Grapher
-import Effect.ReadFS
+import DepTypes (
+  DepEnvironment (EnvDevelopment, EnvProduction),
+  DepType (PipType),
+  Dependency (..),
+  VerConstraint (CEq),
+  insertEnvironment,
+  insertLocation,
+ )
+import Diag.Common (
+  MissingDeepDeps (MissingDeepDeps),
+  MissingEdges (MissingEdges),
+ )
+import Discovery.Walk (
+  WalkStep (WalkContinue),
+  findFileNamed,
+  walk',
+ )
+import Effect.Exec (AllowErr (Never), Command (..), Exec, execJson)
+import Effect.Grapher (
+  LabeledGrapher,
+  direct,
+  edge,
+  label,
+  withLabeling,
+ )
+import Effect.ReadFS (ReadFS, readContentsJson)
 import GHC.Generics (Generic)
 import Graphing (Graphing)
-import Path
-import Strategy.Python.Errors
-import Types
+import Path (Abs, Dir, File, Path, parent)
+import Strategy.Python.Errors (PipenvCmdFailed (PipenvCmdFailed))
+import Types (
+  DependencyResults (..),
+  DiscoveredProject (..),
+  DiscoveredProjectType (PipenvProjectType),
+  GraphBreadth (Complete),
+ )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject PipenvProject]
 discover dir = context "Pipenv" $ do

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -18,6 +18,7 @@ import Network.HTTP.Req (
   useHttpsURI,
  )
 import Strategy.Dart.Errors (refPubDocUrl)
+import Strategy.Python.Errors (commitPoetryLockToVCS)
 import Strategy.Ruby.Errors (bundlerLockFileRationaleUrl, rubyFossaDocUrl)
 import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 import Text.URI (mkURI)
@@ -36,6 +37,7 @@ urlsToCheck =
   , bundlerLockFileRationaleUrl
   , rubyFossaDocUrl
   , refPubDocUrl
+  , commitPoetryLockToVCS
   ]
 
 spec :: Spec


### PR DESCRIPTION
# Overview

Improves warn/errors for pipenv and poetry errors. 

<img width="894" alt="CleanShot 2022-02-14 at 12 49 38@2x" src="https://user-images.githubusercontent.com/86321858/153935836-9158429e-c8b5-4928-9d0b-d3131280475d.png">


## Acceptance criteria

- When poetry performs suboptimal analysis warnings are shown with context
- When pipenv performs suboptimal analysis warnings are shown with context

## Testing plan

```
make install-dev
fossa-dev analyze ../example/poetry-without-lock -o
```

```
make install-dev
# uninstall pipenv 
fossa-dev analyze ../example/pipenv-proj -o
```

## Risks

N/A

## References

Works on: https://github.com/fossas/team-analysis/issues/854

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
