### PR TITLE
Prevent VSCode from refining duration imports

### DIFF
--- a/src/Control/Timeout.hs
+++ b/src/Control/Timeout.hs
@@ -28,12 +28,37 @@ import Control.Effect.Lift (Has, Lift, sendIO)
 import Control.Monad (when)
 import Control.Timeout.Internal (
   Cancel (..),
-  Duration (..),
-  durationToMicro,
  )
 import Data.Functor (($>))
 
--- Whether a cancellable should cancel right now, or poll again.
+-- | Several time-based functions accept 'Int', which mmakes it difficult to
+-- reason about which subdivision of time that int represents.  To aid this,
+-- our timeout functions accept 'Duration' which provides semantically-obvious
+-- constructors, and is exported to the correct resolution when passed to its
+-- underlying function.
+data Duration
+  = Seconds Int
+  | Minutes Int
+  | MilliSeconds Int
+  | MicroSeconds Int
+  deriving (Show)
+
+instance Eq Duration where
+  a == b = durationToMicro a == durationToMicro b
+
+instance Ord Duration where
+  compare a b = compare (durationToMicro a) (durationToMicro b)
+
+-- | threadDelay only accepts microseconds, so we simplfy that with the tiny
+-- abstraction of 'Duration'.
+durationToMicro :: Duration -> Int
+durationToMicro = \case
+  Seconds n -> n * 1_000_000
+  Minutes n -> n * 60_000_000
+  MilliSeconds n -> n * 1000
+  MicroSeconds n -> n
+
+-- | Whether a cancellable should cancel right now, or poll again.
 -- Use checkForCancel instead if you want to fail.
 shouldCancelRightNow :: Cancel -> IO Bool
 shouldCancelRightNow (Cancel mvar) = not <$> isEmptyMVar mvar
@@ -60,7 +85,7 @@ checkForCancel err cancel = do
 -- The intended usage is:
 -- @
 -- timeout' duration $ \cancelToken -> do
---   longRunningComputation cancelFlag
+--   longRunningComputation cancelToken
 -- @
 --
 -- Which will run @longRunningComputation@ until it returns, and set the cancel
@@ -86,7 +111,7 @@ timeout' duration act = do
   -- requires the timeout to fully expire.
   act (Cancel cancel) `finally` kill handle
 
--- Legacy timeout function, using external cancellation, but cannot work with
+-- | Legacy timeout function, using external cancellation, but cannot work with
 -- other IO-capable monad stacks or effects.
 timeoutIO ::
   -- | number of seconds before timeout

--- a/src/Control/Timeout.hs
+++ b/src/Control/Timeout.hs
@@ -31,7 +31,7 @@ import Control.Timeout.Internal (
  )
 import Data.Functor (($>))
 
--- | Several time-based functions accept 'Int', which mmakes it difficult to
+-- | Several time-based functions accept 'Int', which makes it difficult to
 -- reason about which subdivision of time that int represents.  To aid this,
 -- our timeout functions accept 'Duration' which provides semantically-obvious
 -- constructors, and is exported to the correct resolution when passed to its

--- a/src/Control/Timeout/Internal.hs
+++ b/src/Control/Timeout/Internal.hs
@@ -9,4 +9,3 @@ import Control.Concurrent (MVar)
 -- Opaque wrapper around MVar (sort of like an atomic variable)
 -- Only created by using `timeout'`
 newtype Cancel = Cancel (MVar ()) deriving (Eq)
-

--- a/src/Control/Timeout/Internal.hs
+++ b/src/Control/Timeout/Internal.hs
@@ -2,8 +2,6 @@
 
 module Control.Timeout.Internal (
   Cancel (..),
-  Duration (..),
-  durationToMicro,
 ) where
 
 import Control.Concurrent (MVar)
@@ -12,24 +10,3 @@ import Control.Concurrent (MVar)
 -- Only created by using `timeout'`
 newtype Cancel = Cancel (MVar ()) deriving (Eq)
 
-data Duration
-  = Seconds Int
-  | Minutes Int
-  | MilliSeconds Int
-  | MicroSeconds Int
-  deriving (Show)
-
-instance Eq Duration where
-  a == b = durationToMicro a == durationToMicro b
-
-instance Ord Duration where
-  compare a b = compare (durationToMicro a) (durationToMicro b)
-
--- threadDelay only accepts microseconds, so we simplfy that with the tiny
--- abstraction of 'Duration'.
-durationToMicro :: Duration -> Int
-durationToMicro = \case
-  Seconds n -> n * 1_000_000
-  Minutes n -> n * 60_000_000
-  MilliSeconds n -> n * 1000
-  MicroSeconds n -> n


### PR DESCRIPTION
# Overview

VSCode really wants us to import `Duration` from `Control.Timeout.Internal` instead of `Control.Timeout`, where it's re-exported for API cleanliness.

This is from `App.Fossa.Config.Common`, but it occurs in multiple places.

![image](https://user-images.githubusercontent.com/18744724/160503669-c88b63f7-5ab8-4655-8e7c-cf5af1323835.png)

We can fix this issue by moving `Duration` into `Control.Timeout`, since it didn't need to be in the internal module anyway.

## Acceptance criteria

- VSCode stops suggesting that you refine your imports when importing `Duration` from `Control.Timeout`.
