### PR TITLE
Golang: Improve Errors and Warns

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 - Nodejs: Improves error and warning messages. ([#805](https://github.com/fossas/fossa-cli/pull/805))
 - Swift: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/802))
 - Cocoapods: Improves error and warning messages. ([#807](https://github.com/fossas/fossa-cli/pull/807))
+- Golang: Improves error and warning messages. ([#809](https://github.com/fossas/fossa-cli/pull/809))
 
 ## v3.1.0 
 

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -7,6 +7,7 @@ module Strategy.Go.GoList (
 ) where
 
 import Control.Effect.Diagnostics hiding (fromMaybe)
+import Control.Monad (void)
 import Data.Aeson (FromJSON, withObject, (.!=), (.:), (.:?))
 import Data.Aeson.Internal (formatError)
 import Data.Aeson.Types (parseJSON)
@@ -84,7 +85,11 @@ analyze' dir = do
       Left (path, err) -> fatal (CommandParseError goListJsonCmd (toText (formatError path err)))
       Right (mods :: [GoListModule]) -> do
         context "Adding direct dependencies" $ buildGraph (toRequires mods)
-        _ <- recover $ warnOnErr MissingDeepDeps . warnOnErr MissingEdges $ (fillInTransitive dir)
+        void
+          . recover
+          . warnOnErr MissingDeepDeps
+          . warnOnErr MissingEdges
+          $ fillInTransitive dir
         pure ()
   pure (graph, Complete)
   where

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -15,6 +15,10 @@ import Data.Maybe (fromMaybe)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import DepTypes (Dependency)
+import Diag.Common (
+  MissingDeepDeps (MissingDeepDeps),
+  MissingEdges (MissingEdges),
+ )
 import Effect.Exec (
   AllowErr (Never),
   Command (..),
@@ -80,7 +84,7 @@ analyze' dir = do
       Left (path, err) -> fatal (CommandParseError goListJsonCmd (toText (formatError path err)))
       Right (mods :: [GoListModule]) -> do
         context "Adding direct dependencies" $ buildGraph (toRequires mods)
-        _ <- recover (fillInTransitive dir)
+        _ <- recover $ warnOnErr MissingDeepDeps . warnOnErr MissingEdges $ (fillInTransitive dir)
         pure ()
   pure (graph, Complete)
   where

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -17,7 +17,7 @@ module Strategy.Go.Gomod (
 ) where
 
 import Control.Algebra (Has)
-import Control.Effect.Diagnostics (Diagnostics, context, recover)
+import Control.Effect.Diagnostics (Diagnostics, context, recover, warnOnErr)
 import Data.Char (isSpace)
 import Data.Foldable (traverse_)
 import Data.Functor (void)
@@ -30,6 +30,10 @@ import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Void (Void)
 import DepTypes (Dependency)
+import Diag.Common (
+  MissingDeepDeps (MissingDeepDeps),
+  MissingEdges (MissingEdges),
+ )
 import Effect.Exec (Exec)
 import Effect.Grapher (direct, label)
 import Effect.ReadFS (ReadFS, readContentsParser)
@@ -343,7 +347,7 @@ analyze' file = do
 
     context "Building dependency graph" $ buildGraph gomod
 
-    _ <- recover (fillInTransitive (parent file))
+    _ <- recover $ warnOnErr MissingDeepDeps . warnOnErr MissingEdges $ (fillInTransitive (parent file))
     pure ()
   pure (graph, Partial)
 

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -346,8 +346,11 @@ analyze' file = do
     gomod <- readContentsParser gomodParser file
 
     context "Building dependency graph" $ buildGraph gomod
-
-    _ <- recover $ warnOnErr MissingDeepDeps . warnOnErr MissingEdges $ (fillInTransitive (parent file))
+    void
+      . recover
+      . warnOnErr MissingDeepDeps
+      . warnOnErr MissingEdges
+      $ fillInTransitive (parent file)
     pure ()
   pure (graph, Partial)
 

--- a/src/Strategy/Go/GopkgLock.hs
+++ b/src/Strategy/Go/GopkgLock.hs
@@ -61,8 +61,11 @@ analyze' ::
 analyze' file = graphingGolang $ do
   golock <- readContentsToml golockCodec file
   context "Building dependency graph" $ buildGraph (lockProjects golock)
-  _ <- recover $ warnOnErr MissingDeepDeps . warnOnErr MissingEdges $ (fillInTransitive (parent file))
-  pure ()
+  void
+    . recover
+    . warnOnErr MissingDeepDeps
+    . warnOnErr MissingEdges
+    $ fillInTransitive (parent file)
 
 buildGraph :: Has GolangGrapher sig m => [Project] -> m ()
 buildGraph = void . traverse_ go

--- a/src/Strategy/Go/GopkgLock.hs
+++ b/src/Strategy/Go/GopkgLock.hs
@@ -13,6 +13,10 @@ import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Text (Text)
 import DepTypes
+import Diag.Common (
+  MissingDeepDeps (MissingDeepDeps),
+  MissingEdges (MissingEdges),
+ )
 import Effect.Exec
 import Effect.Grapher
 import Effect.ReadFS
@@ -57,7 +61,7 @@ analyze' ::
 analyze' file = graphingGolang $ do
   golock <- readContentsToml golockCodec file
   context "Building dependency graph" $ buildGraph (lockProjects golock)
-  _ <- recover (fillInTransitive (parent file))
+  _ <- recover $ warnOnErr MissingDeepDeps . warnOnErr MissingEdges $ (fillInTransitive (parent file))
   pure ()
 
 buildGraph :: Has GolangGrapher sig m => [Project] -> m ()

--- a/src/Strategy/Go/GopkgToml.hs
+++ b/src/Strategy/Go/GopkgToml.hs
@@ -70,9 +70,11 @@ analyze' ::
 analyze' file = graphingGolang $ do
   gopkg <- readContentsToml gopkgCodec file
   context "Building dependency graph" $ buildGraph gopkg
-
-  _ <- recover $ warnOnErr MissingDeepDeps . warnOnErr MissingEdges $ (fillInTransitive (parent file))
-  pure ()
+  void
+    . recover
+    . warnOnErr MissingDeepDeps
+    . warnOnErr MissingEdges
+    $ fillInTransitive (parent file)
 
 buildGraph :: Has GolangGrapher sig m => Gopkg -> m ()
 buildGraph = void . Map.traverseWithKey go . resolve

--- a/src/Strategy/Go/GopkgToml.hs
+++ b/src/Strategy/Go/GopkgToml.hs
@@ -16,6 +16,10 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import DepTypes
+import Diag.Common (
+  MissingDeepDeps (MissingDeepDeps),
+  MissingEdges (MissingEdges),
+ )
 import Effect.Exec
 import Effect.Grapher
 import Effect.ReadFS
@@ -67,7 +71,7 @@ analyze' file = graphingGolang $ do
   gopkg <- readContentsToml gopkgCodec file
   context "Building dependency graph" $ buildGraph gopkg
 
-  _ <- recover (fillInTransitive (parent file))
+  _ <- recover $ warnOnErr MissingDeepDeps . warnOnErr MissingEdges $ (fillInTransitive (parent file))
   pure ()
 
 buildGraph :: Has GolangGrapher sig m => Gopkg -> m ()

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -7,12 +7,8 @@ module Strategy.Gomodules (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Effect.Diagnostics (Diagnostics, context, warnOnErr, (<||>))
+import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Data.Aeson (ToJSON)
-import Diag.Common (
-  MissingDeepDeps (MissingDeepDeps),
-  MissingEdges (MissingEdges),
- )
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
@@ -66,7 +62,7 @@ getDeps project = do
       }
   where
     staticAnalysis :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => m (Graphing Dependency, GraphBreadth)
-    staticAnalysis = context "Static analysis" $ (Gomod.analyze' (gomodulesGomod project))
+    staticAnalysis = context "Static analysis" (Gomod.analyze' (gomodulesGomod project))
 
     dynamicAnalysis :: (Has Exec sig m, Has Diagnostics sig m) => m (Graphing Dependency, GraphBreadth)
     dynamicAnalysis =


### PR DESCRIPTION
# Overview

This PR improves error/warn messages for golang.

## Out of Scope
- ParserError and CommandParserError are not covered (this is covered by https://github.com/fossas/fossa-cli/pull/801)

## Acceptance criteria

- Error messages are shown when `fillInTransitive` fails due to `go list` command.

## Testing plan
 
1. Force static analysis: `PATH='' ./fossa analyze example/ -o`

## Risks

N/A

## References

Works on: https://github.com/fossas/team-analysis/issues/854

## Notes

I intend to have one refactor PR, once all error/warn diag are merged to have common actionable diagnostic format. 

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
