### PR TITLE
Run themis on vendored dependencies

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -44,6 +44,8 @@
   - {name: Data.Text.tail, within: []}
   - {name: Data.Text.init, within: []}
   - {name: Data.Text.last, within: []}
+    # TODO: remove special-case
+  - {name: Data.List.NonEmpty.fromList, within: [App.Fossa.Analyze.Filter], message: "Pattern-match on nonEmpty instead of forcing the list."}
   - {name: "Prelude.!!", within: []}
   - {name: "Data.Map.!", within: []}
     # TODO: remove the need to special-case this test module.

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -181,6 +181,7 @@ library
     App.Fossa.DumpBinaries
     App.Fossa.EmbeddedBinary
     App.Fossa.FossaAPIV1
+    App.Fossa.LicenseScanner
     App.Fossa.ListTargets
     App.Fossa.Main
     App.Fossa.ManualDeps

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -188,6 +188,7 @@ library
     App.Fossa.ProjectInference
     App.Fossa.Report
     App.Fossa.Report.Attribution
+    App.Fossa.RunThemis
     App.Fossa.Subcommand
     App.Fossa.Test
     App.Fossa.VPS.Scan.Core

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -91,6 +91,7 @@ common deps
     , hedn                         ^>=0.3.0.1
     , http-client                  ^>=0.7.1
     , http-types                   ^>=0.12.3
+    , lzma                         ^>=0.0.0.3
     , lzma-conduit                 ^>=1.2.1
     , megaparsec                   ^>=9.1.0
     , modern-uri                   ^>=0.3.4

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -3,6 +3,11 @@
 module App.Fossa.ArchiveUploader (
   archiveUploadSourceUnit,
   archiveNoUploadSourceUnit,
+  arcToLocator,
+  forceVendoredToArchive,
+  duplicateFailureBundle,
+  duplicateNames,
+  hashFile,
   VendoredDependency (..),
 ) where
 

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -12,12 +12,15 @@ module App.Fossa.FossaAPIV1 (
   getIssues,
   getOrganization,
   getAttribution,
+  getSignedLicenseScanURL,
   getSignedURL,
   getProject,
   archiveUpload,
   archiveBuildUpload,
   assertUserDefinedBinaries,
   assertRevisionBinaries,
+  licenseScanFinalize,
+  licenseScanResultUpload,
   resolveUserDefinedBinary,
   resolveProjectDependencies,
   vsiCreateScan,
@@ -42,6 +45,7 @@ import App.Types (
   ReleaseGroupMetadata (releaseGroupName, releaseGroupRelease),
  )
 import App.Version (versionNumber)
+import Codec.Compression.GZip qualified as GZIP
 import Control.Algebra (Algebra, Has, type (:+:))
 import Control.Carrier.Empty.Maybe (Empty, EmptyC, runEmpty)
 import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (..), context, fatal, fromMaybeText)
