### PR TITLE
remove wirechunk references

### DIFF
--- a/docs/references/files/fossa-deps.md
+++ b/docs/references/files/fossa-deps.md
@@ -2,8 +2,6 @@
 
 Fossa-deps file is a file named `fossa-deps.{yaml, yml, json}` at the root of the project. It can be used to provide manual and vendor dependencies. 
 
-You can use [this configuration generator tool](https://wirechunk.com/topics/c4f67ee8-29f4-4fd3-8b87-76b80da015f6) to easily create a fossa-deps file.
-
 ## Fields
 
 ### `referenced-dependencies:`


### PR DESCRIPTION
http://wirechunk.com has been down for almost a week, with a `server not found` error.  I think the site has been decommissioned.  This will get our link-checker job back on track. 