### PR TITLE
Move dump commands to their own module

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -177,6 +177,7 @@ library
     App.Fossa.Container.Analyze
     App.Fossa.Container.Scan
     App.Fossa.Container.Test
+    App.Fossa.DumpBinaries
     App.Fossa.EmbeddedBinary
     App.Fossa.FossaAPIV1
     App.Fossa.ListTargets

--- a/src/App/Fossa/DumpBinaries.hs
+++ b/src/App/Fossa/DumpBinaries.hs
@@ -1,0 +1,19 @@
+module App.Fossa.DumpBinaries (
+  dumpSubCommand,
+) where
+
+import App.Fossa.Config.DumpBinaries (
+  DumpBinsConfig (..),
+  DumpBinsOpts,
+  mkSubCommand,
+ )
+import App.Fossa.EmbeddedBinary (allBins, dumpEmbeddedBinary)
+import App.Fossa.Subcommand (SubCommand)
+import Control.Effect.Lift (Has, Lift)
+import Data.Foldable (for_)
+
+dumpSubCommand :: SubCommand DumpBinsOpts DumpBinsConfig
+dumpSubCommand = mkSubCommand dumpBinsMain
+
+dumpBinsMain :: Has (Lift IO) sig m => DumpBinsConfig -> m ()
+dumpBinsMain (DumpBinsConfig dir) = for_ allBins $ dumpEmbeddedBinary dir

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -8,20 +8,15 @@ module App.Fossa.EmbeddedBinary (
   withWigginsBinary,
   withSyftBinary,
   withThemisAndIndex,
-  dumpSubCommand,
+  allBins,
+  dumpEmbeddedBinary,
 ) where
 
-import App.Fossa.Config.DumpBinaries (
-  DumpBinsConfig (..),
-  DumpBinsOpts,
-  mkSubCommand,
- )
-import App.Fossa.Subcommand (SubCommand)
 import Control.Effect.Exception (bracket)
 import Control.Effect.Lift (Has, Lift, sendIO)
 import Data.ByteString (ByteString, writeFile)
 import Data.FileEmbed.Extra (embedFileIfExists)
-import Data.Foldable (for_, traverse_)
+import Data.Foldable (traverse_)
 import Data.Tagged (Tagged, applyTag, unTag)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Path (
@@ -53,12 +48,6 @@ data PackagedBinary
   | Themis
   | ThemisIndex
   deriving (Show, Eq, Enum, Bounded)
-
-dumpSubCommand :: SubCommand DumpBinsOpts DumpBinsConfig
-dumpSubCommand = mkSubCommand dumpBinsMain
-
-dumpBinsMain :: Has (Lift IO) sig m => DumpBinsConfig -> m ()
-dumpBinsMain (DumpBinsConfig dir) = for_ allBins $ dumpEmbeddedBinary dir
 
 allBins :: [PackagedBinary]
 allBins = enumFromTo minBound maxBound

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -5,7 +5,7 @@ module App.Fossa.Main (appMain) where
 import App.Fossa.Analyze qualified as Analyze
 import App.Fossa.Analyze.Log4jReport qualified as Log4j
 import App.Fossa.Container qualified as Container
-import App.Fossa.EmbeddedBinary qualified as Embed
+import App.Fossa.DumpBinaries qualified as Dump
 import App.Fossa.ListTargets qualified as ListTargets
 import App.Fossa.Report qualified as Report
 import App.Fossa.Subcommand (GetSeverity, SubCommand (..), runSubCommand)
@@ -66,7 +66,7 @@ subcommands = public <|> private
         mconcat
           [ internal
           , initCommand
-          , decodeSubCommand Embed.dumpSubCommand
+          , decodeSubCommand Dump.dumpSubCommand
           , decodeSubCommand Log4j.log4jSubCommand
           ]
     public =


### PR DESCRIPTION
These were causing circular dependencies due to them just being in the wrong place, so I moved them.  `EmbeddedBinary` shouldn't depend on `SubCommand`