### PR TITLE
Wraps organizationId in a new type

### DIFF
--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -86,11 +86,12 @@ import Fossa.API.Types (
   Build,
   Contributors,
   Issues,
+  OrgId,
   Organization (organizationId),
   Project,
   SignedURL (signedURL),
   UploadResponse,
-  useApiOpts, OrgId
+  useApiOpts,
  )
 import Network.HTTP.Client qualified as C
 import Network.HTTP.Client qualified as HTTP

--- a/src/App/Fossa/FossaAPIV1.hs
+++ b/src/App/Fossa/FossaAPIV1.hs
@@ -90,7 +90,7 @@ import Fossa.API.Types (
   Project,
   SignedURL (signedURL),
   UploadResponse,
-  useApiOpts,
+  useApiOpts, OrgId
  )
 import Network.HTTP.Client qualified as C
 import Network.HTTP.Client qualified as HTTP
@@ -195,7 +195,7 @@ uploadUrl :: Url scheme -> Url scheme
 uploadUrl baseurl = baseurl /: "api" /: "builds" /: "custom"
 
 -- | This renders an organization + locator into a path piece for the fossa API
-renderLocatorUrl :: Int -> Locator -> Text
+renderLocatorUrl :: OrgId -> Locator -> Text
 renderLocatorUrl orgId Locator{..} =
   locatorFetcher <> "+" <> toText (show orgId) <> "/" <> normalizeGitProjectName locatorProject <> "$" <> fromMaybe "" locatorRevision
 
@@ -324,7 +324,7 @@ mangleError err = case err of
 
 -----
 
-projectEndpoint :: Url scheme -> Int -> Locator -> Url scheme
+projectEndpoint :: Url scheme -> OrgId -> Locator -> Url scheme
 projectEndpoint baseurl orgid locator = baseurl /: "api" /: "cli" /: renderLocatorUrl orgid locator /: "project"
 
 getProject ::
@@ -345,7 +345,7 @@ getProject apiopts ProjectRevision{..} = fossaReq $ do
 
 -----
 
-buildsEndpoint :: Url 'Https -> Int -> Locator -> Url 'Https
+buildsEndpoint :: Url 'Https -> OrgId -> Locator -> Url 'Https
 buildsEndpoint baseurl orgId locator = baseurl /: "api" /: "cli" /: renderLocatorUrl orgId locator /: "latest_build"
 
 getLatestBuild ::
@@ -515,7 +515,7 @@ slashWord8 = fromIntegral $ fromEnum '/'
 
 ----------
 
-issuesEndpoint :: Url 'Https -> Int -> Locator -> Url 'Https
+issuesEndpoint :: Url 'Https -> OrgId -> Locator -> Url 'Https
 issuesEndpoint baseUrl orgId locator = baseUrl /: "api" /: "cli" /: renderLocatorUrl orgId locator /: "issues"
 
 getIssues ::
@@ -532,7 +532,7 @@ getIssues apiOpts ProjectRevision{..} = fossaReq $ do
 
 ---------------
 
-attributionEndpoint :: Url 'Https -> Int -> Locator -> ReportOutputFormat -> Url 'Https
+attributionEndpoint :: Url 'Https -> OrgId -> Locator -> ReportOutputFormat -> Url 'Https
 attributionEndpoint baseurl orgId locator format = appendSegment format $ baseurl /: "api" /: "revisions" /: renderLocatorUrl orgId locator /: "attribution"
   where
     appendSegment :: ReportOutputFormat -> Url a -> Url a
@@ -700,7 +700,7 @@ instance ToJSON a => HttpBody (ReqBodyJsonCompat a) where
   getRequestContentType _ = pure "application/json"
 
 data VSICreateScanRequestBody = VSICreateScanRequestBody