@@ -65,7 +69,7 @@ import Data.ByteString.Char8 qualified as C
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Maybe (catMaybes, fromMaybe)
-import Data.String.Conversion (decodeUtf8, toText)
+import Data.String.Conversion (decodeUtf8, toStrict, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Word (Word8)
@@ -99,6 +103,7 @@ import Network.HTTP.Req (
   Option,
   POST (POST),
   PUT (PUT),
+  ReqBodyBs (ReqBodyBs),
   ReqBodyFile (ReqBodyFile),
   ReqBodyJson (ReqBodyJson),
   Scheme (Https),
@@ -119,6 +124,7 @@ import Network.HTTP.Req.Extra (httpConfigRetryTimeouts)
 import Network.HTTP.Types qualified as HTTP
 import Path (File, Path, Rel)
 import Srclib.Types (
+  LicenseSourceUnit,
   Locator (..),
   SourceUnit,
   parseLocator,
@@ -377,6 +383,28 @@ archiveBuildUpload apiOpts archiveProjects = runEmpty $
         req POST (archiveBuildURL baseUrl) (ReqBodyJson archiveProjects) bsResponse (baseOpts <> opts)
     pure (responseBody resp)
 
+---------- license-scan build queueing. This Endpoint ensures that after a license-scan is uploaded, it is scanned.
+
+licenseScanFinalizeUrl :: Url 'Https -> Url 'Https
+licenseScanFinalizeUrl baseUrl = baseUrl /: "api" /: "license_scan" /: "finalize"
+
+-- TODO: /license_scan/finalize just returns a 201 if there's a success. No need to parse the body
+licenseScanFinalize ::
+  (Has (Lift IO) sig m, Has Diagnostics sig m) =>
+  ApiOpts ->
+  ArchiveComponents ->
+  m (Maybe ())
+licenseScanFinalize apiOpts archiveProjects = runEmpty $
+  fossaReqAllow401 $ do
+    (baseUrl, baseOpts) <- useApiOpts apiOpts
+
+    let opts = "dependency" =: True <> "rawLicenseScan" =: True
+
+    _ <-
+      context "Queuing a build for all license scan uploads" $
+        req POST (licenseScanFinalizeUrl baseUrl) (ReqBodyJson archiveProjects) ignoreResponse (baseOpts <> opts)
+    pure ()
+
 ---------- The signed URL endpoint returns a URL endpoint that can be used to directly upload to an S3 bucket.
 
 signedURLEndpoint :: Url 'Https -> Url 'Https
@@ -398,6 +426,27 @@ getSignedURL apiOpts revision packageName = fossaReq $ do
       req GET (signedURLEndpoint baseUrl) NoReqBody jsonResponse (baseOpts <> opts)
   pure (responseBody response)
 
+---------- The signed License Scan URL endpoint returns a URL endpoint that can be used to directly upload the results of a license scan to an S3 bucket.
+
+signedLicenseScanURLEndpoint :: Url 'Https -> Url 'Https
+signedLicenseScanURLEndpoint baseUrl = baseUrl /: "api" /: "license_scan" /: "signed_url"
+
+getSignedLicenseScanURL ::
+  (Has (Lift IO) sig m, Has Diagnostics sig m) =>
+  ApiOpts ->
+  Text ->
+  Text ->
+  m SignedURL
+getSignedLicenseScanURL apiOpts revision packageName = fossaReq $ do
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+
+  let opts = "packageSpec" =: packageName <> "revision" =: revision
+
+  response <-
+    context ("Retrieving a signed S3 URL for license scan results of " <> packageName) $
+      req GET (signedLicenseScanURLEndpoint baseUrl) NoReqBody jsonResponse (baseOpts <> opts)
+  pure (responseBody response)
+
 ---------- The archive upload function uploads the file it is given directly to the signed URL it is provided.
 
 archiveUpload ::
@@ -416,6 +465,27 @@ archiveUpload signedArcURI arcFile = fossaReq $ do
     Right (url, options) -> uploadArchiveRequest url options
   where
     uploadArchiveRequest url options = reqCb PUT url (ReqBodyFile arcFile) lbsResponse options (pure . requestEncoder)
+
+---------- The license scan result upload function uploads the JSON license result directly to the signed URL it is provided.
+
+licenseScanResultUpload ::
+  (Has (Lift IO) sig m, Has Diagnostics sig m) =>
+  SignedURL ->
+  LicenseSourceUnit ->
+  m LbsResponse
+licenseScanResultUpload signedArcURI licenseScanResult = fossaReq $ do
+  let arcURL = URI.mkURI $ signedURL signedArcURI
+
+  uri <- fromMaybeText ("Invalid URL: " <> signedURL signedArcURI) arcURL
+  validatedURI <- fromMaybeText ("Invalid URI: " <> toText (show uri)) (useURI uri)
+
+  context ("Uploading license scan result to " <> signedURL signedArcURI) $ case validatedURI of
+    Left (httpUrl, httpOptions) -> uploadArchiveRequest httpUrl httpOptions
+    Right (httpsUrl, httpsOptions) -> uploadArchiveRequest httpsUrl httpsOptions
+  where
+    zippedLicenseResult = toStrict $ GZIP.compress $ encode licenseScanResult
+    uploadArchiveRequest :: (MonadHttp m) => Url scheme -> Option scheme -> m LbsResponse
+    uploadArchiveRequest url options = reqCb PUT url (ReqBodyBs zippedLicenseResult) lbsResponse options (pure . requestEncoder)
 
 -- requestEncoder properly encodes the Request path.
 -- The default encoding logic does not encode "+" ot "$" characters which makes AWS very angry.

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -483,7 +483,9 @@ licenseScanResultUpload signedArcURI licenseScanResult = fossaReq $ do
     Left (httpUrl, httpOptions) -> uploadArchiveRequest httpUrl httpOptions
     Right (httpsUrl, httpsOptions) -> uploadArchiveRequest httpsUrl httpsOptions
   where
+    zippedLicenseResult :: BS.ByteString
     zippedLicenseResult = toStrict $ GZIP.compress $ encode licenseScanResult
+    -- We send gzipped json, so we can't use req's JSON utilities.
     uploadArchiveRequest :: (MonadHttp m) => Url scheme -> Option scheme -> m LbsResponse
     uploadArchiveRequest url options = reqCb PUT url (ReqBodyBs zippedLicenseResult) lbsResponse options (pure . requestEncoder)
 

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -26,8 +26,7 @@ import Data.ByteString qualified as B
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes)
-import Data.String.Conversion (encodeUtf8, toString, toText)
-import Effect.Exec (Exec, runExecIO)
+import Effect.Exec (Exec)
 import Effect.Logger (Logger, Pretty (pretty), logError)
 import Fossa.API.Types (
   ApiOpts,
@@ -51,6 +50,7 @@ instance ToDiagnostic NoSuccessfulScans where
 runLicenseScanOnDir ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
+  , Has Exec sig m
   ) =>
   Path Abs Dir ->
   m [LicenseUnit]
@@ -59,12 +59,12 @@ runLicenseScanOnDir scanDir = withThemisAndIndex $ themisRunner scanDir
 themisRunner ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Exec sig m
   ) =>
   Path Abs Dir ->
   ThemisBins ->
   m [LicenseUnit]
-themisRunner scanDir themisBins = do
-  runExecIO $ runThemis themisBins scanDir
+themisRunner scanDir themisBins = runThemis themisBins scanDir
 
 runThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> m [LicenseUnit]
 runThemis themisBins scanDir = do
@@ -78,6 +78,7 @@ scanAndUploadVendoredDep ::
   , Has (Lift IO) sig m
   , Has Logger sig m
   , Has StickyLogger sig m
+  , Has Exec sig m
   ) =>
   ApiOpts ->
   Path Abs Dir ->
