### PR TITLE
Add C/C++ callout to VSI flag

### DIFF
--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -222,7 +222,7 @@ cliParser =
 vsiEnableOpt :: Parser (Flag VSIAnalysis)
 vsiEnableOpt = visible <|> legacy
   where
-    visible = flagOpt VSIAnalysis (long "experimental-enable-vsi" <> help "Analyzes project files on disk to detect vendored open source libraries")
+    visible = flagOpt VSIAnalysis (long "experimental-enable-vsi" <> help "Analyzes project files on disk to detect vendored open source libraries (used for C/C++ support)")
     legacy = flagOpt VSIAnalysis (long "enable-vsi" <> hidden)
 
 skipVSIGraphResolutionOpt :: Parser VSI.Locator


### PR DESCRIPTION
# Overview

Adds `(used for C/C++ support)` to the end of the `experimental-enable-vsi` command.

## Acceptance criteria

Help text displays this additional text.

## Testing plan

Run `fossa analyze --help`, observe the output:
```
  --experimental-enable-vsi
                           Analyzes project files on disk to detect vendored
                           open source libraries (used for C/C++ support)
```

## Risks

None

## References

This was requested in an customer call and is so small I didn't think it worth a ticket.

## Checklist

I didn't change the changelog for this because it's such a trivial change but if you disagree let me know.

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
