### PR TITLE
Feat/cocoapods declared license scanning

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -364,7 +364,7 @@ library
     Strategy.Ruby.BundleShow
     Strategy.Ruby.Errors
     Strategy.Ruby.GemfileLock
-    Strategy.Ruby.Gemspec
+    Strategy.Ruby.Parse
     Strategy.Scala
     Strategy.Swift.Errors
     Strategy.Swift.PackageResolved
@@ -484,7 +484,7 @@ test-suite unit-tests
     RPM.SpecFileSpec
     Ruby.BundleShowSpec
     Ruby.GemfileLockSpec
-    Ruby.GemspecSpec
+    Ruby.ParseSpec
     Swift.PackageResolvedSpec
     Swift.PackageSwiftSpec
     Swift.Xcode.PbxprojParserSpec

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -422,6 +422,7 @@ test-suite unit-tests
     Cargo.MetadataSpec
     Carthage.CarthageSpec
     Clojure.ClojureSpec
+    Cocoapods.CocoapodsSpec
     Cocoapods.PodfileLockSpec
     Cocoapods.PodfileSpec
     Composer.ComposerJsonSpec

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -51,6 +51,7 @@ import Path (Abs, Dir, Path)
 import Path.IO qualified as PIO
 import Strategy.Bundler qualified as Bundler
 import Strategy.Cargo qualified as Cargo
+import Strategy.Cocoapods qualified as Cocaopods
 import Strategy.Composer qualified as Composer
 import Strategy.Maven qualified as Maven
 import Strategy.Node qualified as Node
@@ -92,6 +93,7 @@ runAll basedir = do
   single Cargo.discover
   single Node.discover
   single Bundler.discover
+  single Cocaopods.discover
   where
     single f = withDiscoveredProjects f basedir runSingle
 

--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -7,7 +7,7 @@ module Discovery.Walk (
   -- * Helpers
   fileName,
   findFileNamed,
-) where
+findFilesMatchingGlob) where
 
 import Control.Carrier.Writer.Church
 import Control.Effect.Diagnostics
@@ -22,6 +22,7 @@ import Data.String.Conversion (toString)
 import Data.Text (Text)
 import Effect.ReadFS
 import Path
+import qualified Data.Glob as Glob
 
 data WalkStep
   = -- | Continue walking subdirectories
@@ -80,6 +81,9 @@ fileName = toFilePath . filename
 
 findFileNamed :: String -> [Path a File] -> Maybe (Path a File)
 findFileNamed name = find (\f -> fileName f == name)
+
+findFilesMatchingGlob :: Glob.Glob a -> [Path a File] -> [Path a File]
+findFilesMatchingGlob g = filter (`Glob.matches` g)
 
 -------------- Stolen from path-io; adapted to our own ReadFS effect
 

--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -7,7 +7,8 @@ module Discovery.Walk (
   -- * Helpers
   fileName,
   findFileNamed,
-findFilesMatchingGlob) where
+  findFilesMatchingGlob,
+) where
 
 import Control.Carrier.Writer.Church
 import Control.Effect.Diagnostics
@@ -15,6 +16,7 @@ import Control.Monad.Trans
 import Control.Monad.Trans.Maybe
 import Data.Foldable (find)
 import Data.Functor (void)
+import Data.Glob qualified as Glob
 import Data.List ((\\))
 import Data.Maybe (mapMaybe)
 import Data.Set qualified as Set
@@ -22,7 +24,6 @@ import Data.String.Conversion (toString)
 import Data.Text (Text)
 import Effect.ReadFS
 import Path
-import qualified Data.Glob as Glob
 
 data WalkStep
   = -- | Continue walking subdirectories

--- a/src/Strategy/Bundler.hs
+++ b/src/Strategy/Bundler.hs
@@ -18,13 +18,14 @@ import Control.Effect.Diagnostics (
  )
 import Control.Effect.Diagnostics qualified as Diag
 import Data.Aeson (ToJSON)
