### PR TITLE
Don't use NE.fromlist

### DIFF
--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -74,9 +74,10 @@ projectRevision =
     }
 
 sourceUnits :: NE.NonEmpty SourceUnit
-sourceUnits =
-  NE.fromList
-    [ SourceUnit
+sourceUnits = unit NE.:| []
+  where
+    unit = 
+       SourceUnit
         { sourceUnitName = "testSourceUnitName"
         , sourceUnitType = "testSourceUnitType"
         , sourceUnitManifest = "testSourceUnitManifest"
@@ -85,7 +86,7 @@ sourceUnits =
         , sourceUnitOriginPaths = []
         , additionalData = Nothing
         }
-    ]
+    
 
 -- | A base dir for testing.  This directory is not guaranteed to exist.  If you
 -- want a real directory you should use `withTempDir`.

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -76,8 +76,8 @@ projectRevision =
 sourceUnits :: NE.NonEmpty SourceUnit
 sourceUnits = unit NE.:| []
   where
-    unit = 
-       SourceUnit
+    unit =
+      SourceUnit
         { sourceUnitName = "testSourceUnitName"
         , sourceUnitType = "testSourceUnitType"
         , sourceUnitManifest = "testSourceUnitManifest"
@@ -86,7 +86,6 @@ sourceUnits = unit NE.:| []
         , sourceUnitOriginPaths = []
         , additionalData = Nothing
         }
-    
 
 -- | A base dir for testing.  This directory is not guaranteed to exist.  If you
 -- want a real directory you should use `withTempDir`.


### PR DESCRIPTION
# Overview

Merge skew and early PR checks caused an `hlint` issue to slip through.  You can see the error here: https://github.com/fossas/fossa-cli/runs/5686530735?check_suite_focus=true