### PR TITLE
feat: Resolve vendored podspecs to git locators

### DIFF
--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -28,7 +28,7 @@ jobs:
         ghc --version || echo "no ghc"
         cabal --version || echo "no cabal"
         ghcup --version || echo "no ghcup"
-        
+
     - uses: actions/cache@v2
       name: Cache cabal store
       with:
@@ -52,7 +52,7 @@ jobs:
       run: |
         cabal update
         $RUN_CMD || $RUN_CMD
-    
+
     - name: Run all integration tests
       run: |
         cabal test --project-file=cabal.project.ci.linux integration-tests --test-show-details=direct --test-option=--times

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ vendor-bins/
 /release
 
 # Debug output
+fossa.debug.json
 fossa.debug.json.gz
 fossa.telemetry.json
 

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,16 @@ MOUNTED_DEV_TOOLS := docker run
 MOUNTED_DEV_TOOLS += --rm
 MOUNTED_DEV_TOOLS += --mount "type=bind,source=${current_dir},target=/fossa-cli"
 MOUNTED_DEV_TOOLS += --workdir "/fossa-cli"
-MOUNTED_DEV_TOOLS += ${DEV_TOOLS} 
+MOUNTED_DEV_TOOLS += ${DEV_TOOLS}
 
 build:
 	cabal build
 
 test:
 	cabal test unit-tests --test-show-details=streaming --test-option=--format=checks --test-option=--times --test-option=--color
+
+integration-test:
+	cabal test integration-tests --test-show-details=streaming --test-option=--format=checks --test-option=--times --test-option=--color
 
 test-all:
 	cabal test
@@ -85,4 +88,4 @@ check-ci:
 	docker pull ${DEV_TOOLS}
 	${MOUNTED_DEV_TOOLS} make check
 
-.PHONY: build test analyze install-local fmt check check-fmt lint check-ci fmt-ci build-test-data clean-test-data install-dev test-all
+.PHONY: build test integration-test analyze install-local fmt check check-fmt lint check-ci fmt-ci build-test-data clean-test-data install-dev test-all

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # FOSSA CLI
 