-import Data.Glob as Glob (matches, toGlob, (</>))
+import Data.Glob as Glob (toGlob, (</>))
 import Data.Text (isSuffixOf)
 import Diag.Common (AllDirectDeps (AllDirectDeps), MissingEdges (MissingEdges))
 import Discovery.Walk (
   WalkStep (WalkContinue),
   findFileNamed,
-  walk', findFilesMatchingGlob
+  findFilesMatchingGlob,
+  walk',
  )
 import Effect.Exec (Exec, Has)
 import Effect.ReadFS (ReadFS, readContentsParser)
@@ -35,7 +36,7 @@ import Strategy.Ruby.Errors (
   BundlerMissingLockFile (..),
  )
 import Strategy.Ruby.GemfileLock qualified as GemfileLock
-import Strategy.Ruby.Gemspec (Assignment (Assignment, label, value), readAssignments, rubyLicenseValuesP)
+import Strategy.Ruby.Parse (Assignment (Assignment, label, value), gemspecLicenseValuesP, readAssignments)
 import Types (
   DependencyResults (..),
   DiscoveredProject (..),
@@ -89,7 +90,7 @@ instance LicenseAnalyzeProject BundlerProject where
 
 findLicenses :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m [LicenseResult]
 findLicenses gemspecPath = do
-  assignments <- readContentsParser (readAssignments rubyLicenseValuesP) gemspecPath
+  assignments <- readContentsParser (readAssignments gemspecLicenseValuesP) gemspecPath
   let licenses = foldMap value . filter isLicenseKey $ assignments
 
   -- license keys are recommended to be SPDX, but there isn't any requirement:

--- a/src/Strategy/Bundler.hs
+++ b/src/Strategy/Bundler.hs
@@ -24,7 +24,7 @@ import Diag.Common (AllDirectDeps (AllDirectDeps), MissingEdges (MissingEdges))
 import Discovery.Walk (
   WalkStep (WalkContinue),
   findFileNamed,
-  walk',
+  walk', findFilesMatchingGlob
  )
 import Effect.Exec (Exec, Has)
 import Effect.ReadFS (ReadFS, readContentsParser)
@@ -56,7 +56,7 @@ findProjects = walk' $ \dir _ files -> do
   let maybeGemfile = findFileNamed "Gemfile" files
       gemfileLock = findFileNamed "Gemfile.lock" files
       -- Bundler globs for *.gemspec files, so collect all of them for analysis.
-      gemSpecFiles = filter (`Glob.matches` (Glob.toGlob dir </> "*.gemspec")) files
+      gemSpecFiles = findFilesMatchingGlob (Glob.toGlob dir </> "*.gemspec") files
 
   case maybeGemfile of
     Nothing -> pure ([], WalkContinue)

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -11,11 +11,13 @@ import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context, errCtx, warnOnErr, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
 import Data.Aeson (ToJSON)
+import Data.Glob qualified as Glob
 import Diag.Common (MissingDeepDeps (MissingDeepDeps), MissingEdges (MissingEdges))
 import Discovery.Walk (
   WalkStep (WalkContinue),
   findFileNamed,
-  walk', findFilesMatchingGlob
+  findFilesMatchingGlob,
+  walk',
  )
 import Effect.ReadFS (Has, ReadFS)
 import GHC.Generics (Generic)
@@ -29,7 +31,6 @@ import Types (
   DiscoveredProjectType (CocoapodsProjectType),
   GraphBreadth (Complete, Partial),
  )
-import qualified Data.Glob as Glob
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject CocoapodsProject]
 discover dir = context "Cocoapods" $ do

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -7,11 +7,14 @@ module Strategy.Cocoapods (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
+import App.Pathfinder.Types (LicenseAnalyzeProject, licenseAnalyzeProject)
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context, errCtx, warnOnErr, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
 import Data.Aeson (ToJSON)
 import Data.Glob qualified as Glob
+import Data.List (find)
+import Data.Text (isSuffixOf)
 import Diag.Common (MissingDeepDeps (MissingDeepDeps), MissingEdges (MissingEdges))
 import Discovery.Walk (
   WalkStep (WalkContinue),
@@ -19,18 +22,24 @@ import Discovery.Walk (
   findFilesMatchingGlob,
   walk',
  )
-import Effect.ReadFS (Has, ReadFS)
+import Effect.ReadFS (Has, ReadFS, readContentsParser)
 import GHC.Generics (Generic)
-import Path (Abs, Dir, File, Path)
+import Path (Abs, Dir, File, Path, toFilePath)
 import Strategy.Cocoapods.Errors (MissingPodLockFile (MissingPodLockFile))
 import Strategy.Cocoapods.Podfile qualified as Podfile
 import Strategy.Cocoapods.PodfileLock qualified as PodfileLock
+import Strategy.Ruby.Parse (Assignment (Assignment, label, value), PodSpecAssignmentValue (PodspecDict, PodspecStr), Symbol (Symbol), findBySymbol, podspecAssignmentValuesP, readAssignments)
 import Types (
   DependencyResults (..),
   DiscoveredProject (..),
   DiscoveredProjectType (CocoapodsProjectType),
   GraphBreadth (Complete, Partial),
+  License (License),
+  LicenseResult (LicenseResult, licenseFile, licensesFound),
+  LicenseType (UnknownType),
  )
+import Data.Maybe (fromMaybe)
+import Data.List.Extra (singleton)
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject CocoapodsProject]
 discover dir = context "Cocoapods" $ do
@@ -67,6 +76,25 @@ instance ToJSON CocoapodsProject
 
 instance AnalyzeProject CocoapodsProject where
   analyzeProject _ = getDeps
+
+instance LicenseAnalyzeProject CocoapodsProject where
+  licenseAnalyzeProject = traverse readLicense . cocoaPodsSpecFiles
+
+-- |For now, if the 'license' assignment statement is a dictionary this
+-- code only extracts the value in the `:type` key. It also only looks at
+-- the first `license` assignment it finds in the spec file.
+readLicense :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m LicenseResult
+readLicense specFile = do
+  assignments <- readContentsParser (readAssignments podspecAssignmentValuesP) specFile
+  let maybeLicense = do
+        licenseAssignment <- value <$> find (("license" `isSuffixOf`) . label) assignments
+        case licenseAssignment of
+          PodspecStr s -> Just $ License UnknownType s
+          PodspecDict d -> Just . License UnknownType . snd =<< findBySymbol (Symbol "type") d
+  pure $ LicenseResult
+    { licenseFile = toFilePath specFile
+    , licensesFound = maybe [] singleton maybeLicense
+    }
 
 mkProject :: CocoapodsProject -> DiscoveredProject CocoapodsProject
 mkProject project =

--- a/src/Strategy/Ruby/Parse.hs
+++ b/src/Strategy/Ruby/Parse.hs
@@ -49,7 +49,8 @@ betweenDelim (d1, d2) =
       )
   where
     -- only the close delimiter can stop parsing, so only check
