### PR TITLE
Dart: Improve Errors and Warns

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Ruby: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/800))
 - UX: Parser error messages include call to action. ([#801](https://github.com/fossas/fossa-cli/pull/801))
 - Python: `setup.py` error messages are _less_ noisy. ([#801](https://github.com/fossas/fossa-cli/pull/801))
+- Dart: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/806))
 
 ## v3.1.0 
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -260,6 +260,7 @@ library
     Data.Tagged
     Data.Text.Extra
     DepTypes
+    Diag.Common
     Diag.Diagnostic
     Diag.Monad
     Diag.Result
@@ -291,6 +292,7 @@ library
     Strategy.Conda
     Strategy.Conda.CondaList
     Strategy.Conda.EnvironmentYml
+    Strategy.Dart.Errors
     Strategy.Dart.PubDeps
     Strategy.Dart.PubSpec
     Strategy.Dart.PubSpecLock

--- a/src/Diag/Common.hs
+++ b/src/Diag/Common.hs
@@ -1,0 +1,16 @@
+module Diag.Common (
+  MissingDeepDeps (..),
+  MissingEdges (..),
+) where
+
+import Diag.Diagnostic (ToDiagnostic (renderDiagnostic))
+
+data MissingDeepDeps = MissingDeepDeps
+instance ToDiagnostic MissingDeepDeps where
+  renderDiagnostic (MissingDeepDeps) =
+    "Could not analyze deep dependencies."
+
+data MissingEdges = MissingEdges
+instance ToDiagnostic MissingEdges where
+  renderDiagnostic (MissingEdges) =
+    "Could not analyze edges between dependencies."

--- a/src/Strategy/Dart/Errors.hs
+++ b/src/Strategy/Dart/Errors.hs
@@ -1,0 +1,25 @@
+module Strategy.Dart.Errors (
+  PubspecLimitation (..),
+  refPubDocUrl,
+) where
+
+import App.Docs (strategyLangDocUrl)
+import Data.Text (Text)
+import Diag.Diagnostic (ToDiagnostic (..))
+import Prettyprinter (Pretty (pretty), indent, vsep)
+
+refPubDocUrl :: Text
+refPubDocUrl = strategyLangDocUrl "dart/dart.md"
+
+data PubspecLimitation = PubspecLimitation
+
+instance ToDiagnostic PubspecLimitation where
+  renderDiagnostic (PubspecLimitation) =
+    vsep
+      [ "Could not perform analysis using lockfile."
+      , ""
+      , "Build your project and ensure pubspec.lock file exists and is readable prior to using fossa-cli."
+      , ""
+      , "Refer to:"
+      , indent 2 $ pretty $ "- " <> refPubDocUrl
+      ]

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -11,6 +11,7 @@ import Discovery.Walk (WalkStep (WalkContinue), findFileNamed, walk')
 import Effect.Exec (Exec, Has)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
+import Control.Monad (void)
 import GHC.Generics (Generic)
 import Path
 import Strategy.Dart.Errors (PubspecLimitation (..))

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -2,6 +2,7 @@ module Strategy.Pub (discover) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context, errCtx, fatalText, recover, warnOnErr, (<||>))
+import Control.Monad (void)
 import Data.Aeson (ToJSON)
 import Diag.Common (
   MissingDeepDeps (MissingDeepDeps),
@@ -11,7 +12,6 @@ import Discovery.Walk (WalkStep (WalkContinue), findFileNamed, walk')
 import Effect.Exec (Exec, Has)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
-import Control.Monad (void)
 import GHC.Generics (Generic)
 import Path
 import Strategy.Dart.Errors (PubspecLimitation (..))

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -64,11 +64,10 @@ getDeps project = do
   (graph, graphBreadth) <- case pubLock project of
     Just lockFile -> analyzeDepsCmd lockFile (pubSpecDir project) <||> analyzePubLockFile lockFile
     Nothing -> do
-      _ <-
-        recover $
-          warnOnErr MissingDeepDeps
-            . warnOnErr MissingEdges
-            $ errCtx PubspecLimitation (fatalText "Missing pubspec.lock file")
+      void . recover $
+        warnOnErr MissingDeepDeps
+          . warnOnErr MissingEdges
+          $ errCtx PubspecLimitation (fatalText "Missing pubspec.lock file")
       analyzePubSpecFile $ pubSpec project
   pure $
     DependencyResults

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -1,14 +1,19 @@
 module Strategy.Pub (discover) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
+import Control.Effect.Diagnostics (Diagnostics, context, errCtx, fatalText, recover, warnOnErr, (<||>))
 import Data.Aeson (ToJSON)
+import Diag.Common (
+  MissingDeepDeps (MissingDeepDeps),
+  MissingEdges (MissingEdges),
+ )
 import Discovery.Walk (WalkStep (WalkContinue), findFileNamed, walk')
 import Effect.Exec (Exec, Has)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
 import Path
+import Strategy.Dart.Errors (PubspecLimitation (..))
 import Strategy.Dart.PubDeps (analyzeDepsCmd)
 import Strategy.Dart.PubSpec (analyzePubSpecFile)
 import Strategy.Dart.PubSpecLock (analyzePubLockFile)
@@ -58,7 +63,13 @@ getDeps :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m, Has Logger 
 getDeps project = do
   (graph, graphBreadth) <- case pubLock project of
     Just lockFile -> analyzeDepsCmd lockFile (pubSpecDir project) <||> analyzePubLockFile lockFile
-    Nothing -> analyzePubSpecFile $ pubSpec project
+    Nothing -> do
+      _ <-
+        recover $
+          warnOnErr MissingDeepDeps
+            . warnOnErr MissingEdges
+            $ errCtx PubspecLimitation (fatalText "Missing pubspec.lock file")
+      analyzePubSpecFile $ pubSpec project
   pure $
     DependencyResults
       { dependencyGraph = graph

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -17,6 +17,7 @@ import Network.HTTP.Req (
   runReq,
   useHttpsURI,
  )
+import Strategy.Dart.Errors (refPubDocUrl)
 import Strategy.Ruby.Errors (bundlerLockFileRationaleUrl, rubyFossaDocUrl)
 import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 import Text.URI (mkURI)
@@ -34,6 +35,7 @@ urlsToCheck =
   , fossaYmlDocUrl
   , bundlerLockFileRationaleUrl
   , rubyFossaDocUrl
+  , refPubDocUrl
   ]
 
 spec :: Spec


### PR DESCRIPTION
# Overview

This PR improves error/warn messages for dart.

## Out of Scope
- ParserError and CommandParserError are not covered (this is covered by https://github.com/fossas/fossa-cli/pull/801)

## Acceptance criteria

- When suboptimal strategy is used, warning with limitation is rendered. 

## Testing plan

- Analyze dart project without Pubspec.lock file.

## Risks

N/A

## References

Works on: https://github.com/fossas/team-analysis/issues/854

## Notes

I intend to have one refactor PR, once all error/warn diag are merged to have common actionable diagnostic format. 

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
