### PR TITLE
Unarchive vendored deps + Handle empty directories

### DIFF
--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -127,7 +127,7 @@ scanVendoredDep ::
   m (NonEmpty LicenseUnit)
 scanVendoredDep baseDir VendoredDependency{..} = context "Scanning vendored deps for license data" $ do
   logSticky $ "License Scanning '" <> vendoredName <> "' at '" <> vendoredPath <> "'"
-  scanPath <- resolvePath' $ toString vendoredPath
+  scanPath <- resolvePath' baseDir $ toString vendoredPath
   case scanPath of
     SomeFile (Abs path) -> scanArchive $ ScannableArchive path
     SomeFile (Rel path) -> scanArchive . ScannableArchive $ baseDir </> path

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -108,6 +108,7 @@ toSourceUnit ::
   , Has StickyLogger sig m
   , Has Logger sig m
   , Has Exec sig m
+  , Has ReadFS sig m
   ) =>
   Path Abs Dir ->
   FoundDepsFile ->
@@ -151,6 +152,7 @@ scanAndUpload ::
   , Has StickyLogger sig m
   , Has Logger sig m
   , Has Exec sig m
+  , Has ReadFS sig m
   ) =>
   Path Abs Dir ->
   ApiOpts ->

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -71,7 +71,7 @@ import Control.Effect.Replay (ReplayableValue)
 import Control.Effect.Replay.TH (deriveReplayable)
 import Control.Exception qualified as E
 import Control.Exception.Extra (safeCatch)
-import Control.Monad (join, (<=<))
+import Control.Monad ((<=<))
 import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict)
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -97,6 +97,7 @@ import Path (
 import Path.IO qualified as PIO
 import Prettyprinter (indent, line, pretty, vsep)
 import System.Directory qualified as Directory
+import System.FilePath qualified as FP
 import System.IO (IOMode (ReadMode), withFile)
 import System.PosixCompat (isRegularFile)
 import System.PosixCompat.Files (isDirectory)
@@ -105,7 +106,6 @@ import System.PosixCompat.Types (CDev (..), CIno (..))
 import Text.Megaparsec (Parsec, runParser)
 import Text.Megaparsec.Error (errorBundlePretty)
 import Toml qualified
-import qualified System.FilePath as FP
 
 -- | A unique file identifier for a directory.
 -- Uniqueness is guaranteed within a single OS.

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -105,6 +105,7 @@ import System.PosixCompat.Types (CDev (..), CIno (..))
 import Text.Megaparsec (Parsec, runParser)
 import Text.Megaparsec.Error (errorBundlePretty)
 import Toml qualified
+import qualified System.FilePath as FP
 
 -- | A unique file identifier for a directory.
 -- Uniqueness is guaranteed within a single OS.
@@ -132,7 +133,7 @@ data ReadFSF a where
   DoesDirExist :: SomeBase Dir -> ReadFSF Bool
   ResolveFile' :: Path Abs Dir -> Text -> ReadFSF (Either ReadFSErr (Path Abs File))
   ResolveDir' :: Path Abs Dir -> Text -> ReadFSF (Either ReadFSErr (Path Abs Dir))
-  ResolvePath :: FilePath -> ReadFSF (Either ReadFSErr SomePath)
+  ResolvePath :: Path Abs Dir -> FilePath -> ReadFSF (Either ReadFSErr SomePath)
   ListDir :: Path Abs Dir -> ReadFSF (Either ReadFSErr ([Path Abs Dir], [Path Abs File]))
   GetIdentifier :: Path Abs Dir -> ReadFSF (Either ReadFSErr DirID)
 
@@ -233,11 +234,11 @@ resolveDir :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> Text 
 resolveDir dir path = fromEither =<< resolveDir' dir path
 
 -- | Resolve some path to an existing
-resolvePath :: Has ReadFS sig m => FilePath -> m (Either ReadFSErr SomePath)
-resolvePath = sendSimple . ResolvePath
+resolvePath :: Has ReadFS sig m => Path Abs Dir -> FilePath -> m (Either ReadFSErr SomePath)
+resolvePath root = sendSimple . ResolvePath root
 
-resolvePath' :: (Has ReadFS sig m, Has Diagnostics sig m) => FilePath -> m SomePath
-resolvePath' = fromEither <=< resolvePath
+resolvePath' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> FilePath -> m SomePath
+resolvePath' root = fromEither <=< resolvePath root
 
 -- | Check whether a file exists
 doesFileExist :: Has ReadFS sig m => Path Abs File -> m Bool
@@ -343,7 +344,10 @@ runReadFSIO = interpret $ \case
         let (CIno fileID) = Posix.fileID status
             (CDev devID) = Posix.deviceID status
          in DirID{dirFileID = toInteger fileID, dirDeviceID = toInteger devID}
-  ResolvePath path -> join <$> ((identifyPath path <$> Posix.getFileStatus path) `catchingIO` FileReadError path)
+  ResolvePath root path -> do
+    let fullpath = toString root FP.</> path
+    stat <- Posix.getFileStatus fullpath `catchingIO` ResolveError (toString root) path
+    pure (stat >>= identifyPath fullpath)
   -- NB: these never throw
   DoesFileExist file -> sendIO (Directory.doesFileExist (fromSomeFile file))
   DoesDirExist dir -> sendIO (Directory.doesDirectoryExist (fromSomeDir dir))


### PR DESCRIPTION
# Overview

This PR deals with 2 tickets, since their logic is very closely intertwined.

Delivers ANE-24

Scenario: a user runs with `--experimental-native-license-scan` and the following `fossa-deps` file:

```yaml
vendored-dependencies:
- name: foo
  path: /path/to/foo.zip
```

This PR accepts this form by unarchiving the `zip` file (or other archive that we support) to a temp directory, and running the scan from there.  We also try to report errors related to the archive using the path to the unzipped archive, rather than the temp directory (which is why we have `ScannableArchive`).

Delivers ANE-158

Scenario:  same as above, with this file instead:

```yaml
vendored-dependencies:
- name: foo
  path: /path/to/foo
```

If `/path/to/foo` is an empty directory (i.e. walking the tree downwards produces 0 files), we need to report sensible errors to the user.

## Acceptance criteria

- [ ] Happy path works, pointing to non-empty directory
- [ ] Happy path works, pointing to well-formed archive with the correct file extension.
- [ ] Good errors during known failure cases 

## Testing plan

- [ ] Both happy paths above
- [ ] Empty directory
- [ ] Archive with no file extension
- [ ] Archive with incorrect file extension (i.e. rename `foo.zip` to `foo.tar.gz`)
  - Note that this also works for ANY file.  If we don't recognize the extension, or the format doesn't match the extension we see, we should handle that cleanly.
- [ ] Archive with no files
- [ ] Unsupported archive format with valid extension
  - The formats we support are listed [here](https://github.com/fossas/fossa-cli/blob/6c6fda19616b8141a1bd2a0fe39aeb48abcff068/src/Discovery/Archive.hs#L59-L67).

Automated tests are not possible since we can't mock `Exec` and `ReadFS` in tests (YET!).

## Risks

None, this feature is about to be beta, and touches no non-beta features or code.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
