### PR TITLE
Redacts api creds when passed as command line args

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -441,6 +441,7 @@ test-suite unit-tests
     Conda.CondaListSpec
     Conda.EnvironmentYmlSpec
     Control.Carrier.DiagnosticsSpec
+    Control.Carrier.Telemetry.UtilSpec
     Control.Carrier.TelemetrySpec
     Control.TimeoutSpec
     Dart.PubDepsSpec

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -30,6 +30,7 @@ module App.Fossa.Config.Common (
   -- * Global Defaults
   defaultTimeoutDuration,
   collectRevisionData',
+  fossaApiKeyCmdText,
 ) where
 
 import App.Fossa.Config.ConfigFile (
@@ -74,7 +75,7 @@ import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.Bifunctor (Bifunctor (first))
 import Data.Functor.Extra ((<$$>))
 import Data.Maybe (fromMaybe)
-import Data.String.Conversion (ToText (toText))
+import Data.String.Conversion (ToText (toText), toString)
 import Data.Text (Text, strip, toLower)
 import Discovery.Filters (targetFilterParser)
 import Effect.Exec (Exec)
@@ -315,6 +316,9 @@ parseTelemetryScope = eitherReader $ \scope ->
     "full" -> Right FullTelemetry
     _ -> Left "Failed to parse telemetry scope, expected either: full or off"
 
+fossaApiKeyCmdText :: Text
+fossaApiKeyCmdText = "fossa-api-key"
+
 commonOpts :: Parser CommonOpts
 commonOpts =
   CommonOpts
@@ -322,6 +326,6 @@ commonOpts =
     <*> optional (uriOption (long "endpoint" <> short 'e' <> metavar "URL" <> help "The FOSSA API server base URL (default: https://app.fossa.com)"))
     <*> optional (strOption (long "project" <> short 'p' <> help "this repository's URL or VCS endpoint (default: VCS remote 'origin')"))
     <*> optional (strOption (long "revision" <> short 'r' <> help "this repository's current revision hash (default: VCS hash HEAD)"))
-    <*> optional (strOption (long "fossa-api-key" <> help "the FOSSA API server authentication key (default: FOSSA_API_KEY from env)"))
+    <*> optional (strOption (long (toString fossaApiKeyCmdText) <> help "the FOSSA API server authentication key (default: FOSSA_API_KEY from env)"))
     <*> optional (strOption (long "config" <> short 'c' <> help "Path to configuration file including filename (default: .fossa.yml)"))
     <*> optional (option parseTelemetryScope (long "with-telemetry-scope" <> help "Scope of telemetry to use, the options are 'full' or 'off'. (default: 'full')"))

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -75,7 +75,8 @@ import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.Bifunctor (Bifunctor (first))
 import Data.Functor.Extra ((<$$>))
 import Data.Maybe (fromMaybe)
-import Data.String.Conversion (ToText (toText), toString)
+import Data.String (IsString)
+import Data.String.Conversion (ToText (toText))
 import Data.Text (Text, strip, toLower)
 import Discovery.Filters (targetFilterParser)
 import Effect.Exec (Exec)
@@ -316,7 +317,7 @@ parseTelemetryScope = eitherReader $ \scope ->
     "full" -> Right FullTelemetry
     _ -> Left "Failed to parse telemetry scope, expected either: full or off"
 
-fossaApiKeyCmdText :: Text
+fossaApiKeyCmdText :: IsString a => a
 fossaApiKeyCmdText = "fossa-api-key"
 
 commonOpts :: Parser CommonOpts
@@ -326,6 +327,6 @@ commonOpts =
     <*> optional (uriOption (long "endpoint" <> short 'e' <> metavar "URL" <> help "The FOSSA API server base URL (default: https://app.fossa.com)"))
     <*> optional (strOption (long "project" <> short 'p' <> help "this repository's URL or VCS endpoint (default: VCS remote 'origin')"))
     <*> optional (strOption (long "revision" <> short 'r' <> help "this repository's current revision hash (default: VCS hash HEAD)"))
-    <*> optional (strOption (long (toString fossaApiKeyCmdText) <> help "the FOSSA API server authentication key (default: FOSSA_API_KEY from env)"))
+    <*> optional (strOption (long fossaApiKeyCmdText <> help "the FOSSA API server authentication key (default: FOSSA_API_KEY from env)"))
     <*> optional (strOption (long "config" <> short 'c' <> help "Path to configuration file including filename (default: .fossa.yml)"))
     <*> optional (option parseTelemetryScope (long "with-telemetry-scope" <> help "Scope of telemetry to use, the options are 'full' or 'off'. (default: 'full')"))

--- a/src/Control/Carrier/Telemetry/Utils.hs
+++ b/src/Control/Carrier/Telemetry/Utils.hs
@@ -5,8 +5,11 @@ module Control.Carrier.Telemetry.Utils (
   getCommandArgs,
   mkTelemetryCtx,
   mkTelemetryRecord,
+  -- for testing
+  redactApiKeyFromCmdArgs,
 ) where
 
+import App.Fossa.Config.Common (fossaApiKeyCmdText)
 import App.Version (isDirty, versionOrBranch)
 import Control.Algebra (Has)
 import Control.Carrier.Lift (Lift, sendIO)
@@ -20,9 +23,10 @@ import Control.Carrier.Telemetry.Types (
 import Control.Concurrent.STM (STM, atomically, newEmptyTMVarIO, tryReadTMVar)
 import Control.Concurrent.STM.TBMQueue (TBMQueue, newTBMQueueIO, tryReadTBMQueue)
 import Control.Monad (join, replicateM)
+import Data.List (elemIndex)
 import Data.Maybe (catMaybes)
 import Data.String.Conversion (toText)
-import Data.Text (Text)
+import Data.Text (Text, isPrefixOf)
 import Data.Time (diffUTCTime, getCurrentTime, nominalDiffTimeToSeconds)
 import Data.Tracing.Instrument (
   getCounterRegistry,
@@ -86,7 +90,33 @@ getCurrentCliEnvironment =
     else CliProductionEnvironment
 
 getCommandArgs :: IO [Text]
-getCommandArgs = map toText <$> Environment.getFullArgs
+getCommandArgs = redactApiKeyFromCmdArgs <$> (map toText <$> Environment.getFullArgs)
+
+-- | Redacts Api Key from raw command args.
+redactApiKeyFromCmdArgs :: [Text] -> [Text]
+redactApiKeyFromCmdArgs = redactApiKeyWhenDirectlySupplied . redactApiKeyWhenPassedAsArg
+  where
+    -- When provided with --fossa-api-key=someKey
+    redactApiKeyWhenDirectlySupplied :: [Text] -> [Text]
+    redactApiKeyWhenDirectlySupplied =
+      map
+        ( \arg ->
+            if ("--" <> fossaApiKeyCmdText <> "=") `isPrefixOf` arg
+              then ("--" <> fossaApiKeyCmdText <> "=<REDACTED>")
+              else arg
+        )
+
+    -- When provided with --fossa-api-key someKey
+    redactApiKeyWhenPassedAsArg :: [Text] -> [Text]
+    redactApiKeyWhenPassedAsArg args =
+      case elemIndex ("--" <> fossaApiKeyCmdText) args of
+        Nothing -> args
+        Just i -> replaceAtWith args (i + 1) "<REDACTED>"
+
+    replaceAtWith :: [Text] -> Int -> Text -> [Text]
+    replaceAtWith args replaceAt replaceWith = case splitAt replaceAt args of
+      (start, _ : end) -> start ++ replaceWith : end
+      _ -> args
 
 getSystemInfo :: IO SystemInfo
 getSystemInfo =

--- a/src/Control/Carrier/Telemetry/Utils.hs
+++ b/src/Control/Carrier/Telemetry/Utils.hs
@@ -90,7 +90,7 @@ getCurrentCliEnvironment =
     else CliProductionEnvironment
 
 getCommandArgs :: IO [Text]
-getCommandArgs = redactApiKeyFromCmdArgs <$> (map toText <$> Environment.getFullArgs)
+getCommandArgs = redactApiKeyFromCmdArgs . map toText <$> Environment.getFullArgs
 
 -- | Redacts Api Key from raw command args.
 redactApiKeyFromCmdArgs :: [Text] -> [Text]

--- a/test/Control/Carrier/Telemetry/UtilSpec.hs
+++ b/test/Control/Carrier/Telemetry/UtilSpec.hs
@@ -1,0 +1,23 @@
+module Control.Carrier.Telemetry.UtilSpec (spec) where
+
+import Control.Carrier.Telemetry.Utils (redactApiKeyFromCmdArgs)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = do
+  describe "redactApiKeyFromCmdArgs" $ do
+    it "should redact api key, when supplied via =" $ do
+      let providedArgs = ["fossa", "analyze", "--fossa-api-key=secret"]
+          redactedArgs = ["fossa", "analyze", "--fossa-api-key=<REDACTED>"]
+
+      (redactApiKeyFromCmdArgs providedArgs) `shouldBe` redactedArgs
+
+    it "should redact api key, when supplied via arg" $ do
+      let providedArgs = ["fossa", "analyze", "--fossa-api-key", "secret"]
+          redactedArgs = ["fossa", "analyze", "--fossa-api-key", "<REDACTED>"]
+      (redactApiKeyFromCmdArgs providedArgs) `shouldBe` redactedArgs
+
+    it "should not redact any other args" $ do
+      let providedArgs = ["fossa", "analyze", "--output", "--debug", "--project", "fossa-api"]
+          redactedArgs = ["fossa", "analyze", "--output", "--debug", "--project", "fossa-api"]
+      (redactApiKeyFromCmdArgs providedArgs) `shouldBe` redactedArgs


### PR DESCRIPTION
# Overview

Redacts API key from telemetry bundle when provided via command line args.

## Acceptance criteria

When user adds `--fossa-api-key=Secret` or `--fossa-api-key Secret`, we redact them in telemetry bundle.

## Testing plan

1. Run `make install-dev`
2. Run `fossa-dev analyze --with-telemetry-scope full --debug --fossa-api-key SECRET`
3. Note in `fossa.telemetry.json` we have redacted API key
4. Run `fossa-dev analyze --with-telemetry-scope full --debug --fossa-api-key=SECRET`
5. Note in `fossa.telemetry.json` we have redacted API key

## Risks

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