-  { vsiCreateScanRequestBodyOrgID :: Int
+  { vsiCreateScanRequestBodyOrgID :: OrgId
   , vsiCreateScanRequestBodyProjectID :: Text
   , vsiCreateScanRequestBodyRevisionID :: Text
   }

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -32,7 +32,8 @@ import Fossa.API.Types (
   ApiOpts,
   Archive (Archive, archiveName),
   ArchiveComponents (ArchiveComponents),
-  Organization (organizationId), OrgId
+  OrgId,
+  Organization (organizationId),
  )
 import Path (Abs, Dir, Path, parseRelDir, (</>))
 import Srclib.Types (

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -32,7 +32,7 @@ import Fossa.API.Types (
   ApiOpts,
   Archive (Archive, archiveName),
   ArchiveComponents (ArchiveComponents),
-  Organization (organizationId),
+  Organization (organizationId), OrgId
  )
 import Path (Abs, Dir, Path, parseRelDir, (</>))
 import Srclib.Types (
@@ -178,8 +178,8 @@ licenseScanSourceUnit baseDir apiOpts vendoredDeps = do
 
   pure $ NE.map arcToLocator (archivesWithOrganization orgId archives)
   where
-    archivesWithOrganization :: Int -> NonEmpty Archive -> NonEmpty Archive
+    archivesWithOrganization :: OrgId -> NonEmpty Archive -> NonEmpty Archive
     archivesWithOrganization orgId = NE.map $ includeOrgId orgId
 
-    includeOrgId :: Int -> Archive -> Archive
+    includeOrgId :: OrgId -> Archive -> Archive
     includeOrgId orgId arc = arc{archiveName = showT orgId <> "/" <> archiveName arc}

--- a/src/App/Fossa/VPS/Scan/Core.hs
+++ b/src/App/Fossa/VPS/Scan/Core.hs
@@ -8,8 +8,8 @@ module App.Fossa.VPS.Scan.Core (
 import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Prelude
 import Fossa.API.Types (OrgId)
+import Prelude
 
 data SherlockInfo = SherlockInfo
   { sherlockUrl :: Text

--- a/src/App/Fossa/VPS/Scan/Core.hs
+++ b/src/App/Fossa/VPS/Scan/Core.hs
@@ -9,6 +9,7 @@ import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Prelude
+import Fossa.API.Types (OrgId)
 
 data SherlockInfo = SherlockInfo
   { sherlockUrl :: Text
@@ -25,5 +26,5 @@ instance FromJSON SherlockInfo where
 
 newtype Locator = Locator {unLocator :: Text}
 
-createLocator :: Text -> Int -> Locator
+createLocator :: Text -> OrgId -> Locator
 createLocator projectName organizationId = Locator $ "custom+" <> toText (show organizationId) <> "/" <> projectName

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -258,7 +258,7 @@ data Organization = Organization
 
 instance FromJSON Organization where
   parseJSON = withObject "Organization" $ \obj ->
-    Organization <$> (OrgId <$> obj .: "organizationId")
+    Organization <$> obj .: "organizationId"
       <*> obj .:? "usesSAML" .!= False
       <*> obj .:? "supportsCliLicenseScanning" .!= False
 

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -238,16 +238,10 @@ instance Pretty Issues where
   pretty = renderedIssues
 
 newtype OrgId = OrgId Int
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, FromJSON, ToJSON)
 
 instance Show OrgId where
   show (OrgId orgId) = show orgId
-
-instance FromJSON OrgId where
-  parseJSON = fmap OrgId . parseJSON
-
-instance ToJSON OrgId where
-  toJSON (OrgId orgId) = toJSON orgId
 
 data Organization = Organization
   { organizationId :: OrgId

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -15,6 +15,7 @@ module Fossa.API.Types (
   IssueRule (..),
   IssueType (..),
   Issues (..),
+  OrgId (..),
   Organization (..),
   Project (..),
   SignedURL (..),
@@ -236,8 +237,20 @@ instance ToJSON IssueRule where
 instance Pretty Issues where
   pretty = renderedIssues
 
+newtype OrgId = OrgId Int
+  deriving (Eq, Ord)
+
+instance Show OrgId where
+  show (OrgId orgId) = show orgId
+
+instance FromJSON OrgId where
+  parseJSON = fmap OrgId . parseJSON
+
+instance ToJSON OrgId where
+  toJSON (OrgId orgId) = toJSON orgId
+
 data Organization = Organization
-  { organizationId :: Int
+  { organizationId :: OrgId
   , orgUsesSAML :: Bool
   , orgDoLocalLicenseScan :: Bool
   }
@@ -245,7 +258,7 @@ data Organization = Organization
 
 instance FromJSON Organization where
   parseJSON = withObject "Organization" $ \obj ->
-    Organization <$> obj .: "organizationId"
+    Organization <$> (OrgId <$> obj .: "organizationId")
       <*> obj .:? "usesSAML" .!= False
       <*> obj .:? "supportsCliLicenseScanning" .!= False
 

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -12,6 +12,7 @@ import Data.Text (Text)
 import Fossa.API.Types (
   ApiKey (ApiKey),
   ApiOpts (ApiOpts),
+  OrgId (OrgId),
   Organization (Organization),
  )
 import Srclib.Types (Locator (Locator))
@@ -42,7 +43,7 @@ spec = do
     describe "SAML URL builder" $ do
       it' "should render simple locators" $ do
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
-            org = Just $ Organization 1 True False
+            org = Just $ Organization (OrgId 1) True False
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getBuildURLWithOrg org revision apiOpts locator
 
@@ -50,7 +51,7 @@ spec = do
 
       it' "should render git@ locators" $ do
         let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
-            org = Just $ Organization 103 True False
+            org = Just $ Organization (OrgId 103) True False
             revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
         actual <- getBuildURLWithOrg org revision apiOpts locator
 
@@ -58,7 +59,7 @@ spec = do
 
       it' "should render full url correctly" $ do
         let locator = Locator "a" "b" $ Just "c"
-            org = Just $ Organization 33 True False
+            org = Just $ Organization (OrgId 33) True False
             revision = ProjectRevision "" "not this revision" $ Just "master"
         actual <- getBuildURLWithOrg org revision apiOpts locator
 
@@ -77,7 +78,7 @@ spec = do
         . withMockApi
           ( \case
               GetApiOpts -> pure apiOpts
-              GetOrganization -> pure $ Organization 1 True False
+              GetOrganization -> pure $ Organization (OrgId 1) True False
               req -> assertNotCalled req
           )
         $ do

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -28,7 +28,7 @@ apiOpts =
   API.ApiOpts (Just [uri|https://app.fossa.com/|]) $ API.ApiKey "testApiKey"
 
 organization :: API.Organization
-organization = API.Organization 42 True False
+organization = API.Organization (API.OrgId 42) True False
 
 project :: API.Project
 project =


### PR DESCRIPTION
# Overview

I noticed that `Organization.organizationId` was just a bare `Int` and that made me uneasy, so I wrapped it.  This turned out to be particularly easy because the only thing we ever do with organization IDs seems to be to `show` them and it's easy to make that a pass-through.

## Acceptance criteria

Organization IDs are never accessed as a raw type.

## Testing plan

1. Ran all the unit tests.
2. Did an analysis upload from a local project
3. Pulled a report from that project.

## Risks

There's always a risk that something was using the organization IDs in a weird way, but the type system should catch that.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
