### PR TITLE
Experimental native scan flag

### DIFF
--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -267,7 +267,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
         then do
           logInfo "Running in VSI only mode, skipping manual source units"
           pure Nothing
-        else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir maybeApiOpts
+        else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir maybeApiOpts allowNativeLicenseScan
   let additionalSourceUnits :: [SourceUnit]
       additionalSourceUnits = mapMaybe (join . resultToMaybe) [manualSrcUnits, vsiResults, binarySearchResults, dynamicLinkedResults]
   traverse_ (Diag.flushLogs SevError SevDebug) [vsiResults, binarySearchResults, manualSrcUnits, dynamicLinkedResults]

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -234,6 +234,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   let maybeApiOpts = case destination of
         OutputStdout -> Nothing
         UploadScan opts _ -> Just opts
+      allowNativeLicenseScan = Config.allowNativeLicenseScan cfg
       BaseDir basedir = Config.baseDir cfg
       destination = Config.scanDestination cfg
       filters = Config.filterSet cfg

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -2,7 +2,6 @@
 
 module App.Fossa.ArchiveUploader (
   archiveUploadSourceUnit,
-  archiveNoUploadSourceUnit,
   arcToLocator,
   forceVendoredToArchive,
   duplicateFailureBundle,
@@ -108,10 +107,6 @@ archiveUploadSourceUnit baseDir apiOpts vendoredDeps = do
       archivesWithOrganization = updateArcName (toText $ show orgId) <$> archives
 
   pure $ arcToLocator <$> archivesWithOrganization
-
--- archiveNoUploadSourceUnit exists for when users run `fossa analyze -o` and do not upload their source units.
-archiveNoUploadSourceUnit :: [VendoredDependency] -> [Locator]
-archiveNoUploadSourceUnit = map (arcToLocator . forceVendoredToArchive)
 
 -- | List of names that occur more than once in a list of vendored dependencies.
 duplicateNames :: NonEmpty VendoredDependency -> [Text]

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.Config.Analyze (
+  AllowNativeLicenseScan (..),
   AnalyzeCliOpts,
   AnalyzeConfig (..),
   BinaryDiscovery (..),
@@ -101,6 +102,8 @@ import System.Info qualified as SysInfo
 import Types (TargetFilter)
 
 -- CLI flags, for use with 'Data.Flag'
+data AllowNativeLicenseScan = AllowNativeLicenseScan
+
 data BinaryDiscovery = BinaryDiscovery
 
 data IncludeAll = IncludeAll
@@ -130,6 +133,7 @@ data AnalyzeCliOpts = AnalyzeCliOpts
   , analyzeUnpackArchives :: Flag UnpackArchives
   , analyzeJsonOutput :: Flag JsonOutput
   , analyzeIncludeAllDeps :: Flag IncludeAll
+  , analyzeAllowNativeLicenseScan :: Flag AllowNativeLicenseScan
   , analyzeBranch :: Maybe Text
   , analyzeMetadata :: ProjectMetadata
   , analyzeOnlyTargets :: [TargetFilter]
@@ -176,6 +180,7 @@ data StandardAnalyzeConfig = StandardAnalyzeConfig
   , unpackArchives :: Flag UnpackArchives
   , jsonOutput :: Flag JsonOutput
   , includeAllDeps :: Flag IncludeAll
+  , allowNativeLicenseScan :: Flag AllowNativeLicenseScan
   }
   deriving (Eq, Ord, Show)
 
@@ -198,6 +203,8 @@ cliParser =
     <*> flagOpt UnpackArchives (long "unpack-archives" <> help "Recursively unpack and analyze discovered archives")
     <*> flagOpt JsonOutput (long "json" <> help "Output project metadata as json to the console. Useful for communicating with the FOSSA API")
     <*> flagOpt IncludeAll (long "include-unused-deps" <> help "Include all deps found, instead of filtering non-production deps.  Ignored by VSI.")
+    -- Intentionally hidden until some critical bugs are addressed
+    <*> flagOpt AllowNativeLicenseScan (long "experimental-native-license-scan" <> hidden)
     <*> optional (strOption (long "branch" <> short 'b' <> help "this repository's current branch (default: current VCS branch)"))
     <*> metadataOpts
     <*> many (option (eitherReader targetOpt) (long "only-target" <> help "Only scan these targets. See targets.only in the fossa.yml spec." <> metavar "PATH"))
@@ -341,6 +348,7 @@ mergeStandardOpts maybeConfig envvars cliOpts@AnalyzeCliOpts{..} = do
     <*> pure analyzeUnpackArchives
     <*> pure analyzeJsonOutput
     <*> pure analyzeIncludeAllDeps
+    <*> pure analyzeAllowNativeLicenseScan
 
 collectFilters ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -2,7 +2,6 @@
 
 module App.Fossa.LicenseScanner (
   licenseScanSourceUnit,
-  licenseNoScanSourceUnit,
 ) where
 
 import App.Fossa.ArchiveUploader (
@@ -10,7 +9,6 @@ import App.Fossa.ArchiveUploader (
   arcToLocator,
   duplicateFailureBundle,
   duplicateNames,
-  forceVendoredToArchive,
  )
 import App.Fossa.EmbeddedBinary (ThemisBins, withThemisAndIndex)
 import App.Fossa.FossaAPIV1 qualified as Fossa
@@ -185,7 +183,3 @@ licenseScanSourceUnit baseDir apiOpts vendoredDeps = do
 
     includeOrgId :: Int -> Archive -> Archive
     includeOrgId orgId arc = arc{archiveName = showT orgId <> "/" <> archiveName arc}
-
--- | licenseNoScanSourceUnit exists for when users run `fossa analyze -o` and do not upload their source units.
-licenseNoScanSourceUnit :: [VendoredDependency] -> [Locator]
-licenseNoScanSourceUnit = map (arcToLocator . forceVendoredToArchive)


### PR DESCRIPTION
# Overview

Delivers ANE-148

We should allow users to enable native license scanning on an opt-in basis for the beta program.  Note that previous behavior hard-coded ourselves into Archive upload, while this PR partially unlocks the native scan path.

This can only be tested with E2E tests, so no tests were added.

## Acceptance criteria

- When `--experimental-native-license-scan` and NOT `--output`, run license scan using themis.
- When `--output`, do not run themis or archive upload.
- When no `vendored-dependencies` in `fossa-deps` (or no `fossa-deps` file), do not run themis.

## Testing plan

- Run with `--output` (with and without the new flag), and some vendored deps in `fossa-deps` file.  Should not see any results from themis scan.
- Run with no `fossa-deps` file.  Should not see any results from themis.
- Run with `fossa-deps` file where `vendored-dependencies` is an empty array.  Should not see any results from themis.
- For AC #1, you can build with a bash script in `vendor-bins/themis-cli`:

```bash
#! /bin/bash
echo "Attempted to run themis executable" >> themis-file
echo "arguments passed:" "$@" >> themis-file
```

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