-    -- for escaped versions of that.
+    -- for escaped versions of that. The intent here is to consume the
+    -- escaped ending delimiter before 'between' sees it and stops parsing.
     delimEscape = string $ "\\" <> toText d2
 
 -- |This is a parser for a ruby string literal. The strings it parses could look

--- a/src/Strategy/Ruby/Parse.hs
+++ b/src/Strategy/Ruby/Parse.hs
@@ -9,11 +9,15 @@ module Strategy.Ruby.Parse (
   Symbol (..),
   parseRubySymbol,
   parseRubyDict,
+  PodSpecAssignmentValue (..),
+  podspecAssignmentValuesP,
+  findBySymbol,
 ) where
 
 import Control.Applicative ((<|>))
 import Data.Char (isSpace)
 import Data.Functor (($>))
+import Data.List (find)
 import Data.List.Extra (singleton)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
@@ -169,6 +173,17 @@ parseRubyDict rhs = between (char '{') (char '}') (sepBy keyValParse $ char ',')
       (,)
         <$> lexeme parseRubySymbol
         <*> (lexeme (string "=>") *> lexeme rhs)
+
+data PodSpecAssignmentValue
+  = PodspecStr Text
+  | PodspecDict [(Symbol, Text)]
+
+findBySymbol :: Symbol -> [(Symbol, Text)] -> Maybe (Symbol, Text)
+findBySymbol sym = find ((== sym) . fst)
+
+podspecAssignmentValuesP :: Parser PodSpecAssignmentValue
+podspecAssignmentValuesP =
+  (PodspecStr <$> rubyString) <|> (PodspecDict <$> parseRubyDict rubyString)
 
 -- |Ruby has a special syntax for making an array of strings that looks like
 -- these examples:

