### PR TITLE
[ANE-23] Query for CLI-side license scanning

### DIFF
--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -99,7 +99,7 @@ waitForMonorepoScan ::
   m ()
 waitForMonorepoScan apiOpts revision cancelFlag = do
   checkForTimeout cancelFlag
-  Fossa.Organization orgId _ <- Fossa.getOrganization apiOpts
+  orgId <- Fossa.organizationId <$> Fossa.getOrganization apiOpts
   let locator = VPSCore.createLocator (projectName revision) orgId
 
   logSticky' "[ Getting latest scan ID ]"

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -95,7 +95,7 @@ archiveUploadSourceUnit baseDir apiOpts vendoredDeps = do
 
   -- The organizationID is needed to prefix each locator name. The FOSSA API automatically prefixes the locator when queuing the build
   -- but not when reading from a source unit.
-  Fossa.Organization orgId _ <- Fossa.getOrganization apiOpts
+  orgId <- Fossa.organizationId <$> Fossa.getOrganization apiOpts
 
   let updateArcName :: Text -> Archive -> Archive
       updateArcName updateText arc = arc{archiveName = updateText <> "/" <> archiveName arc}

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -512,6 +512,7 @@ getAttributionRaw apiOpts ProjectRevision{..} = fossaReq $ do
 data Organization = Organization
   { organizationId :: Int
   , orgUsesSAML :: Bool
+  , orgDoLocalLicenseScan :: Bool
   }
   deriving (Eq, Ord, Show)
 
@@ -519,6 +520,7 @@ instance FromJSON Organization where
   parseJSON = withObject "Organization" $ \obj ->
     Organization <$> obj .: "organizationId"
       <*> obj .:? "usesSAML" .!= False
+      <*> obj .:? "doLocalLicenseScan" .!= False
 
 organizationEndpoint :: Url scheme -> Url scheme
 organizationEndpoint baseurl = baseurl /: "api" /: "cli" /: "organization"

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -520,7 +520,7 @@ instance FromJSON Organization where
   parseJSON = withObject "Organization" $ \obj ->
     Organization <$> obj .: "organizationId"
       <*> obj .:? "usesSAML" .!= False
-      <*> obj .:? "doLocalLicenseScan" .!= False
+      <*> obj .:? "supportsCliLicenseScanning" .!= False
 
 organizationEndpoint :: Url scheme -> Url scheme
 organizationEndpoint baseurl = baseurl /: "api" /: "cli" /: "organization"

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -303,7 +303,7 @@ getProject ::
 getProject apiopts ProjectRevision{..} = fossaReq $ do
   (baseurl, baseopts) <- useApiOpts apiopts
 
-  Organization orgid _ <- getOrganization apiopts
+  orgid <- organizationId <$> getOrganization apiopts
 
   let endpoint = projectEndpoint baseurl orgid $ Locator "custom" projectName Nothing
 
@@ -362,7 +362,7 @@ getLatestBuild ::
 getLatestBuild apiOpts ProjectRevision{..} = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
-  Organization orgId _ <- getOrganization apiOpts
+  orgId <- organizationId <$> getOrganization apiOpts
 
   response <- req GET (buildsEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse baseOpts
   pure (responseBody response)
@@ -464,7 +464,7 @@ getIssues ::
 getIssues apiOpts ProjectRevision{..} = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
-  Organization orgId _ <- getOrganization apiOpts
+  orgId <- organizationId <$> getOrganization apiOpts
   response <- req GET (issuesEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse baseOpts
   pure (responseBody response)
 
@@ -486,7 +486,7 @@ getAttribution apiOpts ProjectRevision{..} = fossaReq $ do
           <> "includeDeepDependencies" =: True
           <> "includeHashAndVersionData" =: True
           <> "includeDownloadUrl" =: True
-  Organization orgId _ <- getOrganization apiOpts
+  orgId <- organizationId <$> getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse opts
   pure (responseBody response)
 
@@ -503,7 +503,7 @@ getAttributionRaw apiOpts ProjectRevision{..} = fossaReq $ do
           <> "includeDeepDependencies" =: True
           <> "includeHashAndVersionData" =: True
           <> "includeDownloadUrl" =: True
-  Organization orgId _ <- getOrganization apiOpts
+  orgId <- organizationId <$> getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse opts
   pure (responseBody response)
 
@@ -676,7 +676,7 @@ vsiCreateScan :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> Proj
 vsiCreateScan apiOpts ProjectRevision{..} = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
-  Organization orgId _ <- getOrganization apiOpts
+  orgId <- organizationId <$> getOrganization apiOpts
   let projectID = renderLocator $ Locator "custom" projectName Nothing
   let reqBody = VSICreateScanRequestBody orgId projectRevision projectID
 

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -40,7 +40,7 @@ spec = do
   describe "SAML URL builder" $ do
     it "should render simple locators" $ do
       let locator = Locator "fetcher123" "project123" $ Just "revision123"
-          org = Just $ Organization 1 True
+          org = Just $ Organization 1 True False
           revision = ProjectRevision "" "not this revision" $ Just "master123"
           -- Loggers and Diagnostics modify monads, so we need a no-op monad
           actual = stripDiag $ getBuildURLWithOrg org revision apiOpts locator
@@ -49,7 +49,7 @@ spec = do
 
     it "should render git@ locators" $ do
       let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
-          org = Just $ Organization 103 True
+          org = Just $ Organization 103 True False
           revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
           actual = stripDiag $ getBuildURLWithOrg org revision apiOpts locator
 
@@ -57,7 +57,7 @@ spec = do
 
     it "should render full url correctly" $ do
       let locator = Locator "a" "b" $ Just "c"
-          org = Just $ Organization 33 True
+          org = Just $ Organization 33 True False
           revision = ProjectRevision "" "not this revision" $ Just "master"
           actual = stripDiag $ getBuildURLWithOrg org revision apiOpts locator
 


### PR DESCRIPTION
# Overview

Provide types to query core for whether to perform license scan server-side or locally.  Default to server-side.

## Checklist

- ~[ ] I added tests for this PR's change (or confirmed tests are not viable)~.
- ~[ ] If this PR introduced a user-visible change, I added documentation into `docs/`~.
- ~[ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top~.
- ~[ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry)~.
- ~[ ] I linked this PR to any referenced GitHub issues, if they exist~.
