### PR TITLE
Update HACKING.md

### DIFF
--- a/docs/contributing/HACKING.md
+++ b/docs/contributing/HACKING.md
@@ -52,7 +52,14 @@ You'll use this command a lot.
 
 ### Building
 
-In the base directory, run `cabal build`
+In the base directory, run `cabal build`.  if you want to build the full binary, run `./vendor_download.sh` first (requires a FOSSA-org `GITHUB_TOKEN` set in the environment).
+
+#### Note for Non-FOSSA users
+
+Currently, building the full-featured binary requires the use of external binaries fetched from closed-source repos in the FOSSA organization (`fossas`).
+If you build without these binaries, a compiler warning will be emitted.  If ghc's `-Werror` option is enabled, this will fail the build, and is therefore not enabled by default.
+
+There is no supported way for Non-FOSSA users to obtain these binaries, though we are working on a solution to allow this in the future.  As a result, **we cannot accept pull requests from any forked repository**, since those builds will fail in CI.
 
 ### Running tests
 

--- a/docs/contributing/HACKING.md
+++ b/docs/contributing/HACKING.md
@@ -59,7 +59,7 @@ In the base directory, run `cabal build`.  if you want to build the full binary,
 Currently, building the full-featured binary requires the use of external binaries fetched from closed-source repos in the FOSSA organization (`fossas`).
 If you build without these binaries, a compiler warning will be emitted.  If ghc's `-Werror` option is enabled, this will fail the build, and is therefore not enabled by default.
 
-There is no supported way for Non-FOSSA users to obtain these binaries, though we are working on a solution to allow this in the future.  As a result, **we cannot accept pull requests from any forked repository**, since those builds will fail in CI.
+There is no supported way for Non-FOSSA users to obtain these binaries, though we are working on a solution to allow this in the future.  As a result, **we cannot accept pull requests from any forked repository**, since those builds will fail in CI.  This means that outside contributions are effectively impossible until we resolve these build limitations.
 
 ### Running tests
 


### PR DESCRIPTION
Document our current limitation for fork/pull workflows and vendored binaries.

Related to #828 