--- a/test/Cocoapods/CocoapodsSpec.hs
+++ b/test/Cocoapods/CocoapodsSpec.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Cocoapods.CocoapodsSpec (spec) where
+
+import App.Pathfinder.Types (LicenseAnalyzeProject (licenseAnalyzeProject))
+import Data.Text (Text)
+import Path (Abs, Dir, File, Path, mkRelDir, mkRelFile, toFilePath, (</>))
+import Path.IO (getCurrentDir)
+import Strategy.Cocoapods (CocoapodsProject (..))
+import Test.Effect (it', shouldBe')
+import Test.Hspec (Spec, describe, runIO)
+import Types (
+  License (License),
+  LicenseResult (..),
+  LicenseType (UnknownType),
+ )
+
+mkCocoapodsProject :: Path Abs Dir -> Path Abs File -> CocoapodsProject
+mkCocoapodsProject baseDir path =
+  CocoapodsProject
+    { cocoapodsPodfile = Nothing
+    , cocoapodsPodfileLock = Nothing
+    , cocoapodsDir = baseDir
+    , cocoaPodsSpecFiles = [path]
+    }
+
+expectedLicenseResult :: Path Abs File -> Text -> LicenseResult
+expectedLicenseResult specFile licenseName =
+  LicenseResult
+    { licenseFile = toFilePath specFile
+    , licensesFound = [License UnknownType licenseName]
+    }
+
+licenseScanSpec :: Spec
+licenseScanSpec = do
+  currDir <- runIO getCurrentDir
+  let specDir = currDir </> $(mkRelDir "test/cocoapods/testdata")
+  describe "Cocoapods podspec file declared license scanning" $ do
+    it' "Can extract a string literal license" $ do
+      let specFile = specDir </> $(mkRelFile "stringLicense.podspec")
+          project = mkCocoapodsProject specDir specFile
+      res <- licenseAnalyzeProject project
+      res `shouldBe'` [expectedLicenseResult specFile "MIT"]
+    it' "Can extract a license from a dictionary" $ do
+      let specFile = specDir </> $(mkRelFile "dictLicense.podspec")
+          project = mkCocoapodsProject specDir specFile
+      res <- licenseAnalyzeProject project
+      res `shouldBe'` [expectedLicenseResult specFile "GPL"]
+
+spec :: Spec
+spec = licenseScanSpec

--- a/test/Cocoapods/testdata/dictLicense.podspec
+++ b/test/Cocoapods/testdata/dictLicense.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name             = 'foo'
+  s.version          = '0.0.0'
+  s.summary          = 'fake'
+  s.homepage         = 'https://foo.bar'
+  s.license          = {:type => "GPL",
+                        :file => "LICENSE.txt",
+                        :text => "<license text>"}
+  s.author           = { 'foo' => 'bar' }
+  s.source           = { :git => 'https://github.com', :tag => s.version.to_s }
+  s.platform     = :ios, '0'
+
+  s.source_files = 'src/'
+  s.public_header_files = 'include/'
+  s.resource_bundles = {
+    'Resource1' => ['assets/*']
+  }
+end

--- a/test/Cocoapods/testdata/stringLicense.podspec
+++ b/test/Cocoapods/testdata/stringLicense.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name             = 'foo'
+  s.version          = '0.0.0'
+  s.summary          = 'fake'
+  s.homepage         = 'https://foo.bar'
+  s.license          = 'MIT'
+  s.author           = { 'foo' => 'bar' }
+  s.source           = { :git => 'https://github.com', :tag => s.version.to_s }
+  s.platform     = :ios, '0'
+
+  s.source_files = 'src/'
+  s.public_header_files = 'include/'
+  s.resource_bundles = {
+    'Resource1' => ['assets/*']
+  }
+end