@@ -129,6 +130,7 @@ licenseScanSourceUnit ::
   , Has (Lift IO) sig m
   , Has Logger sig m
   , Has StickyLogger sig m
+  , Has Exec sig m
   ) =>
   Path Abs Dir ->
   ApiOpts ->

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.LicenseScanner (
+  licenseScanSourceUnit,
+  licenseNoScanSourceUnit,
+) where
+
+import App.Fossa.ArchiveUploader (
+  VendoredDependency (..),
+  arcToLocator,
+  duplicateFailureBundle,
+  duplicateNames,
+  forceVendoredToArchive,
+ )
+import App.Fossa.EmbeddedBinary (ThemisBins, withThemisAndIndex)
+import App.Fossa.FossaAPIV1 qualified as Fossa
+import App.Fossa.RunThemis (
+  execThemis,
+ )
+import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (renderDiagnostic), context, fatalText, fromMaybe)
+import Control.Effect.Lift (Has, Lift)
+import Control.Effect.StickyLogger (StickyLogger, logSticky)
+import Control.Monad (unless, void)
+import Crypto.Hash (Digest, MD5, hash)
+import Data.ByteString qualified as B
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (catMaybes)
+import Data.String.Conversion (encodeUtf8, toString, toText)
+import Effect.Exec (Exec, runExecIO)
+import Effect.Logger (Logger, Pretty (pretty), logError)
+import Fossa.API.Types (
+  ApiOpts,
+  Archive (Archive, archiveName),
+  ArchiveComponents (ArchiveComponents),
+  Organization (organizationId),
+ )
+import Path (Abs, Dir, Path, parseRelDir, (</>))
+import Srclib.Types (
+  LicenseScanType (CliLicenseScanned),
+  LicenseSourceUnit (..),
+  LicenseUnit (..),
+  Locator (..),
+ )
+
+data NoSuccessfulScans = NoSuccessfulScans
+
+instance ToDiagnostic NoSuccessfulScans where
+  renderDiagnostic _ = "No native license scans were successful"
+
+runLicenseScanOnDir ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  ) =>
+  Path Abs Dir ->
+  m [LicenseUnit]
+runLicenseScanOnDir scanDir = withThemisAndIndex $ themisRunner scanDir
+
+themisRunner ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  ) =>
+  Path Abs Dir ->
+  ThemisBins ->
+  m [LicenseUnit]
+themisRunner scanDir themisBins = do
+  runExecIO $ runThemis themisBins scanDir
+
+runThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> m [LicenseUnit]
+runThemis themisBins scanDir = do
+  context "Running license scan binary" $ execThemis themisBins scanDir
+
+md5 :: B.ByteString -> Digest MD5
+md5 = hash
+
+scanAndUploadVendoredDep ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has StickyLogger sig m
+  ) =>
+  ApiOpts ->
+  Path Abs Dir ->
+  VendoredDependency ->
+  m (Maybe Archive)
+scanAndUploadVendoredDep apiOpts baseDir vendoredDeps@VendoredDependency{..} = context "compressing and uploading vendored deps" $ do
+  logSticky $ "License Scanning '" <> vendoredName <> "' at '" <> vendoredPath <> "'"
+  vendoredDepDir <- case parseRelDir $ toString vendoredPath of
+    Left _ -> fatalText "Error constructing scan dir for vendored scan"
+    Right val -> pure val
+  let cliScanDir = baseDir </> vendoredDepDir
+  themisScanResult <- runLicenseScanOnDir cliScanDir
+  case NE.nonEmpty themisScanResult of
+    Nothing -> Nothing <$ logError ("No license results found after scanning " <> pretty (toString cliScanDir))
+    Just results -> uploadVendoredDep apiOpts vendoredDeps results
+
+uploadVendoredDep ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has StickyLogger sig m
+  ) =>
+  ApiOpts ->
+  VendoredDependency ->
+  NE.NonEmpty LicenseUnit ->
+  m (Maybe Archive)
+uploadVendoredDep apiOpts VendoredDependency{..} themisScanResult = do
+  let licenseSourceUnit =
+        LicenseSourceUnit
+          { licenseSourceUnitName = vendoredPath
+          , licenseSourceUnitType = CliLicenseScanned
+          , licenseSourceUnitLicenseUnits = themisScanResult
+          }
+
+  depVersion <- case vendoredVersion of
+    Nothing -> pure $ toText . show . md5 . encodeUtf8 . show $ themisScanResult
+    Just version -> pure version
+
+  signedURL <- Fossa.getSignedLicenseScanURL apiOpts depVersion vendoredName
+
+  logSticky $ "Uploading '" <> vendoredName <> "' to secure S3 bucket"
+  void $ Fossa.licenseScanResultUpload signedURL licenseSourceUnit
+
+  pure $ Just $ Archive vendoredName depVersion
+
+-- | licenseScanSourceUnit receives a list of vendored dependencies, a root path, and API settings.
+-- Using this information, it license scans each vendored dependency, uploads the license scan results and then queues a build for the dependency.
+licenseScanSourceUnit ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has StickyLogger sig m
+  ) =>
+  Path Abs Dir ->
+  ApiOpts ->
+  NonEmpty VendoredDependency ->
+  m (NonEmpty Locator)
+licenseScanSourceUnit baseDir apiOpts vendoredDeps = do
+  -- Users with many instances of vendored dependencies may accidentally have complete duplicates. Remove them.
+  let uniqDeps = NE.nub vendoredDeps
+
+  -- However, users may also have vendored dependencies that have duplicate names but are not complete duplicates.
+  -- These aren't valid and can't be automatically handled, so fail the scan with them.
+  let duplicates = duplicateNames uniqDeps
+  unless (null duplicates) $ fatalText $ duplicateFailureBundle duplicates
+
+  -- At this point, we have a good list of deps, so go for it.
+  maybeArchives <- traverse (scanAndUploadVendoredDep apiOpts baseDir) uniqDeps
+  archives <- fromMaybe NoSuccessfulScans $ NE.nonEmpty $ catMaybes $ NE.toList maybeArchives
+
+  -- archiveBuildUpload takes archives without Organization information. This orgID is appended when creating the build on the backend.
+  -- We don't care about the response here because if the build has already been queued, we get a 401 response.
+  void $ Fossa.licenseScanFinalize apiOpts $ ArchiveComponents $ NE.toList archives
+
+  -- The organizationID is needed to prefix each locator name. The FOSSA API automatically prefixes the locator when queuing the build
+  -- but not when reading from a source unit.
+  orgId <- organizationId <$> Fossa.getOrganization apiOpts
+
+  pure $ NE.map arcToLocator (archivesWithOrganization orgId archives)
+  where
+    archivesWithOrganization :: Int -> NonEmpty Archive -> NonEmpty Archive
+    archivesWithOrganization orgId = NE.map (includeOrgId orgId)
+
+    includeOrgId :: Int -> Archive -> Archive
+    includeOrgId orgId arc = arc{archiveName = toText (show orgId) <> "/" <> archiveName arc}
+
+-- | licenseNoScanSourceUnit exists for when users run `fossa analyze -o` and do not upload their source units.
+licenseNoScanSourceUnit :: [VendoredDependency] -> [Locator]
+licenseNoScanSourceUnit = map (arcToLocator . forceVendoredToArchive)

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -14,7 +14,11 @@ module App.Fossa.ManualDeps (
   analyzeFossaDepsFile,
 ) where
 
