### PR TITLE
Cocoapods: Improve Errors and Warns

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Maven: Improves error and warning messages. ([#808](https://github.com/fossas/fossa-cli/pull/808))
 - Nodejs: Improves error and warning messages. ([#805](https://github.com/fossas/fossa-cli/pull/805))
 - Swift: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/802))
+- Cocoapods: Improves error and warning messages. ([#807](https://github.com/fossas/fossa-cli/pull/807))
 
 ## v3.1.0 
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -286,6 +286,7 @@ library
     Strategy.Cargo
     Strategy.Carthage
     Strategy.Cocoapods
+    Strategy.Cocoapods.Errors
     Strategy.Cocoapods.Podfile
     Strategy.Cocoapods.PodfileLock
     Strategy.Composer

--- a/src/Strategy/Cocoapods/Errors.hs
+++ b/src/Strategy/Cocoapods/Errors.hs
@@ -1,0 +1,25 @@
+module Strategy.Cocoapods.Errors (
+  MissingPodLockFile (..),
+  refPodDocUrl,
+) where
+
+import App.Docs (platformDocUrl)
+import Data.Text (Text)
+import Diag.Diagnostic (ToDiagnostic (..))
+import Prettyprinter (Pretty (pretty), indent, vsep)
+
+refPodDocUrl :: Text
+refPodDocUrl = platformDocUrl "ios/cocoapods.md"
+
+data MissingPodLockFile = MissingPodLockFile
+
+instance ToDiagnostic MissingPodLockFile where
+  renderDiagnostic (MissingPodLockFile) =
+    vsep
+      [ "We could not perform analysis using Podfile.lock."
+      , ""
+      , "Ensure a valid Podfile.lock file exists prior to using fossa-cli."
+      , ""
+      , "Refer to:"
+      , indent 2 $ pretty $ "- " <> refPodDocUrl
+      ]

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -17,6 +17,7 @@ import Network.HTTP.Req (
   runReq,
   useHttpsURI,
  )
+import Strategy.Cocoapods.Errors (refPodDocUrl)
 import Strategy.Dart.Errors (refPubDocUrl)
 import Strategy.Node.Errors (
   fossaNodeDocUrl,
@@ -56,6 +57,7 @@ urlsToCheck =
   , swiftFossaDocUrl
   , swiftPackageResolvedRef
   , xcodeCoordinatePkgVersion
+  , refPodDocUrl
   ]
 
 spec :: Spec


### PR DESCRIPTION
# Overview

This PR improves error/warn messages for cocoapods.

## Out of Scope
- ParserError and CommandParserError are not covered (this is covered by https://github.com/fossas/fossa-cli/pull/801)

## Acceptance criteria

- When suboptimal strategy is used, warning with limitation is rendered. 

## Testing plan

- Analyze cocoapods project without Podfile.lock file.

## Risks

N/A

## References

Works on: https://github.com/fossas/team-analysis/issues/854

## Notes

I intend to have one refactor PR, once all error/warn diag are merged to have common actionable diagnostic format. 

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