--- a/test/Cocoapods/testdata/stringLicense.podspec
+++ b/test/Cocoapods/testdata/stringLicense.podspec
@@ -3,6 +3,8 @@ Pod::Spec.new do |s|
   s.version          = '0.0.0'
   s.summary          = 'fake'
   s.homepage         = 'https://foo.bar'
+  # This next license line should be skipped
+  # s.license          = 'LGPL'
   s.license          = 'MIT'
   s.author           = { 'foo' => 'bar' }
   s.source           = { :git => 'https://github.com', :tag => s.version.to_s }

--- a/test/Ruby/ParseSpec.hs
+++ b/test/Ruby/ParseSpec.hs
@@ -78,6 +78,8 @@ symbolParseSpec =
   describe "Parsing ruby symbols" $ do
     it "Can parse a symbol " $
       parseRubySymbol `shouldParse` ":he1l_o" `to` Symbol "he1l_o"
+    it "Stops when a fat arrow is on the end of a simple symbol" $
+      parseRubySymbol `shouldParse` ":foo=>" `to` Symbol "foo"
     it "Can parse a symbol made from a string literal with '\"'" $
       parseRubySymbol `shouldParse` ":\"f\\\"o o\"" `to` Symbol "f\\\"o o"
     it "Can parse a symbol made from a string literal with \"'\"" $
@@ -103,7 +105,7 @@ assignmentParseSpec =
 
 -- TODO: Parse when there isn't a space between the fat arrow and the key/value
 multiKeyDict :: Text
-multiKeyDict = "{ :key => \"val\", :\"key\" => \"hello\"}"
+multiKeyDict = "{ :key=> \"val\", :\"key\" => \"hello\"}"
 
 expectedMultiKeyDict :: [(Symbol, Text)]
 expectedMultiKeyDict =

--- a/test/Ruby/ParseSpec.hs
+++ b/test/Ruby/ParseSpec.hs
@@ -51,8 +51,17 @@ stringParseSpec =
 rubyStringArray :: Text
 rubyStringArray = "[ \"hello\",\"world\" ,\t\"foo\",\"bar\"]"
 
+commentedRubyStringArray :: Text
+commentedRubyStringArray = "[ #cmt\n\"hello\"#cmt\n,\"world\" ,\t\"foo\",\"bar\"]"
+
 rubyWordArray :: Text
 rubyWordArray = "%w( hello world \t foo \nbar)"
+
+commentedRubyWordArray :: Text
+commentedRubyWordArray = "%w( hello #comment world \t foo \nbar)"
+
+commentExpectedArray :: [Text]
+commentExpectedArray = ["hello", "#comment", "world", "foo", "bar"]
 
 expectedArray :: [Text]
 expectedArray = ["hello", "world", "foo", "bar"]
@@ -68,8 +77,12 @@ arrayParseSpec =
   describe "Parsing arrays of items in ruby" $ do
     it "Can parse an array of strings" $
       parseRubyArray rubyString `shouldParse` rubyStringArray `to` expectedArray
+    it "Word arrays should treat interspersed comments as words" $
+      parseRubyArray rubyString `shouldParse` commentedRubyStringArray `to` expectedArray
     it "Can parse an array of words" $
       parseRubyWordsArray `shouldParse` rubyWordArray `to` expectedArray
+    it "Comments in word arrays are treated as words" $
+      parseRubyWordsArray `shouldParse` commentedRubyWordArray `to` commentExpectedArray
     it "Can parse an array of words with escaped ending delimiter" $
       parseRubyWordsArray `shouldParse` escapedRubyWordArray `to` escapedExpectedArray
 
@@ -107,6 +120,9 @@ assignmentParseSpec =
 multiKeyDict :: Text
 multiKeyDict = "{ :key=> \"val\", :\"key\" => \"hello\"}"
 