+import App.Fossa.ArchiveUploader (VendoredDependency (..), archiveNoUploadSourceUnit, archiveUploadSourceUnit)
+import App.Fossa.LicenseScanner (licenseNoScanSourceUnit, licenseScanSourceUnit)
 import Control.Effect.Diagnostics (Diagnostics, context, fatalText)
+import Control.Effect.Lift (Has, Lift)
+import Control.Effect.StickyLogger (StickyLogger)
 import Control.Monad (when)
 import Data.Aeson (
   FromJSON (parseJSON),
@@ -23,12 +27,7 @@ import Data.Aeson (
   (.:),
   (.:?),
  )
-
-import App.Fossa.ArchiveUploader (VendoredDependency (..), archiveNoUploadSourceUnit, archiveUploadSourceUnit)
-import App.Fossa.LicenseScanner (licenseNoScanSourceUnit, licenseScanSourceUnit)
-import Control.Effect.Lift
-import Control.Effect.StickyLogger (StickyLogger)
-import Data.Aeson.Extra
+import Data.Aeson.Extra (TextLike (unTextLike), forbidMembers)
 import Data.Aeson.Types (Parser)
 import Data.Functor.Extra ((<$$>))
 import Data.List.NonEmpty qualified as NE
@@ -37,8 +36,8 @@ import Data.Text (Text)
 import DepTypes (DepType (..))
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS, doesFileExist, readContentsJson, readContentsYaml)
-import Fossa.API.Types
-import Path
+import Fossa.API.Types (ApiOpts)
+import Path (Abs, Dir, File, Path, mkRelFile, (</>))
 import Path.Extra (tryMakeRelative)
 import Srclib.Converter (depTypeToFetcher)
 import Srclib.Types (AdditionalDepData (..), Locator (..), SourceRemoteDep (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (SourceUnitDependency), SourceUserDefDep (..))

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -187,6 +187,7 @@ toAdditionalData customDeps remoteDeps =
 hasNoDeps :: ManualDependencies -> Bool
 hasNoDeps ManualDependencies{..} = null referencedDependencies && null customDependencies && null vendoredDependencies && null remoteDependencies
 
+-- TODO: Change these to Maybe NonEmpty
 data ManualDependencies = ManualDependencies
   { referencedDependencies :: [ReferencedDependency]
   , customDependencies :: [CustomDependency]

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -34,6 +34,7 @@ import Data.List.NonEmpty qualified as NE
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
 import DepTypes (DepType (..))
+import Effect.Exec (Exec)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS, doesFileExist, readContentsJson, readContentsYaml)
 import Fossa.API.Types (ApiOpts)
@@ -49,7 +50,17 @@ data FoundDepsFile
 
 data ArchiveUploadType = ArchiveUpload | CLILicenseScan
 
-analyzeFossaDepsFile :: (Has Diagnostics sig m, Has ReadFS sig m, Has (Lift IO) sig m, Has StickyLogger sig m, Has Logger sig m) => Path Abs Dir -> Maybe ApiOpts -> m (Maybe SourceUnit)
+analyzeFossaDepsFile ::
+  ( Has Diagnostics sig m
+  , Has ReadFS sig m
+  , Has (Lift IO) sig m
+  , Has StickyLogger sig m
+  , Has Logger sig m
+  , Has Exec sig m
+  ) =>
+  Path Abs Dir ->
+  Maybe ApiOpts ->
+  m (Maybe SourceUnit)
 analyzeFossaDepsFile root maybeApiOpts = do
   maybeDepsFile <- findFossaDepsFile root
   case maybeDepsFile of
@@ -81,7 +92,18 @@ findFossaDepsFile root = do
     (_, _, True) -> pure $ Just $ ManualJSON jsonFile
     (False, False, False) -> pure Nothing
 
-toSourceUnit :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has StickyLogger sig m, Has Logger sig m) => Path Abs Dir -> FoundDepsFile -> ManualDependencies -> Maybe ApiOpts -> m SourceUnit
+toSourceUnit ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has StickyLogger sig m
+  , Has Logger sig m
+  , Has Exec sig m
+  ) =>
+  Path Abs Dir ->
+  FoundDepsFile ->
+  ManualDependencies ->
+  Maybe ApiOpts ->
+  m SourceUnit
 toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts = do
   -- If the file exists and we have no dependencies to report, that's a failure.
   when (hasNoDeps manualDeps) $ fatalText "No dependencies found in fossa-deps file"

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.RunThemis (
+  execThemis,
+) where
+
+import App.Fossa.EmbeddedBinary (
+  BinaryPaths,
+  ThemisBins (..),
+  ThemisIndex,
+  toPath,
+ )
+import Control.Effect.Diagnostics (Diagnostics, Has)
+import Data.String.Conversion (toText)
+import Data.Tagged (Tagged, unTag)
+import Data.Text (Text)
+import Effect.Exec (
+  AllowErr (Never),
+  Command (..),
+  Exec,
+  execJson,
+ )
+import Path (Abs, Dir, Path, fromAbsFile, parent)
+import Srclib.Types (LicenseUnit)
+
+-- TODO: We should log the themis version and index version
+execThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> m [LicenseUnit]
+execThemis themisBins scanDir = do
+  execJson @[LicenseUnit] scanDir $ themisCommand themisBins
+
+themisCommand :: ThemisBins -> Command
+themisCommand ThemisBins{..} = do
+  Command
+    { cmdName = toText $ fromAbsFile $ toPath $ unTag themisBinaryPaths
+    , cmdArgs = generateThemisArgs indexBinaryPaths
+    , cmdAllowErr = Never
+    }
+
+generateThemisArgs :: Tagged ThemisIndex BinaryPaths -> [Text]
+generateThemisArgs taggedThemisIndex =
+  [ "--license-data-dir"
+  , toText . parent . toPath $ unTag taggedThemisIndex
+  , "--srclib-with-matches"
+  , "."
+  ]

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -20,7 +20,7 @@ import Effect.Exec (
   Exec,
   execJson,
  )
