### PR TITLE
Gradle: Improve Errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 - Swift: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/802))
 - Cocoapods: Improves error and warning messages. ([#807](https://github.com/fossas/fossa-cli/pull/807))
 - Golang: Improves error and warning messages. ([#809](https://github.com/fossas/fossa-cli/pull/809))
+- Gradle: Improves error and warning messages. ([#804](https://github.com/fossas/fossa-cli/pull/804))
 
 ## v3.1.0 
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -316,6 +316,7 @@ library
     Strategy.Googlesource.RepoManifest
     Strategy.Gradle
     Strategy.Gradle.Common
+    Strategy.Gradle.Errors
     Strategy.Gradle.ResolutionApi
     Strategy.Haskell.Cabal
     Strategy.Haskell.Stack

--- a/src/App/Support.hs
+++ b/src/App/Support.hs
@@ -1,4 +1,4 @@
-module App.Support (supportUrl, reportDefectMsg, reportDefectWithFileMsg) where
+module App.Support (supportUrl, reportDefectMsg, reportDefectWithFileMsg, reportDefectWithDebugBundle) where
 
 import Data.Text (Text)
 import Prettyprinter (Doc, Pretty (pretty), indent, vsep)
@@ -14,4 +14,15 @@ reportDefectWithFileMsg filepath =
   vsep
     [ pretty $ "If you believe this to be a defect, please report a bug to FOSSA support at " <> supportUrl <> ", with a copy of:"
     , indent 2 (pretty filepath)
+    ]
+
+reportDefectWithDebugBundle :: Doc ann
+reportDefectWithDebugBundle =
+  vsep
+    [ reportDefectMsg
+    , ""
+    , "In your bug report, please include fossa's debug bundle file: fossa.debug.json.gz."
+    , ""
+    , "You can generate debug bundle by using `--debug` flag, for example:"
+    , indent 2 "fossa analyze --debug"
     ]

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -43,10 +43,9 @@ import Data.Text qualified as Text
 import DepTypes (
   Dependency (..),
  )
-import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
 import Discovery.Walk (WalkStep (..), fileName, walk')
 import Effect.Exec (AllowErr (..), Command (..), Exec, execThrow)
-import Effect.Logger (Logger, Pretty (pretty), logDebug, viaShow)
+import Effect.Logger (Logger, Pretty (pretty), logDebug)
 import Effect.ReadFS (ReadFS, doesFileExist)
 import GHC.Generics (Generic)
 import Graphing (Graphing)

--- a/src/Strategy/Gradle/Errors.hs
+++ b/src/Strategy/Gradle/Errors.hs
@@ -1,0 +1,36 @@
+module Strategy.Gradle.Errors (
+  GradleCmdErrCtx (..),
+  FailedToListProjects (..),
+  refGradleDocUrl,
+) where
+
+import App.Docs (strategyLangDocUrl)
+import Data.Text (Text)
+import Diag.Diagnostic (ToDiagnostic (renderDiagnostic))
+import Effect.Logger (viaShow)
+import Path
+import Prettyprinter (Pretty (pretty), indent, vsep)
+
+refGradleDocUrl :: Text
+refGradleDocUrl = strategyLangDocUrl "gradle/gradle.md"
+
+newtype FailedToListProjects = FailedToListProjects (Path Abs Dir) deriving (Eq, Ord, Show)
+instance ToDiagnostic FailedToListProjects where
+  renderDiagnostic (FailedToListProjects dir) =
+    vsep
+      [ "Found a gradle build manifest in " <> viaShow dir <> " but, could not list projects."
+      ]
+
+newtype GradleCmdErrCtx = GradleCmdErrCtx (Path Abs Dir) deriving (Eq, Ord, Show)
+instance ToDiagnostic GradleCmdErrCtx where
+  renderDiagnostic (GradleCmdErrCtx path) =
+    vsep
+      [ "Failed to run gradle, gradlew, or gradlew.bat for gradle analysis in the directory:"
+      , indent 2 $ pretty . show $ path
+      , ""
+      , indent 2 $ pretty $ "Ensure gradlew or gradlew.bat exists in or in the parent directory of: " <> show path <> "."
+      , indent 2 "If you are not using the gradle wrapper, ensure gradle executable is in your PATH."
+      , ""
+      , "Documentation:"
+      , indent 2 $ pretty $ "- " <> refGradleDocUrl
+      ]

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -19,6 +19,7 @@ import Network.HTTP.Req (
  )
 import Strategy.Cocoapods.Errors (refPodDocUrl)
 import Strategy.Dart.Errors (refPubDocUrl)
+import Strategy.Gradle.Errors (refGradleDocUrl)
 import Strategy.Node.Errors (
   fossaNodeDocUrl,
   npmLockFileDocUrl,
@@ -58,6 +59,7 @@ urlsToCheck =
   , swiftPackageResolvedRef
   , xcodeCoordinatePkgVersion
   , refPodDocUrl
+  , refGradleDocUrl
   ]
 
 spec :: Spec


### PR DESCRIPTION
# Overview

This PR improves error/warn messages for gradle.

## Out of Scope
- ParserError and CommandParserError are not covered (this is covered by https://github.com/fossas/fossa-cli/pull/801)

## Acceptance criteria

- Error messages are shown when gradle, gradlew, or gradlew.bat cannot find projects, and fails.

## Testing plan

1. Create empty gradle project `touch settings.gradle`, 
2. Analyze with: `PATH='' ./fossa analyze example/ -o`

## Risks

N/A

## References

Works on: https://github.com/fossas/team-analysis/issues/854

## Notes

I intend to have one refactor PR, once all error/warn diag are merged to have common actionable diagnostic format. 

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
