### PR TITLE
Pkg json peer deps

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,11 +1,9 @@
 # FOSSA CLI Changelog
 
-## Unreleased
-
-- Configuration: Users can now use `.fossa.yaml` as a configuration file name. Previously, only `.fossa.yml` was supported. ([#851](https://github.com/fossas/fossa-cli/pull/851))
-
 ## v3.1.7
+- Configuration: Users can now use `.fossa.yaml` as a configuration file name. Previously, only `.fossa.yml` was supported. ([#851](https://github.com/fossas/fossa-cli/pull/851))
 - fossa-deps: Fixes an archive uploading bug for vendor dependency by queuing archive builds individually. ([#826](https://github.com/fossas/fossa-cli/pull/826))
+- nodejs: Capture peer dependencies transitively for npm `package-lock.json` files. ([#849](https://github.com/fossas/fossa-cli/pull/849))
 
 ## v3.1.6
 - Respects Go module replacement directives in the Go Mod Graph strategy. ([#841](https://github.com/fossas/fossa-cli/pull/841))

--- a/docs/references/strategies/languages/nodejs/npm-lockfile.md
+++ b/docs/references/strategies/languages/nodejs/npm-lockfile.md
@@ -44,3 +44,28 @@ The `requires` field signifies all of the dependencies that are needed by the de
 The `dependencies` field signifies all of the dependencies included in `babel-code-frame`'s `node_modules` folder within the top level `node_modules` folder. Notice that these dependencies are not always included in the `requires` section.
 
 > Note: `npm-shrinkwrap.json` is an identically formatted file that can be used for [publishing packages](https://docs.npmjs.com/cli/shrinkwrap).
+
+### Peer Dependencies
+
+Top-level peer dependencies from `package.json` are treated as if they were direct dependencies of the project. Peer dependencies are for transitive deps are also treated as transitive dependencies.
+
+In newer version of NPM the `package-lock.json` file may also include a `packagages` key which holds similar information to the those under the `dependencies` key. `packages` includes information about
+peer dependencies for each dependency or transitive dependency the project uses. For example, an entry might look like this:
+
+```json
+    "node_modules/chai-dom": {
+        "version": "1.11.0",
+        "resolved": "https://registry.npmjs.org/chai-dom/-/chai-dom-1.11.0.tgz",
+        "integrity": "sha512-ZzGlEfk1UhHH5+N0t9bDqstOxPEXmn3EyXvtsok5rfXVDOFDJbHVy12rED6ZwkJAUDs2w7/Da4Hlq2LB63kltg==",
+        "peer": true,
+        "engines": {
+            "node": ">= 0.12.0"
+        },
+        "peerDependencies": {
+            "chai": ">= 3",
+            "mocha": ">= 2"
+        }
+    }
+```
+
+When `fossa-cli` does analysis of `chai-dom`, it will include `chai` and `mocha` as dependencies`chai-dom`. The transitive deps for `chai` and `mocha` will also be captured.

--- a/docs/references/strategies/languages/nodejs/npm-lockfile.md
+++ b/docs/references/strategies/languages/nodejs/npm-lockfile.md
@@ -47,10 +47,13 @@ The `dependencies` field signifies all of the dependencies included in `babel-co
 
 ### Peer Dependencies
 
-Top-level peer dependencies from `package.json` are treated as if they were direct dependencies of the project. Peer dependencies are for transitive deps are also treated as transitive dependencies.
+Top-level peer dependencies from `package.json` are treated as if they were direct dependencies of the project. Peer dependencies of transitive deps are also treated as transitive dependencies. If a transitive peer dependency also happens to 
+be a direct dependency then it is reported as direct rather than transitive, however. The reason FOSSA does this is because as of `npm` 7+ peer dependencies and transitive peer dependencies are installed by default. 
 
-In newer version of NPM the `package-lock.json` file may also include a `packagages` key which holds similar information to the those under the `dependencies` key. `packages` includes information about
-peer dependencies for each dependency or transitive dependency the project uses. For example, an entry might look like this:
+FOSSA doesn't report peer dependencies in a special way because FOSSA does not model peer dependencies natively. Because direct peer dependencies are defined in the same place as regular direct dependencies (`package.json`) and because NPM installs them by default for FOSSA's purposes they are considered direct. If FOSSA didn't report these dependencies users may potentially miss license information about dependencies that would have implications for the distribution of their projects.
+
+Transitive peer dependencies are found in the `packages` key of `package-lock.json` files produced by recent versions of `npm`.  The `packages` key holds similar information to the those under the `dependencies` key, but `packages`
+includes information about peer dependencies for each dependency or transitive dependency the project uses. For example, an entry might look like this:
 
 ```json
     "node_modules/chai-dom": {
@@ -68,4 +71,4 @@ peer dependencies for each dependency or transitive dependency the project uses.
     }
 ```
 
-When `fossa-cli` does analysis of `chai-dom`, it will include `chai` and `mocha` as dependencies`chai-dom`. The transitive deps for `chai` and `mocha` will also be captured.
+In this example, when `fossa-cli` does analysis of `chai-dom`, it will include `chai` and `mocha` as dependencies`chai-dom`. The transitive deps for `chai` and `mocha` will also be captured.

--- a/docs/references/strategies/languages/nodejs/npm-lockfile.md
+++ b/docs/references/strategies/languages/nodejs/npm-lockfile.md
@@ -1,18 +1,32 @@
 # Npm Lockfile
 
-The `package-lock.json` file is generated when npm modifies `node_modules` or `package.json` and describes the exact dependency tree generated. One example of this is when `npm install` is run.
+The `package-lock.json` file is generated when npm modifies `node_modules` or
+`package.json` and describes the exact dependency tree generated. One example of
+this is when `npm install` is run.
 
-> Note: In old versions of npm, `package-lock.json` was only modified when dependencies were installed.
+> Note: In old versions of npm, `package-lock.json` was only modified when
+> dependencies were installed.
 
 ## Project Discovery
 
-Search for files named `package.json` and check for a corresponding `package-lock.json` in the same directory, ignoring directories named `node_modules`.
+Search for files named `package.json` and check for a corresponding
+`package-lock.json` in the same directory, ignoring directories named
+`node_modules`.
 
-> Note: When using NPM workspaces, only the root of the project will have a `package-lock.json`. The other `package.json` files in the project directory will be combined to determine which dependencies are direct and which ones are development.
+> Note: When using NPM workspaces, only the root of the project will have a
+> `package-lock.json`. The other `package.json` files in the project directory
+> will be combined to determine which dependencies are direct and which ones are
+> development.
 
 ## Analysis
 
-Opening a `package-lock.json` file reveals the project's dependency tree. This dependency tree contains information about a dependency's version, its transitive dependencies, the URL where the dependency is located at, and whether or not the dependency is used as a development dependency or not. The transitive dependency information is listed in an unintuitive way. Under each dependency there may be two fields, `requires` and `dependencies` as in the following example:
+Opening a `package-lock.json` file reveals the project's dependency tree. This
+dependency tree contains information about a dependency's version, its
+transitive dependencies, the URL where the dependency is located at, and whether
+or not the dependency is used as a development dependency or not. The transitive
+dependency information is listed in an unintuitive way. Under each dependency
+there may be two fields, `requires` and `dependencies` as in the following
+example:
 
 ```json
     "babel-code-frame": {
@@ -39,21 +53,40 @@ Opening a `package-lock.json` file reveals the project's dependency tree. This d
     }
 ```
 
-The `requires` field signifies all of the dependencies that are needed by the dependency in order to properly function.
+The `requires` field signifies all of the dependencies that are needed by the
+dependency in order to properly function.
 
-The `dependencies` field signifies all of the dependencies included in `babel-code-frame`'s `node_modules` folder within the top level `node_modules` folder. Notice that these dependencies are not always included in the `requires` section.
+The `dependencies` field signifies all of the dependencies included in
+`babel-code-frame`'s `node_modules` folder within the top level `node_modules`
+folder. Notice that these dependencies are not always included in the `requires`
+section.
 
-> Note: `npm-shrinkwrap.json` is an identically formatted file that can be used for [publishing packages](https://docs.npmjs.com/cli/shrinkwrap).
+> Note: `npm-shrinkwrap.json` is an identically formatted file that can be used
+> for [publishing packages](https://docs.npmjs.com/cli/shrinkwrap).
 
 ### Peer Dependencies
 
-Top-level peer dependencies from `package.json` are treated as if they were direct dependencies of the project. Peer dependencies of transitive deps are also treated as transitive dependencies. If a transitive peer dependency also happens to 
-be a direct dependency then it is reported as direct rather than transitive, however. The reason FOSSA does this is because as of `npm` 7+ peer dependencies and transitive peer dependencies are installed by default. 
+Top-level peer dependencies from `package.json` are treated as if they were
+direct dependencies of the project. Peer dependencies of transitive deps are
+also treated as transitive dependencies. If a transitive peer dependency also
+happens to be a direct dependency then it is reported as direct rather than
+transitive, however. The reason FOSSA does this is because as of `npm` 7+ peer
+dependencies and transitive peer dependencies are installed by default.
 
-FOSSA doesn't report peer dependencies in a special way because FOSSA does not model peer dependencies natively. Because direct peer dependencies are defined in the same place as regular direct dependencies (`package.json`) and because NPM installs them by default for FOSSA's purposes they are considered direct. If FOSSA didn't report these dependencies users may potentially miss license information about dependencies that would have implications for the distribution of their projects.
+`fossa-cli` doesn't report peer dependencies in a special way because FOSSA does
+not model peer dependencies natively. Because direct peer dependencies are
+defined in the same place as regular direct dependencies (`package.json`) and
+because NPM installs them by default for FOSSA's purposes they are considered
+direct. If FOSSA didn't report these dependencies users may potentially miss
+license information about dependencies that would have implications for the
+distribution of their projects.
 
-Transitive peer dependencies are found in the `packages` key of `package-lock.json` files produced by recent versions of `npm`.  The `packages` key holds similar information to the those under the `dependencies` key, but `packages`
-includes information about peer dependencies for each dependency or transitive dependency the project uses. For example, an entry might look like this:
+Transitive peer dependencies are found in the `packages` key of
+`package-lock.json` files produced by recent versions of `npm`.  The `packages`
+key holds similar information to the those under the `dependencies` key, but
+`packages` includes information about peer dependencies for each dependency or
+transitive dependency the project uses. For example, an entry might look like
+this:
 
 ```json
     "node_modules/chai-dom": {
@@ -71,4 +104,6 @@ includes information about peer dependencies for each dependency or transitive d
     }
 ```
 
-In this example, when `fossa-cli` does analysis of `chai-dom`, it will include `chai` and `mocha` as dependencies`chai-dom`. The transitive deps for `chai` and `mocha` will also be captured.
+In this example, when `fossa-cli` does analysis of `chai-dom`, it will include
+`chai` and `mocha` as dependencies`chai-dom`. The transitive deps for `chai` and
+`mocha` will also be captured.

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -472,8 +472,8 @@ test-suite unit-tests
     Maven.PluginStrategySpec
     Maven.PomStrategySpec
     Nim.NimbleSpec
-    Node.NpmLockSpec
     Node.PackageJsonSpec
+    Node.PackageLockSpec
     NuGet.NuspecSpec
     NuGet.PackageReferenceSpec
     NuGet.PackagesConfigSpec

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -219,7 +219,7 @@ extractDepLists PkgJsonGraph{..} = foldMap extractSingle $ Map.elems jsonLookup
     extractSingle :: PackageJson -> FlatDeps
     extractSingle PackageJson{..} =
       FlatDeps
-        (applyTag @Production $ mapToSet packageDeps)
+        (applyTag @Production $ mapToSet (packageDeps `Map.union` packagePeerDeps))
         (applyTag @Development $ mapToSet packageDevDeps)
         (Map.keysSet jsonLookup)
 

--- a/src/Strategy/Node/Npm/PackageLock.hs
+++ b/src/Strategy/Node/Npm/PackageLock.hs
@@ -163,7 +163,10 @@ buildGraph packageJson directSet =
         else addDep isRecursive parent name dep
 
     -- Look up if a given npm package has peer dependencies, then add them to
-    -- the graph recursively.
+    -- the graph recursively. All peer dependencies added via this function will
+    -- be added as deep dependencies. If there are direct peer dependencies
+    -- those are discovered when reading @package.json@ and added like a regular
+    -- dependency in 'maybeAddDep'.
     addPeerDeps :: Has NpmGrapher sig m => NpmPackage -> m ()
     addPeerDeps currentPkg =
       maybe (pure ()) graphPeerDeps (Map.lookup (lockName currentPkg) lockPackages)

--- a/src/Strategy/Node/Npm/PackageLock.hs
+++ b/src/Strategy/Node/Npm/PackageLock.hs
@@ -70,8 +70,7 @@ instance FromJSON NpmPackagesPkg where
 
 data NpmPackageJson = NpmPackageJson
   { packageDependencies :: Map Text NpmDep
-  , -- |  Data from the "packages" field of package-json.lock
-    packagePackages :: Map Text NpmPackagesPkg
+  , packagePackages :: Map Text NpmPackagesPkg
   }
   deriving (Eq, Ord, Show)
 

--- a/src/Strategy/Node/PackageJson.hs
+++ b/src/Strategy/Node/PackageJson.hs
@@ -110,6 +110,7 @@ data PackageJson = PackageJson
   , packageDevDeps :: Map Text Text
   , packageLicense :: Maybe PkgJsonLicense
   , packageLicenses :: Maybe [PkgJsonLicenseObj]
+  , packagePeerDeps :: Map Text Text
   }
   deriving (Eq, Ord, Show)
 
@@ -167,6 +168,7 @@ instance FromJSON PackageJson where
       <*> obj .:? "devDependencies" .!= Map.empty
       <*> obj .:? "license"
       <*> obj .:? "licenses"
+      <*> obj .:? "peerDependencies" .!= Map.empty
 
 instance ToJSON PackageJson where
   toJSON PackageJson{..} =
@@ -178,6 +180,7 @@ instance ToJSON PackageJson where
       , "devDependencies" .= packageDevDeps
       , "license" .= packageLicense
       , "licenses" .= packageLicenses
+      , "peerDependencies" .= packagePeerDeps
       ]
 
 newtype Manifest = Manifest {unManifest :: Path Abs File} deriving (Eq, Show, Ord, Generic, ToJSONKey, ToJSON)

--- a/test/Node/NpmLockSpec.hs
+++ b/test/Node/NpmLockSpec.hs
@@ -42,7 +42,8 @@ import Test.Hspec (Spec, describe, it, runIO)
 mockInput :: NpmPackageJson
 mockInput =
   NpmPackageJson
-    { packageDependencies =
+    { packagePackages = Map.empty
+    , packageDependencies =
         Map.fromList
           [
             ( "packageOne"

--- a/test/Node/NpmLockSpec.hs
+++ b/test/Node/NpmLockSpec.hs
@@ -313,6 +313,8 @@ buildGraphSpec testDir =
         graph
 
     it' "Should process peer dependencies" $ do
+      -- I stripped this file down manually to have a smaller example to test
+      -- `npm` would generate a much more complicated package-lock.json
       parsed <- readContentsJson $ testDir </> $(mkRelFile "peerdeps-package-json.lock")
       -- Top-level peerDependencies are treated just like direct
       -- dependencies. For this test "winston-mail" is a top-level peer

--- a/test/Node/PackageJsonSpec.hs
+++ b/test/Node/PackageJsonSpec.hs
@@ -53,6 +53,7 @@ pkgJsonMock license licenses =
     , packageDevDeps = Map.fromList [("packageTwo", "^2.0.0")]
     , packageLicense = license
     , packageLicenses = licenses
+    , packagePeerDeps = Map.empty
     }
 
 mockInput :: PackageJson
@@ -232,6 +233,7 @@ packageJsonGen = do
   devDeps <- keyValMap
   license <- Gen.maybe licenseGen
   licenses <- Gen.maybe $ Gen.list (Range.linear 0 5) licenseObjGen
+  pkgPeerDeps <- keyValMap
   pure
     PackageJson
       { packageName = name
@@ -241,6 +243,7 @@ packageJsonGen = do
       , packageDevDeps = devDeps
       , packageLicense = license
       , packageLicenses = licenses
+      , packagePeerDeps = pkgPeerDeps
       }
 
 pkgJsonParseSpec :: Spec

--- a/test/Node/testdata/peerdeps-package-json.lock
+++ b/test/Node/testdata/peerdeps-package-json.lock
@@ -1,0 +1,103 @@
+{
+    "name": "winston-peerdeps",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "winston-peerdeps",
+            "version": "1.0.0",
+            "license": "ISC",
+            "peerDependencies": {
+                "winston-mail": "^2.0.0"
+            }
+        },
+        "node_modules/async": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+            "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+            "peer": true
+        },
+        "node_modules/mustache": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+            "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+            "peer": true,
+            "bin": {
+                "mustache": "bin/mustache"
+            },
+            "engines": {
+                "npm": ">=1.4.0"
+            }
+        },
+        "node_modules/underscore": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+            "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
+        },
+        "node_modules/winston": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.6.0.tgz",
+            "integrity": "sha512-9j8T75p+bcN6D00sF/zjFVmPp+t8KMPB1MzbbzYjeN9VWxdsYnTB40TkbNUEXAmILEfChMvAMgidlX64OG3p6w==",
+            "peer": true,
+            "dependencies": {
+                "async": "^3.2.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/winston-mail": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/winston-mail/-/winston-mail-2.0.0.tgz",
+            "integrity": "sha512-Wp+mKiieoV6FAZJNyNMS62Zsf5FBSxe17j0f4fpFYeA+rfW8nEZ2eBGGl7+vq+dr3dEpefV5D+ZI3d9jaqdRfw==",
+            "peer": true,
+            "dependencies": {
+                "mustache": "^2.2.1"
+            },
+            "engines": {
+                "node": ">= 0.6.0"
+            },
+            "peerDependencies": {
+                "winston": ">=0.5.0"
+            }
+        }
+    },
+    "dependencies": {
+        "async": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+            "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+            "peer": true
+        },
+        "mustache": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+            "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+            "peer": true
+        },
+        "underscore": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+            "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
+        },
+        "winston": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.6.0.tgz",
+            "integrity": "sha512-9j8T75p+bcN6D00sF/zjFVmPp+t8KMPB1MzbbzYjeN9VWxdsYnTB40TkbNUEXAmILEfChMvAMgidlX64OG3p6w==",
+            "peer": true,
+            "requires": {
+                "async": "^3.2.3"
+            }
+        },
+        "winston-mail": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/winston-mail/-/winston-mail-2.0.0.tgz",
+            "integrity": "sha512-Wp+mKiieoV6FAZJNyNMS62Zsf5FBSxe17j0f4fpFYeA+rfW8nEZ2eBGGl7+vq+dr3dEpefV5D+ZI3d9jaqdRfw==",
+            "peer": true,
+            "requires": {
+                "mustache": "^2.2.1"
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Overview

Fossa-cli wasn't capturing peer dependencies in some situations. This PR makes `package-lock.json` analysis also capture peerDeps and transitive peerDeps. This was happening because we weren't creating edges between deps and their peers, so those dependencies were getting stripped out.

## Acceptance criteria

When someone analyzes a project with both direct and peer dependencies we should report all peer dependencies as well as transitive deps of peer deps.

## Testing plan

There is a unit test which tests a minimal example. To replicate the problem on master you can put the following `package.json` file in a directory, run `npm install` and then analyze that directory. Neither `chai-dom` nor `chai` will appear as a dependency even though it is a peer dependency of `chai-dom`.

```json
{
  "name": "test",
  "main": "index.js",
  "peerDependencies": {
    "chai-dom": "^1.10.0"
  },
  "dependencies": {
    "underscore": "^1.13.2"
  }
}
```

When the same project is run against this branch those `chai`/`chai-dom` (amongst many others) will now be included as dependencies.

## Risks

Please look over the documentation and let me know if it was written in the right voice/includes the right information. 

## Checklist

- [x] I added tests for this PR's change (or confirmed tests are not viable).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
- [x] I linked this PR to any referenced GitHub issues, if they exist.