-import Path (Abs, Dir, Path, fromAbsFile, parent)
+import Path (Abs, Dir, Path, parent)
 import Srclib.Types (LicenseUnit)
 
 -- TODO: We should log the themis version and index version
@@ -31,7 +31,7 @@ execThemis themisBins scanDir = do
 themisCommand :: ThemisBins -> Command
 themisCommand ThemisBins{..} = do
   Command
-    { cmdName = toText $ fromAbsFile $ toPath $ unTag themisBinaryPaths
+    { cmdName = toText . toPath $ unTag themisBinaryPaths
     , cmdArgs = generateThemisArgs indexBinaryPaths
     , cmdAllowErr = Never
     }

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -22,7 +22,7 @@ import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.TaskPool (TaskPool, forkTask)
 import Data.ByteString.Lazy qualified as BL
 import Data.Conduit.Binary (sinkLbs)
-import Data.Conduit.Lzma qualified as Lzma
+import Data.Conduit.Lzma qualified as CLzma
 import Data.Foldable (traverse_)
 import Data.List (isSuffixOf)
 import Data.String.Conversion (toText)
@@ -120,7 +120,7 @@ extractTarGz dir tarGzFile =
 
 extractTarXz :: Has (Lift IO) sig m => Path Abs Dir -> Path Abs File -> m ()
 extractTarXz dir tarXzFile = do
-  decompressed <- sendIO (runResourceT . runConduit $ sourceFileBS (toFilePath tarXzFile) .| Lzma.decompress Nothing .| sinkLbs)
+  decompressed <- sendIO (runResourceT . runConduit $ sourceFileBS (toFilePath tarXzFile) .| CLzma.decompress Nothing .| sinkLbs)
   sendIO $ Tar.unpack (fromAbsDir dir) . removeTarLinks . Tar.read $ decompressed
 
 extractTarBz2 :: Has (Lift IO) sig m => Path Abs Dir -> Path Abs File -> m ()

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -69,7 +69,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2022-02-02-db4cf6c"
+THEMIS_TAG="2022-03-18-efb2343"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json
@@ -94,7 +94,7 @@ FILTER=".name == \"index.gob\""
 jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $THEMIS_RELEASE_JSON | while read ASSET; do
   URL="$(echo $ASSET | jq -c -r '.url')"
   NAME="$(echo $ASSET | jq -c -r '.name')"
-  OUTPUT="$(echo vendor-bins/$NAME)"
+  OUTPUT="vendor-bins/$NAME"
 
   echo "Downloading '$NAME' to '$OUTPUT'"
   curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT


### PR DESCRIPTION
_This PR supersedes #817, which is unrecoverable due to merge conflicts and rebase hell._

The initial base for this PR was created via:
- checking out the latest version of #817
- running `git diff origin/master HEAD > 817.patch`
- switching to a new, clean branch
- running `git apply 817.patch`
- minor merge cleanup

# Overview

[Closes ANE-25](https://fossa.atlassian.net/browse/ANE-25) — Use themis to license scan vendored dependencies
[Closes ANE-26](https://fossa.atlassian.net/browse/ANE-26) — Upload cli-side license data to S3 and trigger the build

Run `themis-cli` on the list of vendored dependencies in `fossa-deps.yml`, upload the resulting scan to S3 and then trigger a build on Core.

Things this PR does not do:

- we do not add the license data to the output from the `--output` flag (https://fossa.atlassian.net/browse/ANE-97)
- We do not emit any useful or actionable errors or warnings (https://fossa.atlassian.net/browse/ANE-96)

There are also no tests. I *think* that this code is similar to other code-paths that are not tested, but please let me know if there are areas that are reasonable to test.

## Acceptance criteria

This PR changes the behavior for vendored dependencies found in `fossa-deps.yml`.

* If `archiveOrCLI` in `App.Fossa.ManualDeps` is set to `ArchiveUpload`, then there should be no change: we should run an archive upload on any vendored dependencies
* If `archiveOrCLI` is set to `CLILicenseScan`, then we should run a license scan on any vendored dependencies

Running a license scan means:

* we run themis the  directories pointed to by the vendored dependency
* the results from each of the themis scans are gzipped and uploaded to S3
* Once all of the scans are completed and uploaded, we trigger a `CLILicenseScanBuild` job for each vendored dependency.

- [ ] `archiveOrCLI` must be set to `ArchiveUpload` before this is merged into master

## Testing plan

### Core setup

Check out the [CLI license scan endpoint](https://github.com/fossas/FOSSA/pull/7165) PR. The branch name is `cli-license-scan-endpoint`

```
git checkout cli-license-scan-endpoint
```

Do whatever you normally do to get core running on your system. You'll need to have minio, the agent and a faktory worker running, so you might also need to do:

```
docker compose up -d s3 agent faktory-worker
```

You'll want to watch these logs to make sure that the right job is getting queued:

```
docker compose logs --follow faktory-worker
```

### test directory setup

Make a simple yarn project with a single vendored dependency:

```
mkdir ~/fossa/license-scan-dirs/archive-upload-with-target
cd ~/fossa/license-scan-dirs/archive-upload-with-target
mkdir yarn-package
```

Put this in `fossa-deps.yml`:

```yml
vendored-dependencies:
  - name: yarn-package
    path: yarn-package
    version: 1.0.2
```

Put this in `yarn-package/package.json`:

```json
{
  "name": "yarn-testing",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "MIT",
  "dependencies": {
    "bson": "4.5.1"
  },
}
```

```
cd yarn-package
yarn install
rm -rf node_modules
```

Now do the same for a directory with multiple archives:

```
mkdir ~/fossa/license-scan-dirs/archive-upload-with-multple-targets
cd ~/fossa/license-scan-dirs/archive-upload-with-multiple-targets
mkdir first-yarn-package
mkdir second-yarn-package
```

Put this in `fossa-deps.yml`:

```yml
vendored-dependencies:
  - name: first-yarn-package
    path: first-yarn-package
    version: 1.0.2
  - name: second-yarn-package
    path: second-yarn-package
    version: 2.0.1
```

in first-yarn-package/package.json:

```
{
  "name": "yarn-testing",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "MIT",
  "dependencies": {
    "bson": "4.5.1"
  },
  "devDependencies": {
    "@storybook/addon-actions": "6.3.7",
    "@storybook/addon-docs": "6.3.7"
  }
}
```

in second-yarn-package/package.json:

```
{
  "name": "yarn-testing-2",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "Apache-2.0",
  "dependencies": {
    "bson": "4.5.1"
  },
  "devDependencies": {
    "@storybook/addon-actions": "6.3.7",
    "@storybook/addon-docs": "6.3.7"
  }
}
```

```
cd first-yarn-package
yarn install
rm -rf node_modules
cd ../second-yarn-package
yarn install
rm -rf node_modules
```

### Run the CLI

Without any changes, run the CLI:

```
export FOSSA_API_KEY='valid api key for your dev setup'
cabal run fossa -- analyze -e http://localhost:9578 ~/fossa/license-scan-dirs/archive-upload-with-target
```

This should successfully go through the previously existing archive upload workflow.

Now edit `src/App/Fossa/ManualDeps.hs`. On line 92 change `ArchiveUpload` to `CLILicenseScan`

```haskell
  let archiveOrCLI = CLILicenseScan
```

Edit `fossa-deps.yml` and change the version of the dependency from `1.0.1` to `1.0.2`.

run the scan again:

```
cabal run fossa -- analyze -e http://localhost:9578 ~/fossa/license-scan-dirs/archive-upload-with-target
```

This time it should run a license scan on the `yarn-package` directory and upload the results to your local minio.

There should be no difference in the UI. The license scan result from a cli-side license scan should be the same as a license scan done on the servers.

However, what happens on the back end is very different.

The archive upload workflow uploads the contents of the vendored dependency to `archive_components/archive+<org ID>/<locator>`.

So, if your ORG ID is 1, you'll see a file uploaded to `archive_components/archive+1/yarn-package$1.0.1`.

Download that file and gunzip it. Check that you see the contents of the yarn-package directory.

The CLI license scan workflow scans the contents of the vendored dependency and uploads the results of that license scan to `archive_license_data/archive+<org ID>/locator`.

So, if your ORG ID is 1, you'll see a file uploaded to `archive_license_data/archive+1/yarn-package$1.0.2`.

Download that file and gunzip it. Check that you see a JSON file containing the results of a license scan. It should look like this:

```
mv ~/Downloads/yarn-package\$1.0.1 ~/Downloads/yarn-package\$1.0.1.gz; gunzip ~/Downloads/yarn-package\$1.0.1.gz; cat ~/Downloads/yarn-package\$1.0.1
```

```json
{"Name":"yarn-package","Type":"cli-license-scanned","LicenseUnits":[{"Files":["yarn.lock"],"Name":"No_license_found","Type":"LicenseUnit","Dir":"","Info":{"Description":""},"Data":[{"path":"yarn.lock","ThemisVersion":"db4cf6c4b22e29bc4f2a4bd48488b8d3c2a3f5d9","Copyrights":null,"match_data":null,"Copyright":null}]},{"Files":["package.json"],"Name":"mit","Type":"LicenseUnit","Dir":"","Info":{"Description":""},"Data":[{"path":"package.json","ThemisVersion":"db4cf6c4b22e29bc4f2a4bd48488b8d3c2a3f5d9","Copyrights":null,"match_data":[{"index":0,"match_string":"MIT\",","length":4,"location":201}],"Copyright":null}]}]}
```

The contents of the file are just the JSON output.

In both cases, the UI should show an MIT license found for the `yarn-package` dependency.

Do the same thing for the project in `~/fossa/license-scan-dirs/archive-upload-with-multple-targets`:

cd ~/fossa/license-scan-dirs/archive-upload-with-multple-targets

```
cabal run fossa -- analyze -e http://localhost:9578 ~/fossa/license-scan-dirs/archive-upload-with-multiple-targets
```

You should see two new files in minio in `archive_components/archive+<org ID>`.

You should also see two `CliLicenseScannedBuild` tasks run in your faktory logs.

You should see an MIT license for `first-package` and an Apache-2.0 license for `second-package`.

## Risks



## References


## Checklist

- [x] I confirmed tests are not viable
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [ ] I linked this PR to any referenced GitHub issues, if they exist.
