### PR TITLE
refactor: New hlint rule: replace mapM with traverse

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -17,6 +17,7 @@
 - suggest: {lhs: return, rhs: pure}
 - suggest: {lhs: () <$ x, rhs: Control.Monad.void x}
 - suggest: {lhs: x <&> f, rhs: f <$> x}
+- suggest: {lhs: mapM, rhs: traverse}
 
 - suggest: {lhs: Data.Text.pack, rhs: Data.String.Conversion.toText}
 - ignore: {name: "Use toText", within: ["Data.String.Conversion"]}


### PR DESCRIPTION
# Overview

Adds "replace `mapM` with `traverse`" as an `hlint` rule. See also https://github.com/fossas/fossa-cli/pull/851#discussion_r835590880.
