### PR TITLE
Add warning when server doesn't allow native

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,12 @@
 ## v3.2.2
 
 - nodejs: Fix a bug where cycles involved peer dependencies would cause an infinite loop. ([#870](https://github.com/fossas/fossa-cli/pull/870))
+- Experimental: Allow local license scanning of vendored dependencies (specified in `fossa-deps.yml` file) when using `--experimental-native-license-scan`.
+  - [#868](https://github.com/fossas/fossa-cli/pull/868)
+  - [#858](https://github.com/fossas/fossa-cli/pull/858)
+  - [#838](https://github.com/fossas/fossa-cli/pull/838)
+  - [#814](https://github.com/fossas/fossa-cli/pull/814)
+  - [#873](https://github.com/fossas/fossa-cli/pull/873)
 
 ## v3.2.1
 

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -167,10 +167,10 @@ scanAndUpload root apiOpts vdeps allowNative = runFossaApiClient apiOpts $ do
         doNative <- orgDoLocalLicenseScan <$> getOrganization
         if doNative
           then pure CLILicenseScan
-          -- If they've selected native scanning, but the server doesn't support it,
+          else -- If they've selected native scanning, but the server doesn't support it,
           -- we should let them know.
           -- TODO: Add a --forbid-archive-upload CLI flag
-          else logWarn "Server does not support native license scanning" $> ArchiveUpload
+            logWarn "Server does not support native license scanning" $> ArchiveUpload
       else pure ArchiveUpload
 
   let scanner = case archiveOrCLI of

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -34,6 +34,7 @@ import Data.Aeson (
 import Data.Aeson.Extra (TextLike (unTextLike), forbidMembers)
 import Data.Aeson.Types (Parser)
 import Data.Flag (Flag, fromFlag)
+import Data.Functor (($>))
 import Data.Functor.Extra ((<$$>))
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
@@ -41,7 +42,7 @@ import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
 import DepTypes (DepType (..))
 import Effect.Exec (Exec)
-import Effect.Logger (Logger)
+import Effect.Logger (Logger, logWarn)
 import Effect.ReadFS (ReadFS, doesFileExist, readContentsJson, readContentsYaml)
 import Fossa.API.Types (ApiOpts, Organization (orgDoLocalLicenseScan))
 import Path (Abs, Dir, File, Path, mkRelFile, (</>))
@@ -164,7 +165,12 @@ scanAndUpload root apiOpts vdeps allowNative = runFossaApiClient apiOpts $ do
     if fromFlag AllowNativeLicenseScan allowNative
       then do
         doNative <- orgDoLocalLicenseScan <$> getOrganization
-        pure if doNative then CLILicenseScan else ArchiveUpload
+        if doNative
+          then pure CLILicenseScan
+          -- If they've selected native scanning, but the server doesn't support it,
+          -- we should let them know.
+          -- TODO: Add a --forbid-archive-upload CLI flag
+          else logWarn "Server does not support native license scanning" $> ArchiveUpload
       else pure ArchiveUpload
 
   let scanner = case archiveOrCLI of


### PR DESCRIPTION
Prepare release notes and add a warning for when the server does not permit native license scanning.