### PR TITLE
Adds release docs

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -41,3 +41,6 @@ functions with `hspec` is a nightmare.  In short, `hspec` is `IO`-only, and `fus
 monads (not really, but it does work similarly).  To make this easier for us, we created the `Test.Effect` module,
 and use that to mimic `hspec` for an effectful system.  [More details can be found here.](testing-with-effects.md)
 
+## Releases
+
+We have a release process that manages building our archives and updating our release notes.  [Read more about our releases here](releases.md).

--- a/docs/contributing/releases.md
+++ b/docs/contributing/releases.md
@@ -5,9 +5,9 @@ So you've made a change that you want to get out to users.  Great!  Let's get th
 We'll assume that you want to release all changes currently on `master`.  You should not release anything from another branch.
 
 1. First, make sure that you update the release notes.
-    a. Create a PR that updates the [Changelog.md](/Changelog.md).
-    b. Rename the "Unreleased" section and to the next version, incrementing the version number as appropriate.
-    c. Make sure that change makes it to the `master` branch before continuing.
+    1. Create a PR that updates the [Changelog.md](/Changelog.md).
+    2. Rename the "Unreleased" section and to the next version, incrementing the version number as appropriate.
+    3. Make sure that change makes it to the `master` branch before continuing.
 2. Ensure that your local master branch is up to date and then create a _tag_ for the new release.
     The commands would look something like the following.
     ```shell

--- a/docs/contributing/releases.md
+++ b/docs/contributing/releases.md
@@ -1,0 +1,23 @@
+# Releases
+
+So you've made a change that you want to get out to users.  Great!  Let's get that released!
+
+We'll assume that you want to release all changes currently on `master`.  You should not release anything from another branch.
+
+1. First, make sure that you update the release notes.
+    a. Create a PR that updates the [Changelog.md](/Changelog.md).
+    b. Rename the "Unreleased" section and to the next version, incrementing the version number as appropriate.
+    c. Make sure that change makes it to the `master` branch before continuing.
+2. Ensure that your local master branch is up to date and then create a _tag_ for the new release.
+    The commands would look something like the following.
+    ```shell
+    git checkout master
+    git pull origin
+
+    git tag -a vX.Y.Z -m "Releases vX.Y.Z"
+    git push origin vX.Y.Z
+    ```
+    Replace `vX.Y.Z` with your version number, such as `v3.1.4`.  The tag _must_ start with `v`.
+3. GitHub Actions will take the tag and run some tests before generating a draft release which can be found on the [releases page](https://github.com/fossas/fossa-cli/releases).
+4. If nothing has changed to dissuade you it's time to publish.  Edit the draft release and hit "publish" at the bottom.  You should not need to change anything else about the release.
+5. Inform our users!

--- a/docs/contributing/releases.md
+++ b/docs/contributing/releases.md
@@ -5,7 +5,7 @@ So you've made a change that you want to get out to users.  Great!  Let's get th
 We'll assume that you want to release all changes currently on `master`.  You should not release anything from another branch.
 
 1. First, make sure that you update the release notes.
-    1. Create a PR that updates the [Changelog.md](/Changelog.md).
+    1. Create a PR that updates the [Changelog.md](./../../Changelog.md).
     2. Rename the "Unreleased" section and to the next version, incrementing the version number as appropriate.
     3. Make sure that change makes it to the `master` branch before continuing.
 2. Ensure that your local master branch is up to date and then create a _tag_ for the new release.
@@ -20,6 +20,6 @@ We'll assume that you want to release all changes currently on `master`.  You sh
     Replace `vX.Y.Z` with your version number, such as `v3.1.4`.  The tag _must_ start with `v`.
 3. GitHub Actions will take the tag and run some tests before generating a draft release which can be found on the [releases page](https://github.com/fossas/fossa-cli/releases).
 4. If nothing has changed to dissuade you it's time to publish.
-    1. Add the notes for this release from [Changelog.md](/Changelog.md) to the release description.
+    1. Add the notes for this release from [Changelog.md](./../../Changelog.md) to the release description.
     2. Hit "publish" at the bottom.
 5. Inform our users!

--- a/docs/contributing/releases.md
+++ b/docs/contributing/releases.md
@@ -19,5 +19,7 @@ We'll assume that you want to release all changes currently on `master`.  You sh
     ```
     Replace `vX.Y.Z` with your version number, such as `v3.1.4`.  The tag _must_ start with `v`.
 3. GitHub Actions will take the tag and run some tests before generating a draft release which can be found on the [releases page](https://github.com/fossas/fossa-cli/releases).
-4. If nothing has changed to dissuade you it's time to publish.  Edit the draft release and hit "publish" at the bottom.  You should not need to change anything else about the release.
+4. If nothing has changed to dissuade you it's time to publish.
+    1. Add the notes for this release from [Changelog.md](/Changelog.md) to the release description.
+    2. Hit "publish" at the bottom.
 5. Inform our users!


### PR DESCRIPTION
# Overview

Adds docs about our release process.

## Acceptance criteria

- The release process should be sufficiently described such that a novice engineer on the project can publish a new release.

## Testing plan

Went through the steps with v3.1.4

## Risks

None.

## References

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
