### PR TITLE
add `resolvePath` util to `ReadFS`

### DIFF
--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -187,6 +187,7 @@ readFSToDebug = interpret $ \case
   cons@DoesDirExist{} -> recording cons
   cons@ResolveFile'{} -> recording cons
   cons@ResolveDir'{} -> recording cons
+  cons@ResolvePath{} -> recording cons
   cons@ListDir{} -> ignoring cons
   cons@GetIdentifier{} -> recording cons
 

--- a/src/Data/String/Conversion.hs
+++ b/src/Data/String/Conversion.hs
@@ -18,7 +18,7 @@ import Data.Text.Encoding qualified as TE
 import Data.Text.Encoding.Error qualified as TE
 import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding qualified as TLE
-import GHC.TypeLits
+import GHC.TypeLits (ErrorMessage (Text), TypeError)
 import Path (Path, SomeBase)
 import Path qualified
 
@@ -80,8 +80,8 @@ instance ToText (Path b t) where
 
 instance ToText (SomeBase t) where
   toText path = case path of
-    Path.Abs p -> toText . Path.toFilePath $ p
-    Path.Rel p -> toText . Path.toFilePath $ p
+    Path.Abs p -> toText p
+    Path.Rel p -> toText p
 
 ----- ToLText
 
@@ -125,6 +125,11 @@ instance TypeError ( 'Text "Error: Use decodeUtf8 instead") => ToString BL.ByteS
 
 instance ToString (Path b t) where
   toString = Path.toFilePath
+
+instance ToString (SomeBase t) where
+  toString = \case
+    Path.Rel p -> toString p
+    Path.Abs p -> toString p
 
 ----- LazyStrict
 

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -89,7 +89,6 @@ import Path (
   File,
   Path,
   SomeBase (Abs),
-  fromAbsFile,
   fromSomeDir,
   fromSomeFile,
   parseSomeDir,
@@ -276,41 +275,41 @@ type Parser = Parsec Void Text
 
 -- | Read from a file, parsing its contents
 readContentsParser :: forall a sig m. (Has ReadFS sig m, Has Diagnostics sig m) => Parser a -> Path Abs File -> m a
-readContentsParser parser file = context ("Parsing file '" <> toText (fromAbsFile file) <> "'") $ do
+readContentsParser parser file = context ("Parsing file '" <> toText (toString file) <> "'") $ do
   contents <- readContentsText file
-  case runParser parser (fromAbsFile file) contents of
-    Left err -> fatal $ FileParseError (fromAbsFile file) (toText (errorBundlePretty err))
+  case runParser parser (toString file) contents of
+    Left err -> fatal $ FileParseError (toString file) (toText (errorBundlePretty err))
     Right a -> pure a
 
 -- | Read JSON from a file
 readContentsJson :: (FromJSON a, Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m a
-readContentsJson file = context ("Parsing JSON file '" <> toText (fromAbsFile file) <> "'") $ do
+readContentsJson file = context ("Parsing JSON file '" <> toText (toString file) <> "'") $ do
   contents <- readContentsBS file
   case eitherDecodeStrict contents of
-    Left err -> fatal $ FileParseError (fromAbsFile file) (toText err)
+    Left err -> fatal $ FileParseError (toString file) (toText err)
     Right a -> pure a
 
 readContentsToml :: (Has ReadFS sig m, Has Diagnostics sig m) => Toml.TomlCodec a -> Path Abs File -> m a
-readContentsToml codec file = context ("Parsing TOML file '" <> toText (fromAbsFile file) <> "'") $ do
+readContentsToml codec file = context ("Parsing TOML file '" <> toText (toString file) <> "'") $ do
   contents <- readContentsText file
   case Toml.decode codec contents of
-    Left err -> fatal $ FileParseError (fromAbsFile file) (Toml.prettyTomlDecodeErrors err)
+    Left err -> fatal $ FileParseError (toString file) (Toml.prettyTomlDecodeErrors err)
     Right a -> pure a
 
 -- | Read YAML from a file
 readContentsYaml :: (FromJSON a, Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m a
-readContentsYaml file = context ("Parsing YAML file '" <> toText (fromAbsFile file) <> "'") $ do
+readContentsYaml file = context ("Parsing YAML file '" <> toText (toString file) <> "'") $ do
   contents <- readContentsBS file
   case decodeEither' contents of
-    Left err -> fatal $ FileParseError (fromAbsFile file) (toText $ prettyPrintParseException err)
+    Left err -> fatal $ FileParseError (toString file) (toText $ prettyPrintParseException err)
     Right a -> pure a
 
 -- | Read XML from a file
 readContentsXML :: (FromXML a, Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m a
-readContentsXML file = context ("Parsing XML file '" <> toText (fromAbsFile file) <> "'") $ do
+readContentsXML file = context ("Parsing XML file '" <> toText (toString file) <> "'") $ do
   contents <- readContentsText file
   case parseXML contents of
-    Left err -> fatal $ FileParseError (fromAbsFile file) (xmlErrorPretty err)
+    Left err -> fatal $ FileParseError (toString file) (xmlErrorPretty err)
     Right a -> pure a
 
 type ReadFSIOC = SimpleC ReadFSF

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -257,26 +257,26 @@ type ReadFSIOC = SimpleC ReadFSF
 runReadFSIO :: Has (Lift IO) sig m => ReadFSIOC m a -> m a
 runReadFSIO = interpret $ \case
   ReadContentsBS' file -> do
-    BS.readFile (fromSomeFile file)
-      `catchingIO` FileReadError (fromSomeFile file)
+    BS.readFile (toString file)
+      `catchingIO` FileReadError (toString file)
   ReadContentsBSLimit' file limit -> do
     readContentsBSLimit' file limit
-      `catchingIO` FileReadError (fromSomeFile file)
+      `catchingIO` FileReadError (toString file)
   ReadContentsText' file -> do
-    (decodeUtf8 <$> BS.readFile (fromSomeFile file))
-      `catchingIO` FileReadError (fromSomeFile file)
+    (decodeUtf8 <$> BS.readFile (toString file))
+      `catchingIO` FileReadError (toString file)
   ResolveFile' dir path -> do
     PIO.resolveFile dir (toString path)
-      `catchingIO` ResolveError (toFilePath dir) (toString path)
+      `catchingIO` ResolveError (toString dir) (toString path)
   ResolveDir' dir path -> do
     PIO.resolveDir dir (toString path)
-      `catchingIO` ResolveError (toFilePath dir) (toString path)
+      `catchingIO` ResolveError (toString dir) (toString path)
   ListDir dir -> do
     PIO.listDir dir
-      `catchingIO` ListDirError (toFilePath dir)
+      `catchingIO` ListDirError (toString dir)
   GetIdentifier dir -> do
-    (extractIdentifier <$> Posix.getFileStatus (toFilePath dir))
-      `catchingIO` FileReadError (toFilePath dir)
+    (extractIdentifier <$> Posix.getFileStatus (toString dir))
+      `catchingIO` FileReadError (toString dir)
     where
       extractIdentifier :: Posix.FileStatus -> DirID
       extractIdentifier status =

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -362,4 +362,4 @@ readContentsBSLimit' :: SomeBase File -> Int -> IO ByteString
 readContentsBSLimit' file limit = withFile (fromSomeFile file) ReadMode $ \handle -> BS.hGetSome handle limit
 
 catchingIO :: Has (Lift IO) sig m => IO a -> (Text -> ReadFSErr) -> m (Either ReadFSErr a)
-catchingIO io mangle = safeCatch (Right <$> sendIO io) (\(e :: E.IOException) -> pure (Left (mangle (toText (show e)))))
+catchingIO io mangle = (Right <$> sendIO io) `safeCatch` (\(e :: E.IOException) -> pure . Left . mangle . toText $ show e)

--- a/src/Strategy/Maven/Pom/Resolver.hs
+++ b/src/Strategy/Maven/Pom/Resolver.hs
@@ -6,18 +6,42 @@ module Strategy.Maven.Pom.Resolver (
 ) where
 
 import Algebra.Graph.AdjacencyMap qualified as AM
-import Control.Algebra
-import Control.Carrier.State.Strict
-import Control.Effect.Diagnostics hiding (fromMaybe)
+import Control.Algebra (Has)
+import Control.Carrier.State.Strict (
+  State,
+  get,
+  modify,
+  runState,
+ )
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  context,
+  fatal,
+  recover,
+  (<||>),
+ )
 import Control.Monad (unless)
 import Data.Foldable (traverse_)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Effect.ReadFS
-import Path
-import Strategy.Maven.Pom.PomFile
+import Effect.ReadFS (
+  ReadFS,
+  ReadFSErr (FileReadError),
+  doesFileExist,
+  readContentsXML,
+  resolveDir,
+  resolveFile,
+ )
+import Path (Abs, Dir, File, Path, mkRelFile, parent, (</>))
+import Strategy.Maven.Pom.PomFile (
+  MavenCoordinate,
+  Pom (pomCoord, pomParentCoord),
+  RawParent (rawParentRelativePath),
+  RawPom (rawPomModules, rawPomParent),
+  validatePom,
+ )
 
 data GlobalClosure = GlobalClosure
   { globalGraph :: AM.AdjacencyMap MavenCoordinate
@@ -88,14 +112,14 @@ recursiveLoadPom path = do
 
     recurseRelative :: Text {- relative filepath -} -> m ()
     recurseRelative rel = do
-      resolvedPath :: Maybe (Path Abs File) <- recover $ resolvePath (parent path) rel
+      resolvedPath :: Maybe (Path Abs File) <- recover $ resolvePomPath (parent path) rel
       traverse_ recursiveLoadPom resolvedPath
 
 -- resolve a Filepath (in Text) that may either point to a directory or an exact
 -- pom file. when it's a directory, we default to pointing at the "pom.xml" in
 -- that directory.
-resolvePath :: forall sig m. (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> Text -> m (Path Abs File)
-resolvePath cur txt = context "Resolving parent pom.xml path" $ do
+resolvePomPath :: forall sig m. (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> Text -> m (Path Abs File)
+resolvePomPath cur txt = context "Resolving parent pom.xml path" $ do
   let resolveToFile :: m (Path Abs File)
       resolveToFile = do
         file <- resolveFile cur txt


### PR DESCRIPTION
# Overview

This PR adds a function called `resolvePath`.  If you pass `resolvePath` an arbitrary `Filepath` it will:

- Confirm its existence in the filesystem
- Detect whether it's a file or directory (or neither)
- Detect whether the path is absolute or relative.

## Acceptance criteria

- Effect message handler is written well
- String conversion cleanup is acceptable
- Errors are clear and understandable

## Testing plan

No tests, we don't yet have mocking capabilities for `ReadFS`, and if we did, there's not too much we can do with `FileStatus` anyway.  This is also not yet in any code path.

## References

Needed to implement ANE-24

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
