### PR TITLE
Fixes odd verbiage in gradle docs

### DIFF
--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -196,13 +196,13 @@ For more details, see the [manual dependencies](../../../../features/manual-depe
 
 ## Configurations For Development and Testing
 
-We classify any dependencies originating from following configuration as development dependency:
+We classify any dependencies originating from the following configurations as a development dependency:
 
 ```
 - compileOnly
 ```
 
-We classify any dependencies originating from following configuration as test dependency: 
+We classify any dependencies originating from the following configurations as a test dependency:
 
 ```
 - testImplementation
@@ -212,7 +212,7 @@ We classify any dependencies originating from following configuration as test de
 - testRuntimeClasspath
 ```
 
-Note, by default we exclude test and development dependencies from analysis.
+Note, by default we exclude test and development dependencies from the analysis.
 
 ## Android Gradle Configurations For Development and Testing
 

--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -196,13 +196,13 @@ For more details, see the [manual dependencies](../../../../features/manual-depe
 
 ## Configurations For Development and Testing
 
-We classify following configurations are for development:
+We classify any dependencies originating from following configuration as development dependency:
 
 ```
 - compileOnly
 ```
 
-and following are for testing: 
+We classify any dependencies originating from following configuration as test dependency: 
 
 ```
 - testImplementation
@@ -211,6 +211,9 @@ and following are for testing:
 - testCompileClasspath
 - testRuntimeClasspath
 ```
+
+Note, by default we exclude test and development dependencies from analysis.
+
 ## Android Gradle Configurations For Development and Testing
 
 We classify following configurations, and any dependencies originating from it as a test environment dependency:


### PR DESCRIPTION
Fixes verbiage in Gradle docs regarding test and dev configurations.

Reference: https://teamfossa.slack.com/archives/C0155DTGWB1/p1648512089147009