### PR TITLE
ANE-119: Fixes --version command for windows binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,10 @@ jobs:
       run: |
         make build-test-data
 
+    - name: Check git status
+      run: |
+        git status --porcelain
+
     - name: Build
       # Occasionally, we run out of memory on the build process.
       # Since cabal uses incremental compilation, we can retry from where we left off

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ integration-test/artifacts/
 # One offs
 test/App/Fossa/VSI/DynLinked/testdata/hello_standard
 test/App/Fossa/VSI/DynLinked/testdata/hello_setuid
+test/App/Fossa/VSI/DynLinked/testdata/hello_standard.exe
+test/App/Fossa/VSI/DynLinked/testdata/hello_setuid.exe

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,5 @@ fossa.debug.json.gz
 integration-test/artifacts/
 
 # One offs
-test/App/Fossa/VSI/DynLinked/testdata/hello_standard
-test/App/Fossa/VSI/DynLinked/testdata/hello_setuid
-test/App/Fossa/VSI/DynLinked/testdata/hello_standard.exe
-test/App/Fossa/VSI/DynLinked/testdata/hello_setuid.exe
+test/App/Fossa/VSI/DynLinked/testdata/hello_standard*
+test/App/Fossa/VSI/DynLinked/testdata/hello_setuid*

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.1.8
+- Windows: Fixes a --version command for windows release binary. 
+
 ## v3.1.7
 - Configuration: Users can now use `.fossa.yaml` as a configuration file name. Previously, only `.fossa.yml` was supported. ([#851](https://github.com/fossas/fossa-cli/pull/851))
 - fossa-deps: Fixes an archive uploading bug for vendor dependency by queuing archive builds individually. ([#826](https://github.com/fossas/fossa-cli/pull/826))


### PR DESCRIPTION
# Overview

This PR ignores test binaries created for unit testing. Consequently, this ensures windows releases are clean, and `--version` command on binary yields the release tag value. 

## Acceptance criteria

- `--version` command for windows binary shows release tag information.

## Testing plan

1. `--version` should not show ("dirty") in version information for non-git tag binaries.
2. `--version` should show tag value information for the windows release binary.

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-119

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