+commentedMultiKeyDict :: Text
+commentedMultiKeyDict = "{ :key=> #cmt\n\"val\", #cmt\n :\"key\" => \"hello\" #cmt\n}"
+
 expectedMultiKeyDict :: [(Symbol, Text)]
 expectedMultiKeyDict =
   [ (Symbol "key", "val")
@@ -120,6 +136,8 @@ dictLiteralParseSpec =
       parseRubyDict rubyString `shouldParse` "{ :key => \"val\"}" `to` [(Symbol "key", "val")]
     it "Parses a dictionary with a several items" $
       parseRubyDict rubyString `shouldParse` multiKeyDict `to` expectedMultiKeyDict
+    it "Parses a dictionary with interspersed comments" $
+      parseRubyDict rubyString `shouldParse` commentedMultiKeyDict `to` expectedMultiKeyDict
 
 spec :: Spec
 spec = context "Ruby GemSpec tests" $ do

--- a/test/Ruby/ParseSpec.hs
+++ b/test/Ruby/ParseSpec.hs
@@ -1,10 +1,10 @@
-module Ruby.GemspecSpec (spec) where
+module Ruby.ParseSpec (spec) where
 
 import Data.Char (isSeparator)
 import Data.Foldable (for_)
 import Data.String.Conversion (toString)
 import Data.Text (Text)
-import Strategy.Ruby.Gemspec (Assignment (Assignment), parseRubyArray, parseRubyAssignment, parseRubyWordsArray, rubyString)
+import Strategy.Ruby.Parse (Assignment (Assignment), Symbol (Symbol), parseRubyArray, parseRubyAssignment, parseRubySymbol, parseRubyWordsArray, rubyString)
 import Test.Hspec (Spec, context, describe, it, shouldBe)
 import Text.Megaparsec (MonadParsec (eof), ParseErrorBundle, Parsec, runParser, takeWhile1P)
 
@@ -73,6 +73,16 @@ arrayParseSpec =
     it "Can parse an array of words with escaped ending delimiter" $
       parseRubyWordsArray `shouldParse` escapedRubyWordArray `to` escapedExpectedArray
 
+symbolParseSpec :: Spec
+symbolParseSpec =
+  describe "Parsing ruby symbols" $ do
+    it "Can parse a symbol " $
+      parseRubySymbol `shouldParse` ":he1l_o" `to` Symbol "he1l_o"
+    it "Can parse a symbol made from a string literal with '\"'" $
+      parseRubySymbol `shouldParse` ":\"f\\\"o o\"" `to` Symbol "f\\\"o o"
+    it "Can parse a symbol made from a string literal with \"'\"" $
+      parseRubySymbol `shouldParse` ":\'f\\'o o\'" `to` Symbol "f\\'o o"
+
 assignmentParseSpec :: Spec
 assignmentParseSpec =
   describe "Ruby assignment parsing test" $ do
@@ -95,3 +105,4 @@ spec = context "Ruby GemSpec tests" $ do
   stringParseSpec
   assignmentParseSpec
   arrayParseSpec
+  symbolParseSpec


### PR DESCRIPTION
# Overview

_Provide an overview of this change. Describe the intent of this change, and how it implements that intent._

This changes implements and adds support for declared license scanning in cocaopods projects. 

_What is this PR trying to accomplish?_

* Discovery should find a podspec file in a cocoapods project directory
* The parser should be able to find license strings within the podspec file and report them out in pathfinder.

## Testing plan

I used unit tests. 

I ran manual tests against a set of about 60 cocoapods projects and found the correct licenses for all the podspecs that had a string literal as a license (one project didn't).

## Risks

Many of the cocoapods projects didn't have a podspec in the same directory as the `Podfile` and `Podfile.lock`. I describe these cases [here](https://github.com/fossas/team-analysis/wiki/Cocoapods-Gemspec-Declared-License-Scanning#cocoapods-notes). I don't think this is a risk for this PR but I think we should be aware of it going forward. 

## References

[Documentation on testing](https://github.com/fossas/team-analysis/wiki/Cocoapods-Gemspec-Declared-License-Scanning#cocoapods-notes)

Closes ANE-102.

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
