### PR TITLE
Don't ignore 'server' key in config file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Fossa CLI Changelog
 
+## v3.1.2
+
+- Fixes a bug which ignored the `server` field in the config file. ([#821](https://github.com/fossas/fossa-cli/pull/821))
+
 ## v3.1.1
 
 - UX: Parser error messages include call to action. ([#801](https://github.com/fossas/fossa-cli/pull/801))

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -31,7 +31,6 @@ import App.Fossa.Config.Common (
   metadataOpts,
   pathOpt,
   targetOpt,
-  validateApiKey,
   validateDir,
  )
 import App.Fossa.Config.ConfigFile (
@@ -76,7 +75,7 @@ import Effect.Exec (
  )
 import Effect.Logger (Logger, Severity (SevDebug, SevInfo), logWarn)
 import Effect.ReadFS (ReadFS)
-import Fossa.API.Types (ApiOpts (ApiOpts))
+import Fossa.API.Types (ApiOpts)
 import Options.Applicative (
   Alternative (many),
   InfoMod,
@@ -389,10 +388,8 @@ collectScanDestination maybeCfgFile envvars AnalyzeCliOpts{..} =
   if analyzeOutput
     then pure OutputStdout
     else do
-      apiKey <- validateApiKey maybeCfgFile envvars commons
-      let baseuri = optBaseUrl commons
-          apiOpts = ApiOpts baseuri apiKey
-          metaMerged = maybe analyzeMetadata (mergeFileCmdMetadata analyzeMetadata) (maybeCfgFile)
+      apiOpts <- collectApiOpts maybeCfgFile envvars commons
+      let metaMerged = maybe analyzeMetadata (mergeFileCmdMetadata analyzeMetadata) (maybeCfgFile)
       pure $ UploadScan apiOpts metaMerged
 
 collectModeOptions ::

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -31,7 +31,7 @@ module App.Fossa.Config.Common (
 ) where
 
 import App.Fossa.Config.ConfigFile (
-  ConfigFile (configApiKey, configProject, configRevision),
+  ConfigFile (configApiKey, configProject, configRevision, configServer),
   ConfigProject (configProjID),
   ConfigRevision (configBranch, configCommit),
   mergeFileCmdMetadata,
@@ -86,7 +86,7 @@ import Options.Applicative (
 import Path (Abs, Dir, Path, Rel, parseRelDir)
 import Path.IO (resolveDir')
 import Text.Megaparsec (errorBundlePretty, runParser)
-import Text.URI (URI)
+import Text.URI (URI, mkURI)
 import Types (TargetFilter)
 
 data ScanDestination
@@ -174,7 +174,8 @@ validateApiKey maybeConfigFile EnvVars{envApiKey} CommonOpts{optAPIKey} = do
 collectApiOpts :: (Has Diagnostics sig m) => Maybe ConfigFile -> EnvVars -> CommonOpts -> m ApiOpts
 collectApiOpts maybeconfig envvars globals = do
   apikey <- validateApiKey maybeconfig envvars globals
-  let baseuri = optBaseUrl globals
+  let configUri = maybeconfig >>= configServer >>= mkURI
+      baseuri = optBaseUrl globals <|> configUri
   pure $ ApiOpts baseuri apikey
 
 collectRevisionOverride :: Maybe ConfigFile -> OverrideProject -> OverrideProject

--- a/src/App/Fossa/Config/Container/Analyze.hs
+++ b/src/App/Fossa/Config/Container/Analyze.hs
@@ -10,13 +10,13 @@ module App.Fossa.Config.Container.Analyze (
 ) where
 
 import App.Fossa.Config.Common (
-  CommonOpts (optBaseUrl, optProjectName, optProjectRevision),
+  CommonOpts (optProjectName, optProjectRevision),
   ScanDestination (..),
   collectAPIMetadata,
+  collectApiOpts,
   collectRevisionOverride,
   commonOpts,
   metadataOpts,
-  validateApiKey,
  )
 import App.Fossa.Config.ConfigFile (ConfigFile)
 import App.Fossa.Config.Container.Common (
@@ -31,7 +31,6 @@ import App.Types (
 import Control.Effect.Diagnostics (Diagnostics, Has)
 import Data.Flag (Flag, flagOpt, fromFlag)
 import Data.Text (Text)
-import Fossa.API.Types (ApiOpts (ApiOpts))
 import Options.Applicative (
   CommandFields,
   Mod,
@@ -121,8 +120,6 @@ collectScanDestination maybeCfgFile envvars ContainerAnalyzeOptions{..} =
   if fromFlag NoUpload containerNoUpload
     then pure OutputStdout
     else do
-      apiKey <- validateApiKey maybeCfgFile envvars analyzeCommons
-      let baseuri = optBaseUrl analyzeCommons
-          apiOpts = ApiOpts baseuri apiKey
-          metaMerged = collectAPIMetadata maybeCfgFile containerMetadata
+      apiOpts <- collectApiOpts maybeCfgFile envvars analyzeCommons
+      let metaMerged = collectAPIMetadata maybeCfgFile containerMetadata
       pure $ UploadScan apiOpts metaMerged


### PR DESCRIPTION
# Overview

During the entrypoint refactor, we didn't include new logic that picks up the `server` from the config file.

There was also duplicated code in that area, which was a remnant of an older version of that change.

## Acceptance criteria

- `server` is not ignored, unless `--endpoint` is used.

## Testing plan

Intercept the config object by setting `FOSSA_CONFIG_DEBUG=1`, confirm that the `server` option is picked up.

## Risks

None, I audited the other config file fields to make sure this case wasn't happening for any other fields.

## Checklist

- [ ] I added tests for this PR's change (or confirmed tests are not viable).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
