### PR TITLE
refactor: Improve misc. GitHub configurations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fossas/analysis

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,32 +2,42 @@
 
 _Provide an overview of this change. Describe the intent of this change, and how it implements that intent._
 
+_Example: This PR accomplishes X by doing Y._
+
 ## Acceptance criteria
 
-_What is this PR trying to accomplish?_
+_If this PR is successful, what impact does it have on the user experience?_
+
+_Example: When users do X, Y should now happen._
 
 ## Testing plan
 
-_How did you validate that this PR works? How did you check that the acceptance criteria were fulfilled?_
+_How did you validate that this PR works? What literal steps did you take when manually checking that your code works?_
 
-_This section should list reproduction steps that a reviewer can run through (and provide any needed test cases)._
+_Example:_
+
+1. _Set up test case X._
+2. _Run command Y. Make sure Z happens._
+
+_This section should list concrete steps that a reviewer can sanity check and repeat on their own machine (and provide any needed test cases)._
 
 ## Risks
 
-_Highlight any areas that you're unsure of, or want reviewers to pay particular attention to._
+_Highlight any areas that you're unsure of, want feedback on, or want reviewers to pay particular attention to._
+
+_Example: I'm not sure I did X correctly, can reviewers please double-check that for me?_
 
 ## References
 
-_List any referenced GitHub issues. If PR references tickets in other systems (e.g. Zendesk), they should probably be mirrored as a GitHub Issue._
+_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._
 
-_Make sure to use keywords to link this PR to GitHub issues ([GitHub Docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))._
+_Example:_
 
-_Example:_ Closes org/repo#123.
+- _[ANE-123](https://fossa.atlassian.net/browse/ANE-123): Implement X._
 
 ## Checklist
 
-- [ ] I added tests for this PR's change (or confirmed tests are not viable).
+- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
 - [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
 - [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
-- [ ] I updated `*schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yaml, yml}`. You may also need to update these if you have added/removed new dependency (e.g. pip) or analysis target type (e.g. poetry).
-- [ ] I linked this PR to any referenced GitHub issues, if they exist.
+- [ ] I updated `docs/references/files/*.schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yml}`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,5 +39,5 @@ _Example:_
 
 - [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
 - [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
-- [ ] I updated `Changelog.md` if this change is externally facing. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
-- [ ] I updated `docs/references/files/*.schema.json` if I have made changes for `.fossa.yml`, `fossa-deps.{json, yml}`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
+- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
+- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


### PR DESCRIPTION
# Overview

This PR makes some small misc. improvements to our GitHub configurations:

1. It rewords the PR template to be clearer and adds short examples.
2. It adds `CODEOWNERS` to the repository. Once this is merged, we can turn on "review required from code owners". This way contributions from other FOSSA folks will require code review from the Analysis team.
