### PR TITLE
Nodejs: Improve Errors (5 of many)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 - Pipenv: Improves error and warning messages. ([#803](https://github.com/fossas/fossa-cli/pull/803))
 - Poetry: Improves error and warning messages. ([#803](https://github.com/fossas/fossa-cli/pull/803))
 - Maven: Improves error and warning messages. ([#808](https://github.com/fossas/fossa-cli/pull/808))
+- Nodejs: Improves error and warning messages. ([#805](https://github.com/fossas/fossa-cli/pull/805))
 
 ## v3.1.0 
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -331,6 +331,7 @@ library
     Strategy.Nim
     Strategy.Nim.NimbleLock
     Strategy.Node
+    Strategy.Node.Errors
     Strategy.Node.Npm.PackageLock
     Strategy.Node.PackageJson
     Strategy.Node.YarnV1.YarnLock

--- a/src/App/Docs.hs
+++ b/src/App/Docs.hs
@@ -5,7 +5,7 @@ module App.Docs (
   strategyLangDocUrl,
 ) where
 
-import App.Version (currentBranch, versionNumber)
+import App.Version (versionOrBranch)
 import Data.Text (Text)
 
 sourceCodeUrl :: Text
@@ -15,13 +15,13 @@ guidePathOf :: Text -> Text -> Text
 guidePathOf revision repoRelUrl = sourceCodeUrl <> "/blob/" <> revision <> repoRelUrl
 
 userGuideUrl :: Text
-userGuideUrl = guidePathOf (maybe currentBranch ("v" <>) versionNumber) "/docs/README.md"
+userGuideUrl = guidePathOf versionOrBranch "/docs/README.md"
 
 fossaYmlDocUrl :: Text
-fossaYmlDocUrl = guidePathOf (maybe currentBranch ("v" <>) versionNumber) "/docs/references/files/fossa-yml.md"
+fossaYmlDocUrl = guidePathOf versionOrBranch "/docs/references/files/fossa-yml.md"
 
 newIssueUrl :: Text
 newIssueUrl = sourceCodeUrl <> "/issues/new"
 
 strategyLangDocUrl :: Text -> Text
-strategyLangDocUrl path = guidePathOf (maybe currentBranch ("v" <>) versionNumber) ("/docs/references/strategies/languages/" <> path)
+strategyLangDocUrl path = guidePathOf versionOrBranch ("/docs/references/strategies/languages/" <> path)

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -5,6 +5,7 @@ module App.Version (
   fullVersionDescription,
   isDirty,
   currentBranch,
+  versionOrBranch,
 ) where
 
 import App.Version.TH (getCurrentTag)
@@ -60,3 +61,6 @@ fullVersionDescription = Text.concat items
       , compilerId
       , ")"
       ]
+
+versionOrBranch :: Text
+versionOrBranch = maybe currentBranch ("v" <>) versionNumber

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -96,6 +96,7 @@ discover dir = context "NodeJS" $ do
       pure []
     else do
       globalGraph <- context "Building global workspace graph" $ pure $ buildManifestGraph manifestMap
+      -- TODO: refactor splitGraph to report which cycle we hit, not just report some unknown cycle
       graphs <- context "Splitting global graph into chunks" $ fromMaybe CyclicPackageJson $ splitGraph globalGraph
       context "Converting graphs to analysis targets" $ traverse (mkProject <=< identifyProjectType) graphs
 

--- a/src/Strategy/Node/Errors.hs
+++ b/src/Strategy/Node/Errors.hs
@@ -26,7 +26,7 @@ fossaNodeDocUrl = strategyLangDocUrl "nodejs/nodejs.md"
 
 data CyclicPackageJson = CyclicPackageJson
 instance ToDiagnostic CyclicPackageJson where
-  renderDiagnostic (CyclicPackageJson) = "We detected cyclic references in package.json"
+  renderDiagnostic (CyclicPackageJson) = "We detected cyclic references between package.json files in the workspace."
 
 data MissingNodeLockFile = MissingNodeLockFile
 instance ToDiagnostic MissingNodeLockFile where

--- a/src/Strategy/Node/Errors.hs
+++ b/src/Strategy/Node/Errors.hs
@@ -1,0 +1,42 @@
+module Strategy.Node.Errors (
+  MissingNodeLockFile (..),
+  fossaNodeDocUrl,
+  npmLockFileDocUrl,
+  yarnLockfileDocUrl,
+) where
+
+import App.Docs (strategyLangDocUrl)
+import Data.Text (Text)
+import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
+import Prettyprinter (Pretty (pretty), indent, vsep)
+
+yarnLockfileDocUrl :: Text
+yarnLockfileDocUrl = "https://classic.yarnpkg.com/lang/en/docs/yarn-lock/"
+
+npmLockFileDocUrl :: Text
+npmLockFileDocUrl = "https://docs.npmjs.com/cli/v8/configuring-npm/package-lock-json"
+
+fossaNodeDocUrl :: Text
+fossaNodeDocUrl = strategyLangDocUrl "nodejs/nodejs.md"
+
+data MissingNodeLockFile = MissingNodeLockFile
+instance ToDiagnostic MissingNodeLockFile where
+  renderDiagnostic (MissingNodeLockFile) =
+    vsep
+      [ "We could not perform lockfile analysis for your nodejs project."
+      , ""
+      , indent 2 $
+          vsep
+            [ "Ensure valid lockfile exist and is readable prior to running fossa."
+            , indent 2 "For yarn package manager, you can perform: `yarn install` to install dependencies and generate lockfile."
+            , indent 2 "For node package manager, you can perform: `npm install` to install dependencies and generate lockfile."
+            ]
+      , ""
+      , "Refer to:"
+      , indent 2 $
+          vsep
+            [ pretty $ "- " <> fossaNodeDocUrl
+            , pretty $ "- " <> npmLockFileDocUrl
+            , pretty $ "- " <> yarnLockfileDocUrl
+            ]
+      ]

--- a/src/Strategy/Node/Errors.hs
+++ b/src/Strategy/Node/Errors.hs
@@ -1,8 +1,10 @@
 module Strategy.Node.Errors (
   MissingNodeLockFile (..),
+  CyclicPackageJson (..),
   fossaNodeDocUrl,
   npmLockFileDocUrl,
   yarnLockfileDocUrl,
+  yarnV2LockfileDocUrl,
 ) where
 
 import App.Docs (strategyLangDocUrl)
@@ -13,11 +15,18 @@ import Prettyprinter (Pretty (pretty), indent, vsep)
 yarnLockfileDocUrl :: Text
 yarnLockfileDocUrl = "https://classic.yarnpkg.com/lang/en/docs/yarn-lock/"
 
+yarnV2LockfileDocUrl :: Text
+yarnV2LockfileDocUrl = "https://yarnpkg.com/getting-started/qa#should-lockfiles-be-committed-to-the-repository"
+
 npmLockFileDocUrl :: Text
 npmLockFileDocUrl = "https://docs.npmjs.com/cli/v8/configuring-npm/package-lock-json"
 
 fossaNodeDocUrl :: Text
 fossaNodeDocUrl = strategyLangDocUrl "nodejs/nodejs.md"
+
+data CyclicPackageJson = CyclicPackageJson
+instance ToDiagnostic CyclicPackageJson where
+  renderDiagnostic (CyclicPackageJson) = "We detected cyclic references in package.json"
 
 data MissingNodeLockFile = MissingNodeLockFile
 instance ToDiagnostic MissingNodeLockFile where
@@ -38,5 +47,6 @@ instance ToDiagnostic MissingNodeLockFile where
             [ pretty $ "- " <> fossaNodeDocUrl
             , pretty $ "- " <> npmLockFileDocUrl
             , pretty $ "- " <> yarnLockfileDocUrl
+            , pretty $ "- " <> yarnV2LockfileDocUrl
             ]
       ]

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -22,6 +22,7 @@ import Strategy.Node.Errors (
   fossaNodeDocUrl,
   npmLockFileDocUrl,
   yarnLockfileDocUrl,
+  yarnV2LockfileDocUrl,
  )
 import Strategy.Python.Errors (commitPoetryLockToVCS)
 import Strategy.Ruby.Errors (bundlerLockFileRationaleUrl, rubyFossaDocUrl)
@@ -46,6 +47,7 @@ urlsToCheck =
   , npmLockFileDocUrl
   , yarnLockfileDocUrl
   , fossaNodeDocUrl
+  , yarnV2LockfileDocUrl
   ]
 
 spec :: Spec

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -18,6 +18,11 @@ import Network.HTTP.Req (
   useHttpsURI,
  )
 import Strategy.Dart.Errors (refPubDocUrl)
+import Strategy.Node.Errors (
+  fossaNodeDocUrl,
+  npmLockFileDocUrl,
+  yarnLockfileDocUrl,
+ )
 import Strategy.Python.Errors (commitPoetryLockToVCS)
 import Strategy.Ruby.Errors (bundlerLockFileRationaleUrl, rubyFossaDocUrl)
 import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
@@ -38,6 +43,9 @@ urlsToCheck =
   , rubyFossaDocUrl
   , refPubDocUrl
   , commitPoetryLockToVCS
+  , npmLockFileDocUrl
+  , yarnLockfileDocUrl
+  , fossaNodeDocUrl
   ]
 
 spec :: Spec


### PR DESCRIPTION
# Overview

This PR improves error/warn messages for nodejs.

## Out of Scope
- ParserError and CommandParserError are not covered (this is covered by https://github.com/fossas/fossa-cli/pull/801)

## Acceptance criteria

- When suboptimal strategy is used, warning with limitation is rendered. 

## Testing plan

- Analyze node project without lock file. 

## Risks

N/A

## References

Works on: https://github.com/fossas/team-analysis/issues/854

## Notes

I intend to have one refactor PR, once all error/warn diag are merged to have common actionable diagnostic format. 

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.