### PR TITLE
Skips uploading an empty set of archives.

### DIFF
--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -25,7 +25,7 @@ import Data.Aeson (
 import Data.Aeson.Extra
 import Data.ByteString.Lazy qualified as BS
 import Data.Functor.Extra ((<$$>))
-import Data.List (intercalate, nub)
+import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -85,7 +85,10 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts = do
   when (hasNoDeps manualDeps) $ fatalText "No dependencies found in fossa-deps file"
   archiveLocators <- case maybeApiOpts of
     Nothing -> pure $ archiveNoUploadSourceUnit vendoredDependencies
-    Just apiOpts -> archiveUploadSourceUnit root apiOpts vendoredDependencies
+    Just apiOpts -> 
+      if null vendoredDependencies
+        then pure []
+        else archiveUploadSourceUnit root apiOpts vendoredDependencies
 
   let renderedPath = toText root
       referenceLocators = refToLocator <$> referencedDependencies

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -86,9 +86,9 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts = do
   archiveLocators <- case maybeApiOpts of
     Nothing -> pure $ archiveNoUploadSourceUnit vendoredDependencies
     Just apiOpts -> 
-      if null vendoredDependencies
-        then pure []
-        else archiveUploadSourceUnit root apiOpts vendoredDependencies
+      case NE.nonEmpty vendoredDependencies of
+        Just nonEmptyVendoredDeps -> NE.toList <$> archiveUploadSourceUnit root apiOpts nonEmptyVendoredDeps
+        Nothing -> pure []
 
   let renderedPath = toText root
       referenceLocators = refToLocator <$> referencedDependencies

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -85,7 +85,7 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts = do
   when (hasNoDeps manualDeps) $ fatalText "No dependencies found in fossa-deps file"
   archiveLocators <- case maybeApiOpts of
     Nothing -> pure $ archiveNoUploadSourceUnit vendoredDependencies
-    Just apiOpts -> 
+    Just apiOpts ->
       case NE.nonEmpty vendoredDependencies of
         Just nonEmptyVendoredDeps -> NE.toList <$> archiveUploadSourceUnit root apiOpts nonEmptyVendoredDeps
         Nothing -> pure []


### PR DESCRIPTION
# Overview

A user is seeing that their project is unable to use fossa-deps.json when they only have referenced-dependencies. They are getting a 443 and the error “archives must be a non-empty array” which corresponds to the CLI trying to queue an empty array of archive deps even though the user never specifies any vendored-dependencies.

The user reported that they had no issues on CLI v2.15.6 but had issues with v3.1.2. I validated that both versions no longer work which leads me to believe this is related to a change in the server response.

Note: this issue only impacts users uploading dependency graphs. Running fossa analyze -o succeeds because the build queue step is skipped

## Acceptance criteria

- The CLI no longer attempts to queue empty archive arrays
- A user can specify only referenced-dependencies in the fossa-deps file and fossa analyze will succeed.

## Testing plan

Tested on a local project with the following `fossa-deps.yml`: 

```yaml
referenced-dependencies:
- name: Django
  version: 1.0.0
  type: pypi
```

Before the change there was an error:

```
    Error

      An error occurred when accessing the FOSSA API.

      Error message from API:

          archives must be a non-empty array
```

After the change there was none.

Also tested with a non-empty `vendored-dependencies`

## Risks

This bug comes from coordination with the server.  This doesn't address any other future errors we may get.

This code is hard to test, so right now there are no additional tests.  The change should be small enough that that is acceptable.  There are plans to make this easier in the future.

## References

None

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
