### PR TITLE
Emits Error/Warns for vsi, binary-deps, fossa-deps analysis, and updates scan summary to show deps from fossa-deps file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,9 @@
 - Clojure: Improves error and warning messages. ([#813](https://github.com/fossas/fossa-cli/pull/813))
 - Nim: Improves error and warning messages. ([#813](https://github.com/fossas/fossa-cli/pull/813))
 - Rust: Improves error and warning messages. ([#813](https://github.com/fossas/fossa-cli/pull/813))
+- UX: Improves errors for dynamic deps, and binary deps analysis. ([#819](https://github.com/fossas/fossa-cli/pull/819))
+- UX: Improves analysis scan summary rendering. ([#819](https://github.com/fossas/fossa-cli/pull/819))
+
 
 ## v3.1.0 
 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -180,7 +180,7 @@ runDependencyAnalysis basedir filters project = do
       graphResult <- Diag.runDiagnosticsIO . diagToDebug . stickyLogStack . withEmptyStack . Diag.context "Project Analysis" $ do
         debugMetadata "DiscoveredProject" project
         analyzeProject targets (projectData project)
-      Diag.flushLogs SevWarn SevWarn graphResult
+      Diag.flushLogs SevError SevDebug graphResult
       output $ Scanned dpi (mkResult basedir project <$> graphResult)
 
 applyFiltersToProject :: Path Abs Dir -> AllFilters -> DiscoveredProject n -> Maybe FoundTargets
@@ -259,7 +259,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
         else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir apiOpts
   let additionalSourceUnits :: [SourceUnit]
       additionalSourceUnits = mapMaybe (join . resultToMaybe) [manualSrcUnits, vsiResults, binarySearchResults]
-  traverse_ (Diag.flushLogs SevError SevWarn) [vsiResults, binarySearchResults, manualSrcUnits]
+  traverse_ (Diag.flushLogs SevError SevDebug) [vsiResults, binarySearchResults, manualSrcUnits]
 
   (projectScans, ()) <-
     Diag.context "discovery/analysis tasks"

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -27,6 +27,7 @@ import App.Fossa.Analyze.GraphMangler (graphingToGraph)
 import App.Fossa.Analyze.Project (ProjectResult (..), mkResult)
 import App.Fossa.Analyze.ScanSummary (renderScanSummary)
 import App.Fossa.Analyze.Types (
+  AnalysisScanResult (AnalysisScanResult),
   AnalyzeProject (..),
   AnalyzeTaskEffs,
   DiscoveredProjectIdentifier (..),
@@ -42,7 +43,7 @@ import App.Fossa.Config.Analyze (
   IATAssertion (IATAssertion),
   IncludeAll (IncludeAll),
   ScanDestination (..),
-  StandardAnalyzeConfig (),
+  StandardAnalyzeConfig (severity),
   UnpackArchives (UnpackArchives),
  )
 import App.Fossa.Config.Analyze qualified as Config
@@ -279,7 +280,9 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   let projectResults = mapMaybe toProjectResult projectScans
   let filteredProjects = mapMaybe toProjectResult projectScansWithSkippedProdPath
 
-  renderScanSummary projectScansWithSkippedProdPath vsiResults binarySearchResults manualSrcUnits
+  let analysisResult = AnalysisScanResult projectScansWithSkippedProdPath vsiResults binarySearchResults manualSrcUnits
+
+  renderScanSummary (severity cfg) analysisResult
 
   -- Need to check if vendored is empty as well, even if its a boolean that vendoredDeps exist
   case checkForEmptyUpload includeAll projectResults filteredProjects additionalSourceUnits of

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -180,7 +180,7 @@ runDependencyAnalysis basedir filters project = do
       graphResult <- Diag.runDiagnosticsIO . diagToDebug . stickyLogStack . withEmptyStack . Diag.context "Project Analysis" $ do
         debugMetadata "DiscoveredProject" project
         analyzeProject targets (projectData project)
-      Diag.flushLogs SevWarn SevDebug graphResult
+      Diag.flushLogs SevWarn SevWarn graphResult
       output $ Scanned dpi (mkResult basedir project <$> graphResult)
 
 applyFiltersToProject :: Path Abs Dir -> AllFilters -> DiscoveredProject n -> Maybe FoundTargets

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -258,6 +258,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
         else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir apiOpts
   let additionalSourceUnits :: [SourceUnit]
       additionalSourceUnits = mapMaybe (join . resultToMaybe) [manualSrcUnits, vsiResults, binarySearchResults]
+  traverse_ (Diag.flushLogs SevError SevWarn) [vsiResults, binarySearchResults, manualSrcUnits]
 
   (projectScans, ()) <-
     Diag.context "discovery/analysis tasks"

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -133,8 +133,8 @@ renderScanSummary severity analysisResults =
       when (severity /= SevDebug) $ do
         logInfo "You can pass `--debug` option to eagerly show all warning and failure messages."
 
-      summaryWithWarnErrors <- dumpResultLogsToTempFile analysisResults
-      logInfo . pretty $ "You can also view analysis summary at: " <> show summaryWithWarnErrors
+      summaryWithWarnErrorsTmpFile <- dumpResultLogsToTempFile analysisResults
+      logInfo . pretty $ "You can also view analysis summary with warning and error messages at: " <> show summaryWithWarnErrorsTmpFile
       logInfo "------------"
 
 summarize :: AnalysisScanResult -> Maybe ([Doc AnsiStyle])
@@ -297,7 +297,7 @@ dumpResultLogsToTempFile (AnalysisScanResult projects vsi binary manualDeps) = d
           . unAnnotate
           . mconcat
           $ scanSummary
-            ++ (mapMaybe renderDiscoveredProjectScanResult projects)
+            ++ (mapMaybe renderDiscoveredProjectScanResult (sort projects))
             ++ catMaybes
               [ renderSourceUnit "vsi analysis" vsi
               , renderSourceUnit "binary-deps analysis" binary

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -189,7 +189,7 @@ getManualVendorDepsIdentifier srcUnit = refDeps ++ foundRemoteDeps ++ customDeps
     refDeps =
       withPostfix "reference" $
         map (locatorProject) $
-          filter (\l -> locatorFetcher l == depTypeToFetcher ArchiveType) allBuildDeps
+          filter (\l -> locatorFetcher l /= depTypeToFetcher ArchiveType) allBuildDeps
 
     allBuildDeps :: [Locator]
     allBuildDeps = maybe [] (map sourceDepLocator . buildDependencies) (sourceUnitBuild srcUnit)

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -10,6 +10,7 @@ import App.Fossa.Analyze.Project (
   projectResultType,
  )
 import App.Fossa.Analyze.Types (
+  AnalysisScanResult (AnalysisScanResult),
   DiscoveredProjectIdentifier (dpiProjectPath, dpiProjectType),
   DiscoveredProjectScan (..),
  )
@@ -19,7 +20,7 @@ import Control.Effect.Diagnostics qualified as Diag (Diagnostics)
 import Control.Monad (when)
 import Data.Foldable (traverse_)
 import Data.List (sort)
-import Data.Maybe (catMaybes, mapMaybe)
+import Data.Maybe (catMaybes, mapMaybe, maybeToList)
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
 import Diag.Result (EmittedWarn (IgnoredErrGroup), Result (Failure, Success), renderFailure, renderSuccess)
@@ -27,10 +28,20 @@ import Effect.Logger (
   AnsiStyle,
   Logger,
   Pretty (pretty),
+  Severity (SevDebug),
   hsep,
   logInfo,
  )
-import Path
+import Path (
+  Abs,
+  Dir,
+  File,
+  Path,
+  Rel,
+  fromAbsFile,
+  mkRelFile,
+  (</>),
+ )
 import Path.IO
 import Prettyprinter (
   Doc,
@@ -42,13 +53,23 @@ import Prettyprinter (
   viaShow,
   vsep,
  )
-import Prettyprinter.Render.Terminal (Color (Green, Red, Yellow), bold, color, renderStrict)
+import Prettyprinter.Render.Terminal (
+  Color (Green, Red, Yellow),
+  bold,
+  color,
+  renderStrict,
+ )
+import Srclib.Converter (depTypeToFetcher)
 import Srclib.Types (
-  AdditionalDepData (userDefinedDeps),
-  SourceUnit (additionalData),
+  AdditionalDepData (remoteDeps, userDefinedDeps),
+  Locator (locatorFetcher, locatorProject),
+  SourceRemoteDep (srcRemoteDepName),
+  SourceUnit (additionalData, sourceUnitBuild),
+  SourceUnitBuild (buildDependencies),
+  SourceUnitDependency (sourceDepLocator),
   SourceUserDefDep (srcUserDepName),
  )
-import Types (DiscoveredProjectType, projectTypeToText)
+import Types (DepType (ArchiveType), DiscoveredProjectType, projectTypeToText)
 
 data ScanCount = ScanCount
   { numProjects :: Int
@@ -102,45 +123,49 @@ instance Pretty ScanCount where
 -- * __poetry__ project in path: succeeded
 -- * __fpm__ project in path: skipped
 -- * __setuptools__ project in path: skipped
-renderScanSummary ::
-  (Has Diag.Diagnostics sig m, Has Logger sig m, Has (Lift IO) sig m) =>
-  [DiscoveredProjectScan] ->
-  -- | Resulted source unit from @analyzeVSI@
-  Result (Maybe SourceUnit) ->
-  -- | Resulted source unit from @analyzeDiscoverBinaries@
-  Result (Maybe SourceUnit) ->
-  -- | Resulted source unit from @manualSrcUnits@
-  Result (Maybe SourceUnit) ->
-  m ()
-renderScanSummary dps vsi binary manualDeps = do
-  let projects = sort dps -- consistent ordering for repeated analysis
-  let totalScanCount =
-        mconcat
-          [ getScanCount projects
-          , srcUnitToScanCount vsi
-          , srcUnitToScanCount binary
-          , srcUnitToScanCount manualDeps
-          ]
+renderScanSummary :: (Has Diag.Diagnostics sig m, Has Logger sig m, Has (Lift IO) sig m) => Severity -> AnalysisScanResult -> m ()
+renderScanSummary severity analysisResults =
+  case summarize analysisResults of
+    Nothing -> pure ()
+    Just summary -> do
+      logInfoVsep summary
+      logInfo ""
+      when (severity /= SevDebug) $ do
+        logInfo "You can pass `--debug` option to eagerly show all warning and failure messages."
 
-  when (numProjects totalScanCount > 0) $ do
-    logInfoVsep
-      [ ""
-      , "Scan Summary"
-      , "------------"
-      , pretty fullVersionDescription
-      , ""
-      , pretty totalScanCount
-      ]
-    logInfo ""
-    logInfoVsep $ itemize listSymbol summarizeProjectScan projects
-    logInfoVsep $ summarizeSrcUnit "vsi analysis" Nothing vsi
-    logInfoVsep $ summarizeSrcUnit "binary-deps analysis" (Just getBinaryIdentifier) binary
-    logInfoVsep $ summarizeSrcUnit "fossa-deps analysis" Nothing manualDeps
-    logInfo ""
-    logInfo "You can pass `--debug` option to show all warning and failure messages."
-    scanSummaryLogs <- dumpResultLogsToTempFile projects vsi binary manualDeps
-    logInfo . pretty $ "You can also view them at: " <> show scanSummaryLogs
-    logInfo "------------"
+      summaryWithWarnErrors <- dumpResultLogsToTempFile analysisResults
+      logInfo . pretty $ "You can also view analysis summary at: " <> show summaryWithWarnErrors
+      logInfo "------------"
+
+summarize :: AnalysisScanResult -> Maybe ([Doc AnsiStyle])
+summarize (AnalysisScanResult dps vsi binary manualDeps) =
+  if (numProjects totalScanCount <= 0)
+    then Nothing
+    else
+      Just $
+        [ ""
+        , "Scan Summary"
+        , "------------"
+        , pretty fullVersionDescription
+        , ""
+        , pretty totalScanCount
+        , ""
+        ]
+          <> itemize listSymbol summarizeProjectScan projects
+          <> ["-"]
+          <> summarizeSrcUnit "vsi analysis" Nothing vsi
+          <> summarizeSrcUnit "binary-deps analysis" (Just getBinaryIdentifier) binary
+          <> summarizeSrcUnit "fossa-deps file analysis" (Just getManualVendorDepsIdentifier) manualDeps
+          <> [""]
+  where
+    projects = sort dps
+    totalScanCount =
+      mconcat
+        [ getScanCount projects
+        , srcUnitToScanCount vsi
+        , srcUnitToScanCount binary
+        , srcUnitToScanCount manualDeps
+        ]
 
 listSymbol :: Doc AnsiStyle
 listSymbol = "* "
@@ -150,6 +175,37 @@ itemize symbol f = map ((symbol <>) . f)
 
 getBinaryIdentifier :: SourceUnit -> [Text]
 getBinaryIdentifier srcUnit = maybe [] (srcUserDepName <$>) (userDefinedDeps =<< additionalData srcUnit)
+
+getManualVendorDepsIdentifier :: SourceUnit -> [Text]
+getManualVendorDepsIdentifier srcUnit = refDeps ++ foundRemoteDeps ++ customDeps ++ vendorDeps
+  where
+    vendorDeps :: [Text]
+    vendorDeps =
+      withPostfix "vendor" $
+        map (locatorProject) $
+          filter (\l -> locatorFetcher l == depTypeToFetcher ArchiveType) allBuildDeps
+
+    refDeps :: [Text]
+    refDeps =
+      withPostfix "reference" $
+        map (locatorProject) $
+          filter (\l -> locatorFetcher l == depTypeToFetcher ArchiveType) allBuildDeps
+
+    allBuildDeps :: [Locator]
+    allBuildDeps = maybe [] (map sourceDepLocator . buildDependencies) (sourceUnitBuild srcUnit)
+
+    customDeps :: [Text]
+    customDeps =
+      withPostfix "custom" $
+        maybe [] (srcUserDepName <$>) (userDefinedDeps =<< additionalData srcUnit)
+
+    foundRemoteDeps :: [Text]
+    foundRemoteDeps =
+      withPostfix "remote" $
+        maybe [] (srcRemoteDepName <$>) (remoteDeps =<< additionalData srcUnit)
+
+    withPostfix :: Text -> [Text] -> [Text]
+    withPostfix bracketText = map (<> " (" <> bracketText <> ")")
 
 srcUnitToScanCount :: Result (Maybe SourceUnit) -> ScanCount
 srcUnitToScanCount (Failure _ _) = ScanCount 1 0 0 1 0
@@ -163,9 +219,11 @@ summarizeSrcUnit ::
   [Doc AnsiStyle]
 summarizeSrcUnit analysisHeader maybeGetter (Success wg (Just unit)) =
   case maybeGetter <*> Just unit of
+    Just txts ->
+      [successColorCoded wg $ (listSymbol <> analysisHeader) <> renderSucceeded wg]
+        <> itemize ("  *" <> listSymbol) pretty txts
     Nothing -> [successColorCoded wg (listSymbol <> analysisHeader <> renderSucceeded wg)]
-    Just txts -> map (\i -> successColorCoded wg (listSymbol <> analysisHeader <> pretty (" for " <> i) <> renderSucceeded wg)) txts
-summarizeSrcUnit analysisHeader _ (Failure _ _) = [failColorCoded $ annotate bold analysisHeader <> renderFailed]
+summarizeSrcUnit analysisHeader _ (Failure _ _) = [failColorCoded $ annotate bold $ listSymbol <> analysisHeader <> renderFailed]
 summarizeSrcUnit _ _ _ = []
 
 summarizeProjectScan :: DiscoveredProjectScan -> Doc AnsiStyle
@@ -207,7 +265,10 @@ renderSucceeded :: [EmittedWarn] -> Doc AnsiStyle
 renderSucceeded ew =
   if countWarnings ew == 0
     then ": succeeded"
-    else ": succeeded with " <> viaShow (countWarnings ew) <> ": warning"
+    else ": succeeded with " <> viaShow (countWarnings ew) <> plural " warning" " warnings" numWarns
+  where
+    numWarns :: Int
+    numWarns = countWarnings ew
 
 renderFailed :: Doc AnsiStyle
 renderFailed = ": failed"
@@ -228,23 +289,15 @@ countWarnings ws =
     isIgnoredErrGroup IgnoredErrGroup{} = True
     isIgnoredErrGroup _ = False
 
-dumpResultLogsToTempFile ::
-  (Has (Lift IO) sig m) =>
-  [DiscoveredProjectScan] ->
-  -- | Resulted source unit from @analyzeVSI@
-  Result (Maybe SourceUnit) ->
-  -- | Resulted source unit from @analyzeDiscoverBinaries@
-  Result (Maybe SourceUnit) ->
-  -- | Resulted source unit from @manualSrcUnits@
-  Result (Maybe SourceUnit) ->
-  m (Path Abs File)
-dumpResultLogsToTempFile projects vsi binary manualDeps = do
+dumpResultLogsToTempFile :: (Has (Lift IO) sig m) => AnalysisScanResult -> m (Path Abs File)
+dumpResultLogsToTempFile (AnalysisScanResult projects vsi binary manualDeps) = do
   let doc =
         renderStrict
           . layoutPretty defaultLayoutOptions
           . unAnnotate
           . mconcat
-          $ (mapMaybe renderDiscoveredProjectScanResult projects)
+          $ scanSummary
+            ++ (mapMaybe renderDiscoveredProjectScanResult projects)
             ++ catMaybes
               [ renderSourceUnit "vsi analysis" vsi
               , renderSourceUnit "binary-deps analysis" binary
@@ -255,6 +308,9 @@ dumpResultLogsToTempFile projects vsi binary manualDeps = do
   sendIO $ TIO.writeFile (fromAbsFile $ tmpDir </> scanSummaryFileName) doc
   pure (tmpDir </> scanSummaryFileName)
   where
+    scanSummary :: [Doc AnsiStyle]
+    scanSummary = maybeToList (vsep <$> summarize (AnalysisScanResult projects vsi binary manualDeps))
+
     renderSourceUnit :: Doc AnsiStyle -> Result (Maybe SourceUnit) -> Maybe (Doc AnsiStyle)
     renderSourceUnit header (Failure ws eg) = Just $ renderFailure ws eg $ vsep $ summarizeSrcUnit header Nothing (Failure ws eg)
     renderSourceUnit header (Success ws (Just res)) = renderSuccess ws $ vsep $ summarizeSrcUnit header Nothing (Success ws (Just res))

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -1,5 +1,6 @@
 module App.Fossa.Analyze.Types (
   AnalyzeProject (..),
+  AnalysisScanResult (..),
   AnalyzeTaskEffs,
   AnalyzeExperimentalPreferences (..),
   DiscoveredProjectScan (..),
@@ -19,6 +20,7 @@ import Effect.Exec (Exec)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
 import Path
+import Srclib.Types (SourceUnit)
 import Types (DependencyResults, DiscoveredProjectType, FoundTargets)
 
 newtype AnalyzeExperimentalPreferences = AnalyzeExperimentalPreferences
@@ -34,6 +36,13 @@ type AnalyzeTaskEffs sig m =
   , Has Debug sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
   )
+
+data AnalysisScanResult = AnalysisScanResult
+  { analyzersScanResult :: [DiscoveredProjectScan]
+  , vsiScanResult :: Result (Maybe SourceUnit)
+  , binaryDepsScanResult :: Result (Maybe SourceUnit)
+  , fossaDepsScanResult :: Result (Maybe SourceUnit)
+  }
 
 data DiscoveredProjectScan
   = SkippedDueToProvidedFilter DiscoveredProjectIdentifier

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup.hs
@@ -52,6 +52,6 @@ newtype MissingLinuxMetadata = MissingLinuxMetadata (Path Abs File)
 instance ToDiagnostic MissingLinuxMetadata where
   renderDiagnostic (MissingLinuxMetadata path) =
     vsep
-      [ "Could not infer linux package manager, and it's metadata for:"
+      [ "Could not infer linux package manager, and its metadata for:"
       , pretty . show $ path
       ]

--- a/src/App/Fossa/VSI/DynLinked/Internal/Lookup.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Lookup.hs
@@ -7,12 +7,17 @@ import App.Fossa.VSI.DynLinked.Internal.Lookup.DEB (debTactic)
 import App.Fossa.VSI.DynLinked.Internal.Lookup.RPM (rpmTactic)
 import App.Fossa.VSI.DynLinked.Types (DynamicDependency (..))
 import Control.Algebra (Has)
-import Control.Applicative ((<|>))
-import Control.Effect.Diagnostics (Diagnostics, (<||>))
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  ToDiagnostic (renderDiagnostic),
+  warn,
+  (<||>),
+ )
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Effect.Exec (Exec)
 import Path (Abs, Dir, File, Path)
+import Prettyprinter (pretty, vsep)
 
 -- | Resolve the provided file paths, which represent dynamic dependencies of a binary, into a set of @DynamicDependency@.
 dynamicDependencies ::
@@ -32,10 +37,21 @@ dynamicDependencies root files = do
 
 resolveFile :: (Has Diagnostics sig m, Has Exec sig m) => Maybe APKLookupTable -> Path Abs Dir -> Path Abs File -> m DynamicDependency
 resolveFile table root file = do
-  resolved <- rpmTactic root file <||> debTactic root file
-  case resolved <|> apkTactic table file of
-    Nothing -> pure $ fallbackTactic file
+  resolved <- rpmTactic root file <||> debTactic root file <||> pure (apkTactic table file)
+  case resolved of
     Just result -> pure result
+    Nothing -> do
+      warn $ MissingLinuxMetadata file
+      pure $ fallbackTactic file
 
 fallbackTactic :: Path Abs File -> DynamicDependency
 fallbackTactic file = DynamicDependency file Nothing
+
+newtype MissingLinuxMetadata = MissingLinuxMetadata (Path Abs File)
+
+instance ToDiagnostic MissingLinuxMetadata where
+  renderDiagnostic (MissingLinuxMetadata path) =
+    vsep
+      [ "Could not infer linux package manager, and it's metadata for:"
+      , pretty . show $ path
+      ]

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -16,7 +16,7 @@ import Codec.Archive.Zip qualified as Zip
 import Codec.Compression.BZip qualified as BZip
 import Codec.Compression.GZip qualified as GZip
 import Conduit (runConduit, runResourceT, sourceFileBS, (.|))
-import Control.Effect.Diagnostics (Diagnostics, Has, context)
+import Control.Effect.Diagnostics (Diagnostics, Has, context, fatalOnSomeException)
 import Control.Effect.Finally (Finally, onExit)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.TaskPool (TaskPool, forkTask)
@@ -75,7 +75,7 @@ selectUnarchiver file
 --
 -- If the file is not supported for extraction, results in 'Nothing'.
 withArchive' ::
-  (Has (Lift IO) sig m, Has Finally sig m) =>
+  (Has (Lift IO) sig m, Has Finally sig m, Has Diagnostics sig m) =>
   -- | Path to archive
   Path Abs File ->
   -- | Callback
@@ -87,7 +87,7 @@ withArchive' file go = traverse (\e -> withArchive e file go) (selectUnarchiver 
 -- on the temporary directory. Archive contents are removed when the callback
 -- finishes.
 withArchive ::
-  (Has (Lift IO) sig m, Has Finally sig m) =>
+  (Has (Lift IO) sig m, Has Diagnostics sig m, Has Finally sig m) =>
   -- | Archive extraction function
   (Path Abs Dir -> Path Abs File -> m ()) ->
   -- | Path to archive
@@ -95,7 +95,7 @@ withArchive ::
   -- | Callback
   (Path Abs Dir -> m c) ->
   m c
-withArchive extract file go = do
+withArchive extract file go = fatalOnSomeException "withArchive" $ do
   tmpDir <- mkTempDir (fileName file)
   extract tmpDir file
   go tmpDir

--- a/test/Discovery/ArchiveSpec.hs
+++ b/test/Discovery/ArchiveSpec.hs
@@ -16,42 +16,19 @@ import Data.Map qualified as Map
 import Data.String.Conversion (ToText (..))
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
-import Discovery.Archive (extractRpm, extractZip, withArchive)
+import Discovery.Archive (extractRpm, extractTar, extractTarBz2, extractTarGz, extractTarXz, extractZip, withArchive)
 import Discovery.Walk (WalkStep (WalkContinue), walk')
 import Effect.ReadFS (ReadFS, runReadFSIO)
 import Path (Abs, Dir, File, Path, Rel, SomeBase (Abs, Rel), mkRelDir, mkRelFile, toFilePath, (</>))
 import Path.Extra (tryMakeRelative)
 import Path.IO qualified as PIO
 import ResultUtil
-import Test.Hspec (Spec, SpecWith, describe, it, runIO, shouldBe)
+import Test.Hspec (Spec, describe, it, runIO, shouldBe)
 
 spec :: Spec
 spec = do
-  specArchiveExtractsAndCleans "extract zip archive to a temporary location" simpleZipPath
-  specArchiveExtractsAndCleans "extract tar archive to a temporary location" simpleTarPath
-  specArchiveExtractsAndCleans "extract tar.gz archive to a temporary location" simpleTarGzPath
-  specArchiveExtractsAndCleans "extract tar.xz archive to a temporary location" simpleTarXzPath
-  specArchiveExtractsAndCleans "extract tar.bz2 archive to a temporary location" simpleTarBz2Path
-
-  describe "extract el7 (xz) rpm to a temporary location" $ do
-    target <- runIO rpmCurlEl7Path
-    result <- runIO . runStack . runFinally . runDiagnostics . runReadFSIO $ withArchive extractRpm target hashFiles
-
-    it "should have extracted the correct contents" $
-      assertOnSuccess result $ \_ contents -> contents `shouldBe` rpmCurlEl7ExpectedFiles
-
-  describe "extract fc35 (zstd) rpm to a temporary location" $ do
-    target <- runIO rpmCurlFc35Path
-    result <- runIO . runStack . runFinally . runDiagnostics . runReadFSIO $ withArchive extractRpm target hashFiles
-
-    it "should have extracted the correct contents" $
-      assertOnSuccess result $ \_ contents -> contents `shouldBe` rpmCurlFc35ExpectedFiles
-
-specArchiveExtractsAndCleans :: String -> IO (Path Abs File) -> SpecWith ()
-specArchiveExtractsAndCleans msg archivePath = do
-  describe msg $ do
-    target <- runIO archivePath
-
+  describe "extract zip archive to a temporary location" $ do
+    target <- runIO simpleZipPath
     result <- runIO $
       runStack . runDiagnostics . runFinally . withArchive extractZip target $ \dir -> do
         contentA <- sendIO . TIO.readFile . toFilePath $ dir </> $(mkRelDir "simple") </> $(mkRelFile "a.txt")
@@ -66,6 +43,88 @@ specArchiveExtractsAndCleans msg archivePath = do
       assertOnSuccess result $ \_ (extractedDir, _, _) -> do
         tempDirExists <- sendIO $ PIO.doesDirExist extractedDir
         tempDirExists `shouldBe` False
+
+  describe "extract tar archive to a temporary location" $ do
+    target <- runIO simpleTarPath
+    result <- runIO $
+      runStack . runDiagnostics . runFinally . withArchive extractTar target $ \dir -> do
+        contentA <- sendIO . TIO.readFile . toFilePath $ dir </> $(mkRelDir "simple") </> $(mkRelFile "a.txt")
+        contentB <- sendIO . TIO.readFile . toFilePath $ dir </> $(mkRelDir "simple") </> $(mkRelFile "b.txt")
+        pure (dir, contentA, contentB)
+
+    it "should have extracted the correct contents" $ do
+      assertOnSuccess result $ \_ (_, _, extractedContentB) -> extractedContentB `shouldBe` expectedSimpleContentB
+      assertOnSuccess result $ \_ (_, extractedContentA, _) -> extractedContentA `shouldBe` expectedSimpleContentA
+
+    it "should have cleaned up the temporary directory" $ do
+      assertOnSuccess result $ \_ (extractedDir, _, _) -> do
+        tempDirExists <- sendIO $ PIO.doesDirExist extractedDir
+        tempDirExists `shouldBe` False
+
+  describe "extract tar.gz archive to a temporary location" $ do
+    target <- runIO simpleTarGzPath
+    result <- runIO $
+      runStack . runDiagnostics . runFinally . withArchive extractTarGz target $ \dir -> do
+        contentA <- sendIO . TIO.readFile . toFilePath $ dir </> $(mkRelDir "simple") </> $(mkRelFile "a.txt")
+        contentB <- sendIO . TIO.readFile . toFilePath $ dir </> $(mkRelDir "simple") </> $(mkRelFile "b.txt")
+        pure (dir, contentA, contentB)
+
+    it "should have extracted the correct contents" $ do
+      assertOnSuccess result $ \_ (_, _, extractedContentB) -> extractedContentB `shouldBe` expectedSimpleContentB
+      assertOnSuccess result $ \_ (_, extractedContentA, _) -> extractedContentA `shouldBe` expectedSimpleContentA
+
+    it "should have cleaned up the temporary directory" $ do
+      assertOnSuccess result $ \_ (extractedDir, _, _) -> do
+        tempDirExists <- sendIO $ PIO.doesDirExist extractedDir
+        tempDirExists `shouldBe` False
+
+  describe "extract tar.xz archive to a temporary location" $ do
+    target <- runIO simpleTarXzPath
+    result <- runIO $
+      runStack . runDiagnostics . runFinally . withArchive extractTarXz target $ \dir -> do
+        contentA <- sendIO . TIO.readFile . toFilePath $ dir </> $(mkRelDir "simple") </> $(mkRelFile "a.txt")
+        contentB <- sendIO . TIO.readFile . toFilePath $ dir </> $(mkRelDir "simple") </> $(mkRelFile "b.txt")
+        pure (dir, contentA, contentB)
+
+    it "should have extracted the correct contents" $ do
+      assertOnSuccess result $ \_ (_, _, extractedContentB) -> extractedContentB `shouldBe` expectedSimpleContentB
+      assertOnSuccess result $ \_ (_, extractedContentA, _) -> extractedContentA `shouldBe` expectedSimpleContentA
+
+    it "should have cleaned up the temporary directory" $ do
+      assertOnSuccess result $ \_ (extractedDir, _, _) -> do
+        tempDirExists <- sendIO $ PIO.doesDirExist extractedDir
+        tempDirExists `shouldBe` False
+
+  describe "extract tar.bz2 archive to a temporary location" $ do
+    target <- runIO simpleTarBz2Path
+    result <- runIO $
+      runStack . runDiagnostics . runFinally . withArchive extractTarBz2 target $ \dir -> do
+        contentA <- sendIO . TIO.readFile . toFilePath $ dir </> $(mkRelDir "simple") </> $(mkRelFile "a.txt")
+        contentB <- sendIO . TIO.readFile . toFilePath $ dir </> $(mkRelDir "simple") </> $(mkRelFile "b.txt")
+        pure (dir, contentA, contentB)
+
+    it "should have extracted the correct contents" $ do
+      assertOnSuccess result $ \_ (_, _, extractedContentB) -> extractedContentB `shouldBe` expectedSimpleContentB
+      assertOnSuccess result $ \_ (_, extractedContentA, _) -> extractedContentA `shouldBe` expectedSimpleContentA
+
+    it "should have cleaned up the temporary directory" $ do
+      assertOnSuccess result $ \_ (extractedDir, _, _) -> do
+        tempDirExists <- sendIO $ PIO.doesDirExist extractedDir
+        tempDirExists `shouldBe` False
+
+  describe "extract el7 (xz) rpm to a temporary location" $ do
+    target <- runIO rpmCurlEl7Path
+    result <- runIO . runStack . runFinally . runDiagnostics . runReadFSIO $ withArchive extractRpm target hashFiles
+
+    it "should have extracted the correct contents" $
+      assertOnSuccess result $ \_ contents -> contents `shouldBe` rpmCurlEl7ExpectedFiles
+
+  describe "extract fc35 (zstd) rpm to a temporary location" $ do
+    target <- runIO rpmCurlFc35Path
+    result <- runIO . runStack . runFinally . runDiagnostics . runReadFSIO $ withArchive extractRpm target hashFiles
+
+    it "should have extracted the correct contents" $
+      assertOnSuccess result $ \_ contents -> contents `shouldBe` rpmCurlFc35ExpectedFiles
 
 simpleZipPath :: IO (Path Abs File)
 simpleZipPath = PIO.resolveFile' "test/Discovery/testdata/simple.zip"


### PR DESCRIPTION
# Overview

This PR, 

- Emits warning when jar analysis fails
- Emits warning when dynamic linking analysis fails to retrieve linux metadata 
- Emits errors/warn emitted in vsi, binary-deps, and fossa-deps analysis
- Updates analysis scan summary to show fossa-deps dependency type
- Updates scan summary's errors/warns file, to include scan summary

## Screenshot

![CleanShot 2022-02-23 at 16 42 00@2x](https://user-images.githubusercontent.com/86321858/155429419-1b841147-0d76-40c3-83f9-892a73500fe8.png)

## Acceptance criteria

- When corrupted jar file is provided - warning is emitted
- When corrupted jar file is provided, analysis does not throw exception
- Emits warning, and errors associated with vsi, binary-deps, and fossa-deps analysis
- Scan summary show custom, remote, vendor, and reference deps for fossa-deps analysis

## Testing plan

- Relied on manual QA, and automated test. 
- For manual QA, I intentionally corrupted valid jar file, invalid/valid fossa-deps.yml and ran fossa analyze. 

```
make install-dev
fossa-dev analyze --experimental-enable-binary-discovery --output
```

## Risks

N/A

## References

Works on https://github.com/fossas/team-analysis/issues/855

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
