### PR TITLE
Maven: Improve Errors and Warns

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 - Dart: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/806))
 - Pipenv: Improves error and warning messages. ([#803](https://github.com/fossas/fossa-cli/pull/803))
 - Poetry: Improves error and warning messages. ([#803](https://github.com/fossas/fossa-cli/pull/803))
+- Maven: Improves error and warning messages. ([#808](https://github.com/fossas/fossa-cli/pull/808))
 
 ## v3.1.0 
 

--- a/docs/references/strategies/languages/maven/maven.md
+++ b/docs/references/strategies/languages/maven/maven.md
@@ -5,8 +5,10 @@ For maven projects, we offer a more-accurate strategy (mavenplugin), and a strat
 | Strategy    | Direct Deps | Deep Deps | Edges |
 | ---         | ---         | ---       | ---   |
 | [mavenplugin][mavenplugin] | ✅          | ✅        | ✅    |
+| [treecmd][treecmd]         | ✅          | ✅        | ✅    |
 | [pomxml][pomxml]           | ✅          | ❌        | ❌    |
 
+[treecmd](treecmd.md)
 [mavenplugin](mavenplugin.md)
 [pomxml](pomxml.md)
 

--- a/docs/references/strategies/languages/maven/treecmd.md
+++ b/docs/references/strategies/languages/maven/treecmd.md
@@ -1,0 +1,17 @@
+# Maven - Tree Command
+
+This maven tactic uses native, `mvn dependency:tree` command to retrieve
+dependency information. 
+
+## Project Discovery
+
+Find `pom.xml` files, and treat those as maven projects. Skip all subdirectories.
+
+## Analysis
+
+1. Executes `mvn dependency:tree -DoutputType=dot -DoutputFile=... --fail-at-end`
+2. Parse and analyze generated dot file for dependency analysis
+
+## References
+
+- [Maven dependency:tree](https://maven.apache.org/plugins/maven-dependency-plugin/usage.html#dependency:tree)

--- a/src/Diag/Monad.hs
+++ b/src/Diag/Monad.hs
@@ -129,7 +129,7 @@ ResultT ma <||> ResultT ma' = ResultT $ do
     Failure ws eg -> do
       resA' <- ma'
       case resA' of
-        Success ws' a' -> pure (Success (ws' <> (errGroupToWarning eg : ws) <> ws') a')
+        Success ws' a' -> pure (Success (ws' <> (errGroupToWarning eg : ws)) a')
         Failure ws' eg' -> pure (Failure (ws' <> ws) (eg <> eg'))
 {-# INLINE (<||>) #-}
 

--- a/src/Diag/Monad.hs
+++ b/src/Diag/Monad.hs
@@ -130,7 +130,7 @@ ResultT ma <||> ResultT ma' = ResultT $ do
       resA' <- ma'
       case resA' of
         Success ws' a' -> pure (Success (ws' <> (errGroupToWarning eg : ws)) a')
-        Failure ws' eg' -> pure (Failure (ws' <> ws) (eg <> eg'))
+        Failure ws' eg' -> pure (Failure (ws' <> ws) (eg <> eg')) -- match the order of alternatives for error group aggregation
 {-# INLINE (<||>) #-}
 
 ---------- Base Result operations

--- a/src/Diag/Monad.hs
+++ b/src/Diag/Monad.hs
@@ -129,8 +129,8 @@ ResultT ma <||> ResultT ma' = ResultT $ do
     Failure ws eg -> do
       resA' <- ma'
       case resA' of
-        Success ws' a' -> pure (Success (ws' <> (errGroupToWarning eg : ws)) a')
-        Failure ws' eg' -> pure (Failure (ws' <> ws) (eg' <> eg))
+        Success ws' a' -> pure (Success (ws' <> (errGroupToWarning eg : ws) <> ws') a')
+        Failure ws' eg' -> pure (Failure (ws' <> ws) (eg <> eg'))
 {-# INLINE (<||>) #-}
 
 ---------- Base Result operations

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -88,7 +88,7 @@ getDepsDynamicAnalysis closure =
   context "Dynamic Analysis" $
     warnOnErr MissingEdges
       . warnOnErr MissingDeepDeps
-      $ getDepsPlugin closure <||> getDepsTreeCmd closure
+      $ (getDepsPlugin closure <||> getDepsTreeCmd closure)
 
 getDepsPlugin ::
   ( Has (Lift IO) sig m

--- a/src/Strategy/Maven/Pom/Resolver.hs
+++ b/src/Strategy/Maven/Pom/Resolver.hs
@@ -89,25 +89,8 @@ recursiveLoadPom path = do
 
     recurseRelative :: Text {- relative filepath -} -> m ()
     recurseRelative rel = do
-      (resolvedPath :: Maybe (Path Abs File)) <-
-        context rel $
-          recover $
-            warnOnErr (PomProjectInheritanceResolutionFailed path)
-              . errCtx (FailedToResolveParentPom rel)
-              $ (resolvePath (parent path) rel)
+      resolvedPath :: Maybe (Path Abs File) <- recover $ resolvePath (parent path) rel
       traverse_ recursiveLoadPom resolvedPath
-
-newtype PomProjectInheritanceResolutionFailed = PomProjectInheritanceResolutionFailed (Path Abs File)
-instance ToDiagnostic PomProjectInheritanceResolutionFailed where
-  renderDiagnostic (PomProjectInheritanceResolutionFailed pomPath) =
-    vsep
-      [ "Dependencies originated or using inheritance may have missing or incorrect dependency information,"
-      , pretty $ "for: " <> show pomPath
-      ]
-
-newtype FailedToResolveParentPom = FailedToResolveParentPom Text
-instance ToDiagnostic FailedToResolveParentPom where
-  renderDiagnostic (FailedToResolveParentPom relativePath) = pretty $ "Failed to resolve relative path: " <> relativePath <> " for parent pom."
 
 -- resolve a Filepath (in Text) that may either point to a directory or an exact
 -- pom file. when it's a directory, we default to pointing at the "pom.xml" in

--- a/src/Strategy/Maven/Pom/Resolver.hs
+++ b/src/Strategy/Maven/Pom/Resolver.hs
@@ -17,7 +17,6 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Effect.ReadFS
 import Path
-import Prettyprinter (Pretty (pretty), vsep)
 import Strategy.Maven.Pom.PomFile
 
 data GlobalClosure = GlobalClosure

--- a/src/Strategy/Maven/Pom/Resolver.hs
+++ b/src/Strategy/Maven/Pom/Resolver.hs
@@ -17,6 +17,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Effect.ReadFS
 import Path
+import Prettyprinter (Pretty (pretty), vsep)
 import Strategy.Maven.Pom.PomFile
 
 data GlobalClosure = GlobalClosure
@@ -88,8 +89,25 @@ recursiveLoadPom path = do
 
     recurseRelative :: Text {- relative filepath -} -> m ()
     recurseRelative rel = do
-      (resolvedPath :: Maybe (Path Abs File)) <- recover (resolvePath (parent path) rel)
+      (resolvedPath :: Maybe (Path Abs File)) <-
+        context rel $
+          recover $
+            warnOnErr (PomProjectInheritanceResolutionFailed path)
+              . errCtx (FailedToResolveParentPom rel)
+              $ (resolvePath (parent path) rel)
       traverse_ recursiveLoadPom resolvedPath
+
+newtype PomProjectInheritanceResolutionFailed = PomProjectInheritanceResolutionFailed (Path Abs File)
+instance ToDiagnostic PomProjectInheritanceResolutionFailed where
+  renderDiagnostic (PomProjectInheritanceResolutionFailed pomPath) =
+    vsep
+      [ "Dependencies originated or using inheritance may have missing or incorrect dependency information,"
+      , pretty $ "for: " <> show pomPath
+      ]
+
+newtype FailedToResolveParentPom = FailedToResolveParentPom Text
+instance ToDiagnostic FailedToResolveParentPom where
+  renderDiagnostic (FailedToResolveParentPom relativePath) = pretty $ "Failed to resolve relative path: " <> relativePath <> " for parent pom."
 
 -- resolve a Filepath (in Text) that may either point to a directory or an exact
 -- pom file. when it's a directory, we default to pointing at the "pom.xml" in


### PR DESCRIPTION
# Overview

This PR improves error/warn messages for maven.

## Out of Scope
- ParserError and CommandParserError are not covered (this is covered by https://github.com/fossas/fossa-cli/pull/801)

## Acceptance criteria

- When suboptimal strategy is used, warning with limitation is rendered. 

## Testing plan

- Analyze maven project without mvn executable.

## Risks

N/A

## References

Works on: https://github.com/fossas/team-analysis/issues/854

## Notes

I intend to have one refactor PR, once all error/warn diag are merged to have common actionable diagnostic format. 

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
