### PR TITLE
Run themis on deps

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -91,6 +91,7 @@ common deps
     , hedn                         ^>=0.3.0.1
     , http-client                  ^>=0.7.1
     , http-types                   ^>=0.12.3
+    , lzma                         ^>=0.0.0.3
     , lzma-conduit                 ^>=1.2.1
     , megaparsec                   ^>=9.1.0
     , modern-uri                   ^>=0.3.4

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -258,6 +258,8 @@ analyze cfg = Diag.context "fossa-analyze" $ do
         else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir apiOpts
   let additionalSourceUnits :: [SourceUnit]
       additionalSourceUnits = mapMaybe (join . resultToMaybe) [manualSrcUnits, vsiResults, binarySearchResults]
+  -- do not swallow errors
+  traverse_ (Diag.flushLogs SevError SevWarn) [manualSrcUnits, vsiResults, binarySearchResults]
 
   (projectScans, ()) <-
     Diag.context "discovery/analysis tasks"

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -97,7 +97,7 @@ extractThemisFiles = do
           , binaryFilePath = $(mkRelFile "index.gob")
           }
   sendIO $ extractLzma (toPath compressedThemisIndex) (toPath decompressedThemisIndex)
-  pure $ ThemisBins themisActual (applyTag @ThemisIndex decompressedThemisIndex)
+  pure $ ThemisBins themisActual $ applyTag @ThemisIndex decompressedThemisIndex
 
 withSyftBinary ::
   ( Has (Lift IO) sig m

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -7,7 +7,7 @@ module App.Fossa.EmbeddedBinary (
   withEmbeddedBinary,
   dumpEmbeddedBinary,
   toExecutablePath,
-  BinaryPaths,
+  BinaryPaths (..),
   withWigginsBinary,
   withSyftBinary,
   withThemisBinaryAndIndex,

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -16,7 +16,6 @@ import App.Fossa.Config.DumpBinaries (
   DumpBinsOpts,
   mkSubCommand,
  )
-import Data.String.Conversion (toLazy, toStrict)
 import App.Fossa.Subcommand (SubCommand)
 import Codec.Compression.Lzma qualified as Lzma
 import Control.Effect.Exception (bracket)
@@ -24,6 +23,7 @@ import Control.Effect.Lift (Has, Lift, sendIO)
 import Data.ByteString (ByteString, writeFile)
 import Data.FileEmbed.Extra (embedFileIfExists)
 import Data.Foldable (for_, traverse_)
+import Data.String.Conversion (toLazy, toStrict)
 import Data.Tagged (Tagged, applyTag, unTag)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Path (

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -90,14 +90,13 @@ withThemisAndIndex = bracket extractThemisFiles cleanupThemisBins
 extractThemisFiles :: Has (Lift IO) sig m => m ThemisBins
 extractThemisFiles = do
   themisActual <- applyTag @ThemisBinary <$> extractEmbeddedBinary Themis
-  compressedThemisIndex <- applyTag @ThemisIndex <$> extractEmbeddedBinary ThemisIndex
+  compressedThemisIndex <- extractEmbeddedBinary ThemisIndex
   let decompressedThemisIndex =
         BinaryPaths
-          { binaryPathContainer = binaryPathContainer $ unTag compressedThemisIndex
+          { binaryPathContainer = binaryPathContainer compressedThemisIndex
           , binaryFilePath = $(mkRelFile "index.gob")
           }
-  sendIO $ extractLzma (toPath $ unTag compressedThemisIndex) (toPath decompressedThemisIndex)
-
+  sendIO $ extractLzma (toPath compressedThemisIndex) (toPath decompressedThemisIndex)
   pure $ ThemisBins themisActual (applyTag @ThemisIndex decompressedThemisIndex)
 
 withSyftBinary ::

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -93,7 +93,7 @@ withThemisBinaryAndIndex ::
   ) =>
   ([BinaryPaths] -> m c) ->
   m c
-withThemisBinaryAndIndex = bracket (traverse extractEmbeddedBinary [Themis, ThemisIndex]) (traverse cleanupExtractedBinaries)
+withThemisBinaryAndIndex = bracket (traverse extractEmbeddedBinary [Themis, ThemisIndex]) cleanupMultipleBinaries
 
 withEmbeddedBinary ::
   ( Has (Lift IO) sig m
@@ -105,6 +105,12 @@ withEmbeddedBinary bin = bracket (extractEmbeddedBinary bin) cleanupExtractedBin
 
 cleanupExtractedBinaries :: (Has (Lift IO) sig m) => BinaryPaths -> m ()
 cleanupExtractedBinaries (BinaryPaths binPath _) = sendIO $ removeDirRecur binPath
+
+-- Horrible hack to get withThemisBinaryAndIndex working while Wes figures out a better way
+-- to run multiple binaries
+cleanupMultipleBinaries :: (Has (Lift IO) sig m) => [BinaryPaths] -> m ()
+cleanupMultipleBinaries ((BinaryPaths binPath _) : _) = sendIO $ removeDirRecur binPath
+cleanupMultipleBinaries [] = pure ()
 
 extractEmbeddedBinary :: (Has (Lift IO) sig m) => PackagedBinary -> m BinaryPaths
 extractEmbeddedBinary bin = do

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -100,10 +100,11 @@ extractThemisBinaryAndIndex :: (Has (Lift IO) sig m) => m [BinaryPaths]
 extractThemisBinaryAndIndex = do
   themisBinaryPaths <- extractEmbeddedBinary Themis
   compressedIndexBinaryPaths <- extractEmbeddedBinary ThemisIndex
-  let decompressedIndexBinaryPaths = BinaryPaths {
-    binaryPathContainer = binaryPathContainer compressedIndexBinaryPaths
-  , binaryFilePath = $(mkRelFile "index.gob")
-  }
+  let decompressedIndexBinaryPaths =
+        BinaryPaths
+          { binaryPathContainer = binaryPathContainer compressedIndexBinaryPaths
+          , binaryFilePath = $(mkRelFile "index.gob")
+          }
   sendIO $ extractLzma (toExecutablePath compressedIndexBinaryPaths) (toExecutablePath decompressedIndexBinaryPaths)
   pure [themisBinaryPaths, decompressedIndexBinaryPaths]
 

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -87,6 +87,7 @@ cleanupThemisBins (ThemisBins a b) = traverse_ cleanupExtractedBinaries [unTag a
 withThemisAndIndex :: Has (Lift IO) sig m => (ThemisBins -> m c) -> m c
 withThemisAndIndex = bracket extractThemisFiles cleanupThemisBins
 
+-- When running Themis we always need both the themis-cli and the decompressed index.gob
 extractThemisFiles :: Has (Lift IO) sig m => m ThemisBins
 extractThemisFiles = do
   themisActual <- applyTag @ThemisBinary <$> extractEmbeddedBinary Themis

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -69,6 +69,7 @@ data BinaryPaths = BinaryPaths
   { binaryPathContainer :: Path Abs Dir
   , binaryFilePath :: Path Rel File
   }
+  deriving (Eq, Show, Ord)
 
 toExecutablePath :: BinaryPaths -> Path Abs File
 toExecutablePath BinaryPaths{..} = binaryPathContainer </> binaryFilePath

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -413,7 +413,7 @@ licenseScanFinalize apiOpts archiveProjects = runEmpty $
 
     _ <-
       context "Queuing a build for all license scan uploads" $
-        req POST (licenseScanFinalizeUrl baseUrl) (ReqBodyJson archiveProjects) bsResponse (baseOpts <> opts)
+        req POST (licenseScanFinalizeUrl baseUrl) (ReqBodyJson archiveProjects) ignoreResponse (baseOpts <> opts)
     pure ()
 
 ---------- The signed URL endpoint returns a URL endpoint that can be used to directly upload to an S3 bucket.

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -60,11 +60,10 @@ import Control.Monad.IO.Class (MonadIO (..))
 import Data.Aeson
 import Data.ByteString qualified as BS
 import Data.ByteString.Char8 qualified as C
-import Data.ByteString.Lazy qualified as BL
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Maybe (catMaybes, fromMaybe)
-import Data.String.Conversion (encodeUtf8, toStrict, toText)
+import Data.String.Conversion (toStrict, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Word (Word8)

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -410,10 +410,8 @@ licenseScanFinalize apiOpts archiveProjects = runEmpty $
 
     let opts = "dependency" =: True <> "rawLicenseScan" =: True
 
-    -- The response appears to either be "Created" for new builds, or an error message for existing builds.
-    -- Making the actual return value of "Created" essentially worthless.
     resp <-
-      context "Queuing a build for all archive uploads" $
+      context "Queuing a build for all license scan uploads" $
         req POST (licenseScanFinalizeUrl baseUrl) (ReqBodyJson archiveProjects) bsResponse (baseOpts <> opts)
     pure (responseBody resp)
 
@@ -455,7 +453,7 @@ getSignedLicenseScanURL apiOpts revision packageName = fossaReq $ do
   let opts = "packageSpec" =: packageName <> "revision" =: revision
 
   response <-
-    context ("Retrieving a signed S3 URL for " <> packageName) $
+    context ("Retrieving a signed S3 URL for license scan results of " <> packageName) $
       req GET (signedLicenseScanURLEndpoint baseUrl) NoReqBody jsonResponse (baseOpts <> opts)
   pure (responseBody response)
 

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -55,6 +55,7 @@ import Control.Monad.IO.Class (MonadIO (..))
 import Data.Aeson
 import Data.ByteString qualified as BS
 import Data.ByteString.Char8 qualified as C
+import Data.ByteString.Lazy qualified as BL
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Maybe (catMaybes, fromMaybe)
@@ -419,7 +420,7 @@ archiveUpload signedArcURI arcFile = fossaReq $ do
 licenseScanResultUpload ::
   (Has (Lift IO) sig m, Has Diagnostics sig m) =>
   SignedURL ->
-  Text ->
+  BL.ByteString ->
   m LbsResponse
 licenseScanResultUpload signedArcURI licenseScanResult = fossaReq $ do
   let arcURL = URI.mkURI $ signedURL signedArcURI
@@ -431,7 +432,7 @@ licenseScanResultUpload signedArcURI licenseScanResult = fossaReq $ do
     Left (url, options) -> uploadArchiveRequest url options
     Right (url, options) -> uploadArchiveRequest url options
   where
-    zippedLicenseResult = toStrict $ GZIP.compress $ encodeUtf8 $ toLText licenseScanResult
+    zippedLicenseResult = toStrict $ GZIP.compress licenseScanResult
     uploadArchiveRequest url options = reqCb PUT url (ReqBodyBs zippedLicenseResult) lbsResponse options (pure . requestEncoder)
 
 -- requestEncoder properly encodes the Request path.

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -59,7 +59,7 @@ import Data.ByteString.Lazy qualified as BL
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Maybe (catMaybes, fromMaybe)
-import Data.String.Conversion (toText, toLText, encodeUtf8, toStrict)
+import Data.String.Conversion (encodeUtf8, toLText, toStrict, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Word (Word8)

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -62,7 +62,7 @@ import Data.ByteString.Lazy qualified as BL
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Maybe (catMaybes, fromMaybe)
-import Data.String.Conversion (toStrict, toText)
+import Data.String.Conversion (encodeUtf8, toStrict, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Word (Word8)
@@ -436,7 +436,7 @@ archiveUpload signedArcURI arcFile = fossaReq $ do
 licenseScanResultUpload ::
   (Has (Lift IO) sig m, Has Diagnostics sig m) =>
   SignedURL ->
-  BL.ByteString ->
+  LicenseSourceUnit ->
   m LbsResponse
 licenseScanResultUpload signedArcURI licenseScanResult = fossaReq $ do
   let arcURL = URI.mkURI $ signedURL signedArcURI
@@ -448,7 +448,7 @@ licenseScanResultUpload signedArcURI licenseScanResult = fossaReq $ do
     Left (url, options) -> uploadArchiveRequest url options
     Right (url, options) -> uploadArchiveRequest url options
   where
-    zippedLicenseResult = toStrict $ GZIP.compress licenseScanResult
+    zippedLicenseResult = toStrict $ GZIP.compress $ encode licenseScanResult
     uploadArchiveRequest url options = reqCb PUT url (ReqBodyBs zippedLicenseResult) lbsResponse options (pure . requestEncoder)
 
 -- requestEncoder properly encodes the Request path.

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -22,6 +22,7 @@ module App.Fossa.FossaAPIV1 (
   getOrganization,
   getAttribution,
   getAttributionRaw,
+  getSignedLicenseScanURL,
   getSignedURL,
   getProject,
   archiveUpload,
@@ -412,6 +413,27 @@ getSignedURL apiOpts revision packageName = fossaReq $ do
   response <-
     context ("Retrieving a signed S3 URL for " <> packageName) $
       req GET (signedURLEndpoint baseUrl) NoReqBody jsonResponse (baseOpts <> opts)
+  pure (responseBody response)
+
+---------- The signed License Scan URL endpoint returns a URL endpoint that can be used to directly upload the results of a license scan to an S3 bucket.
+
+signedLicenseScanURLEndpoint :: Url 'Https -> Url 'Https
+signedLicenseScanURLEndpoint baseUrl = baseUrl /: "api" /: "license_scan" /: "signed_url"
+
+getSignedLicenseScanURL ::
+  (Has (Lift IO) sig m, Has Diagnostics sig m) =>
+  ApiOpts ->
+  Text ->
+  Text ->
+  m SignedURL
+getSignedLicenseScanURL apiOpts revision packageName = fossaReq $ do
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+
+  let opts = "packageSpec" =: packageName <> "revision" =: revision
+
+  response <-
+    context ("Retrieving a signed S3 URL for " <> packageName) $
+      req GET (signedLicenseScanURLEndpoint baseUrl) NoReqBody jsonResponse (baseOpts <> opts)
   pure (responseBody response)
 
 ---------- The archive upload function uploads the file it is given directly to the signed URL it is provided.

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -59,7 +59,7 @@ import Data.ByteString.Lazy qualified as BL
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Maybe (catMaybes, fromMaybe)
-import Data.String.Conversion (encodeUtf8, toLText, toStrict, toText)
+import Data.String.Conversion (toStrict, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Word (Word8)

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -37,7 +37,7 @@ import Srclib.Types (
 import Data.String.Conversion (encodeUtf8, toString, toText)
 import Data.Text (Text)
 
-import App.Fossa.EmbeddedBinary (BinaryPaths, ThemisBins, withThemisAndIndex)
+import App.Fossa.EmbeddedBinary (ThemisBins, withThemisAndIndex)
 
 runLicenseScanOnDir ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -97,7 +97,7 @@ scanAndUploadVendoredDep apiOpts baseDir VendoredDependency{..} = context "compr
 
   pure $ Archive vendoredName depVersion
 
--- licenseScanSourceUnit receives a list of vendored dependencies, a root path, and API settings.
+-- | licenseScanSourceUnit receives a list of vendored dependencies, a root path, and API settings.
 -- Using this information, it license scans each vendored dependency, uploads the license scan results and then queues a build for the dependency.
 licenseScanSourceUnit ::
   ( Has Diag.Diagnostics sig m
@@ -136,6 +136,6 @@ licenseScanSourceUnit baseDir apiOpts vendoredDeps = do
     includeOrgId :: Int -> Archive -> Archive
     includeOrgId orgId arc = arc{archiveName = toText (show orgId) <> "/" <> archiveName arc}
 
--- licenseNoScanSourceUnit exists for when users run `fossa analyze -o` and do not upload their source units.
+-- | licenseNoScanSourceUnit exists for when users run `fossa analyze -o` and do not upload their source units.
 licenseNoScanSourceUnit :: [VendoredDependency] -> [Locator]
 licenseNoScanSourceUnit = map (arcToLocator . forceVendoredToArchive)

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -37,7 +37,7 @@ import Srclib.Types (
 import Data.String.Conversion (encodeUtf8, toString, toText)
 import Data.Text (Text)
 
-import App.Fossa.EmbeddedBinary (BinaryPaths, withThemisBinaryAndIndex)
+import App.Fossa.EmbeddedBinary (BinaryPaths, ThemisBins, withThemisAndIndex)
 
 runLicenseScanOnDir ::
   ( Has Diagnostics sig m
@@ -46,7 +46,7 @@ runLicenseScanOnDir ::
   ) =>
   ThemisCLIOpts ->
   m [LicenseUnit]
-runLicenseScanOnDir opts = withThemisBinaryAndIndex (themisRunner opts)
+runLicenseScanOnDir opts = withThemisAndIndex (themisRunner opts)
 
 themisRunner ::
   ( Has (Lift IO) sig m
@@ -54,22 +54,16 @@ themisRunner ::
   , Has Logger sig m
   ) =>
   ThemisCLIOpts ->
-  [BinaryPaths] ->
+  ThemisBins ->
   m [LicenseUnit]
-themisRunner opts [themisBinary, themisIndex] = do
-  res <- runExecIO $ runThemis themisBinary themisIndex opts
+themisRunner opts themisBins = do
+  res <- runExecIO $ runThemis themisBins opts
   logDebug $ pretty $ "themis JSON:\n" ++ show res
   pure res
-themisRunner _ [_] = do
-  Diag.fatalText ("only one arg to lambda in themisRunner")
-themisRunner _ [] = do
-  Diag.fatalText ("no args passed to lambda in themisRunner")
-themisRunner _ _ = do
-  Diag.fatalText ("too many args passed to lambda in themisRunner")
 
-runThemis :: (Has Exec sig m, Has Diagnostics sig m, Has Logger sig m) => BinaryPaths -> BinaryPaths -> ThemisCLIOpts -> m [LicenseUnit]
-runThemis themisBinary themisIndex opts = do
-  context "Running license scan binary" $ execThemis themisBinary themisIndex opts
+runThemis :: (Has Exec sig m, Has Diagnostics sig m, Has Logger sig m) => ThemisBins -> ThemisCLIOpts -> m [LicenseUnit]
+runThemis themisBins opts = do
+  context "Running license scan binary" $ execThemis themisBins opts
 
 scanAndUploadVendoredDeps :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m, Has Logger sig m) => ApiOpts -> Path Abs Dir -> [VendoredDependency] -> m [Archive]
 scanAndUploadVendoredDeps apiOpts baseDir = traverse (scanAndUpload apiOpts baseDir)

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -44,8 +44,11 @@ runLicenseScanOnDir ::
   ThemisCLIOpts ->
   m BL.ByteString
 runLicenseScanOnDir opts = withThemisBinaryAndIndex $ \binaryPaths -> do
-  let [themisBinary, themisIndex, _] = binaryPaths
-  logInfo "Running license scan"
+  let themisBinary = head binaryPaths
+      themisIndex = binaryPaths !! 1
+  logInfo $ pretty $ "Running license scan on " ++ show opts
+  logInfo $ pretty $ "themis binary" ++ show themisBinary
+  logInfo $ pretty $ "themis index" ++ show themisIndex
   context "license scan" $ runExecIO $ execThemis themisBinary themisIndex opts
   -- stdout <- context "license scan" $ runExecIO $ execThemis themisBinary opts
   -- logInfo $ pretty stdout

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -104,7 +104,7 @@ scanAndUpload apiOpts baseDir VendoredDependency{..} = context "compressing and 
     Just version -> pure version
 
   logDebug "about to get signed URL"
-  signedURL <- Fossa.getSignedURL apiOpts depVersion vendoredName
+  signedURL <- Fossa.getSignedLicenseScanURL apiOpts depVersion vendoredName
 
   logSticky $ "Uploading '" <> vendoredName <> "' to secure S3 bucket"
   _ <- Fossa.licenseScanResultUpload signedURL licenseSourceUnit

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -17,7 +17,6 @@ import Control.Effect.Lift
 
 import Crypto.Hash (Digest, MD5, hash)
 import Data.ByteString qualified as B
-import Data.ByteString.Lazy qualified as BL
 import Effect.Exec (Exec, runExecIO)
 import Effect.Logger (Logger, logDebug)
 
@@ -32,8 +31,6 @@ import Prettyprinter (Pretty (pretty))
 import Srclib.Types (
   LicenseSourceUnit (..),
   LicenseUnit (..),
-  LicenseUnitData (..),
-  LicenseUnitMatchData (..),
   Locator (..),
  )
 

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -128,7 +128,7 @@ licenseScanSourceUnit baseDir apiOpts vendoredDeps = do
 
   -- archiveBuildUpload takes archives without Organization information. This orgID is appended when creating the build on the backend.
   -- We don't care about the response here because if the build has already been queued, we get a 401 response.
-  _ <- Fossa.archiveBuildUpload apiOpts (ArchiveComponents archives)
+  _ <- Fossa.licenseScanFinalize apiOpts (ArchiveComponents archives)
 
   -- The organizationID is needed to prefix each locator name. The FOSSA API automatically prefixes the locator when queuing the build
   -- but not when reading from a source unit.

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -92,6 +92,12 @@ scanAndUpload apiOpts baseDir VendoredDependency{..} = context "compressing and 
   logDebug "back from themis scan"
   logDebug "themis scan results: "
   logDebug $ pretty $ show themisScanResult
+  let licenseSourceUnit =
+        LicenseSourceUnit
+          { licenseSourceUnitName = vendoredPath
+          , licenseSourceUnitType = "cli-license-scanned"
+          , licenseSourceUnitLicenseUnits = themisScanResult
+          }
 
   depVersion <- case vendoredVersion of
     Nothing -> pure (toText (show (md5 $ encodeUtf8 (show themisScanResult))))
@@ -101,7 +107,7 @@ scanAndUpload apiOpts baseDir VendoredDependency{..} = context "compressing and 
   signedURL <- Fossa.getSignedURL apiOpts depVersion vendoredName
 
   logSticky $ "Uploading '" <> vendoredName <> "' to secure S3 bucket"
-  _ <- Fossa.licenseScanResultUpload signedURL $ encodeUtf8 (show themisScanResult)
+  _ <- Fossa.licenseScanResultUpload signedURL licenseSourceUnit
 
   pure $ Archive vendoredName depVersion
 

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -17,7 +17,7 @@ import Control.Effect.Lift
 
 import Crypto.Hash (hash, MD5, Digest)
 import Effect.Exec (Exec, runExecIO)
-import Effect.Logger (Logger, logDebug, logInfo)
+import Effect.Logger (Logger, logDebug)
 import Data.ByteString.Lazy qualified as BL
 import Data.ByteString qualified as B
 
@@ -50,12 +50,8 @@ themisRunner ::
   , Has Logger sig m
   ) => ThemisCLIOpts -> [BinaryPaths] -> m BL.ByteString
 themisRunner opts [themisBinary, themisIndex] = do
-  logInfo $ pretty $ "Running license scan on " ++ show opts
-  logInfo $ pretty $ "themis binary" ++ show themisBinary
-  logInfo $ pretty $ "themis index" ++ show themisIndex
   res <- runExecIO $ runThemis themisBinary themisIndex opts
-  logInfo "scan done!!"
-  logInfo $ pretty $ show res
+  logDebug $ pretty $ "themis JSON:\n" ++ show res
   pure res
 themisRunner _ [_] = do
   Diag.fatalText("only one arg to lambda in themisRunner")
@@ -83,10 +79,7 @@ scanAndUpload apiOpts baseDir VendoredDependency{..} = context "compressing and 
   let cliOpts = generateThemisOpts baseDir vendoredDepDir
   logDebug "about to start themis scan"
   themisScanResult <- runLicenseScanOnDir cliOpts
-  logDebug "back from themis scan" -- <--- I never see this
-  -- logDebug $ pretty $ show themisScanResult
-  -- let themisScanResultBS = encodeUtf8 themisScanResult
-  --     scanHash = hash themisScanResultBS
+  logDebug "back from themis scan"
 
   depVersion <- case vendoredVersion of
     Nothing -> pure (toText (show (md5 $ BL.toStrict themisScanResult)))

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -40,7 +40,7 @@ runLicenseScanOnDir ::
   ) =>
   Path Abs Dir ->
   m [LicenseUnit]
-runLicenseScanOnDir scanDir = withThemisAndIndex (themisRunner scanDir)
+runLicenseScanOnDir scanDir = withThemisAndIndex $ themisRunner scanDir
 
 themisRunner ::
   ( Has (Lift IO) sig m
@@ -62,7 +62,7 @@ md5 = hash
 scanAndUploadVendoredDep :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m) => ApiOpts -> Path Abs Dir -> VendoredDependency -> m Archive
 scanAndUploadVendoredDep apiOpts baseDir VendoredDependency{..} = context "compressing and uploading vendored deps" $ do
   logSticky $ "License Scanning '" <> vendoredName <> "' at '" <> vendoredPath <> "'"
-  vendoredDepDir <- case parseRelDir (toString vendoredPath) of
+  vendoredDepDir <- case parseRelDir $ toString vendoredPath of
     Left _ -> fatalText "Error constructing scan dir for vendored scan"
     Right val -> pure val
   let cliScanDir = baseDir </> vendoredDepDir
@@ -75,7 +75,7 @@ scanAndUploadVendoredDep apiOpts baseDir VendoredDependency{..} = context "compr
           }
 
   depVersion <- case vendoredVersion of
-    Nothing -> pure (toText (show (md5 $ encodeUtf8 (show themisScanResult))))
+    Nothing -> pure $ toText $ show $ md5 $ encodeUtf8 $ show themisScanResult
     Just version -> pure version
 
   signedURL <- Fossa.getSignedLicenseScanURL apiOpts depVersion vendoredName
@@ -102,7 +102,7 @@ licenseScanSourceUnit baseDir apiOpts vendoredDeps = do
 
   -- archiveBuildUpload takes archives without Organization information. This orgID is appended when creating the build on the backend.
   -- We don't care about the response here because if the build has already been queued, we get a 401 response.
-  _ <- Fossa.licenseScanFinalize apiOpts (ArchiveComponents archives)
+  _ <- Fossa.licenseScanFinalize apiOpts $ ArchiveComponents archives
 
   -- The organizationID is needed to prefix each locator name. The FOSSA API automatically prefixes the locator when queuing the build
   -- but not when reading from a source unit.

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -44,9 +44,9 @@ runLicenseScanOnDir ::
   ThemisCLIOpts ->
   m BL.ByteString
 runLicenseScanOnDir opts = withThemisBinaryAndIndex $ \binaryPaths -> do
-  let [themisBinary, themisIndex] = binaryPaths
+  let [themisBinary, themisIndex, _] = binaryPaths
   logInfo "Running license scan"
-  context "license scan" $ runExecIO $ execThemis themisBinary opts
+  context "license scan" $ runExecIO $ execThemis themisBinary themisIndex opts
   -- stdout <- context "license scan" $ runExecIO $ execThemis themisBinary opts
   -- logInfo $ pretty stdout
   -- stdout
@@ -62,6 +62,7 @@ scanAndUpload apiOpts baseDir VendoredDependency{..} = context "compressing and 
     Right val -> pure val
   let cliOpts = generateThemisOpts baseDir vendoredDepDir
   scanResult <- runLicenseScanOnDir cliOpts
+  logDebug $ pretty $ show scanResult
   -- let scanResultBS = encodeUtf8 scanResult
   --     scanHash = hash scanResultBS
 

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -13,10 +13,16 @@ import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.StickyLogger (StickyLogger, logSticky)
 import Control.Effect.Lift
 
-import App.Fossa.ArchiveUploader
+import App.Fossa.ArchiveUploader (
+  VendoredDependency (..),
+  arcToLocator,
+  duplicateFailureBundle,
+  duplicateNames,
+  forceVendoredToArchive,
+ )
 import App.Fossa.FossaAPIV1 qualified as Fossa
 import Control.Effect.Diagnostics (Diagnostics, context, fatalText)
-import Control.Monad (unless)
+import Control.Monad (unless, void)
 import Crypto.Hash (Digest, MD5, hash)
 import Data.ByteString qualified as B
 import Data.List (nub)
@@ -59,7 +65,15 @@ runThemis themisBins scanDir = do
 md5 :: B.ByteString -> Digest MD5
 md5 = hash
 
-scanAndUploadVendoredDep :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m) => ApiOpts -> Path Abs Dir -> VendoredDependency -> m Archive
+scanAndUploadVendoredDep ::
+  ( Has Diag.Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has StickyLogger sig m
+  ) =>
+  ApiOpts ->
+  Path Abs Dir ->
+  VendoredDependency ->
+  m Archive
 scanAndUploadVendoredDep apiOpts baseDir VendoredDependency{..} = context "compressing and uploading vendored deps" $ do
   logSticky $ "License Scanning '" <> vendoredName <> "' at '" <> vendoredPath <> "'"
   vendoredDepDir <- case parseRelDir $ toString vendoredPath of
@@ -75,19 +89,27 @@ scanAndUploadVendoredDep apiOpts baseDir VendoredDependency{..} = context "compr
           }
 
   depVersion <- case vendoredVersion of
-    Nothing -> pure $ toText $ show $ md5 $ encodeUtf8 $ show themisScanResult
+    Nothing -> pure $ toText . show . md5 . encodeUtf8 . show $ themisScanResult
     Just version -> pure version
 
   signedURL <- Fossa.getSignedLicenseScanURL apiOpts depVersion vendoredName
 
   logSticky $ "Uploading '" <> vendoredName <> "' to secure S3 bucket"
-  _ <- Fossa.licenseScanResultUpload signedURL licenseSourceUnit
+  void $ Fossa.licenseScanResultUpload signedURL licenseSourceUnit
 
   pure $ Archive vendoredName depVersion
 
--- archiveUploadSourceUnit receives a list of vendored dependencies, a root path, and API settings.
+-- licenseScanSourceUnit receives a list of vendored dependencies, a root path, and API settings.
 -- Using this information, it license scans each vendored dependency, uploads the license scan results and then queues a build for the dependency.
-licenseScanSourceUnit :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m, Has StickyLogger sig m) => Path Abs Dir -> ApiOpts -> [VendoredDependency] -> m [Locator]
+licenseScanSourceUnit ::
+  ( Has Diag.Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has StickyLogger sig m
+  ) =>
+  Path Abs Dir ->
+  ApiOpts ->
+  [VendoredDependency] ->
+  m [Locator]
 licenseScanSourceUnit baseDir apiOpts vendoredDeps = do
   -- Users with many instances of vendored dependencies may accidentally have complete duplicates. Remove them.
   let uniqDeps = nub vendoredDeps
@@ -102,7 +124,7 @@ licenseScanSourceUnit baseDir apiOpts vendoredDeps = do
 
   -- archiveBuildUpload takes archives without Organization information. This orgID is appended when creating the build on the backend.
   -- We don't care about the response here because if the build has already been queued, we get a 401 response.
-  _ <- Fossa.licenseScanFinalize apiOpts $ ArchiveComponents archives
+  void $ Fossa.licenseScanFinalize apiOpts $ ArchiveComponents archives
 
   -- The organizationID is needed to prefix each locator name. The FOSSA API automatically prefixes the locator when queuing the build
   -- but not when reading from a source unit.

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -31,6 +31,7 @@ import Effect.Exec (Exec, runExecIO)
 import Fossa.API.Types
 import Path
 import Srclib.Types (
+  LicenseScanType (CliLicenseScanned),
   LicenseSourceUnit (..),
   LicenseUnit (..),
   Locator (..),
@@ -82,7 +83,7 @@ scanAndUploadVendoredDep apiOpts baseDir VendoredDependency{..} = context "compr
   let licenseSourceUnit =
         LicenseSourceUnit
           { licenseSourceUnitName = vendoredPath
-          , licenseSourceUnitType = "cli-license-scanned"
+          , licenseSourceUnitType = CliLicenseScanned
           , licenseSourceUnitLicenseUnits = themisScanResult
           }
 

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -90,13 +90,11 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts = do
   -- See https://fossa.atlassian.net/browse/ANE-23
   -- IMPORTANT: Until ANE-23 is implemented, this should always be `ArchiveUpload` on master
   let archiveOrCLI = ArchiveUpload
-  archiveLocators <- case maybeApiOpts of
-    Nothing -> case archiveOrCLI of
-      ArchiveUpload -> pure $ archiveNoUploadSourceUnit vendoredDependencies
-      CLILicenseScan -> pure $ licenseNoScanSourceUnit vendoredDependencies
-    Just apiOpts -> case archiveOrCLI of
-      ArchiveUpload -> archiveUploadSourceUnit root apiOpts vendoredDependencies
-      CLILicenseScan -> licenseScanSourceUnit root apiOpts vendoredDependencies
+  archiveLocators :: [Locator] <- case (maybeApiOpts, defaultArchiveOrCLI) of
+    (Just apiOpts, ArchiveUpload) -> archiveUploadSourceUnit root apiOpts vendoredDependencies
+    (Just apiOpts, CLILicenseScan) -> licenseScanSourceUnit root apiOpts vendoredDependencies
+    (Nothing, ArchiveUpload) -> pure $ archiveNoUploadSourceUnit vendoredDependencies
+    (Nothing, CLILicenseScan) -> pure $ licenseNoScanSourceUnit vendoredDependencies
 
   let renderedPath = toText root
       referenceLocators = refToLocator <$> referencedDependencies

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -90,7 +90,7 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts = do
   -- See https://fossa.atlassian.net/browse/ANE-23
   -- IMPORTANT: Until ANE-23 is implemented, this should always be `ArchiveUpload` on master
   let archiveOrCLI = ArchiveUpload
-  archiveLocators :: [Locator] <- case (maybeApiOpts, defaultArchiveOrCLI) of
+  archiveLocators :: [Locator] <- case (maybeApiOpts, archiveOrCLI) of
     (Just apiOpts, ArchiveUpload) -> archiveUploadSourceUnit root apiOpts vendoredDependencies
     (Just apiOpts, CLILicenseScan) -> licenseScanSourceUnit root apiOpts vendoredDependencies
     (Nothing, ArchiveUpload) -> pure $ archiveNoUploadSourceUnit vendoredDependencies

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -24,8 +24,8 @@ import Data.Aeson (
   (.:?),
  )
 
-import App.Fossa.ArchiveUploader
-import App.Fossa.LicenseScanner
+import App.Fossa.ArchiveUploader (VendoredDependency (..), archiveNoUploadSourceUnit, archiveUploadSourceUnit)
+import App.Fossa.LicenseScanner (licenseNoScanSourceUnit, licenseScanSourceUnit)
 import Control.Effect.Lift
 import Control.Effect.StickyLogger (StickyLogger)
 import Data.Aeson.Extra

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -86,12 +86,15 @@ toSourceUnit :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has StickyLogger si
 toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts = do
   -- If the file exists and we have no dependencies to report, that's a failure.
   when (hasNoDeps manualDeps) $ fatalText "No dependencies found in fossa-deps file"
-  let archiveOrCli = CLILicenseScan
+  -- TODO: This will be set by querying core to see if we should archive upload or cli-side license scan
+  -- See https://fossa.atlassian.net/browse/ANE-23
+  -- TODO IMPORTANT: Until this is done, this should always be `ArchiveUpload` on master
+  let archiveOrCLI = CLILicenseScan
   archiveLocators <- case maybeApiOpts of
-    Nothing -> case archiveOrCli of
+    Nothing -> case archiveOrCLI of
       ArchiveUpload -> pure $ archiveNoUploadSourceUnit vendoredDependencies
       CLILicenseScan -> pure $ licenseNoScanSourceUnit vendoredDependencies
-    Just apiOpts -> case archiveOrCli of
+    Just apiOpts -> case archiveOrCLI of
       ArchiveUpload -> archiveUploadSourceUnit root apiOpts vendoredDependencies
       CLILicenseScan -> licenseScanSourceUnit root apiOpts vendoredDependencies
 

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -86,10 +86,10 @@ toSourceUnit :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has StickyLogger si
 toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts = do
   -- If the file exists and we have no dependencies to report, that's a failure.
   when (hasNoDeps manualDeps) $ fatalText "No dependencies found in fossa-deps file"
-  -- TODO: This will be set by querying core to see if we should archive upload or cli-side license scan
+  -- TODO: archiveOrCLI will eventually be set by querying core to see if we should archive upload or cli-side license scan
   -- See https://fossa.atlassian.net/browse/ANE-23
-  -- TODO IMPORTANT: Until this is done, this should always be `ArchiveUpload` on master
-  let archiveOrCLI = CLILicenseScan
+  -- IMPORTANT: Until ANE-23 is implemented, this should always be `ArchiveUpload` on master
+  let archiveOrCLI = ArchiveUpload
   archiveLocators <- case maybeApiOpts of
     Nothing -> case archiveOrCLI of
       ArchiveUpload -> pure $ archiveNoUploadSourceUnit vendoredDependencies

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module App.Fossa.RunThemis (
   execThemis,
   generateThemisOpts,

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -35,7 +35,7 @@ themisCommand :: ThemisBins -> Command
 themisCommand ThemisBins{..} = do
   Command
     { cmdName = toText $ fromAbsFile $ toPath $ unTag themisBinaryPaths
-    , cmdArgs = generateThemisArgs $ indexBinaryPaths
+    , cmdArgs = generateThemisArgs indexBinaryPaths
     , cmdAllowErr = Never
     }
 

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -12,6 +12,7 @@ import Data.Text (Text)
 import Effect.Logger (Logger, logDebug)
 import Path (Abs, Dir, Path, Rel, fromAbsFile, (</>))
 import Prettyprinter (Pretty (pretty))
+import Srclib.Types (LicenseUnit)
 
 import App.Fossa.EmbeddedBinary (
   BinaryPaths (..),
@@ -22,7 +23,7 @@ import Effect.Exec (
   AllowErr (Never),
   Command (..),
   Exec,
-  execThrow,
+  execJson,
  )
 
 data ThemisCLIOpts = ThemisCLIOpts
@@ -37,13 +38,13 @@ generateThemisOpts baseDir vendoredDepDir =
   where
     fullDir = baseDir </> vendoredDepDir
 
-execThemis :: (Has Exec sig m, Has Diagnostics sig m, Has Logger sig m) => BinaryPaths -> BinaryPaths -> ThemisCLIOpts -> m BL.ByteString
+execThemis :: (Has Exec sig m, Has Diagnostics sig m, Has Logger sig m) => BinaryPaths -> BinaryPaths -> ThemisCLIOpts -> m [LicenseUnit]
 execThemis themisBinaryPath indexGobPath opts = do
   let cmd = themisCommand themisBinaryPath indexGobPath
       scanDir = themisCLIScanDir opts
   logDebug $ pretty $ "themis command: " ++ show cmd
   logDebug $ pretty $ "scanDir: " ++ show scanDir
-  res <- execThrow scanDir cmd
+  res <- execJson @[LicenseUnit] scanDir cmd
   logDebug "back from command"
   pure res
 

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -7,7 +7,7 @@ module App.Fossa.RunThemis (
 ) where
 
 import Control.Carrier.Error.Either (Has)
-import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Diagnostics (Diagnostics, fatal)
 import Data.ByteString.Lazy qualified as BL
 import Data.String.Conversion (toText, toString)
 import Data.Text (Text)
@@ -27,10 +27,12 @@ import Effect.Exec (
   AllowErr (Never),
   Command (..),
   Exec,
+  exec,
   execThrow,
  )
 import Control.Monad (when)
 import Options.Applicative.Help (cmdDesc)
+import Text.Megaparsec.Error.Builder (err)
 
 data ThemisCLIOpts = ThemisCLIOpts
   { themisCLIScanDir :: Path Abs Dir
@@ -50,7 +52,13 @@ execThemis themisBinaryPath indexGobPath opts = do
       scanDir = themisCLIScanDir opts
   logDebug $ pretty $ "themis command: " ++ show cmd
   logDebug $ pretty $ "scanDir: " ++ show scanDir
-  execThrow scanDir cmd
+  res <- execThrow scanDir cmd
+  logDebug "back from command"
+  pure res
+  -- case exec scanDir cmd of
+  --   Left err -> fatal err
+  --   Right stdout -> pure stdout
+
   -- execThrow (themisCLIScanDir opts) (themisCommand themisBinaryPath indexGobPath)
 
 themisCommand :: BinaryPaths -> BinaryPaths -> Command
@@ -64,7 +72,8 @@ themisCommand themisBin indexGobBin = do
 generateThemisArgs :: BinaryPaths -> [Text]
 generateThemisArgs indexPath =
   [ "--license-data-dir"
-  , toText $ binaryPathContainer indexPath
+  -- , toText $ binaryPathContainer indexPath
+  , "/Users/scott/fossa/fossa-cli/vendor-bins"
   , "--srclib-with-matches"
   , "/Users/scott/fossa/license-scan-dirs/archive-upload-with-target/yarn-package/"
   ]

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -25,6 +25,7 @@ import Effect.Exec (
   execJson,
  )
 
+-- TODO: We should log the themis version and index version
 execThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> m [LicenseUnit]
 execThemis themisBins scanDir = do
   execJson @[LicenseUnit] scanDir $ themisCommand themisBins

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -14,6 +14,8 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding (decodeUtf8)
 import Path (Abs, Dir, Path, Rel, fromAbsFile, parseRelDir, (</>))
+import Effect.Logger (Logger, logDebug, logInfo)
+import Prettyprinter (Pretty (pretty))
 
 import App.Fossa.EmbeddedBinary (
   toExecutablePath,
@@ -28,11 +30,13 @@ import Effect.Exec (
   execThrow,
  )
 import Control.Monad (when)
+import Options.Applicative.Help (cmdDesc)
 
 data ThemisCLIOpts = ThemisCLIOpts
   { themisCLIScanDir :: Path Abs Dir
   , themisCLIArgs :: [Text]
   }
+  deriving (Show, Eq, Ord)
 
 generateThemisOpts :: Path Abs Dir -> Path Rel Dir -> ThemisCLIOpts
 generateThemisOpts baseDir vendoredDepDir =
@@ -40,8 +44,14 @@ generateThemisOpts baseDir vendoredDepDir =
     where
       fullDir = baseDir </> vendoredDepDir
 
-execThemis :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> BinaryPaths -> ThemisCLIOpts -> m BL.ByteString
-execThemis themisBinaryPath indexGobPath opts = execThrow (themisCLIScanDir opts) (themisCommand themisBinaryPath indexGobPath)
+execThemis :: (Has Exec sig m, Has Diagnostics sig m, Has Logger sig m) => BinaryPaths -> BinaryPaths -> ThemisCLIOpts -> m BL.ByteString
+execThemis themisBinaryPath indexGobPath opts = do
+  let cmd = themisCommand themisBinaryPath indexGobPath
+      scanDir = themisCLIScanDir opts
+  logDebug $ pretty $ "themis command: " ++ show cmd
+  logDebug $ pretty $ "scanDir: " ++ show scanDir
+  execThrow scanDir cmd
+  -- execThrow (themisCLIScanDir opts) (themisCommand themisBinaryPath indexGobPath)
 
 themisCommand :: BinaryPaths -> BinaryPaths -> Command
 themisCommand themisBin indexGobBin = do
@@ -52,10 +62,10 @@ themisCommand themisBin indexGobBin = do
     }
 
 generateThemisArgs :: BinaryPaths -> [Text]
-generateThemisArgs BinaryPaths{..} =
+generateThemisArgs indexPath =
   [ "--license-data-dir"
-  , toText binaryPathContainer
-  , "--srclib-with-match-string"
-  , "."
+  , toText $ binaryPathContainer indexPath
+  , "--srclib-with-matches"
+  , "/Users/scott/fossa/license-scan-dirs/archive-upload-with-target/yarn-package/"
   ]
 

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -9,14 +9,14 @@ import Control.Effect.Diagnostics (Diagnostics)
 import Data.ByteString.Lazy qualified as BL
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Path (Abs, Dir, Path, Rel, fromAbsFile, (</>))
 import Effect.Logger (Logger, logDebug)
+import Path (Abs, Dir, Path, Rel, fromAbsFile, (</>))
 import Prettyprinter (Pretty (pretty))
 
 import App.Fossa.EmbeddedBinary (
-  toExecutablePath,
   BinaryPaths (..),
-  )
+  toExecutablePath,
+ )
 
 import Effect.Exec (
   AllowErr (Never),
@@ -33,9 +33,9 @@ data ThemisCLIOpts = ThemisCLIOpts
 
 generateThemisOpts :: Path Abs Dir -> Path Rel Dir -> ThemisCLIOpts
 generateThemisOpts baseDir vendoredDepDir =
-  ThemisCLIOpts{ themisCLIScanDir = fullDir, themisCLIArgs = ["--help"]}
-    where
-      fullDir = baseDir </> vendoredDepDir
+  ThemisCLIOpts{themisCLIScanDir = fullDir, themisCLIArgs = ["--help"]}
+  where
+    fullDir = baseDir </> vendoredDepDir
 
 execThemis :: (Has Exec sig m, Has Diagnostics sig m, Has Logger sig m) => BinaryPaths -> BinaryPaths -> ThemisCLIOpts -> m BL.ByteString
 execThemis themisBinaryPath indexGobPath opts = do
@@ -62,4 +62,3 @@ generateThemisArgs indexPath =
   , "--srclib-with-matches"
   , "."
   ]
-

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -5,32 +5,25 @@ module App.Fossa.RunThemis (
 ) where
 
 import Control.Carrier.Error.Either (Has)
-import Control.Effect.Diagnostics (Diagnostics, fatal)
+import Control.Effect.Diagnostics (Diagnostics)
 import Data.ByteString.Lazy qualified as BL
-import Data.String.Conversion (toText, toString)
+import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text qualified as Text
-import Data.Text.Encoding (decodeUtf8)
-import Path (Abs, Dir, Path, Rel, fromAbsFile, parseRelDir, (</>))
-import Effect.Logger (Logger, logDebug, logInfo)
+import Path (Abs, Dir, Path, Rel, fromAbsFile, (</>))
+import Effect.Logger (Logger, logDebug)
 import Prettyprinter (Pretty (pretty))
 
 import App.Fossa.EmbeddedBinary (
   toExecutablePath,
   BinaryPaths (..),
   )
-import Options.Applicative (CommandFields)
 
 import Effect.Exec (
   AllowErr (Never),
   Command (..),
   Exec,
-  exec,
   execThrow,
  )
-import Control.Monad (when)
-import Options.Applicative.Help (cmdDesc)
-import Text.Megaparsec.Error.Builder (err)
 
 data ThemisCLIOpts = ThemisCLIOpts
   { themisCLIScanDir :: Path Abs Dir
@@ -53,11 +46,6 @@ execThemis themisBinaryPath indexGobPath opts = do
   res <- execThrow scanDir cmd
   logDebug "back from command"
   pure res
-  -- case exec scanDir cmd of
-  --   Left err -> fatal err
-  --   Right stdout -> pure stdout
-
-  -- execThrow (themisCLIScanDir opts) (themisCommand themisBinaryPath indexGobPath)
 
 themisCommand :: BinaryPaths -> BinaryPaths -> Command
 themisCommand themisBin indexGobBin = do

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -37,8 +37,8 @@ generateThemisOpts baseDir vendoredDepDir =
     where
       fullDir = baseDir </> vendoredDepDir
 
-execThemis :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> ThemisCLIOpts -> m Text
-execThemis binaryPaths opts = decodeUtf8 . BL.toStrict <$> execThrow (themisCLIScanDir opts) (themisCommand binaryPaths opts)
+execThemis :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> ThemisCLIOpts -> m BL.ByteString
+execThemis binaryPaths opts = execThrow (themisCLIScanDir opts) (themisCommand binaryPaths opts)
 
 themisCommand :: BinaryPaths -> ThemisCLIOpts -> Command
 themisCommand bin ThemisCLIOpts{..} = do

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -72,8 +72,7 @@ themisCommand themisBin indexGobBin = do
 generateThemisArgs :: BinaryPaths -> [Text]
 generateThemisArgs indexPath =
   [ "--license-data-dir"
-  -- , toText $ binaryPathContainer indexPath
-  , "/Users/scott/fossa/fossa-cli/vendor-bins"
+  , toText $ binaryPathContainer indexPath
   , "--srclib-with-matches"
   , "."
   ]

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -6,7 +6,6 @@ module App.Fossa.RunThemis (
 
 import Control.Carrier.Error.Either (Has)
 import Control.Effect.Diagnostics (Diagnostics)
-import Data.ByteString.Lazy qualified as BL
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Effect.Logger (Logger, logDebug)

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -15,7 +15,10 @@ import Data.Text qualified as Text
 import Data.Text.Encoding (decodeUtf8)
 import Path (Abs, Dir, Path, Rel, fromAbsFile, parseRelDir, (</>))
 
-import App.Fossa.EmbeddedBinary (BinaryPaths, toExecutablePath)
+import App.Fossa.EmbeddedBinary (
+  toExecutablePath,
+  BinaryPaths (..),
+  )
 import Options.Applicative (CommandFields)
 
 import Effect.Exec (
@@ -37,14 +40,22 @@ generateThemisOpts baseDir vendoredDepDir =
     where
       fullDir = baseDir </> vendoredDepDir
 
-execThemis :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> ThemisCLIOpts -> m BL.ByteString
-execThemis binaryPaths opts = execThrow (themisCLIScanDir opts) (themisCommand binaryPaths opts)
+execThemis :: (Has Exec sig m, Has Diagnostics sig m) => BinaryPaths -> BinaryPaths -> ThemisCLIOpts -> m BL.ByteString
+execThemis themisBinaryPath indexGobPath opts = execThrow (themisCLIScanDir opts) (themisCommand themisBinaryPath indexGobPath)
 
-themisCommand :: BinaryPaths -> ThemisCLIOpts -> Command
-themisCommand bin ThemisCLIOpts{..} = do
+themisCommand :: BinaryPaths -> BinaryPaths -> Command
+themisCommand themisBin indexGobBin = do
   Command
-    { cmdName = toText $ fromAbsFile $ toExecutablePath bin
-    , cmdArgs = themisCLIArgs
+    { cmdName = toText $ fromAbsFile $ toExecutablePath themisBin
+    , cmdArgs = generateThemisArgs indexGobBin
     , cmdAllowErr = Never
     }
+
+generateThemisArgs :: BinaryPaths -> [Text]
+generateThemisArgs BinaryPaths{..} =
+  [ "--license-data-dir"
+  , toText binaryPathContainer
+  , "--srclib-with-match-string"
+  , "."
+  ]
 

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -75,6 +75,6 @@ generateThemisArgs indexPath =
   -- , toText $ binaryPathContainer indexPath
   , "/Users/scott/fossa/fossa-cli/vendor-bins"
   , "--srclib-with-matches"
-  , "/Users/scott/fossa/license-scan-dirs/archive-upload-with-target/yarn-package/"
+  , "."
   ]
 

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -7,7 +7,7 @@ module App.Fossa.RunThemis (
 import Control.Carrier.Error.Either (Has)
 import Control.Effect.Diagnostics (Diagnostics)
 import Data.String.Conversion (toText)
-import Data.Tagged (unTag)
+import Data.Tagged (Tagged, unTag)
 import Data.Text (Text)
 import Path (Abs, Dir, Path, fromAbsFile)
 import Srclib.Types (LicenseUnit)
@@ -15,6 +15,7 @@ import Srclib.Types (LicenseUnit)
 import App.Fossa.EmbeddedBinary (
   BinaryPaths (..),
   ThemisBins (..),
+  ThemisIndex,
   toPath,
  )
 
@@ -34,14 +35,14 @@ themisCommand :: ThemisBins -> Command
 themisCommand ThemisBins{..} = do
   Command
     { cmdName = toText $ fromAbsFile $ toPath $ unTag themisBinaryPaths
-    , cmdArgs = generateThemisArgs $ unTag indexBinaryPaths
+    , cmdArgs = generateThemisArgs $ indexBinaryPaths
     , cmdAllowErr = Never
     }
 
-generateThemisArgs :: BinaryPaths -> [Text]
-generateThemisArgs BinaryPaths{..} =
+generateThemisArgs :: Tagged ThemisIndex BinaryPaths -> [Text]
+generateThemisArgs taggedThemisIndex =
   [ "--license-data-dir"
-  , toText binaryPathContainer
+  , toText . binaryPathContainer $ unTag taggedThemisIndex
   , "--srclib-with-matches"
   , "."
   ]

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -9,9 +9,7 @@ import Control.Effect.Diagnostics (Diagnostics)
 import Data.String.Conversion (toText)
 import Data.Tagged (unTag)
 import Data.Text (Text)
-import Effect.Logger (Logger, logDebug)
 import Path (Abs, Dir, Path, fromAbsFile)
-import Prettyprinter (Pretty (pretty))
 import Srclib.Types (LicenseUnit)
 
 import App.Fossa.EmbeddedBinary (
@@ -27,14 +25,9 @@ import Effect.Exec (
   execJson,
  )
 
-execThemis :: (Has Exec sig m, Has Diagnostics sig m, Has Logger sig m) => ThemisBins -> Path Abs Dir -> m [LicenseUnit]
+execThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> m [LicenseUnit]
 execThemis themisBins scanDir = do
-  let cmd = themisCommand themisBins
-  logDebug $ pretty $ "themis command: " ++ show cmd
-  logDebug $ pretty $ "scanDir: " ++ show scanDir
-  res <- execJson @[LicenseUnit] scanDir cmd
-  logDebug "back from command"
-  pure res
+  execJson @[LicenseUnit] scanDir $ themisCommand themisBins
 
 themisCommand :: ThemisBins -> Command
 themisCommand ThemisBins{..} = do

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -2,8 +2,6 @@
 
 module App.Fossa.RunThemis (
   execThemis,
-  generateThemisOpts,
-  ThemisCLIOpts (..),
 ) where
 
 import Control.Carrier.Error.Either (Has)
@@ -12,7 +10,7 @@ import Data.String.Conversion (toText)
 import Data.Tagged (unTag)
 import Data.Text (Text)
 import Effect.Logger (Logger, logDebug)
-import Path (Abs, Dir, Path, Rel, fromAbsFile, (</>))
+import Path (Abs, Dir, Path, fromAbsFile)
 import Prettyprinter (Pretty (pretty))
 import Srclib.Types (LicenseUnit)
 
@@ -29,22 +27,9 @@ import Effect.Exec (
   execJson,
  )
 
-data ThemisCLIOpts = ThemisCLIOpts
-  { themisCLIScanDir :: Path Abs Dir
-  , themisCLIArgs :: [Text]
-  }
-  deriving (Show, Eq, Ord)
-
-generateThemisOpts :: Path Abs Dir -> Path Rel Dir -> ThemisCLIOpts
-generateThemisOpts baseDir vendoredDepDir =
-  ThemisCLIOpts{themisCLIScanDir = fullDir, themisCLIArgs = []}
-  where
-    fullDir = baseDir </> vendoredDepDir
-
-execThemis :: (Has Exec sig m, Has Diagnostics sig m, Has Logger sig m) => ThemisBins -> ThemisCLIOpts -> m [LicenseUnit]
-execThemis themisBins opts = do
+execThemis :: (Has Exec sig m, Has Diagnostics sig m, Has Logger sig m) => ThemisBins -> Path Abs Dir -> m [LicenseUnit]
+execThemis themisBins scanDir = do
   let cmd = themisCommand themisBins
-      scanDir = themisCLIScanDir opts
   logDebug $ pretty $ "themis command: " ++ show cmd
   logDebug $ pretty $ "scanDir: " ++ show scanDir
   res <- execJson @[LicenseUnit] scanDir cmd

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -16,6 +16,7 @@ import Codec.Archive.Tar qualified as Tar
 import Codec.Archive.Zip qualified as Zip
 import Codec.Compression.BZip qualified as BZip
 import Codec.Compression.GZip qualified as GZip
+import Codec.Compression.Lzma as Lzma
 import Conduit (runConduit, runResourceT, sourceFileBS, (.|))
 import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Control.Effect.Finally (Finally, onExit)
@@ -24,7 +25,6 @@ import Control.Effect.TaskPool (TaskPool, forkTask)
 import Data.ByteString.Lazy qualified as BL
 import Data.Conduit.Binary (sinkLbs)
 import Data.Conduit.Lzma qualified as CLzma
-import Codec.Compression.Lzma as Lzma
 import Data.Foldable (traverse_)
 import Data.List (isSuffixOf)
 import Data.String.Conversion (toText)

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -144,11 +144,3 @@ removeTarLinks (Tar.Fail e) = Tar.Fail e
 extractZip :: Has (Lift IO) sig m => Path Abs Dir -> Path Abs File -> m ()
 extractZip dir zipFile =
   sendIO $ Zip.withArchive (fromAbsFile zipFile) (Zip.unpackInto (fromAbsDir dir))
-
------------ LZMA and XZ files
--- .lzma and .xz files can only contain a single file, not a directory
-extractLzma :: Has (Lift IO) sig m => Path Abs File -> Path Abs File -> m ()
-extractLzma lzmaFile decompressedFile = do
-  lzmaContents <- sendIO $ BL.readFile (fromAbsFile lzmaFile)
-  let decompressedContents = Lzma.decompress lzmaContents
-  sendIO $ BL.writeFile (fromAbsFile decompressedFile) decompressedContents

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -3,7 +3,6 @@ module Discovery.Archive (
   withArchive,
   withArchive',
   extractRpm,
-  extractLzma,
   extractTar,
   extractTarGz,
   extractTarXz,
@@ -16,7 +15,6 @@ import Codec.Archive.Tar qualified as Tar
 import Codec.Archive.Zip qualified as Zip
 import Codec.Compression.BZip qualified as BZip
 import Codec.Compression.GZip qualified as GZip
-import Codec.Compression.Lzma as Lzma
 import Conduit (runConduit, runResourceT, sourceFileBS, (.|))
 import Control.Effect.Diagnostics (Diagnostics, Has, context, fatalOnSomeException)
 import Control.Effect.Finally (Finally, onExit)

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -31,26 +31,92 @@ data LicenseSourceUnit = LicenseSourceUnit
   }
   deriving (Eq, Ord, Show)
 
+instance ToJSON LicenseSourceUnit where
+  toJSON LicenseSourceUnit{..} =
+    object
+      [ "Name" .= licenseSourceUnitName
+      , "Type" .= licenseSourceUnitType
+      , "LicenseUnits" .= licenseSourceUnitLicenseUnits
+      ]
+
+-- There will be one of these for each license type found by Themis
+-- The data returned from themis-cli is an array of these.
 data LicenseUnit = LicenseUnit
   { licenseUnitName :: Text
   , licenseUnitType :: Text
+  , licenseUnitDir :: Text
+  , licenseUnitFiles :: [Text]
   , licenseUnitData :: [LicenseUnitData]
   }
   deriving (Eq, Ord, Show)
 
+instance ToJSON LicenseUnit where
+  toJSON LicenseUnit{..} =
+    object
+      [ "Name" .= licenseUnitName
+      , "Type" .= licenseUnitType
+      , "Dir" .= licenseUnitDir
+      , "Files" .= licenseUnitFiles
+      , "Data" .= licenseUnitData
+      ]
+
+instance FromJSON LicenseUnit where
+  parseJSON = withObject "LicenseUnit" $ \obj ->
+    LicenseUnit <$> obj .: "Name"
+      <*> obj .: "Type"
+      <*> obj .: "Dir"
+      <*> obj .: "Files"
+      <*> obj .: "Data"
 data LicenseUnitData = LicenseUnitData
   { licenseUnitDataPath :: Text
+  , licenseUnitDataCopyright :: Text
   , licenseUnitDataThemisVersion :: Text
   , licenseUnitDataMatchData :: [LicenseUnitMatchData]
+  , licenseUnitDataCopyrights :: [Text]
   }
   deriving (Eq, Ord, Show)
 
+instance ToJSON LicenseUnitData where
+  toJSON LicenseUnitData{..} =
+    object
+      [ "path" .= licenseUnitDataPath
+      , "Copyright" .= licenseUnitDataCopyright
+      , "ThemisVersion" .= licenseUnitDataThemisVersion
+      , "match_data" .= licenseUnitDataMatchData
+      , "Copyrights" .= licenseUnitDataCopyrights
+      ]
+
+instance FromJSON LicenseUnitData where
+  parseJSON = withObject "LicenseUnitData" $ \obj ->
+    LicenseUnitData <$> obj .: "path"
+      <*> obj .: "Copyright"
+      <*> obj .: "ThemisVersion"
+      <*> obj .: "match_data"
+      <*> obj .: "Copyrights"
 data LicenseUnitMatchData = LicenseUnitMatchData
   { licenseUnitMatchDataMatchString :: Text
   , licenseUnitMatchDataLocation :: Integer
   , licenseUnitMatchDataLength :: Integer
+  , licenseUnitMatchDataIndex :: Integer
   }
   deriving (Eq, Ord, Show)
+
+instance ToJSON LicenseUnitMatchData where
+  toJSON LicenseUnitMatchData{..} =
+    object
+      [ "match_string" .= licenseUnitMatchDataMatchString
+      , "location" .= licenseUnitMatchDataLocation
+      , "length" .= licenseUnitMatchDataLength
+      , "index" .= licenseUnitMatchDataIndex
+      ]
+
+instance FromJSON LicenseUnitMatchData where
+  parseJSON = withObject "LicenseUnitMatchData" $ \obj ->
+    LicenseUnitMatchData <$> obj .: "match_string"
+      <*> obj .: "location"
+      <*> obj .: "length"
+      <*> obj .: "index"
+
 data SourceUnit = SourceUnit
   { sourceUnitName :: Text
   , sourceUnitType :: Text

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -41,7 +41,7 @@ instance ToJSON LicenseScanType where
 data LicenseSourceUnit = LicenseSourceUnit
   { licenseSourceUnitName :: Text
   , licenseSourceUnitType :: LicenseScanType
-  , licenseSourceUnitLicenseUnits :: [LicenseUnit]
+  , licenseSourceUnitLicenseUnits :: (NonEmpty LicenseUnit)
   }
   deriving (Eq, Ord, Show)
 

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -30,8 +30,7 @@ data LicenseScanType = CliLicenseScanned
   deriving (Eq, Ord, Show)
 
 instance ToText LicenseScanType where
-  toText :: LicenseScanType -> Text
-  toText _ = "cli-license-scanned"
+  toText CliLicenseScanned = "cli-license-scanned"
 
 instance ToJSON LicenseScanType where
   toJSON = toJSON . toText

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -17,6 +17,7 @@ module Srclib.Types (
 ) where
 
 import Data.Aeson
+import Data.List.NonEmpty (NonEmpty)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (ToText, toText)
 import Data.Text (Text)
@@ -24,6 +25,8 @@ import Data.Text qualified as Text
 import Path (File, SomeBase)
 import Types (GraphBreadth (..))
 
+-- | LicenseSourceUnit is the base of the results sent to Core for a CLI-side license scan
+-- licenseSourceUnitLicenseUnits will be empty if you scan an empty directory.
 data LicenseSourceUnit = LicenseSourceUnit
   { licenseSourceUnitName :: Text
   , licenseSourceUnitType :: Text
@@ -45,8 +48,8 @@ data LicenseUnit = LicenseUnit
   { licenseUnitName :: Text
   , licenseUnitType :: Text
   , licenseUnitDir :: Text
-  , licenseUnitFiles :: [Text]
-  , licenseUnitData :: [LicenseUnitData]
+  , licenseUnitFiles :: (NonEmpty Text)
+  , licenseUnitData :: (NonEmpty LicenseUnitData)
   , licenseUnitInfo :: LicenseUnitInfo
   }
   deriving (Eq, Ord, Show)
@@ -83,12 +86,13 @@ instance FromJSON LicenseUnitInfo where
   parseJSON = withObject "LicenseUnitInfo" $ \obj ->
     LicenseUnitInfo <$> obj .: "Description"
 
+-- | LicenseUnitData contains data about a license unit. At least one of licenseUnitDataMatchData or licenseUnitDataCopyrights will be non-empty
 data LicenseUnitData = LicenseUnitData
   { licenseUnitDataPath :: Text
   , licenseUnitDataCopyright :: Maybe Text
   , licenseUnitDataThemisVersion :: Text
-  , licenseUnitDataMatchData :: Maybe [LicenseUnitMatchData]
-  , licenseUnitDataCopyrights :: Maybe [Text]
+  , licenseUnitDataMatchData :: Maybe (NonEmpty LicenseUnitMatchData)
+  , licenseUnitDataCopyrights :: Maybe (NonEmpty Text)
   }
   deriving (Eq, Ord, Show)
 
@@ -109,6 +113,7 @@ instance FromJSON LicenseUnitData where
       <*> obj .: "ThemisVersion"
       <*> obj .:? "match_data"
       <*> obj .:? "Copyrights"
+
 data LicenseUnitMatchData = LicenseUnitMatchData
   { licenseUnitMatchDataMatchString :: Text
   , licenseUnitMatchDataLocation :: Integer

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -47,6 +47,7 @@ data LicenseUnit = LicenseUnit
   , licenseUnitDir :: Text
   , licenseUnitFiles :: [Text]
   , licenseUnitData :: [LicenseUnitData]
+  , licenseUnitInfo :: LicenseUnitInfo
   }
   deriving (Eq, Ord, Show)
 
@@ -58,6 +59,7 @@ instance ToJSON LicenseUnit where
       , "Dir" .= licenseUnitDir
       , "Files" .= licenseUnitFiles
       , "Data" .= licenseUnitData
+      , "Info" .= licenseUnitInfo
       ]
 
 instance FromJSON LicenseUnit where
@@ -67,6 +69,20 @@ instance FromJSON LicenseUnit where
       <*> obj .: "Dir"
       <*> obj .: "Files"
       <*> obj .: "Data"
+      <*> obj .: "Info"
+
+data LicenseUnitInfo = LicenseUnitInfo
+  {licenseUnitInfoDescription :: Maybe Text}
+  deriving (Eq, Ord, Show)
+
+instance ToJSON LicenseUnitInfo where
+  toJSON LicenseUnitInfo{..} =
+    object ["Description" .= licenseUnitInfoDescription]
+
+instance FromJSON LicenseUnitInfo where
+  parseJSON = withObject "LicenseUnitInfo" $ \obj ->
+    LicenseUnitInfo <$> obj .: "Description"
+
 data LicenseUnitData = LicenseUnitData
   { licenseUnitDataPath :: Text
   , licenseUnitDataCopyright :: Maybe Text

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -71,7 +71,7 @@ instance FromJSON LicenseUnit where
       <*> obj .: "Data"
       <*> obj .: "Info"
 
-data LicenseUnitInfo = LicenseUnitInfo
+newtype LicenseUnitInfo = LicenseUnitInfo
   {licenseUnitInfoDescription :: Maybe Text}
   deriving (Eq, Ord, Show)
 

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -9,6 +9,7 @@ module Srclib.Types (
   SourceRemoteDep (..),
   Locator (..),
   LicenseSourceUnit (..),
+  LicenseScanType (..),
   LicenseUnit (..),
   LicenseUnitData (..),
   LicenseUnitMatchData (..),
@@ -25,11 +26,21 @@ import Data.Text qualified as Text
 import Path (File, SomeBase)
 import Types (GraphBreadth (..))
 
+data LicenseScanType = CliLicenseScanned
+  deriving (Eq, Ord, Show)
+
+instance ToText LicenseScanType where
+  toText :: LicenseScanType -> Text
+  toText _ = "cli-license-scanned"
+
+instance ToJSON LicenseScanType where
+  toJSON = toJSON . toText
+
 -- | LicenseSourceUnit is the base of the results sent to Core for a CLI-side license scan
 -- licenseSourceUnitLicenseUnits will be empty if you scan an empty directory.
 data LicenseSourceUnit = LicenseSourceUnit
   { licenseSourceUnitName :: Text
-  , licenseSourceUnitType :: Text
+  , licenseSourceUnitType :: LicenseScanType
   , licenseSourceUnitLicenseUnits :: [LicenseUnit]
   }
   deriving (Eq, Ord, Show)

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -114,6 +114,8 @@ data LicenseUnitMatchData = LicenseUnitMatchData
   , licenseUnitMatchDataLocation :: Integer
   , licenseUnitMatchDataLength :: Integer
   , licenseUnitMatchDataIndex :: Integer
+  , licenseUnitDataStartLine :: Integer
+  , licenseUnitDataEndLine :: Integer
   }
   deriving (Eq, Ord, Show)
 
@@ -124,6 +126,8 @@ instance ToJSON LicenseUnitMatchData where
       , "location" .= licenseUnitMatchDataLocation
       , "length" .= licenseUnitMatchDataLength
       , "index" .= licenseUnitMatchDataIndex
+      , "start_line" .= licenseUnitDataStartLine
+      , "end_line" .= licenseUnitDataEndLine
       ]
 
 instance FromJSON LicenseUnitMatchData where
@@ -132,6 +136,8 @@ instance FromJSON LicenseUnitMatchData where
       <*> obj .: "location"
       <*> obj .: "length"
       <*> obj .: "index"
+      <*> obj .: "start_line"
+      <*> obj .: "end_line"
 
 data SourceUnit = SourceUnit
   { sourceUnitName :: Text

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -69,10 +69,10 @@ instance FromJSON LicenseUnit where
       <*> obj .: "Data"
 data LicenseUnitData = LicenseUnitData
   { licenseUnitDataPath :: Text
-  , licenseUnitDataCopyright :: Text
+  , licenseUnitDataCopyright :: Maybe Text
   , licenseUnitDataThemisVersion :: Text
-  , licenseUnitDataMatchData :: [LicenseUnitMatchData]
-  , licenseUnitDataCopyrights :: [Text]
+  , licenseUnitDataMatchData :: Maybe [LicenseUnitMatchData]
+  , licenseUnitDataCopyrights :: Maybe [Text]
   }
   deriving (Eq, Ord, Show)
 
@@ -89,10 +89,10 @@ instance ToJSON LicenseUnitData where
 instance FromJSON LicenseUnitData where
   parseJSON = withObject "LicenseUnitData" $ \obj ->
     LicenseUnitData <$> obj .: "path"
-      <*> obj .: "Copyright"
+      <*> obj .:? "Copyright"
       <*> obj .: "ThemisVersion"
-      <*> obj .: "match_data"
-      <*> obj .: "Copyrights"
+      <*> obj .:? "match_data"
+      <*> obj .:? "Copyrights"
 data LicenseUnitMatchData = LicenseUnitMatchData
   { licenseUnitMatchDataMatchString :: Text
   , licenseUnitMatchDataLocation :: Integer

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -8,6 +8,10 @@ module Srclib.Types (
   SourceUserDefDep (..),
   SourceRemoteDep (..),
   Locator (..),
+  LicenseSourceUnit (..),
+  LicenseUnit (..),
+  LicenseUnitData (..),
+  LicenseUnitMatchData (..),
   renderLocator,
   parseLocator,
 ) where
@@ -20,6 +24,33 @@ import Data.Text qualified as Text
 import Path (File, SomeBase)
 import Types (GraphBreadth (..))
 
+data LicenseSourceUnit = LicenseSourceUnit
+  { licenseSourceUnitName :: Text
+  , licenseSourceUnitType :: Text
+  , licenseSourceUnitLicenseUnits :: [LicenseUnit]
+  }
+  deriving (Eq, Ord, Show)
+
+data LicenseUnit = LicenseUnit
+  { licenseUnitName :: Text
+  , licenseUnitType :: Text
+  , licenseUnitData :: [LicenseUnitData]
+  }
+  deriving (Eq, Ord, Show)
+
+data LicenseUnitData = LicenseUnitData
+  { licenseUnitDataPath :: Text
+  , licenseUnitDataThemisVersion :: Text
+  , licenseUnitDataMatchData :: [LicenseUnitMatchData]
+  }
+  deriving (Eq, Ord, Show)
+
+data LicenseUnitMatchData = LicenseUnitMatchData
+  { licenseUnitMatchDataMatchString :: Text
+  , licenseUnitMatchDataLocation :: Integer
+  , licenseUnitMatchDataLength :: Integer
+  }
+  deriving (Eq, Ord, Show)
 data SourceUnit = SourceUnit
   { sourceUnitName :: Text
   , sourceUnitType :: Text

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -69,7 +69,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2022-02-02-db4cf6c"
+THEMIS_TAG="2022-03-18-efb2343"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

[Closes ANE-25](https://fossa.atlassian.net/browse/ANE-25) — Use themis to license scan vendored dependencies
[Closes ANE-26](https://fossa.atlassian.net/browse/ANE-26) — Upload cli-side license data to S3 and trigger the build

Run `themis-cli` on the list of vendored dependencies in `fossa-deps.yml`, upload the resulting scan to S3 and then trigger a build on Core.

Things this PR does not do:

- we do not add the license data to the output from the `--output` flag (https://fossa.atlassian.net/browse/ANE-97)
- We do not emit any useful or actionable errors or warnings (https://fossa.atlassian.net/browse/ANE-96)

There are also no tests. I *think* that this code is similar to other code-paths that are not tested, but please let me know if there are areas that are reasonable to test.

## Acceptance criteria

This PR changes the behavior for vendored dependencies found in `fossa-deps.yml`.

* If `archiveOrCLI` in `App.Fossa.ManualDeps` is set to `ArchiveUpload`, then there should be no change: we should run an archive upload on any vendored dependencies
* If `archiveOrCLI` is set to `CLILicenseScan`, then we should run a license scan on any vendored dependencies

Running a license scan means:

* we run themis the  directories pointed to by the vendored dependency
* the results from each of the themis scans are gzipped and uploaded to S3
* Once all of the scans are completed and uploaded, we trigger a `CLILicenseScanBuild` job for each vendored dependency.

- [ ] `archiveOrCLI` must be set to `ArchiveUpload` before this is merged into master

## Testing plan

### Core setup

Check out the [CLI license scan endpoint](https://github.com/fossas/FOSSA/pull/7165) PR. The branch name is `cli-license-scan-endpoint`

```
git checkout cli-license-scan-endpoint
```

Do whatever you normally do to get core running on your system. You'll need to have minio, the agent and a faktory worker running, so you might also need to do:

```
docker compose up -d s3 agent faktory-worker
```

You'll want to watch these logs to make sure that the right job is getting queued:

```
docker compose logs --follow faktory-worker
```

### test directory setup

Make a simple yarn project with a single vendored dependency:

```
mkdir ~/fossa/license-scan-dirs/archive-upload-with-target
cd ~/fossa/license-scan-dirs/archive-upload-with-target
mkdir yarn-package
```

Put this in `fossa-deps.yml`:

```yml
vendored-dependencies:
  - name: yarn-package
    path: yarn-package
    version: 1.0.2
```

Put this in `yarn-package/package.json`:

```json
{
  "name": "yarn-testing",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "MIT",
  "dependencies": {
    "bson": "4.5.1"
  },
}
```

```
cd yarn-package
yarn install
rm -rf node_modules
```

Now do the same for a directory with multiple archives:

```
mkdir ~/fossa/license-scan-dirs/archive-upload-with-multple-targets
cd ~/fossa/license-scan-dirs/archive-upload-with-multiple-targets
mkdir first-yarn-package
mkdir second-yarn-package
```

Put this in `fossa-deps.yml`:

```yml
vendored-dependencies:
  - name: first-yarn-package
    path: first-yarn-package
    version: 1.0.2
  - name: second-yarn-package
    path: second-yarn-package
    version: 2.0.1
```

in first-yarn-package/package.json:

```
{
  "name": "yarn-testing",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "MIT",
  "dependencies": {
    "bson": "4.5.1"
  },
  "devDependencies": {
    "@storybook/addon-actions": "6.3.7",
    "@storybook/addon-docs": "6.3.7"
  }
}
```

in second-yarn-package/package.json:

```
{
  "name": "yarn-testing-2",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "Apache-2.0",
  "dependencies": {
    "bson": "4.5.1"
  },
  "devDependencies": {
    "@storybook/addon-actions": "6.3.7",
    "@storybook/addon-docs": "6.3.7"
  }
}
```

```
cd first-yarn-package
yarn install
rm -rf node_modules
cd ../second-yarn-package
yarn install
rm -rf node_modules
```

### Run the CLI

Without any changes, run the CLI:

```
export FOSSA_API_KEY='valid api key for your dev setup'
cabal run fossa -- analyze -e http://localhost:9578 ~/fossa/license-scan-dirs/archive-upload-with-target
```

This should successfully go through the previously existing archive upload workflow.

Now edit `src/App/Fossa/ManualDeps.hs`. On line 92 change `ArchiveUpload` to `CLILicenseScan`

```haskell
  let archiveOrCLI = CLILicenseScan
```

Edit `fossa-deps.yml` and change the version of the dependency from `1.0.1` to `1.0.2`.

run the scan again:

```
cabal run fossa -- analyze -e http://localhost:9578 ~/fossa/license-scan-dirs/archive-upload-with-target
```

This time it should run a license scan on the `yarn-package` directory and upload the results to your local minio.

There should be no difference in the UI. The license scan result from a cli-side license scan should be the same as a license scan done on the servers.

However, what happens on the back end is very different.

The archive upload workflow uploads the contents of the vendored dependency to `archive_components/archive+<org ID>/<locator>`.

So, if your ORG ID is 1, you'll see a file uploaded to `archive_components/archive+1/yarn-package$1.0.1`.

Download that file and gunzip it. Check that you see the contents of the yarn-package directory.

The CLI license scan workflow scans the contents of the vendored dependency and uploads the results of that license scan to `archive_license_data/archive+<org ID>/locator`.

So, if your ORG ID is 1, you'll see a file uploaded to `archive_license_data/archive+1/yarn-package$1.0.2`.

Download that file and gunzip it. Check that you see a JSON file containing the results of a license scan. It should look like this:

```
mv ~/Downloads/yarn-package\$1.0.1 ~/Downloads/yarn-package\$1.0.1.gz; gunzip ~/Downloads/yarn-package\$1.0.1.gz; cat ~/Downloads/yarn-package\$1.0.1
```

```json
{"Name":"yarn-package","Type":"cli-license-scanned","LicenseUnits":[{"Files":["yarn.lock"],"Name":"No_license_found","Type":"LicenseUnit","Dir":"","Info":{"Description":""},"Data":[{"path":"yarn.lock","ThemisVersion":"db4cf6c4b22e29bc4f2a4bd48488b8d3c2a3f5d9","Copyrights":null,"match_data":null,"Copyright":null}]},{"Files":["package.json"],"Name":"mit","Type":"LicenseUnit","Dir":"","Info":{"Description":""},"Data":[{"path":"package.json","ThemisVersion":"db4cf6c4b22e29bc4f2a4bd48488b8d3c2a3f5d9","Copyrights":null,"match_data":[{"index":0,"match_string":"MIT\",","length":4,"location":201}],"Copyright":null}]}]}
```

The contents of the file are just the JSON output.

In both cases, the UI should show an MIT license found for the `yarn-package` dependency.

Do the same thing for the project in `~/fossa/license-scan-dirs/archive-upload-with-multple-targets`:

cd ~/fossa/license-scan-dirs/archive-upload-with-multple-targets

```
cabal run fossa -- analyze -e http://localhost:9578 ~/fossa/license-scan-dirs/archive-upload-with-multiple-targets
```

You should see two new files in minio in `archive_components/archive+<org ID>`.

You should also see two `CliLicenseScannedBuild` tasks run in your faktory logs.

You should see an MIT license for `first-package` and an Apache-2.0 license for `second-package`.

## Risks



## References


## Checklist

- [x] I confirmed tests are not viable
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
