### PR TITLE
Remaining error/warns for analyzers, and updates to scan summary

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,9 @@
 ## Yet to be released
 
 - UX: Parser error messages include call to action. ([#801](https://github.com/fossas/fossa-cli/pull/801))
-- UX: Improves error message when executable is not found. ([#802](https://github.com/fossas/fossa-cli/pull/813))
+- UX: Improves error message when executable is not found. ([#813](https://github.com/fossas/fossa-cli/pull/813))
+- UX: Fixes minor scan summary ordering bug. ([#813](https://github.com/fossas/fossa-cli/pull/813))
+- UX: Writes errors and warnings encountered in analyze to temp file. ([#813](https://github.com/fossas/fossa-cli/pull/813))
 - Ruby: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/800))
 - Python: `setup.py` error messages are _less_ noisy. ([#801](https://github.com/fossas/fossa-cli/pull/801))
 - Dart: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/806))
@@ -15,10 +17,10 @@
 - Cocoapods: Improves error and warning messages. ([#807](https://github.com/fossas/fossa-cli/pull/807))
 - Golang: Improves error and warning messages. ([#809](https://github.com/fossas/fossa-cli/pull/809))
 - Gradle: Improves error and warning messages. ([#804](https://github.com/fossas/fossa-cli/pull/804))
-- Scala: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/813))
-- Clojure: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/813))
-- Nim: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/813))
-- Rust: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/813))
+- Scala: Improves error and warning messages. ([#813](https://github.com/fossas/fossa-cli/pull/813))
+- Clojure: Improves error and warning messages. ([#813](https://github.com/fossas/fossa-cli/pull/813))
+- Nim: Improves error and warning messages. ([#813](https://github.com/fossas/fossa-cli/pull/813))
+- Rust: Improves error and warning messages. ([#813](https://github.com/fossas/fossa-cli/pull/813))
 
 ## v3.1.0 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,9 @@
 
 ## Yet to be released
 
-- Ruby: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/800))
 - UX: Parser error messages include call to action. ([#801](https://github.com/fossas/fossa-cli/pull/801))
+- UX: Improves error message when executable is not found. ([#802](https://github.com/fossas/fossa-cli/pull/813))
+- Ruby: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/800))
 - Python: `setup.py` error messages are _less_ noisy. ([#801](https://github.com/fossas/fossa-cli/pull/801))
 - Dart: Improves error and warning messages. ([#800](https://github.com/fossas/fossa-cli/pull/806))
 - Pipenv: Improves error and warning messages. ([#803](https://github.com/fossas/fossa-cli/pull/803))
@@ -14,11 +15,10 @@
 - Cocoapods: Improves error and warning messages. ([#807](https://github.com/fossas/fossa-cli/pull/807))
 - Golang: Improves error and warning messages. ([#809](https://github.com/fossas/fossa-cli/pull/809))
 - Gradle: Improves error and warning messages. ([#804](https://github.com/fossas/fossa-cli/pull/804))
-- Scala: Improves error and warning messages.
-- Clojure: Improves error and warning messages.
-- Nim: Improves error and warning messages.
-- Rust: Improves error and warning messages.
-- UX: Improves error message when executable is not found. 
+- Scala: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/813))
+- Clojure: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/813))
+- Nim: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/813))
+- Rust: Improves error and warning messages. ([#802](https://github.com/fossas/fossa-cli/pull/813))
 
 ## v3.1.0 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,11 @@
 - Cocoapods: Improves error and warning messages. ([#807](https://github.com/fossas/fossa-cli/pull/807))
 - Golang: Improves error and warning messages. ([#809](https://github.com/fossas/fossa-cli/pull/809))
 - Gradle: Improves error and warning messages. ([#804](https://github.com/fossas/fossa-cli/pull/804))
+- Scala: Improves error and warning messages.
+- Clojure: Improves error and warning messages.
+- Nim: Improves error and warning messages.
+- Rust: Improves error and warning messages.
+- UX: Improves error message when executable is not found. 
 
 ## v3.1.0 
 

--- a/integration-test/Analysis/FixtureUtils.hs
+++ b/integration-test/Analysis/FixtureUtils.hs
@@ -147,7 +147,7 @@ performDiscoveryAndAnalyses targetDir AnalysisTestFixture{..} = do
             Right _ -> pure ()
 
 withResult :: MonadFail m => Result a -> ([EmittedWarn] -> a -> m b) -> m b
-withResult (Failure ws eg) _ = fail (show (renderFailure ws eg))
+withResult (Failure ws eg) _ = fail (show (renderFailure ws eg "An issue occurred"))
 withResult (Success ws a) f = f ws a
 
 -- --------------------------------

--- a/src/App/Docs.hs
+++ b/src/App/Docs.hs
@@ -4,6 +4,7 @@ module App.Docs (
   fossaYmlDocUrl,
   strategyLangDocUrl,
   platformDocUrl,
+  fossaSslCertDocsUrl,
 ) where
 
 import App.Version (versionOrBranch)
@@ -29,3 +30,6 @@ strategyLangDocUrl path = guidePathOf versionOrBranch ("/docs/references/strateg
 
 platformDocUrl :: Text -> Text
 platformDocUrl path = guidePathOf versionOrBranch ("/docs/references/strategies/platforms/" <> path)
+
+fossaSslCertDocsUrl :: Text
+fossaSslCertDocsUrl = guidePathOf versionOrBranch "/docs/walkthroughs/ssl-cert.md"

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -179,7 +179,7 @@ runDependencyAnalysis basedir filters project = do
       graphResult <- Diag.runDiagnosticsIO . diagToDebug . stickyLogStack . withEmptyStack . Diag.context "Project Analysis" $ do
         debugMetadata "DiscoveredProject" project
         analyzeProject targets (projectData project)
-      Diag.flushLogs SevWarn SevWarn graphResult
+      Diag.flushLogs SevWarn SevDebug graphResult
       output $ Scanned dpi (mkResult basedir project <$> graphResult)
 
 applyFiltersToProject :: Path Abs Dir -> AllFilters -> DiscoveredProject n -> Maybe FoundTargets

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module App.Fossa.Analyze.ScanSummary (
   renderScanSummary,
@@ -13,23 +14,35 @@ import App.Fossa.Analyze.Types (
   DiscoveredProjectScan (..),
  )
 import App.Version (fullVersionDescription)
+import Control.Carrier.Lift
 import Control.Effect.Diagnostics qualified as Diag (Diagnostics)
 import Control.Monad (when)
 import Data.Foldable (traverse_)
 import Data.List (sort)
+import Data.Maybe (catMaybes, mapMaybe)
 import Data.Text (Text)
-import Diag.Result (EmittedWarn (IgnoredErrGroup), Result (Failure, Success))
+import Data.Text.IO qualified as TIO
+import Diag.Result (EmittedWarn (IgnoredErrGroup), Result (Failure, Success), renderFailure, renderSuccess)
 import Effect.Logger (
   AnsiStyle,
-  Has,
   Logger,
   Pretty (pretty),
   hsep,
   logInfo,
  )
 import Path
-import Prettyprinter (Doc, annotate, viaShow)
-import Prettyprinter.Render.Terminal (Color (Green, Red, Yellow), bold, color)
+import Path.IO
+import Prettyprinter (
+  Doc,
+  annotate,
+  defaultLayoutOptions,
+  layoutPretty,
+  plural,
+  unAnnotate,
+  viaShow,
+  vsep,
+ )
+import Prettyprinter.Render.Terminal (Color (Green, Red, Yellow), bold, color, renderStrict)
 import Srclib.Types (
   AdditionalDepData (userDefinedDeps),
   SourceUnit (additionalData),
@@ -46,37 +59,20 @@ data ScanCount = ScanCount
   }
   deriving (Show, Eq, Ord)
 
-instance Semigroup (ScanCount) where
+instance Semigroup ScanCount where
   (ScanCount l1 l2 l3 l4 l5) <> (ScanCount r1 r2 r3 r4 r5) = ScanCount (l1 + r1) (l2 + r2) (l3 + r3) (l4 + r4) (l5 + r5)
 
-instance Monoid (ScanCount) where
+instance Monoid ScanCount where
   mempty = ScanCount 0 0 0 0 0
 
 getScanCount :: [DiscoveredProjectScan] -> ScanCount
 getScanCount = foldl countOf (ScanCount 0 0 0 0 0)
   where
     countOf :: ScanCount -> DiscoveredProjectScan -> ScanCount
-    countOf tsc (SkippedDueToProvidedFilter _) =
-      tsc
-        { numProjects = numProjects tsc + 1
-        , numSkipped = numSkipped tsc + 1
-        }
-    countOf tsc (SkippedDueToDefaultProductionFilter _) =
-      tsc
-        { numProjects = numProjects tsc + 1
-        , numSkipped = numSkipped tsc + 1
-        }
-    countOf tsc (Scanned _ (Failure _ _)) =
-      tsc
-        { numProjects = numProjects tsc + 1
-        , numFailed = numFailed tsc + 1
-        }
-    countOf tsc (Scanned _ (Success wg _)) =
-      tsc
-        { numProjects = numProjects tsc + 1
-        , numSucceeded = numSucceeded tsc + 1
-        , numWarnings = numWarnings tsc + countWarnings wg
-        }
+    countOf tsc (SkippedDueToProvidedFilter _) = tsc{numProjects = numProjects tsc + 1, numSkipped = numSkipped tsc + 1}
+    countOf tsc (SkippedDueToDefaultProductionFilter _) = tsc{numProjects = numProjects tsc + 1, numSkipped = numSkipped tsc + 1}
+    countOf tsc (Scanned _ (Failure _ _)) = tsc{numProjects = numProjects tsc + 1, numFailed = numFailed tsc + 1}
+    countOf tsc (Scanned _ (Success wg _)) = tsc{numProjects = numProjects tsc + 1, numSucceeded = numSucceeded tsc + 1, numWarnings = numWarnings tsc + countWarnings wg}
 
 instance Pretty ScanCount where
   pretty ScanCount{..} =
@@ -85,7 +81,7 @@ instance Pretty ScanCount where
       , pretty numSkipped <> " skipped, "
       , pretty numSucceeded <> " succeeded, "
       , pretty numFailed <> " failed, "
-      , pretty numWarnings <> " analysis warnings"
+      , pretty numWarnings <> " analysis " <> plural "warning" "warnings" numWarnings
       ]
 
 -- | Renders Analysis Scan Summary with `ServInfo` severity.
@@ -107,7 +103,7 @@ instance Pretty ScanCount where
 -- * __fpm__ project in path: skipped
 -- * __setuptools__ project in path: skipped
 renderScanSummary ::
-  (Has Diag.Diagnostics sig m, Has Logger sig m) =>
+  (Has Diag.Diagnostics sig m, Has Logger sig m, Has (Lift IO) sig m) =>
   [DiscoveredProjectScan] ->
   -- | Resulted source unit from @analyzeVSI@
   Result (Maybe SourceUnit) ->
@@ -137,11 +133,14 @@ renderScanSummary dps vsi binary manualDeps = do
       ]
     logInfo ""
     logInfoVsep $ itemize listSymbol summarizeProjectScan projects
-
-    -- Additional analysis done outside of standard strategy flow
-    summarizeSrcUnit "vsi analysis" Nothing vsi
-    summarizeSrcUnit "binary-deps analysis" (Just getBinaryIdentifier) binary
-    summarizeSrcUnit "manual and vendor dependencies" Nothing manualDeps
+    logInfoVsep $ summarizeSrcUnit "vsi analysis" Nothing vsi
+    logInfoVsep $ summarizeSrcUnit "binary-deps analysis" (Just getBinaryIdentifier) binary
+    logInfoVsep $ summarizeSrcUnit "fossa-deps analysis" Nothing manualDeps
+    logInfo ""
+    logInfo "You can pass `--debug` option to show all warning and failure messages."
+    scanSummaryLogs <- dumpResultLogsToTempFile projects vsi binary manualDeps
+    logInfo . pretty $ "You can also view them at: " <> show scanSummaryLogs
+    logInfo "------------"
 
 listSymbol :: Doc AnsiStyle
 listSymbol = "* "
@@ -158,18 +157,16 @@ srcUnitToScanCount (Success _ Nothing) = ScanCount 0 0 0 0 0
 srcUnitToScanCount (Success wg (Just _)) = ScanCount 1 0 1 0 (countWarnings wg)
 
 summarizeSrcUnit ::
-  (Has Diag.Diagnostics sig m, Has Logger sig m) =>
   Doc AnsiStyle ->
   Maybe (SourceUnit -> [Text]) ->
   Result (Maybe SourceUnit) ->
-  m ()
-summarizeSrcUnit analysisHeader maybeGetter (Success wg (Just unit)) = do
-  logInfo $ successColorCoded wg $ (listSymbol <> analysisHeader) <> renderSucceeded wg
+  [Doc AnsiStyle]
+summarizeSrcUnit analysisHeader maybeGetter (Success wg (Just unit)) =
   case maybeGetter <*> Just unit of
-    Just txts -> logInfoVsep $ itemize ("  *" <> listSymbol) viaShow txts
-    Nothing -> pure ()
-summarizeSrcUnit analysisHeader _ (Failure _ _) = logInfo . failColorCoded $ annotate bold analysisHeader <> renderFailed
-summarizeSrcUnit _ _ _ = pure ()
+    Nothing -> [successColorCoded wg (listSymbol <> analysisHeader <> renderSucceeded wg)]
+    Just txts -> map (\i -> successColorCoded wg (listSymbol <> analysisHeader <> pretty (" for " <> i) <> renderSucceeded wg)) txts
+summarizeSrcUnit analysisHeader _ (Failure _ _) = [failColorCoded $ annotate bold analysisHeader <> renderFailed]
+summarizeSrcUnit _ _ _ = []
 
 summarizeProjectScan :: DiscoveredProjectScan -> Doc AnsiStyle
 summarizeProjectScan (Scanned dpi (Failure _ _)) = failColorCoded $ renderDiscoveredProjectIdentifier dpi <> renderFailed
@@ -192,7 +189,7 @@ renderProjectPathAndType :: DiscoveredProjectType -> Path Abs Dir -> Doc AnsiSty
 renderProjectPathAndType pt path = annotate bold projectTypeDoc <> pathDoc
   where
     pathDoc = " project in " <> viaShow path
-    projectTypeDoc = viaShow $ projectTypeToText pt
+    projectTypeDoc = pretty $ projectTypeToText pt
 
 successColorCoded :: [EmittedWarn] -> Doc AnsiStyle -> Doc AnsiStyle
 successColorCoded ew =
@@ -230,3 +227,43 @@ countWarnings ws =
     isIgnoredErrGroup :: EmittedWarn -> Bool
     isIgnoredErrGroup IgnoredErrGroup{} = True
     isIgnoredErrGroup _ = False
+
+dumpResultLogsToTempFile ::
+  (Has (Lift IO) sig m) =>
+  [DiscoveredProjectScan] ->
+  -- | Resulted source unit from @analyzeVSI@
+  Result (Maybe SourceUnit) ->
+  -- | Resulted source unit from @analyzeDiscoverBinaries@
+  Result (Maybe SourceUnit) ->
+  -- | Resulted source unit from @manualSrcUnits@
+  Result (Maybe SourceUnit) ->
+  m (Path Abs File)
+dumpResultLogsToTempFile projects vsi binary manualDeps = do
+  let doc =
+        renderStrict
+          . layoutPretty defaultLayoutOptions
+          . unAnnotate
+          . mconcat
+          $ (mapMaybe renderDiscoveredProjectScanResult projects)
+            ++ catMaybes
+              [ renderSourceUnit "vsi analysis" vsi
+              , renderSourceUnit "binary-deps analysis" binary
+              , renderSourceUnit "fossa-deps analysis" manualDeps
+              ]
+
+  tmpDir <- sendIO getTempDir
+  sendIO $ TIO.writeFile (fromAbsFile $ tmpDir </> scanSummaryFileName) doc
+  pure (tmpDir </> scanSummaryFileName)
+  where
+    renderSourceUnit :: Doc AnsiStyle -> Result (Maybe SourceUnit) -> Maybe (Doc AnsiStyle)
+    renderSourceUnit header (Failure ws eg) = Just $ renderFailure ws eg $ vsep $ summarizeSrcUnit header Nothing (Failure ws eg)
+    renderSourceUnit header (Success ws (Just res)) = renderSuccess ws $ vsep $ summarizeSrcUnit header Nothing (Success ws (Just res))
+    renderSourceUnit _ _ = Nothing
+
+    renderDiscoveredProjectScanResult :: DiscoveredProjectScan -> Maybe (Doc AnsiStyle)
+    renderDiscoveredProjectScanResult (Scanned dpi (Failure ws eg)) = Just $ renderFailure ws eg $ summarizeProjectScan (Scanned dpi (Failure ws eg))
+    renderDiscoveredProjectScanResult (Scanned dpi (Success ws res)) = renderSuccess ws $ summarizeProjectScan (Scanned dpi (Success ws res))
+    renderDiscoveredProjectScanResult _ = Nothing
+
+scanSummaryFileName :: Path Rel File
+scanSummaryFileName = $(mkRelFile "fossa-analyze-scan-summary.txt")

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -6,7 +6,7 @@ module App.Fossa.Analyze.Types (
   DiscoveredProjectIdentifier (..),
 ) where
 
-import App.Fossa.Analyze.Project (ProjectResult (projectResultType))
+import App.Fossa.Analyze.Project (ProjectResult)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig)
 import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics, Has)

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -53,10 +53,10 @@ orderByScanStatusAndType (SkippedDueToDefaultProductionFilter lhs) (SkippedDueTo
 orderByScanStatusAndType (SkippedDueToDefaultProductionFilter lhs) (SkippedDueToDefaultProductionFilter rhs) = compare lhs rhs
 orderByScanStatusAndType (SkippedDueToDefaultProductionFilter _) (Scanned _ _) = GT
 orderByScanStatusAndType (SkippedDueToProvidedFilter _) (Scanned _ _) = GT
-orderByScanStatusAndType (Scanned _ (Success lhsEw lhs)) (Scanned _ (Success rhsEw rhs)) =
-  if (projectResultType lhs) /= (projectResultType rhs)
-    then compare (length rhsEw) (length lhsEw)
-    else EQ
+orderByScanStatusAndType (Scanned lhs (Success lhsEw _)) (Scanned rhs (Success rhsEw _)) =
+  if length rhsEw == length lhsEw
+    then compare lhs rhs
+    else compare (length rhsEw) (length lhsEw)
 orderByScanStatusAndType (Scanned lhs (Failure _ _)) (Scanned rhs (Failure _ _)) = compare lhs rhs
 orderByScanStatusAndType (Scanned _ (Success _ _)) (Scanned _ (Failure _ _)) = GT
 orderByScanStatusAndType (Scanned _ _) _ = LT

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -54,9 +54,9 @@ orderByScanStatusAndType (SkippedDueToDefaultProductionFilter lhs) (SkippedDueTo
 orderByScanStatusAndType (SkippedDueToDefaultProductionFilter _) (Scanned _ _) = GT
 orderByScanStatusAndType (SkippedDueToProvidedFilter _) (Scanned _ _) = GT
 orderByScanStatusAndType (Scanned lhs (Success lhsEw _)) (Scanned rhs (Success rhsEw _)) =
-  if length rhsEw == length lhsEw
-    then compare lhs rhs
-    else compare (length rhsEw) (length lhsEw)
+  case compare (length rhsEw) (length lhsEw) of
+    EQ -> compare lhs rhs
+    comp -> comp
 orderByScanStatusAndType (Scanned lhs (Failure _ _)) (Scanned rhs (Failure _ _)) = compare lhs rhs
 orderByScanStatusAndType (Scanned _ (Success _ _)) (Scanned _ (Failure _ _)) = GT
 orderByScanStatusAndType (Scanned _ _) _ = LT

--- a/src/App/Fossa/Container/Analyze.hs
+++ b/src/App/Fossa/Container/Analyze.hs
@@ -2,6 +2,7 @@
 
 module App.Fossa.Container.Analyze (
   analyze,
+  containerScanningDocUrl,
 ) where
 
 import App.Fossa.API.BuildLink (getFossaBuildUrl)
@@ -14,16 +15,19 @@ import App.Fossa.Config.Container (
     scanDestination
   ),
  )
+import App.Fossa.Config.Container.Common (ImageText (ImageText))
 import App.Fossa.Container.Scan (extractRevision, runSyft, toContainerScan)
 import App.Fossa.FossaAPIV1 (UploadResponse (uploadError, uploadLocator), uploadContainerScan)
 import App.Types (ProjectRevision (..))
-import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic, errCtx, renderDiagnostic)
 import Control.Effect.Lift (Lift)
 import Data.Aeson (encode)
 import Data.Foldable (traverse_)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (decodeUtf8)
+import Data.Text (Text)
 import Effect.Logger (
+  AnsiStyle,
   Has,
   Logger,
   Pretty (pretty),
@@ -33,6 +37,7 @@ import Effect.Logger (
   logStdout,
   viaShow,
  )
+import Prettyprinter (Doc, indent, vsep)
 import Srclib.Types (parseLocator)
 
 analyze ::
@@ -44,7 +49,7 @@ analyze ::
   m ()
 analyze ContainerAnalyzeConfig{..} = do
   logDebug "Running embedded syft binary"
-  containerScan <- runSyft imageLocator >>= toContainerScan
+  containerScan <- errCtx (SyftScanFailed imageLocator) (runSyft imageLocator >>= toContainerScan)
   case scanDestination of
     OutputStdout -> logStdout . decodeUtf8 $ encode containerScan
     UploadScan apiOpts projectMeta -> do
@@ -61,3 +66,29 @@ analyze ContainerAnalyzeConfig{..} = do
       logInfo ("  " <> pretty buildUrl)
       -- Report non-critical errors
       traverse_ (\err -> logError $ "FOSSA error: " <> viaShow err) (uploadError resp)
+
+newtype SyftScanFailed = SyftScanFailed ImageText
+
+instance ToDiagnostic SyftScanFailed where
+  renderDiagnostic (SyftScanFailed (ImageText img)) =
+    vsep
+      [ pretty $ "Failed to analyze container for: " <> img
+      , ""
+      , "Please ensure you are providing image in supported formats (e.g. docker container analyze repo/image:tag):"
+      , indent 2 exampleSupportedFmt
+      , ""
+      , "Refer to:"
+      , indent 2 $ pretty ("- " <> containerScanningDocUrl)
+      ]
+    where
+      exampleSupportedFmt :: Doc AnsiStyle
+      exampleSupportedFmt =
+        vsep
+          [ "repo/image:tag           - image from docker daemon"
+          , "path/to/image.tar        - tarball from disk created with `docker image save, podman save, skopeo copy, etc.`"
+          , "registry:repo/image:tag  - pull image directly from a registry (no container runtime required)"
+          , "03xxx29dad99             - docker Image ID provided in `docker images`"
+          ]
+
+containerScanningDocUrl :: Text
+containerScanningDocUrl = "https://docs.fossa.com/docs/container-scanning#using-container-scanning"

--- a/src/Control/Carrier/Diagnostics.hs
+++ b/src/Control/Carrier/Diagnostics.hs
@@ -44,9 +44,9 @@ logDiagnostic :: (Has (Lift IO) sig m, Has Logger sig m, Has Stack sig m) => Dia
 logDiagnostic diag = do
   result <- runDiagnosticsIO diag
   case result of
-    Failure ws eg -> logError (renderFailure ws eg) >> pure Nothing
+    Failure ws eg -> logError (renderFailure ws eg "An issue occurred") >> pure Nothing
     Success ws a -> do
-      case renderSuccess ws of
+      case renderSuccess ws "A task succeeded with warnings" of
         Nothing -> pure ()
         Just rendered -> logWarn rendered
 
@@ -124,9 +124,9 @@ errorBoundaryIO act = errorBoundary $ act `safeCatch` (\(e :: SomeException) -> 
 -- - On success, the associated warnings are logged with the provided
 --   @sevOnSuccess@ severity
 withResult :: Has Logger sig m => Severity -> Severity -> Result a -> (a -> m ()) -> m ()
-withResult sevOnErr _ (Failure ws eg) _ = Effect.Logger.log sevOnErr (renderFailure ws eg)
+withResult sevOnErr _ (Failure ws eg) _ = Effect.Logger.log sevOnErr (renderFailure ws eg "An issue occurred")
 withResult _ sevOnSuccess (Success ws res) f = do
-  case renderSuccess ws of
+  case renderSuccess ws "A task succeeded with warnings" of
     Nothing -> pure ()
     Just rendered -> Effect.Logger.log sevOnSuccess rendered
   f res

--- a/src/Diag/Result.hs
+++ b/src/Diag/Result.hs
@@ -159,8 +159,8 @@ resultToMaybe (Failure _ _) = Nothing
 -- from a Failure into a message suitable for logging
 --
 -- renderFailure displays all types of emitted warnings.
-renderFailure :: [EmittedWarn] -> ErrGroup -> Doc AnsiStyle
-renderFailure ws (ErrGroup _ ectx es) = header "An issue occurred" <> renderedCtx <> renderedErrs <> renderedPossibleErrs
+renderFailure :: [EmittedWarn] -> ErrGroup -> Doc AnsiStyle -> Doc AnsiStyle
+renderFailure ws (ErrGroup _ ectx es) headerDoc = header headerDoc <> renderedCtx <> renderedErrs <> renderedPossibleErrs
   where
     renderedCtx :: Doc AnsiStyle
     renderedCtx =
@@ -191,14 +191,11 @@ renderFailure ws (ErrGroup _ ectx es) = header "An issue occurred" <> renderedCt
 --
 -- when all errors in the list are IgnoredErrGroup, or the provided list is
 -- empty, this returns Nothing
-renderSuccess :: [EmittedWarn] -> Maybe (Doc AnsiStyle)
-renderSuccess ws =
+renderSuccess :: [EmittedWarn] -> Doc AnsiStyle -> Maybe (Doc AnsiStyle)
+renderSuccess ws headerDoc =
   case notIgnoredErrs of
     [] -> Nothing
-    ws' ->
-      Just $
-        header "A task succeeded with warnings"
-          <> subsection "Warning" (map renderEmittedWarn ws')
+    ws' -> Just $ header headerDoc <> subsection "Warning" (map renderEmittedWarn ws')
   where
     notIgnoredErrs :: [EmittedWarn]
     notIgnoredErrs = filter (not . isIgnoredErrGroup) ws

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -166,7 +166,7 @@ renderCmdFailure err =
   where
     -- Infer if the stderr is caused by not having executable in path.
     -- There is no easy way to check for @EBADF@ within process exception,
-    -- given use of library used, and effort needed.
+    -- with the library we use and effort required.
     isCmdNotAvailable :: Bool
     isCmdNotAvailable = expectedCmdNotFoundErrStr == stdErr
 

--- a/src/Strategy/Bundler.hs
+++ b/src/Strategy/Bundler.hs
@@ -11,6 +11,7 @@ import Control.Carrier.Diagnostics (errCtx, warnOnErr)
 import Control.Effect.Diagnostics (Diagnostics, context, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
 import Data.Aeson (ToJSON)
+import Diag.Common (AllDirectDeps (AllDirectDeps), MissingEdges (MissingEdges))
 import Discovery.Walk
 import Effect.Exec
 import Effect.ReadFS
@@ -19,8 +20,6 @@ import Path
 import Strategy.Ruby.BundleShow qualified as BundleShow
 import Strategy.Ruby.Errors (
   BundlerMissingLockFile (..),
-  RubyMissingDepClassification (..),
-  RubyMissingEdges (..),
  )
 import Strategy.Ruby.GemfileLock qualified as GemfileLock
 import Types
@@ -83,8 +82,8 @@ analyzeBundleShow project = do
 
 analyzeGemfileLock :: (Has ReadFS sig m, Has Diagnostics sig m) => BundlerProject -> m DependencyResults
 analyzeGemfileLock project =
-  warnOnErr RubyMissingDepClassification
-    . warnOnErr RubyMissingEdges
+  warnOnErr AllDirectDeps
+    . warnOnErr MissingEdges
     . errCtx (BundlerMissingLockFile $ bundlerGemfile project)
     $ do
       lockFile <- context "Retrieve Gemfile.lock" (Diag.fromMaybeText "No Gemfile.lock present in the project" (bundlerGemfileLock project))

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -62,7 +62,7 @@ import Effect.ReadFS (ReadFS, readContentsToml)
 import GHC.Generics (Generic)
 import Graphing (Graphing, stripRoot)
 import Path (Abs, Dir, File, Path, parent, parseRelFile, toFilePath, (</>))
-import Prettyprinter (Pretty (pretty), viaShow)
+import Prettyprinter (Pretty (pretty))
 import Toml (TomlCodec, dioptional, diwrap, (.=))
 import Toml qualified
 import Types (

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -109,7 +109,7 @@ analyze file = do
   -- This ensures, subsequent analyzes commands' outputs are not contaminated with lein's configuration task's output.
   _ <- exec (parent file) leinVersionCmd
 
-  stdoutBL <- execThrow (parent file) leinDepsCmd
+  stdoutBL <- errCtx FailedToRetrieveLienDependencies $ execThrow (parent file) leinDepsCmd
   let stdoutTL = decodeUtf8 stdoutBL
       stdout = TL.toStrict stdoutTL
 
@@ -123,6 +123,10 @@ analyze file = do
           , dependencyGraphBreadth = Complete
           , dependencyManifestFiles = [file]
           }
+
+data FailedToRetrieveLienDependencies = FailedToRetrieveLienDependencies
+instance ToDiagnostic FailedToRetrieveLienDependencies where
+  renderDiagnostic _ = "We could not successfully retrieve dependencies information using lein deps subcommand."
 
 -- node type for our LabeledGrapher
 data ClojureNode = ClojureNode

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -109,7 +109,7 @@ analyze file = do
   -- This ensures, subsequent analyzes commands' outputs are not contaminated with lein's configuration task's output.
   _ <- exec (parent file) leinVersionCmd
 
-  stdoutBL <- errCtx FailedToRetrieveLienDependencies $ execThrow (parent file) leinDepsCmd
+  stdoutBL <- errCtx FailedToRetrieveLeinDependencies $ execThrow (parent file) leinDepsCmd
   let stdoutTL = decodeUtf8 stdoutBL
       stdout = TL.toStrict stdoutTL
 
@@ -124,8 +124,8 @@ analyze file = do
           , dependencyManifestFiles = [file]
           }
 
-data FailedToRetrieveLienDependencies = FailedToRetrieveLienDependencies
-instance ToDiagnostic FailedToRetrieveLienDependencies where
+data FailedToRetrieveLeinDependencies = FailedToRetrieveLeinDependencies
+instance ToDiagnostic FailedToRetrieveLeinDependencies where
   renderDiagnostic _ = "We could not successfully retrieve dependencies information using lein deps subcommand."
 
 -- node type for our LabeledGrapher

--- a/src/Strategy/Ruby/Errors.hs
+++ b/src/Strategy/Ruby/Errors.hs
@@ -1,7 +1,5 @@
 module Strategy.Ruby.Errors (
   BundlerMissingLockFile (..),
-  RubyMissingEdges (..),
-  RubyMissingDepClassification (..),
 
   -- * Reference docs
   bundlerLockFileRationaleUrl,
@@ -36,13 +34,3 @@ instance ToDiagnostic BundlerMissingLockFile where
       , indent 2 $ pretty $ "- " <> bundlerLockFileRationaleUrl
       , indent 2 $ pretty $ "- " <> rubyFossaDocUrl
       ]
-
-data RubyMissingEdges = RubyMissingEdges
-instance ToDiagnostic RubyMissingEdges where
-  renderDiagnostic (RubyMissingEdges) =
-    "Could not infer edges between dependencies."
-
-data RubyMissingDepClassification = RubyMissingDepClassification
-instance ToDiagnostic RubyMissingDepClassification where
-  renderDiagnostic (RubyMissingDepClassification) =
-    "Could not differentiate between direct and deep dependencies. All dependencies will be classified as direct."

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -24,7 +24,7 @@ import Effect.Exec
 import Effect.ReadFS
 import GHC.Generics (Generic)
 import Path
-import Prettyprinter (viaShow, vsep)
+import Prettyprinter (viaShow)
 import Strategy.Maven.Pom qualified as Pom
 import Strategy.Maven.Pom.Closure (MavenProjectClosure, buildProjectClosures)
 import Strategy.Maven.Pom.Closure qualified as PomClosure

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -24,7 +24,7 @@ import Effect.Exec
 import Effect.ReadFS
 import GHC.Generics (Generic)
 import Path
-import Prettyprinter (viaShow)
+import Prettyprinter (viaShow, vsep)
 import Strategy.Maven.Pom qualified as Pom
 import Strategy.Maven.Pom.Closure (MavenProjectClosure, buildProjectClosures)
 import Strategy.Maven.Pom.Closure qualified as PomClosure
@@ -89,10 +89,8 @@ findProjects = walk' $ \dir _ files -> do
 newtype FailedToListProjects = FailedToListProjects (Path Abs Dir)
   deriving (Eq, Ord, Show)
 
--- TODO(warnings): this warning is not helpful
 instance ToDiagnostic FailedToListProjects where
-  renderDiagnostic (FailedToListProjects dir) =
-    "Found an sbt build manifest, but failed to list sbt projects in " <> viaShow dir
+  renderDiagnostic (FailedToListProjects dir) = "Failed to discover and analyze sbt projects, for sbt build manifest at:" <> viaShow dir
 
 makePomCmd :: Command
 makePomCmd =

--- a/src/Strategy/Swift/Errors.hs
+++ b/src/Strategy/Swift/Errors.hs
@@ -1,6 +1,5 @@
 module Strategy.Swift.Errors (
   MissingPackageResolvedFile (..),
-  SwiftAnalysisDeepDeps (..),
 
   -- * docs
   swiftFossaDocUrl,
@@ -22,11 +21,6 @@ swiftPackageResolvedRef = "https://github.com/apple/swift-package-manager/blob/m
 
 xcodeCoordinatePkgVersion :: Text
 xcodeCoordinatePkgVersion = "https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app"
-
-data SwiftAnalysisDeepDeps = SwiftAnalysisDeepDeps
-instance ToDiagnostic SwiftAnalysisDeepDeps where
-  renderDiagnostic (SwiftAnalysisDeepDeps) =
-    "Could not analyze deep dependencies."
 
 newtype MissingPackageResolvedFile = MissingPackageResolvedFile (Path Abs File)
 

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -21,10 +21,11 @@ import Data.Set (Set, fromList, member)
 import Data.Text (Text)
 import Data.Void (Void)
 import DepTypes (DepType (GitType, SwiftType), Dependency (..), VerConstraint (CEq))
+import Diag.Common (MissingDeepDeps (MissingDeepDeps))
 import Effect.ReadFS (Has, ReadFS, readContentsJson, readContentsParser)
 import Graphing (Graphing, deeps, directs, induceJust, promoteToDirect)
 import Path
-import Strategy.Swift.Errors (MissingPackageResolvedFile (..), SwiftAnalysisDeepDeps (SwiftAnalysisDeepDeps))
+import Strategy.Swift.Errors (MissingPackageResolvedFile (..))
 import Strategy.Swift.PackageResolved (SwiftPackageResolvedFile, resolvedDependenciesOf)
 import Text.Megaparsec (
   MonadParsec (takeWhile1P, try),
@@ -214,7 +215,7 @@ analyzePackageSwift manifestFile resolvedFile = do
     Nothing ->
       do
         recover
-          . warnOnErr SwiftAnalysisDeepDeps
+          . warnOnErr MissingDeepDeps
           . errCtx (MissingPackageResolvedFile manifestFile)
           $ fatalText "Package.resolved file was not discovered"
     Just packageResolved -> context "Identifying dependencies in Package.resolved" $ readContentsJson packageResolved

--- a/src/Strategy/Swift/Xcode/Pbxproj.hs
+++ b/src/Strategy/Swift/Xcode/Pbxproj.hs
@@ -15,12 +15,12 @@ import Data.Maybe (mapMaybe)
 import Data.Set (fromList, member)
 import Data.Text (Text)
 import DepTypes (DepType (GitType, SwiftType), Dependency (..))
+import Diag.Common (MissingDeepDeps (MissingDeepDeps))
 import Effect.ReadFS (Has, ReadFS, readContentsJson, readContentsParser)
 import Graphing (Graphing, deeps, directs, promoteToDirect)
 import Path
 import Strategy.Swift.Errors (
   MissingPackageResolvedFile (MissingPackageResolvedFile),
-  SwiftAnalysisDeepDeps (SwiftAnalysisDeepDeps),
  )
 import Strategy.Swift.PackageResolved (SwiftPackageResolvedFile, resolvedDependenciesOf)
 import Strategy.Swift.PackageSwift (
@@ -114,7 +114,7 @@ analyzeXcodeProjForSwiftPkg xcodeProjFile resolvedFile = do
     Nothing ->
       do
         recover
-          . warnOnErr SwiftAnalysisDeepDeps
+          . warnOnErr MissingDeepDeps
           . errCtx (MissingPackageResolvedFile xcodeProjFile)
           $ fatalText "Package.resolved file was not discovered"
     Just packageResolved ->

--- a/src/VCS/Git.hs
+++ b/src/VCS/Git.hs
@@ -4,6 +4,7 @@ module VCS.Git (
 ) where
 
 import App.Fossa.FossaAPIV1 (Contributors (..))
+import Control.Carrier.Diagnostics (errCtx)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Effect.Lift (Lift, sendIO)
 import Data.Map qualified as Map

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -3,6 +3,7 @@ module App.DocsSpec (
 ) where
 
 import App.Docs (fossaYmlDocUrl, newIssueUrl, userGuideUrl)
+import App.Fossa.Container.Analyze (containerScanningDocUrl)
 import Data.Foldable (for_)
 import Data.Maybe (fromJust)
 import Data.String.Conversion (toString)
@@ -60,6 +61,7 @@ urlsToCheck =
   , xcodeCoordinatePkgVersion
   , refPodDocUrl
   , refGradleDocUrl
+  , containerScanningDocUrl
   ]
 
 spec :: Spec

--- a/test/ResultUtil.hs
+++ b/test/ResultUtil.hs
@@ -11,5 +11,5 @@ expectFailure (Failure _ _) = pure ()
 expectFailure (Success _ _) = expectationFailure "expected a failure"
 
 assertOnSuccess :: Result a -> ([EmittedWarn] -> a -> Expectation) -> Expectation
-assertOnSuccess (Failure ws eg) _ = expectationFailure (show (renderFailure ws eg))
+assertOnSuccess (Failure ws eg) _ = expectationFailure (show (renderFailure ws eg "An issue occurred"))
 assertOnSuccess (Success ws a) f = f ws a

--- a/test/Test/Effect.hs
+++ b/test/Test/Effect.hs
@@ -62,7 +62,7 @@ runTestEffects = runStack . ignoreLogger . handleDiag . runReadFSIO . runExecIO
     handleDiag diag =
       runDiagnostics diag >>= \case
         Failure ws eg -> do
-          expectationFailure' $ toString $ renderIt $ renderFailure ws eg
+          expectationFailure' $ toString $ renderIt $ renderFailure ws eg "An issue occurred"
         Success _ _ -> pure ()
 
 expectationFailure' :: (Has (Lift IO) sig m) => String -> m ()


### PR DESCRIPTION
# Overview

This pr encompasses inclusion of warning/error messages to sets analyzers/API, and modification to analysis scan summary. 

#### Impacted analyzer

- Scala
- Clojure
- Nim
- Rust
- Container Scanning
- Haskell (Cabal)
- Carthage
- Refactors: Ruby, Swift

This PR also updates diagnostic message when provided executable is not in $PATH, this applies to all analyzer using external build tool (dynamic analysis).

Previous PR has included change for:
- https://github.com/fossas/fossa-cli/pull/800
- https://github.com/fossas/fossa-cli/pull/802
- https://github.com/fossas/fossa-cli/pull/803
- https://github.com/fossas/fossa-cli/pull/805
- https://github.com/fossas/fossa-cli/pull/808
- https://github.com/fossas/fossa-cli/pull/804
- https://github.com/fossas/fossa-cli/pull/809
- https://github.com/fossas/fossa-cli/pull/806
- https://github.com/fossas/fossa-cli/pull/807

Further, most common errors dues to API related issue, parser failure when reading a file, or parser failure when reading stdout from command were covered in:
- https://github.com/fossas/fossa-cli/pull/801
- https://github.com/fossas/fossa-cli/pull/792

#### API errors 

- Fixes diagnostic message for internal exception, provides a link to ssl cert docs. 

#### Scan Summary

- By default, fossa-cli's analyze command is ran, warnings related to analysis are not eagerly rendered (while fatal errors are still rendered like before)
- When `--debug` flag is provided, warnings related to analysis are eagerly rendered.
- Scan summary writes a log of all errors and warning to a temporary file, and such file is included in the summary.   

Previous PR: 
- https://github.com/fossas/fossa-cli/pull/790

## Acceptance criteria

- Warnings are rendered when fallback tactic is used
- Analysis failure stemming from cmd not existing $PATH is rendered in user friendly way.
- Analysis failure for following includes user friendly error/warn context. 
  -  Scala
  - Clojure
  - Nim
  - Rust
  - Haskell (Cabal)
  - Carthage
- When `--debug` flag is provided, warnings from analysis are eagerly rendered
- When `--debug` flag is NOT provided, warnings from analysis are NOT eagerly rendered
- Errors in analysis are eagerly rendered 
- All warnings and errors are written to a file in temporary directory, when analysis has at least one scanned target.

## Testing plan

Manual QA was done. 

For errors related to cmd not found in PATH, 
```
PATH='' fossa analyze ./path/some-dynamic-project-elixir/ -o
```

For warnings related to fallback, 
```
PATH='' fossa analyze ./path/some-analyzer-target/ -o
```

For errors related to SSL cert,
```
SSL_CERT_FILE=mock.pem fossa analyze ./path/ -o
```

For errors related to container scanning (intentionally not provide version tag),
```
fossa container analyze redis
```
 
For analysis scan summary,
```
touch '' > example/pubspec.yaml
cd example && wget https://raw.githubusercontent.com/npm/read-package-json/main/package.json > example/pubspec.yaml
cd .. 
fossa analyze ./example/ -o 
```

## Risks

Low risk.

## References

This closes:
- https://github.com/fossas/team-analysis/issues/856
- https://github.com/fossas/team-analysis/issues/855
- https://github.com/fossas/team-analysis/issues/854

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
