### PR TITLE
fix: Config file path should be relative to analyze basedir

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,21 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Configuration: Fixes a bug where `.fossa.yml` was picked up only in the working directory, not in the analysis directory. ([#854](https://github.com/fossas/fossa-cli/pull/854))
+
 ## v3.1.8
-- Windows: Fixes a --version command for windows release binary. 
+
+- Windows: Fixes a --version command for windows release binary.
 
 ## v3.1.7
+
 - Configuration: Users can now use `.fossa.yaml` as a configuration file name. Previously, only `.fossa.yml` was supported. ([#851](https://github.com/fossas/fossa-cli/pull/851))
 - fossa-deps: Fixes an archive uploading bug for vendor dependency by queuing archive builds individually. ([#826](https://github.com/fossas/fossa-cli/pull/826))
 - nodejs: Capture peer dependencies transitively for npm `package-lock.json` files. ([#849](https://github.com/fossas/fossa-cli/pull/849))
 
 ## v3.1.6
+
 - Respects Go module replacement directives in the Go Mod Graph strategy. ([#841](https://github.com/fossas/fossa-cli/pull/841))
 
 ## v3.1.5

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -77,7 +77,7 @@ import Effect.Exec (
   Exec,
  )
 import Effect.Logger (Logger, Severity (SevDebug, SevInfo), logWarn)
-import Effect.ReadFS (ReadFS)
+import Effect.ReadFS (ReadFS, resolveDir)
 import Fossa.API.Types (ApiOpts)
 import Options.Applicative (
   Alternative (many),
@@ -252,10 +252,10 @@ loadConfig ::
   ) =>
   AnalyzeCliOpts ->
   m (Maybe ConfigFile)
-loadConfig AnalyzeCliOpts{commons = CommonOpts{optConfig}} = do
-  -- FIXME: We eventually want to use the basedir to inform the config file root
-  configRelBase <- sendIO getCurrentDir
-  resolveConfigFile configRelBase optConfig
+loadConfig AnalyzeCliOpts{analyzeBaseDir, commons = CommonOpts{optConfig}} = do
+  cwd <- sendIO getCurrentDir
+  configBaseDir <- resolveDir cwd (toText analyzeBaseDir)
+  resolveConfigFile configBaseDir optConfig
 
 mergeOpts ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -76,7 +76,7 @@ import Discovery.Filters (AllFilters (AllFilters), comboExclude, comboInclude)
 import Effect.Exec (
   Exec,
  )
-import Effect.Logger (Logger, Severity (SevDebug, SevInfo), logWarn)
+import Effect.Logger (Logger, Severity (SevDebug, SevInfo), logDebug, logWarn, pretty)
 import Effect.ReadFS (ReadFS, resolveDir)
 import Fossa.API.Types (ApiOpts)
 import Options.Applicative (
@@ -255,6 +255,7 @@ loadConfig ::
 loadConfig AnalyzeCliOpts{analyzeBaseDir, commons = CommonOpts{optConfig}} = do
   cwd <- sendIO getCurrentDir
   configBaseDir <- resolveDir cwd (toText analyzeBaseDir)
+  logDebug $ "Loading configuration file from " <> pretty (show configBaseDir)
   resolveConfigFile configBaseDir optConfig
 
 mergeOpts ::

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -68,13 +68,6 @@ defaultConfigFileNames =
   , $(mkRelFile ".fossa.yaml")
   ]
 
--- data ConfigLocation = ConfigLocation
---   { -- | Did the user specify the path (True/required), or is this default (False/optional)?
---     isRequired :: Bool
---   , -- | What is the absolute file path?
---     configFilePath :: Path Abs File
---   }
-
 data ConfigLocation
   = DefaultConfigLocation (Path Abs Dir)
   | SpecifiedConfigLocation (Path Abs File)


### PR DESCRIPTION
# Overview

This PR fixes configuration file resolution. Originally, running `fossa analyze /foo/bar` would look at the CWD for a `.fossa.yml` instead of in `/foo/bar`. This PR fixes resolution to instead correctly search for `/foo/bar/.fossa.yml`.

## Acceptance criteria

When a user runs `fossa analyze /foo/bar`, the configuration file at `/foo/bar/.fossa.yml` should be used instead of the configuration file at `$(pwd)/.fossa.yml`. This should work for both relative and absolute basedir paths.

## Testing plan

1. Create a test project somewhere (I have one at `/tmp/fossa-test-project`).
2. Set a configuration file that generates an obvious error when used (I set `server` to `localhost`, so the CLI throws a `HostCannotConnect`).
3. Run `fossa analyze PATH_TO_TEST_PROJECT` (`fossa analyze /tmp/fossa-test-project`) with both absolute and relative paths, and check that the expected configuration error occurs.

## Risks

1. Are there any other filepath forms I should test?
2. Does anyone have advice on how to integration test this?
5. Do we need an integration test for this? I'm ambivalent about writing one since it seems relatively high-effort and low-value.

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