-[![Build](https://github.com/fossas/fossa-cli/actions/workflows/build.yml/badge.svg)](https://github.com/fossas/fossa-cli/actions/workflows/build.yml)
+[![Build](https://github.com/fossas/fossa-cli/actions/workflows/build-all.yml/badge.svg)](https://github.com/fossas/fossa-cli/actions/workflows/build.yml)
 [![Dependency scan](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml/badge.svg)](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml) <!-- markdown-link-check-disable-next-line -->
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli.svg?type=shield)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield) <!-- markdown-link-check-disable-next-line -->
 [![FOSSA Downloads](https://img.shields.io/github/downloads/fossas/fossa-cli/total.svg)](https://github.com/fossas/fossa-cli/releases)

--- a/docs/references/strategies/platforms/ios/cocoapods.md
+++ b/docs/references/strategies/platforms/ios/cocoapods.md
@@ -41,9 +41,10 @@ DEPENDENCIES:
   - "five/+zlib (7.0.0)"
 ```
 
+We also look at the `EXTERNAL SOURCES` section to try and resolve locally vendored Cocoapods. If we see a locally vendored Cocoapod using either `:podspec` or `:path` to a local directory, we'll read the Podspec at that directory and also upload that dependency if it has a supported `source`. We currently only support the `git` source.
+
 ## Limitations
 
-- Pods sourced from local path are not supported (e.g. `pod 'AFNetworking', :path => '~/Documents/AFNetworking'`).
 - Pods sourced from http path are not supported (e.g `pod 'JSONKit', :podspec => 'https://example.com/JSONKit.podspec'`).
 - Pods sourced from subversion, mercurial, and bazaar are not supported.
 - Plugins in Podfiles are ignored.

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -116,7 +116,7 @@ warn = send . Warn
 warnOnErr :: (ToDiagnostic warn, Has Diagnostics sig m) => warn -> m a -> m a
 warnOnErr w m = send (WarnOnErr w m)
 
--- | Analagous to @Alternative@'s @<|>@. Try the provided actions, returning the
+-- | Analogous to @Alternative@'s @<|>@. Try the provided actions, returning the
 -- value of the first to succeed
 (<||>) :: Has Diagnostics sig m => m a -> m a -> m a
 (<||>) ma mb = send (FirstToSucceed ma mb)

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -26,6 +26,7 @@ import Discovery.Walk (
   findFilesMatchingGlob,
   walkWithFilters',
  )
+import Effect.Exec (Exec)
 import Effect.ReadFS (Has, ReadFS, readContentsParser)
 import GHC.Generics (Generic)
 import Path (Abs, Dir, File, Path, toFilePath)
@@ -106,7 +107,7 @@ mkProject project =
     , projectData = project
     }
 
-getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => CocoapodsProject -> m DependencyResults
+getDeps :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec sig m) => CocoapodsProject -> m DependencyResults
 getDeps project =
   context "Cocoapods" $
     context
@@ -129,7 +130,7 @@ analyzePodfile project = do
       , dependencyManifestFiles = [podFile]
       }
 
-analyzePodfileLock :: (Has ReadFS sig m, Has Diagnostics sig m) => CocoapodsProject -> m DependencyResults
+analyzePodfileLock :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec sig m) => CocoapodsProject -> m DependencyResults
 analyzePodfileLock project = do
   lockFile <- Diag.fromMaybeText "No Podfile.lock present in the project" (cocoapodsPodfileLock project)
   graph <- PodfileLock.analyze' lockFile

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -115,6 +115,9 @@ buildGraphStatic PodLock{lockPods, lockDeps, lockExternalSources} = staticGraph
       where
         pkg = PodfilePkg podName
 
+-- We use this cache to avoid repeated invocations since gtraverse may revisit
+-- nodes. In practice, this saves quite a bit of time (e.g. on example projects,
+-- it has historically turned ~2 minute analyses into ~15 seconds).
 type PodSpecCache = Map Text PodSpecJSON
 
 buildGraph ::

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -35,7 +35,7 @@ import Data.SemVer qualified as SemVer
 import Data.SemVer.Internal (Version (..))
 import Data.Set (Set)
 import Data.String.Conversion (decodeUtf8, toString, toText)
-import Data.Text (Text)
+import Data.Text (Text, strip)
 import Data.Text.Extra (showT)
 import Data.Void (Void)
 import Data.Yaml ((.:), (.:?))
@@ -154,7 +154,7 @@ buildGraph lockFilePath lockFile@PodLock{lockExternalSources} = do
   case podVersionOutput of
     Left _ -> fatalText "could not analyze vendored pods: `pod --version` was not at least `0.29.0`"
     Right podVersionStdoutRaw -> do
-      let podVersionStdout = decodeUtf8 podVersionStdoutRaw
+      let podVersionStdout = strip $ decodeUtf8 podVersionStdoutRaw
 
       -- `pod ipc spec` is supported for versions 0.29.0 and above. See also:
       -- https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#0290-2013-12-25

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -1,6 +1,7 @@
 module Strategy.Cocoapods.PodfileLock (
   analyze',
   buildGraph,
+  buildGraphStatic,
   PodLock (..),
   Dep (..),
   Pod (..),
@@ -13,8 +14,10 @@ import Control.Effect.Diagnostics (
   Has,
   context,
   run,
+  (<||>),
  )
 import Data.Aeson (FromJSON (parseJSON))
+import Data.Aeson qualified as JSON
 import Data.Aeson.Types (FromJSONKey)
 import Data.Char qualified as C
 import Data.Foldable (asum, traverse_)
@@ -23,89 +26,149 @@ import Data.HashMap.Lazy qualified as HashMap (toList)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
+import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
 import Data.Void (Void)
 import Data.Yaml ((.:), (.:?))
 import Data.Yaml qualified as Yaml
 import DepTypes (DepType (GitType, PodType), Dependency (..), VerConstraint (CEq))
+import Effect.Exec (AllowErr (..), Command (..), Exec, exec, execJson)
 import Effect.Grapher (LabeledGrapher, direct, edge, label, withLabeling)
 import Effect.ReadFS (ReadFS, readContentsYaml)
-import Graphing (Graphing)
+import Graphing (Graphing, gtraverse)
 import Options.Applicative (Alternative ((<|>)))
-import Path
-import Text.Megaparsec (MonadParsec (takeWhileP), Parsec, between, empty, errorBundlePretty, parse, some, takeWhile1P)
+import Path (Abs, Dir, File, Path, parent)
+import System.FilePath ((<.>), (</>))
+import Text.Megaparsec (Parsec, between, empty, errorBundlePretty, parse, some, takeWhile1P, takeWhileP)
 import Text.Megaparsec.Char (char)
 import Text.Megaparsec.Char.Lexer qualified as L
+import Data.Text.Extra (showT)
 
-analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
+analyze' :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' file = do
   podfileLock <- readContentsYaml file
-  context "Building dependency graph" $ pure (buildGraph podfileLock)
+  context "Building dependency graph" $ buildGraph file podfileLock
+
+type PodfileGrapher = LabeledGrapher PodfilePkg PodfileLabel
 
 newtype PodfilePkg = PodfilePkg {pkgName :: Text}
   deriving (Eq, Ord, Show)
 
-type PodfileGrapher = LabeledGrapher PodfilePkg PodfileLabel
-
 newtype PodfileLabel
-  = PodfileVersion (Maybe Text)
+  = PodfileVersion Text
   deriving (Eq, Ord, Show)
 
-toDependency :: Map Text ExternalSource -> PodfilePkg -> Set PodfileLabel -> Dependency
-toDependency externalSrc pkg = foldr applyLabel start
+buildGraphStatic :: PodLock -> Graphing Dependency
+buildGraphStatic PodLock{lockPods, lockDeps, lockExternalSources} = staticGraph
   where
-    start :: Dependency
-    start =
-      Dependency
-        { dependencyType = depType
-        , dependencyName = depName
-        , dependencyVersion = Nothing
-        , dependencyLocations = []
-        , dependencyEnvironments = mempty
-        , dependencyTags = Map.empty
-        }
+    staticGraph :: Graphing Dependency
+    staticGraph =
+      run . withLabeling (toDependency lockExternalSources) $ do
+        -- Add direct dependencies.
+        traverse_ (direct . PodfilePkg . depName) lockDeps
+        -- Add transitive graph.
+        traverse_ addSpec lockPods
 
-    depType :: DepType
-    depType = case Map.lookup (pkgName pkg) externalSrc of
-      Just (ExternalGitType _) -> GitType
-      _ -> PodType
+    toDependency :: Map Text ExternalSource -> PodfilePkg -> Set PodfileLabel -> Dependency
+    toDependency externals PodfilePkg{pkgName} = foldr applyLabel start
+      where
+        start :: Dependency
+        start =
+          Dependency
+            { dependencyType = depType
+            , dependencyName = depName
+            , dependencyVersion = Nothing
+            , dependencyLocations = []
+            , dependencyEnvironments = mempty
+            , dependencyTags = Map.empty
+            }
 
-    depName :: Text
-    depName = case Map.lookup (pkgName pkg) externalSrc of
-      Just (ExternalGitType gitSrc) -> urlOf gitSrc
-      _ -> pkgName pkg
+        depType :: DepType
+        depType = case Map.lookup pkgName externals of
+          Just (ExternalGitType _) -> GitType
+          _ -> PodType
 
-    applyLabel :: PodfileLabel -> Dependency -> Dependency
-    applyLabel (PodfileVersion ver) dep = dep{dependencyVersion = CEq <$> ver}
+        depName :: Text
+        depName = case Map.lookup pkgName externals of
+          Just (ExternalGitType ExternalGitSource{urlOf}) -> urlOf
+          _ -> pkgName
 
-buildGraph :: PodLock -> Graphing Dependency
-buildGraph lockContent =
-  run . withLabeling (toDependency $ lockExternalSources lockContent) $
-    traverse_ addSection sections
-  where
-    sections :: [Section]
-    sections = toSections lockContent
-
-    addSection :: Has PodfileGrapher sig m => Section -> m ()
-    addSection (DependencySection deps) = traverse_ (direct . PodfilePkg . depName) deps
-    addSection (PodSection pods) = traverse_ addSpec pods
+        applyLabel :: PodfileLabel -> Dependency -> Dependency
+        applyLabel (PodfileVersion ver) dep =
+          dep
+            { dependencyVersion =
+                CEq <$> case Map.lookup pkgName externals of
+                  Just (ExternalGitType ExternalGitSource{tagOf, commitOf, branchOf}) -> asum [tagOf, commitOf, branchOf]
+                  _ -> Just ver
+            }
 
     addSpec :: Has PodfileGrapher sig m => Pod -> m ()
-    addSpec pod = do
-      let pkg = PodfilePkg (podName pod)
-      let pkgVersion = case Map.lookup (podName pod) (lockExternalSources lockContent) of
-            Just (ExternalGitType src) ->
-              asum
-                [ tagOf src
-                , commitOf src
-                , branchOf src
-                ]
-            _ -> Just $ podVersion pod
+    addSpec Pod{podName, podVersion, podDeps} = do
+      -- Add edges to transitive dependencies.
+      traverse_ (edge pkg . PodfilePkg . depName) podDeps
+      -- Label pods with versions.
+      label pkg $ PodfileVersion podVersion
+      where
+        pkg = PodfilePkg podName
 
-      -- add edges between spec and specdeps
-      traverse_ (edge pkg . PodfilePkg . depName) $ podSpecs pod
-      -- add a label for version
-      label pkg $ PodfileVersion pkgVersion
+buildGraph ::
+  (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m) =>
+  Path Abs File ->
+  PodLock ->
+  m (Graphing Dependency)
+buildGraph lockFilePath lockFile@PodLock{lockExternalSources} = do
+  -- If `pod` is not installed, then the static graph is the best we can do.
+  podVersion <- exec lockFileDir Command{cmdName = "pod", cmdArgs = ["--version"], cmdAllowErr = Never}
+  case podVersion of
+    Left _ -> pure staticGraph
+    Right _ -> do
+      -- If `pod` _is_ installed, then we can shell out to `pod ipc spec` to
+      -- convert locally vendored `.podspec` files to JSON and read them for
+      -- their Git locators. We do this because locally vendored `.podspec`
+      -- files are often vendored specifically because they are not available on
+      -- the Cocoapods registry.
+      gtraverse replaceVendoredPods staticGraph
+  where
+    staticGraph :: Graphing Dependency
+    staticGraph = buildGraphStatic lockFile
+
+    lockFileDir :: Path Abs Dir
+    lockFileDir = parent lockFilePath
+
+    replaceVendoredPods :: (Has Exec sig m, Has Diagnostics sig m) => Dependency -> m Dependency
+    replaceVendoredPods d@Dependency{dependencyType, dependencyName} = case dependencyType of
+      PodType -> case Map.lookup dependencyName lockExternalSources of
+        Just es -> case es of
+          ExternalPodSpec podSpecPath ->
+            readPodSpecAt podSpecPath
+              <||> pure d
+          ExternalPath podPath ->
+            readPodSpecAt (toText $ toString podPath </> (toString dependencyName <.> "podspec"))
+              <||> pure d
+          ExternalGitType _ -> pure d
+          ExternalOtherType -> pure d
+        Nothing -> pure d
+      _ -> pure d
+
+    readPodSpecAt :: (Has Exec sig m, Has Diagnostics sig m) => Text -> m Dependency
+    readPodSpecAt podSpecPath = context ("Resolving vendored podspec at " <> showT podSpecPath) $ do
+      (PodSpecJSON ExternalGitSource{urlOf, tagOf, commitOf, branchOf}) <-
+        execJson
+          lockFileDir
+          Command
+            { cmdName = "pod"
+            , cmdArgs = ["ipc", "spec", podSpecPath]
+            , cmdAllowErr = Never
+            }
+      pure
+        Dependency
+          { dependencyType = GitType
+          , dependencyName = urlOf
+          , dependencyVersion = CEq <$> asum [tagOf, commitOf, branchOf]
+          , dependencyLocations = []
+          , dependencyEnvironments = mempty
+          , dependencyTags = Map.empty
+          }
 
 type Parser = Parsec Void Text
 
@@ -116,6 +179,8 @@ data Section
 
 data ExternalSource
   = ExternalGitType ExternalGitSource
+  | ExternalPodSpec Text -- This is always a `.podspec` filepath.
+  | ExternalPath Text -- This is a directory containing a `.podspec` with the Pod's name.
   | ExternalOtherType
   deriving (Show, Eq, Ord)
 
@@ -134,12 +199,6 @@ data PodLock = PodLock
   }
   deriving (Show, Eq, Ord)
 
-toSections :: PodLock -> [Section]
-toSections lockContent =
-  [ PodSection $ lockPods lockContent
-  , DependencySection $ lockDeps lockContent
-  ]
-
 newtype Dep = Dep
   { depName :: Text
   }
@@ -148,7 +207,7 @@ newtype Dep = Dep
 data Pod = Pod
   { podName :: Text
   , podVersion :: Text
-  , podSpecs :: [Dep]
+  , podDeps :: [Dep]
   }
   deriving (Eq, Ord, Show)
 
@@ -183,14 +242,18 @@ instance FromJSON Dep where
 
 instance FromJSON ExternalSource where
   parseJSON = Yaml.withObject "External source" $ \obj ->
-    do
-      ExternalGitType
+    ( ExternalGitType
         <$> ( ExternalGitSource
                 <$> obj .: ":git"
                 <*> obj .:? ":tag"
                 <*> obj .:? ":commit"
                 <*> obj .:? ":branch"
             )
+    )
+      -- We don't parse these as filepaths because `path`'s parsing functions do
+      -- not accept `..`.
+      <|> (ExternalPodSpec <$> obj .: ":podspec")
+      <|> (ExternalPath <$> obj .: ":path")
       <|> pure ExternalOtherType
 
 parserPod :: Text -> Maybe Yaml.Value -> Yaml.Parser Pod
@@ -205,3 +268,15 @@ lexeme = L.lexeme sc
 
 sc :: Parser ()
 sc = L.space (void $ some (char ' ')) empty empty
+
+newtype PodSpecJSON = PodSpecJSON ExternalGitSource
+
+instance FromJSON PodSpecJSON where
+  parseJSON = JSON.withObject "PodSpecJSON" $ \o ->
+    PodSpecJSON <$> do
+      source <- o .: "source"
+      ExternalGitSource
+        <$> source .: "git"
+        <*> source .:? "tag"
+        <*> source .:? "commit"
+        <*> source .:? "branch"

--- a/test/Cocoapods/PodfileLockSpec.hs
+++ b/test/Cocoapods/PodfileLockSpec.hs
@@ -18,7 +18,7 @@ import Strategy.Cocoapods.PodfileLock (
   ExternalSource (..),
   Pod (Pod),
   PodLock (..),
-  buildGraph,
+  buildGraphStatic,
  )
 import Test.Hspec qualified as T
 
@@ -91,15 +91,15 @@ externalSources =
     [ ("depWithTag", ExternalGitType $ ExternalGitSource "git@github.example.com:ab/cap.git" (Just "v1.2.3") Nothing Nothing)
     , ("depWithBranch", ExternalGitType $ ExternalGitSource "git@github.example.com:ab/cap.git" Nothing Nothing $ Just "main")
     , ("depWithCommit", ExternalGitType $ ExternalGitSource "git@github.example.com:ab/cap.git" Nothing (Just "9a9a9") Nothing)
-    , ("ChatSecure-Push-iOS", ExternalOtherType)
-    , ("ChatSecureCore", ExternalOtherType)
+    , ("ChatSecure-Push-iOS", ExternalPath "../Submodules/ChatSecure-Push-iOS")
+    , ("ChatSecureCore", ExternalPodSpec "ChatSecureCore.podspec")
     ]
 
 spec :: T.Spec
 spec = do
   T.describe "podfile lock analyzer" $
     T.it "produces the expected output" $ do
-      let graph = buildGraph $ PodLock pods dependencies externalSources
+      let graph = buildGraphStatic $ PodLock pods dependencies externalSources
       expectDeps
         [ dependencyOne
         , dependencyTwo

--- a/test/Cocoapods/testdata/Podfile.lock
+++ b/test/Cocoapods/testdata/Podfile.lock
@@ -33,9 +33,9 @@ EXTERNAL SOURCES:
     :git: "git@github.example.com:ab/cap.git"
     :commit: 9a9a9
   ChatSecure-Push-iOS:
-    :path: Submodules/ChatSecure-Push-iOS/ChatSecure-Push-iOS.podspec
+    :path: "../Submodules/ChatSecure-Push-iOS"
   ChatSecureCore:
-    :path: ChatSecureCore.podspec
+    :podspec: ChatSecureCore.podspec
 
 CHECKOUT OPTIONS:
   Mantle:


### PR DESCRIPTION
# Overview

This PR adds the ability to resolve vendored local podspecs into their source Git repositories. This is desirable because the reason why the podspecs are vendored in the first place is because they're usually unavailable in the Cocoapods registry. It does this by shelling out to `pod ipc spec`.

It also refactors the existing Podfile.lock tactic, and fixes a random typo I came across.

## Remaining work

- [x] This is really slow. I need to make it faster.
  - Maybe parallelize the traversal?
  - It looks like many nodes are being re-traversed due to `gtraverse` - cache or dedupe?
- [x] Add documentation.

## Acceptance criteria

When `pod` is locally available, Cocoapods dependencies listed under `EXTERNAL SOURCES` whose vendored podspecs have a `git` source should now be uploaded as correctly constructed `git` locators, not `pod` locators.

## Testing plan

1. Clone https://github.com/react-native-maps/react-native-maps.
2. Change into the `example` directory.
3. Run `yarn`.
4. Run `fossa analyze --output` in the cloned repository.
5. Examining the output should show that dependencies with external sources (such as `DoubleConversion`) now upload git locators.

## Risks

1. Should I write an integration test for this? If so, can I get a pointer towards an example integration test setup?
2. This PR relies on undocumented semantics for the meaning of `:path` and `:podspec` in `EXTERNAL SOURCES`. In particular, it assumes that `:path` always points to a folder with a `.podspec` file named the same as its pod, and that `:podspec` always points to a `.podspec` file. A [quick GitHub search](https://github.com/search?l=&p=1&q=filename%3APodfile.lock&ref=advsearch&type=Code) seems to support this (examples: [Expo](https://github.com/expo/expo/blob/67e936ed86ce2c3248273617eeba9020e2e83a87/ios/Podfile.lock), [WeatherApp](https://github.com/luizrmm/WeatherApp-2.0/blob/e01c2d124b507219ea2365fda98bb81e6c3a114e/ios/Podfile.lock), [schedule](https://github.com/ibrahimmohamed2411/schedule), [async-dataflow](https://github.com/bancolombia/async-dataflow/blob/c0cb9053589bd25bb989eb5de1c23e3b336a0530/examples/app_async_flutter/ios/Podfile.lock))

## References

- https://fossa.atlassian.net/browse/ANE-155
- https://teamfossa.slack.com/archives/C0155DTGWB1/p1647873192769469

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
