### PR TITLE
Naive discovery exclusion

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.2.6
+
+- Filters: Apply filters during the discvoery phase, reducing end-to-end runtime. ([#877](https://github.com/fossas/fossa-cli/pull/877))
+
 ## v3.2.5
 
 - debug: Reduce the size of debug bundles. ([#890](https://github.com/fossas/fossa-cli/pull/890))

--- a/integration-test/Analysis/FixtureUtils.hs
+++ b/integration-test/Analysis/FixtureUtils.hs
@@ -154,6 +154,7 @@ performDiscoveryAndAnalyses targetDir AnalysisTestFixture{..} = do
             Left err -> fail (show err)
             Right _ -> pure ()
 
+-- TODO: don't use MonadFail here
 withResult :: MonadFail m => Result a -> ([EmittedWarn] -> a -> m b) -> m b
 withResult (Failure ws eg) _ = fail (show (renderFailure ws eg "An issue occurred"))
 withResult (Success ws a) f = f ws a

--- a/integration-test/Analysis/FixtureUtils.hs
+++ b/integration-test/Analysis/FixtureUtils.hs
@@ -69,6 +69,7 @@ import Path (
 import Path.IO qualified as PIO
 import System.Directory.Internal.Prelude (Handle, hClose)
 import Text.URI (mkURI)
+import Type.Operator (type ($))
 import Types (
   DependencyResults,
   DiscoveredProject (projectBuildTargets, projectData),
@@ -100,7 +101,7 @@ data FixtureArtifact = FixtureArtifact
   }
   deriving (Show, Eq, Ord)
 
-type TestC m = ExecIOC (ReadFSIOC (DiagnosticsC (LoggerC (ReaderC AllFilters (ReaderC ExperimentalAnalyzeConfig (FinallyC (StackC (IgnoreTelemetryC m))))))))
+type TestC m = ExecIOC $ ReadFSIOC $ DiagnosticsC $ LoggerC $ ReaderC AllFilters $ ReaderC ExperimentalAnalyzeConfig $ FinallyC $ StackC $ IgnoreTelemetryC m
 
 testRunnerWithLogger :: TestC IO a -> FixtureEnvironment -> IO (Result a)
 testRunnerWithLogger f env =

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -290,6 +290,7 @@ library
     Discovery.Archive.RPM
     Discovery.Filters
     Discovery.Projects
+    Discovery.Simple
     Discovery.Walk
     Effect.Exec
     Effect.Grapher

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -395,6 +395,7 @@ library
     Strategy.Swift.Xcode.PbxprojParser
     Strategy.SwiftPM
     Text.URI.Builder
+    Type.Operator
     Types
 
   hs-source-dirs:  src

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -172,6 +172,7 @@ runDependencyAnalysis ::
   , Has (Output DiscoveredProjectScan) sig m
   , Has Stack sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
+  , Has (Reader AllFilters) sig m
   , Has Telemetry sig m
   ) =>
   -- | Analysis base directory
@@ -288,6 +289,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
       . withTaskPool capabilities updateProgress
       . runAtomicCounter
       . runReader (Config.experimental cfg)
+      . runReader (Config.filterSet cfg)
       $ do
         runAnalyzers basedir filters
         when (fromFlag UnpackArchives $ Config.unpackArchives cfg) $

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -303,7 +303,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
 
   let analysisResult = AnalysisScanResult projectScansWithSkippedProdPath vsiResults binarySearchResults manualSrcUnits dynamicLinkedResults
 
-  renderScanSummary (severity cfg) analysisResult
+  renderScanSummary (severity cfg) analysisResult $ Config.filterSet cfg
 
   -- Need to check if vendored is empty as well, even if its a boolean that vendoredDeps exist
   case checkForEmptyUpload includeAll projectResults filteredProjects additionalSourceUnits of

--- a/src/App/Fossa/Analyze/Discover.hs
+++ b/src/App/Fossa/Analyze/Discover.hs
@@ -4,7 +4,9 @@ module App.Fossa.Analyze.Discover (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, AnalyzeTaskEffs)
+import Control.Effect.Reader (Has, Reader)
 import Data.Aeson qualified as Aeson
+import Discovery.Filters (AllFilters)
 import Path (Abs, Dir, Path)
 import Strategy.Bundler qualified as Bundler
 import Strategy.Cargo qualified as Cargo
@@ -97,4 +99,4 @@ discoverFuncs =
 --       [forall a. (AnalyzeProject a, ToJSON a) =>
 --          Path Abs Dir -> m [DiscoveredProject a]]
 data DiscoverFunc m where
-  DiscoverFunc :: (AnalyzeProject a, Aeson.ToJSON a) => (Path Abs Dir -> m [DiscoveredProject a]) -> DiscoverFunc m
+  DiscoverFunc :: (AnalyzeProject a, Aeson.ToJSON a, Has (Reader AllFilters) sig m) => (Path Abs Dir -> m [DiscoveredProject a]) -> DiscoverFunc m

--- a/src/App/Fossa/Analyze/Log4jReport.hs
+++ b/src/App/Fossa/Analyze/Log4jReport.hs
@@ -123,6 +123,7 @@ analyzeForLog4j basedir = do
   capabilities <- sendIO getNumCapabilities
 
   runReader withoutAnyExperimentalPreferences
+    . runReader (mempty :: AllFilters)
     . ignoreDebug
     $ do
       (projectResults, ()) <-
@@ -170,6 +171,7 @@ runDependencyAnalysisForLog4j ::
   , Has Exec sig m
   , Has (Output ProjectResult) sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
+  , Has (Reader AllFilters) sig m
   , Has Stack sig m
   , Has Telemetry sig m
   ) =>

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -17,10 +17,11 @@ import Control.Effect.Telemetry (Telemetry)
 import Data.Set (Set)
 import Data.Text (Text)
 import Diag.Result (Result (Failure, Success))
+import Discovery.Filters (AllFilters)
 import Effect.Exec (Exec)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
-import Path
+import Path (Abs, Dir, Path)
 import Srclib.Types (SourceUnit)
 import Types (DependencyResults, DiscoveredProjectType, FoundTargets)
 
@@ -36,6 +37,7 @@ type AnalyzeTaskEffs sig m =
   , Has Diagnostics sig m
   , Has Debug sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
+  , Has (Reader AllFilters) sig m
   , Has Telemetry sig m
   )
 

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -49,7 +49,8 @@ import Effect.Logger (
   annotate,
   color,
   logDebug,
-  logInfo, logWarn
+  logInfo,
+  logWarn,
  )
 import Effect.ReadFS (ReadFS)
 import Path (Abs, Dir, Path, toFilePath)

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -49,7 +49,7 @@ import Effect.Logger (
   annotate,
   color,
   logDebug,
-  logInfo,
+  logInfo, logWarn
  )
 import Effect.ReadFS (ReadFS)
 import Path (Abs, Dir, Path, toFilePath)
@@ -71,7 +71,7 @@ listTargetsMain ::
   m ()
 listTargetsMain ListTargetsConfig{..} = do
   capabilities <- sendIO getNumCapabilities
-
+  logWarn "fossa list-targets does not apply any filtering, you may see projects which are not present in the final analysis."
   ignoreDebug
     . runStickyLogger SevInfo
     . runFinally

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -38,6 +38,7 @@ import Data.Aeson.Extra (encodeJSONToText)
 import Data.Foldable (for_, traverse_)
 import Data.Set qualified as Set
 import Data.Set.NonEmpty (toSet)
+import Discovery.Filters (AllFilters)
 import Discovery.Projects (withDiscoveredProjects)
 import Effect.Exec (Exec)
 import Effect.Logger (
@@ -77,6 +78,9 @@ listTargetsMain ListTargetsConfig{..} = do
     . withTaskPool capabilities updateProgress
     . runAtomicCounter
     . runReader experimental
+    -- The current version of `fossa list-targets` does not support filters.
+    -- TODO: support both discovery and post-discovery filtering.
+    . runReader (mempty :: AllFilters)
     $ runAll (unBaseDir baseDir)
 
 runAll ::
@@ -89,6 +93,7 @@ runAll ::
   , Has Debug sig m
   , Has Stack sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
+  , Has (Reader AllFilters) sig m
   , Has Telemetry sig m
   ) =>
   Path Abs Dir ->

--- a/src/App/Pathfinder/Scan.hs
+++ b/src/App/Pathfinder/Scan.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Pathfinder.Scan (

--- a/src/Control/Carrier/Simple.hs
+++ b/src/Control/Carrier/Simple.hs
@@ -192,7 +192,7 @@ interpretState s f = runState s . interpret f
 
 -- | A carrier for arbitrary "first-order" effects
 newtype SimpleC eff m a = SimpleC {runSimpleC :: ReaderC (HandlerFor eff m) m a}
-  deriving (Functor, Applicative, Alternative, Monad, MonadFail, MonadIO)
+  deriving (Functor, Applicative, Alternative, Monad, MonadIO)
 
 -- | A wrapper for an effect handler function
 data HandlerFor eff m where

--- a/src/Control/Carrier/TaskPool.hs
+++ b/src/Control/Carrier/TaskPool.hs
@@ -128,7 +128,7 @@ data Progress = Progress
   deriving (Eq, Ord, Show)
 
 newtype TaskPoolC m a = TaskPoolC {runTaskPoolC :: ReaderC (TVar [m ()]) m a}
-  deriving (Functor, Applicative, Monad, MonadIO, MonadFail)
+  deriving (Functor, Applicative, Monad, MonadIO)
 
 instance MonadTrans TaskPoolC where
   lift = TaskPoolC . lift

--- a/src/Control/Carrier/Telemetry.hs
+++ b/src/Control/Carrier/Telemetry.hs
@@ -35,7 +35,7 @@ import Data.Tracing.Instrument (incCount)
 import System.Exit (ExitCode (ExitSuccess))
 
 newtype TelemetryC m a = TelemetryC {runTelemetryC :: ReaderC TelemetryCtx m a}
-  deriving (Applicative, Functor, Monad, MonadFail, MonadIO)
+  deriving (Applicative, Functor, Monad, MonadIO)
 
 instance (Algebra sig m, MonadIO m, Has (Lift IO) sig m) => Algebra (Telemetry :+: sig) (TelemetryC m) where
   alg hdl sig ctx = case sig of
@@ -116,7 +116,7 @@ bracket' create teardown act =
         actOnException hadFatalException >> throwIO (e :: Exc.SomeException)
 
 newtype IgnoreTelemetryC m a = IgnoreTelemetryC {runIgnoreTelemetryC :: ReaderC TelemetryCtx m a}
-  deriving (Applicative, Functor, Monad, MonadFail, MonadIO)
+  deriving (Applicative, Functor, Monad, MonadIO)
 
 instance Algebra sig m => Algebra (Telemetry :+: sig) (IgnoreTelemetryC m) where
   alg hdl sig ctx = case sig of

--- a/src/Discovery/Filters.hs
+++ b/src/Discovery/Filters.hs
@@ -121,11 +121,13 @@ toolMatches ty = \case
 pathAllowed :: AllFilters -> Path Rel Dir -> Bool
 pathAllowed AllFilters{..} path = allowedInclude && allowedExclude
   where
-    allowedExclude = notElem path $ combinedPaths excludeFilters
+    allowedExclude = not . any (matchPath path) $ combinedPaths excludeFilters
     allowedInclude
       -- If the included path array is empty, allow everything
-      | combinedPaths includeFilters == (mempty :: [Path Rel Dir]) = True
-      | otherwise = elem path $ combinedPaths includeFilters
+      | combinedPaths includeFilters == mempty = True
+      | otherwise = any (matchPath path) $ combinedPaths includeFilters
+    -- child "hello/world/" matches "hello/" and "hello/world/"
+    matchPath child parent = parent == child || parent `isProperPrefixOf` child
 
 comboInclude :: [TargetFilter] -> [Path Rel Dir] -> FilterCombination Include
 comboInclude = FilterCombination

--- a/src/Discovery/Filters.hs
+++ b/src/Discovery/Filters.hs
@@ -16,8 +16,13 @@ module Discovery.Filters (
   combinedTargets,
   Include,
   Exclude,
+  pathAllowed,
+  toolAllowed,
+  withMultiToolFilter,
+  withToolFilter,
 ) where
 
+import Control.Effect.Reader (Has, Reader, ask)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.List ((\\))
 import Data.List.NonEmpty qualified as NE
@@ -38,7 +43,7 @@ import Text.Megaparsec (
   (<|>),
  )
 import Text.Megaparsec.Char (alphaNumChar, char)
-import Types (BuildTarget (..), FoundTargets (FoundTargets, ProjectWithoutTargets), TargetFilter (..))
+import Types (BuildTarget (..), DiscoveredProjectType, FoundTargets (FoundTargets, ProjectWithoutTargets), TargetFilter (..))
 
 -- | filterIsVSIOnly is a very naive check for whether the user provided a filter for the VSI target *only*, at the root of the project with no path specified.
 -- This decision was made because predicating VSI only scans is a stopgap until we have more broad support for *preemptive* analysis filtering.
@@ -86,6 +91,40 @@ instance Semigroup (FilterCombination a) where
 
 instance Monoid (FilterCombination a) where
   mempty = FilterCombination mempty mempty
+
+withMultiToolFilter :: Has (Reader AllFilters) sig m => [DiscoveredProjectType] -> m [a] -> m [a]
+withMultiToolFilter tools act = do
+  filters <- ask
+  if any (toolAllowed filters) tools
+    then act
+    else pure mempty
+
+withToolFilter :: Has (Reader AllFilters) sig m => DiscoveredProjectType -> m [a] -> m [a]
+withToolFilter tool = withMultiToolFilter [tool]
+
+toolAllowed :: AllFilters -> DiscoveredProjectType -> Bool
+toolAllowed AllFilters{..} ty = allowedInclude && allowedExclude
+  where
+    allowedExclude = not . any (toolMatches ty) $ combinedTargets excludeFilters
+    allowedInclude
+      -- If the included target array is empty, allow everything
+      | combinedTargets includeFilters == (mempty :: [TargetFilter]) = True
+      | otherwise = any (toolMatches ty) $ combinedTargets includeFilters
+
+toolMatches :: DiscoveredProjectType -> TargetFilter -> Bool
+toolMatches ty = \case
+  TypeTarget txt -> txt == toText ty
+  TypeDirTarget txt _ -> txt == toText ty
+  TypeDirTargetTarget txt _ _ -> txt == toText ty
+
+pathAllowed :: AllFilters -> Path Rel Dir -> Bool
+pathAllowed AllFilters{..} path = allowedInclude && allowedExclude
+  where
+    allowedExclude = notElem path $ combinedPaths excludeFilters
+    allowedInclude
+      -- If the included path array is empty, allow everything
+      | combinedPaths includeFilters == (mempty :: [Path Rel Dir]) = True
+      | otherwise = elem path $ combinedPaths includeFilters
 
 comboInclude :: [TargetFilter] -> [Path Rel Dir] -> FilterCombination Include
 comboInclude = FilterCombination

--- a/src/Discovery/Filters.hs
+++ b/src/Discovery/Filters.hs
@@ -105,6 +105,7 @@ withToolFilter tool = withMultiToolFilter [tool]
 toolAllowed :: AllFilters -> DiscoveredProjectType -> Bool
 toolAllowed AllFilters{..} ty = allowedInclude && allowedExclude
   where
+    -- TODO: Use FilterCombination's phantom type to confirm that we aren't mixing these up.
     allowedExclude = not . any (toolMatches ty) $ combinedTargets excludeFilters
     allowedInclude
       -- If the included target array is empty, allow everything

--- a/src/Discovery/Simple.hs
+++ b/src/Discovery/Simple.hs
@@ -19,8 +19,8 @@ import Types (DiscoveredProject, DiscoveredProjectType)
 -- The type of the @findProjects@ and @mkProject@ fields enforce that only
 -- those discovery functions which actually conform to the simple discovery
 -- model.  In particular, the @a@ in @m [a]@ returned by @findProjects@ must be
--- the same as the final @m [DiscoveredProject a]@, and the type of @mkProject@
--- enforces that.
+-- the same as in the final @m [DiscoveredProject a]@, and the type of
+-- @mkProject@ enforces that.
 --
 -- If you can define a discovery function in terms of @simpleDiscover@, it's
 -- most likely safe to do so.

--- a/src/Discovery/Simple.hs
+++ b/src/Discovery/Simple.hs
@@ -1,0 +1,28 @@
+module Discovery.Simple (simpleDiscover) where
+
+import Control.Effect.Diagnostics (Diagnostics, context)
+import Control.Effect.Reader (Reader)
+import Data.String.Conversion (toText)
+import Discovery.Filters (AllFilters, withToolFilter)
+import Effect.ReadFS (Has, ReadFS)
+import Path (Abs, Dir, Path)
+import Types (DiscoveredProject, DiscoveredProjectType)
+
+simpleDiscover ::
+  ( Has ReadFS sig m
+  , Has Diagnostics sig m
+  , Has (Reader AllFilters) sig m
+  ) =>
+  -- | @findProjects@
+  (Path Abs Dir -> m [a]) ->
+  -- | @mkProject@
+  (a -> DiscoveredProject a) ->
+  -- | Passed to 'withToolFilter'
+  DiscoveredProjectType ->
+  -- | directory to start discovery in
+  Path Abs Dir ->
+  m [DiscoveredProject a]
+simpleDiscover finder toDiscProj tool dir = withToolFilter tool $
+  context (toText tool) $ do
+    projects <- context "Finding Projects" $ finder dir
+    pure $ map toDiscProj projects

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -184,10 +184,6 @@ instance FromJSON CargoMetadata where
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [DiscoveredProject CargoProject]
 discover = simpleDiscover findProjects mkProject CargoProjectType
 
--- context "Cargo" $ do
---   projects <- context "Finding projects" $ findProjects dir
---   pure (map mkProject projects)
-
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [CargoProject]
 findProjects = walkWithFilters' $ \dir _ files -> do
   case findFileNamed "Cargo.toml" files of

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -24,6 +24,7 @@ import Control.Effect.Diagnostics (
   run,
   warn,
  )
+import Control.Effect.Reader (Reader)
 import Data.Aeson.Types (
   FromJSON (parseJSON),
   Parser,
@@ -39,10 +40,12 @@ import Data.Set (Set)
 import Data.String.Conversion (toText)
 import Data.Text qualified as Text
 import Diag.Diagnostic (renderDiagnostic)
+import Discovery.Filters (AllFilters)
+import Discovery.Simple (simpleDiscover)
 import Discovery.Walk (
   WalkStep (WalkContinue, WalkSkipAll),
   findFileNamed,
-  walk',
+  walkWithFilters',
  )
 import Effect.Exec (
   AllowErr (Never),
@@ -178,13 +181,15 @@ instance FromJSON CargoMetadata where
       <*> (obj .: "workspace_members" >>= traverse parsePkgId)
       <*> obj .: "resolve"
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject CargoProject]
-discover dir = context "Cargo" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [DiscoveredProject CargoProject]
+discover = simpleDiscover findProjects mkProject CargoProjectType
 
-findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [CargoProject]
-findProjects = walk' $ \dir _ files -> do
+-- context "Cargo" $ do
+--   projects <- context "Finding projects" $ findProjects dir
+--   pure (map mkProject projects)
+
+findProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [CargoProject]
+findProjects = walkWithFilters' $ \dir _ files -> do
   case findFileNamed "Cargo.toml" files of
     Nothing -> pure ([], WalkContinue)
     Just toml -> do

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -75,12 +75,12 @@ import Text.Megaparsec.Char.Lexer qualified as L
 import Types (
   DependencyResults (..),
   DiscoveredProject (..),
-  DiscoveredProjectType (BundlerProjectType, CarthageProjectType),
+  DiscoveredProjectType (CarthageProjectType),
   GraphBreadth (Complete),
  )
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [DiscoveredProject CarthageProject]
-discover = simpleDiscover findProjects mkProject BundlerProjectType
+discover = simpleDiscover findProjects mkProject CarthageProjectType
 
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [CarthageProject]
 findProjects = walkWithFilters' $ \dir _ files -> do

--- a/src/Strategy/Glide.hs
+++ b/src/Strategy/Glide.hs
@@ -4,21 +4,30 @@ module Strategy.Glide (
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context)
+import Control.Effect.Reader (Reader)
 import Data.Aeson (ToJSON)
-import Discovery.Walk
-import Effect.ReadFS
+import Discovery.Filters (AllFilters)
+import Discovery.Simple (simpleDiscover)
+import Discovery.Walk (
+  WalkStep (WalkContinue, WalkSkipAll),
+  findFileNamed,
+  walkWithFilters',
+ )
+import Effect.ReadFS (Has, ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Go.GlideLock qualified as GlideLock
-import Types
+import Types (
+  DependencyResults,
+  DiscoveredProject (..),
+  DiscoveredProjectType (GlideProjectType),
+ )
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject GlideProject]
-discover dir = context "Glide" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [DiscoveredProject GlideProject]
+discover = simpleDiscover findProjects mkProject GlideProjectType
 
-findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [GlideProject]
-findProjects = walk' $ \dir _ files -> do
+findProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [GlideProject]
+findProjects = walkWithFilters' $ \dir _ files -> do
   case findFileNamed "glide.lock" files of
     Nothing -> pure ([], WalkContinue)
     Just lockfile -> pure ([GlideProject lockfile dir], WalkSkipAll)

--- a/src/Strategy/Googlesource/RepoManifest.hs
+++ b/src/Strategy/Googlesource/RepoManifest.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Strategy.Googlesource.RepoManifest (
   discover,
@@ -18,11 +15,17 @@ module Strategy.Googlesource.RepoManifest (
   ValidatedProject (..),
 ) where
 
-import Prelude
-
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Applicative (optional, (<|>))
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  ToDiagnostic (..),
+  fatal,
+  fatalText,
+  tagError,
+ )
+import Control.Effect.Reader (Reader)
 import Control.Monad (unless)
 import Data.Aeson (ToJSON)
 import Data.Foldable (find)
@@ -31,27 +34,57 @@ import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
-import DepTypes
-import Discovery.Walk
-import Effect.ReadFS
+import DepTypes (
+  DepEnvironment (EnvProduction),
+  DepType (GooglesourceType),
+  Dependency (..),
+  VerConstraint (CEq),
+ )
+import Discovery.Filters (AllFilters)
+import Discovery.Simple (simpleDiscover)
+import Discovery.Walk (
+  WalkStep (WalkContinue, WalkSkipAll),
+  fileName,
+  walkWithFilters',
+ )
+import Effect.ReadFS (
+  ReadFS,
+  doesFileExist,
+  readContentsText,
+  readContentsXML,
+ )
 import GHC.Generics (Generic)
 import Graphing (Graphing, unfold)
-import Parse.XML
-import Path
+import Parse.XML (FromXML (..), attr, child, children)
+import Path (
+  Abs,
+  Dir,
+  File,
+  Path,
+  dirname,
+  mkRelDir,
+  mkRelFile,
+  parent,
+  parseRelFile,
+  (</>),
+ )
 import Prettyprinter (pretty)
 import Text.GitConfig.Parser (Section (..), parseConfig)
 import Text.Megaparsec (errorBundlePretty)
-import Text.URI
-import Types
+import Text.URI (URI, mkURI, relativeTo, render)
+import Types (
+  DependencyResults (..),
+  DiscoveredProject (..),
+  DiscoveredProjectType (RepoManifestProjectType),
+  GraphBreadth (Partial),
+ )
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject RepoManifestProject]
-discover dir = context "RepoManifest" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [DiscoveredProject RepoManifestProject]
+discover = simpleDiscover findProjects mkProject RepoManifestProjectType
 
 -- We're looking for a file called "manifest.xml" in a directory called ".repo"
-findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [RepoManifestProject]
-findProjects = walk' $ \_ _ files -> do
+findProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [RepoManifestProject]
+findProjects = walkWithFilters' $ \_ _ files -> do
   case find (\f -> "manifest.xml" == fileName f) files of
     Nothing -> pure ([], WalkContinue)
     Just file ->

--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -15,9 +15,24 @@ module Strategy.Haskell.Cabal (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Effect.Diagnostics
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  Has,
+  ToDiagnostic (..),
+  context,
+  errCtx,
+  fatal,
+ )
+import Control.Effect.Reader (Reader)
 import Control.Monad (when)
-import Data.Aeson.Types
+import Data.Aeson.Types (
+  FromJSON (parseJSON),
+  ToJSON,
+  withObject,
+  (.!=),
+  (.:),
+  (.:?),
+ )
 import Data.Foldable (for_)
 import Data.List (isSuffixOf)
 import Data.Map.Strict (Map)
@@ -27,15 +42,40 @@ import Data.Set qualified as Set
 import Data.String.Conversion (toString)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Discovery.Walk
-import Effect.Exec
-import Effect.Grapher
-import Effect.ReadFS
+import Discovery.Filters (AllFilters)
+import Discovery.Simple (simpleDiscover)
+import Discovery.Walk (
+  WalkStep (WalkContinue, WalkSkipAll),
+  fileName,
+  walkWithFilters',
+ )
+import Effect.Exec (
+  AllowErr (Never),
+  Command (..),
+  Exec,
+  execThrow,
+ )
+import Effect.Grapher (
+  MappedGrapher,
+  direct,
+  edge,
+  mapping,
+  withMapping,
+ )
+import Effect.ReadFS (ReadFS, readContentsJson)
 import GHC.Generics (Generic)
 import Graphing (Graphing)
 import Graphing qualified as G
-import Path
-import Types
+import Path (Abs, Dir, File, Path, Rel, mkRelFile, (</>))
+import Types (
+  DepType (HackageType),
+  Dependency (..),
+  DependencyResults (..),
+  DiscoveredProject (..),
+  DiscoveredProjectType (CabalProjectType),
+  GraphBreadth (Complete),
+  VerConstraint (CEq),
+ )
 
 newtype BuildPlan = BuildPlan {installPlans :: [InstallPlan]} deriving (Eq, Ord, Show)
 newtype Component = Component {componentDeps :: Set PlanId} deriving (Eq, Ord, Show)
@@ -112,10 +152,8 @@ cabalGenPlanCmd =
 cabalPlanFilePath :: Path Rel File
 cabalPlanFilePath = $(mkRelFile "dist-newstyle/cache/plan.json")
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject CabalProject]
-discover dir = context "Cabal" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [DiscoveredProject CabalProject]
+discover = simpleDiscover findProjects mkProject CabalProjectType
 
 isCabalFile :: Path Abs File -> Bool
 isCabalFile file = isDotCabal || isCabalDotProject
@@ -124,8 +162,8 @@ isCabalFile file = isDotCabal || isCabalDotProject
     isDotCabal = ".cabal" `isSuffixOf` name
     isCabalDotProject = "cabal.project" == name
 
-findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [CabalProject]
-findProjects = walk' $ \dir _ files -> do
+findProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [CabalProject]
+findProjects = walkWithFilters' $ \dir _ files -> do
   -- NOTE: the long-term more-accurate version here is to parse the `cabal.project` file and look
   -- for relevant cabal files to mark as manifests.
   let manifestFiles = filter isCabalFile files

--- a/src/Strategy/Python/Poetry.hs
+++ b/src/Strategy/Python/Poetry.hs
@@ -64,7 +64,14 @@ instance ToJSON PoetryProject
 instance AnalyzeProject PoetryProject where
   analyzeProject _ = getDeps
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [DiscoveredProject PoetryProject]
+discover ::
+  ( Has ReadFS sig m
+  , Has Diagnostics sig m
+  , Has Logger sig m
+  , Has (Reader AllFilters) sig m
+  ) =>
+  Path Abs Dir ->
+  m [DiscoveredProject PoetryProject]
 discover = simpleDiscover findProjects mkProject PoetryProjectType
 
 -- | Poetry build backend identifier required in [pyproject.toml](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517).
@@ -88,7 +95,14 @@ warnIncorrectBuildBackend currentBackend =
 
 -- | Finds poetry project by searching for pyproject.toml.
 -- If poetry.lock file is also discovered, it is used as a supplement.
-findProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [PoetryProject]
+findProjects ::
+  ( Has ReadFS sig m
+  , Has Diagnostics sig m
+  , Has Logger sig m
+  , Has (Reader AllFilters) sig m
+  ) =>
+  Path Abs Dir ->
+  m [PoetryProject]
 findProjects = walkWithFilters' $ \dir _ files -> do
   let poetryLockFile = findFileNamed "poetry.lock" files
   let pyprojectFile = findFileNamed "pyproject.toml" files

--- a/src/Strategy/Python/Setuptools.hs
+++ b/src/Strategy/Python/Setuptools.hs
@@ -7,29 +7,40 @@ module Strategy.Python.Setuptools (
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
-import Control.Carrier.Output.IO
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Diagnostics qualified as Diag
+import Control.Effect.Reader (Reader)
 import Data.Aeson (ToJSON)
 import Data.List (isInfixOf, isSuffixOf)
 import Data.Maybe (maybeToList)
 import Data.Text (Text)
-import Discovery.Walk
-import Effect.ReadFS
+import Discovery.Filters (AllFilters)
+import Discovery.Simple (simpleDiscover)
+import Discovery.Walk (
+  WalkStep (WalkContinue),
+  fileName,
+  findFileNamed,
+  walkWithFilters',
+ )
+import Effect.ReadFS (Has, ReadFS)
 import GHC.Generics (Generic)
 import Graphing (Graphing)
-import Path
+import Path (Abs, Dir, File, Path)
 import Strategy.Python.ReqTxt qualified as ReqTxt
 import Strategy.Python.SetupPy qualified as SetupPy
-import Types
+import Types (
+  Dependency,
+  DependencyResults (..),
+  DiscoveredProject (..),
+  DiscoveredProjectType (SetuptoolsProjectType),
+  GraphBreadth (Partial),
+ )
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [DiscoveredProject SetuptoolsProject]
-discover dir = context "Setuptools" $ do
-  projects <- context "Finding projects" $ findProjects dir
-  pure (map mkProject projects)
+discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [DiscoveredProject SetuptoolsProject]
+discover = simpleDiscover findProjects mkProject SetuptoolsProjectType
 
-findProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [SetuptoolsProject]
-findProjects = walk' $ \dir _ files -> do
+findProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [SetuptoolsProject]
+findProjects = walkWithFilters' $ \dir _ files -> do
   let reqTxtFiles =
         filter
           (\f -> "req" `isInfixOf` fileName f && ".txt" `isSuffixOf` fileName f)

--- a/src/Strategy/SwiftPM.hs
+++ b/src/Strategy/SwiftPM.hs
@@ -53,11 +53,6 @@ instance ToJSON SwiftProject
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [DiscoveredProject SwiftProject]
 discover = simpleDiscover findProjects mkProject SwiftProjectType
 
--- discover dir = context "Swift" $ do
---   swiftPackageProjects <- context "Finding swift package projects" $ findSwiftPackageProjects dir
---   xCodeProjects <- context "Finding xcode projects using swift package manager" $ findXcodeProjects dir
---   pure $ map mkProject (swiftPackageProjects ++ xCodeProjects)
-
 findProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => Path Abs Dir -> m [SwiftProject]
 findProjects dir = do
   swiftPackageProjects <- context "Finding swift package projects" $ findSwiftPackageProjects dir

--- a/src/Strategy/SwiftPM.hs
+++ b/src/Strategy/SwiftPM.hs
@@ -8,9 +8,12 @@ module Strategy.SwiftPM (
 import App.Fossa.Analyze.Types (AnalyzeProject (..))
 import Control.Carrier.Simple (Has)
 import Control.Effect.Diagnostics (Diagnostics, context)
+import Control.Effect.Reader (Reader)
 import Data.Aeson (ToJSON)
 import Data.Functor (($>))
 import Data.Maybe (listToMaybe)
+import Discovery.Filters (AllFilters)
+import Discovery.Simple (simpleDiscover)
 import Discovery.Walk (
   WalkStep (WalkContinue, WalkSkipSome),
   findFileNamed,
@@ -19,7 +22,7 @@ import Discovery.Walk (
 import Effect.Logger (Logger, Pretty (pretty), logDebug)
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, File, Path, dirname, reldir)
 import Strategy.Swift.PackageSwift (analyzePackageSwift)
 import Strategy.Swift.Xcode.Pbxproj (analyzeXcodeProjForSwiftPkg, hasSomeSwiftDeps)
 import Types (DependencyResults (..), DiscoveredProject (..), DiscoveredProjectType (SwiftProjectType), GraphBreadth (..))
@@ -47,12 +50,21 @@ instance ToJSON SwiftPackageProject
 instance ToJSON XcodeProjectUsingSwiftPm
 instance ToJSON SwiftProject
 
-discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => Path Abs Dir -> m [DiscoveredProject SwiftProject]
-discover dir = context "Swift" $ do
+discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [DiscoveredProject SwiftProject]
+discover = simpleDiscover findProjects mkProject SwiftProjectType
+
+-- discover dir = context "Swift" $ do
+--   swiftPackageProjects <- context "Finding swift package projects" $ findSwiftPackageProjects dir
+--   xCodeProjects <- context "Finding xcode projects using swift package manager" $ findXcodeProjects dir
+--   pure $ map mkProject (swiftPackageProjects ++ xCodeProjects)
+
+findProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => Path Abs Dir -> m [SwiftProject]
+findProjects dir = do
   swiftPackageProjects <- context "Finding swift package projects" $ findSwiftPackageProjects dir
   xCodeProjects <- context "Finding xcode projects using swift package manager" $ findXcodeProjects dir
-  pure $ map mkProject (swiftPackageProjects ++ xCodeProjects)
+  pure (swiftPackageProjects <> xCodeProjects)
 
+-- TODO: determine if walkWithFilters' is safe here
 findSwiftPackageProjects :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [SwiftProject]
 findSwiftPackageProjects = walk' $ \dir _ files -> do
   let packageManifestFile = findFileNamed "Package.swift" files
@@ -64,6 +76,7 @@ findSwiftPackageProjects = walk' $ \dir _ files -> do
     -- Package.resolved without Package.swift or Xcode project file is not a valid swift project.
     (Nothing, _) -> pure ([], WalkContinue)
 
+-- TODO: determine if walkWithFilters' is safe here
 findXcodeProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => Path Abs Dir -> m [SwiftProject]
 findXcodeProjects = walk' $ \dir _ files -> do
   let xcodeProjectFile = findFileNamed "project.pbxproj" files

--- a/src/Type/Operator.hs
+++ b/src/Type/Operator.hs
@@ -1,0 +1,14 @@
+module Type.Operator (
+  type ($),
+) where
+
+-- | Infix application.  Taken from the 'type-operators' package.
+--
+-- @
+-- f :: Either String $ Maybe Int
+-- =
+-- f :: Either String (Maybe Int)
+-- @
+type f $ a = f a
+
+infixr 2 $

--- a/src/Type/Operator.hs
+++ b/src/Type/Operator.hs
@@ -1,8 +1,47 @@
+{-
+Copyright Benedict Aas (c) 2016
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Benedict Aas nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-}
+
+-- This module comes from 'type-operators', version 0.2.0.0
+-- I specifically DID NOT include the rest of the package (or just
+-- add the package itself), because I would like to avoid using the
+-- other type functions from that package, I think they will add
+-- complexity and not value.
+
 module Type.Operator (
   type ($),
 ) where
 
--- | Infix application.  Taken from the 'type-operators' package.
+-- | Infix application.  Useful for removing parentheses in big types.
 --
 -- @
 -- f :: Either String $ Maybe Int

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -201,7 +201,10 @@ newtype BuildTarget = BuildTarget {unBuildTarget :: Text}
   However, many Gradle targets consist of a strategy type, a directory,
   and an exact gradle target.
 -}
-data TargetFilter = TypeTarget Text | TypeDirTarget Text (Path Rel Dir) | TypeDirTargetTarget Text (Path Rel Dir) BuildTarget
+data TargetFilter
+  = TypeTarget Text
+  | TypeDirTarget Text (Path Rel Dir)
+  | TypeDirTargetTarget Text (Path Rel Dir) BuildTarget
   deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON TargetFilter where

--- a/test/App/Fossa/AnalyzeSpec.hs
+++ b/test/App/Fossa/AnalyzeSpec.hs
@@ -12,8 +12,9 @@ import Effect.Exec (ExecIOC)
 import Effect.Logger (LoggerC)
 import Effect.ReadFS (ReadFSIOC)
 import Test.Hspec (Spec, describe, it, shouldBe)
+import Type.Operator (type ($))
 
-type SomeMonad = TelemetryC (ReaderC ExperimentalAnalyzeConfig (ReaderC AllFilters (DebugC (DiagnosticsC (LoggerC (ExecIOC (ReadFSIOC (StackC IO))))))))
+type SomeMonad = TelemetryC $ ReaderC ExperimentalAnalyzeConfig $ ReaderC AllFilters $ DebugC $ DiagnosticsC $ LoggerC $ ExecIOC $ ReadFSIOC $ StackC IO
 
 spec :: Spec
 spec =

--- a/test/App/Fossa/AnalyzeSpec.hs
+++ b/test/App/Fossa/AnalyzeSpec.hs
@@ -7,12 +7,13 @@ import Control.Carrier.Diagnostics (DiagnosticsC)
 import Control.Carrier.Reader (ReaderC)
 import Control.Carrier.Stack (StackC)
 import Control.Carrier.Telemetry (TelemetryC)
+import Discovery.Filters (AllFilters)
 import Effect.Exec (ExecIOC)
 import Effect.Logger (LoggerC)
 import Effect.ReadFS (ReadFSIOC)
 import Test.Hspec (Spec, describe, it, shouldBe)
 
-type SomeMonad = TelemetryC (ReaderC ExperimentalAnalyzeConfig (DebugC (DiagnosticsC (LoggerC (ExecIOC (ReadFSIOC (StackC IO)))))))
+type SomeMonad = TelemetryC (ReaderC ExperimentalAnalyzeConfig (ReaderC AllFilters (DebugC (DiagnosticsC (LoggerC (ExecIOC (ReadFSIOC (StackC IO))))))))
 
 spec :: Spec
 spec =

--- a/test/Discovery/FiltersSpec.hs
+++ b/test/Discovery/FiltersSpec.hs
@@ -28,7 +28,6 @@ import Test.Hspec (
   Spec,
   describe,
   expectationFailure,
-  fdescribe,
   it,
   shouldBe,
  )

--- a/test/Discovery/FiltersSpec.hs
+++ b/test/Discovery/FiltersSpec.hs
@@ -191,20 +191,24 @@ spec = do
       it "should exclude tools correctly" $ do
         toolAllowed (excludeTool CargoProjectType) CargoProjectType `shouldBe` False
         toolAllowed (excludeTool GomodProjectType) CargoProjectType `shouldBe` True
+
       it "should include tools correctly" $ do
         toolAllowed (includeTool CargoProjectType) CargoProjectType `shouldBe` True
         toolAllowed (includeTool GomodProjectType) CargoProjectType `shouldBe` False
+
       -- Multiple filters
       it "should include multiple tools correctly" $ do
         let filts = includeTool CargoProjectType <> includeTool GomodProjectType
         toolAllowed filts CargoProjectType `shouldBe` True
         toolAllowed filts GomodProjectType `shouldBe` True
         toolAllowed filts SetuptoolsProjectType `shouldBe` False
+
       it "should exclude multiple tools correctly" $ do
         let filts = excludeTool CargoProjectType <> excludeTool GomodProjectType
         toolAllowed filts CargoProjectType `shouldBe` False
         toolAllowed filts GomodProjectType `shouldBe` False
         toolAllowed filts SetuptoolsProjectType `shouldBe` True
+
       it "should reject conflicted tools" $ do
         -- Conflicting filters, members of exclude are NEVER allowed
         toolAllowed (includeTool CargoProjectType <> excludeTool CargoProjectType) CargoProjectType `shouldBe` False
@@ -213,16 +217,20 @@ spec = do
       it "should include paths correctly" $ do
         pathAllowed (includePath $(mkRelDir "hello")) $(mkRelDir "hello") `shouldBe` True
         pathAllowed (includePath $(mkRelDir "NOPE")) $(mkRelDir "Yeah") `shouldBe` False
+
       it "should exclude paths correctly" $ do
         pathAllowed (excludePath $(mkRelDir "Nope")) $(mkRelDir "No") `shouldBe` True
         pathAllowed (excludePath $(mkRelDir "Bad")) $(mkRelDir "Bad") `shouldBe` False
+
       it "should match sub-dir paths correctly" $ do
         -- Subdir matching
         pathAllowed (excludePath $(mkRelDir "hello")) $(mkRelDir "hello/world") `shouldBe` False
+
       it "should reject conflicted paths" $ do
         -- Conflicting filters
         let conflict = $(mkRelDir "conflict")
         pathAllowed (excludePath conflict <> includePath conflict) conflict `shouldBe` False
+
       -- Big tests: multiple filters, subdirectory matching
       it "should should handle multi-matching with subdirs" $ do
         let bigFilters = includePath $(mkRelDir "a") <> excludePath $(mkRelDir "a/b/c")
@@ -236,12 +244,14 @@ spec = do
       if null result
         then pure ()
         else expectationFailure "withToolFilter returned non-empty"
+
     it "should return the list continuation when the tool is allowed" $ do
       let filters = excludeTool GomodProjectType
           result = run . runReader filters $ withToolFilter CargoProjectType $ pure [True]
       if null result
         then expectationFailure "withToolFilter returned non-empty"
         else pure ()
+
     it "should return the continuation when the filters are empty" $ do
       let filters = mempty :: AllFilters
           result = run . runReader filters $ withToolFilter CargoProjectType $ pure [True]

--- a/test/Discovery/FiltersSpec.hs
+++ b/test/Discovery/FiltersSpec.hs
@@ -230,7 +230,7 @@ spec = do
         pathAllowed bigFilters $(mkRelDir "a/b/c") `shouldBe` False
         pathAllowed bigFilters $(mkRelDir "a/b/d") `shouldBe` True
 
-  fdescribe "tool filtering helpers" $ do
+  describe "tool filtering helpers" $ do
     it "should return an empty list when the tool is not allowed" $ do
       let filters = excludeTool CargoProjectType
           result = run . runReader filters $ withToolFilter CargoProjectType $ pure [True]

--- a/test/Discovery/FiltersSpec.hs
+++ b/test/Discovery/FiltersSpec.hs
@@ -4,14 +4,40 @@ module Discovery.FiltersSpec (
   spec,
 ) where
 
+import Control.Carrier.Reader (run, runReader)
 import Data.Foldable (traverse_)
 import Data.Set qualified as Set
-import Data.Set.NonEmpty
+import Data.Set.NonEmpty (nonEmpty)
+import Data.String.Conversion (ToText (toText))
 import Data.Text qualified as Text
-import Discovery.Filters
-import Path
-import Test.Hspec
-import Types (BuildTarget (..), FoundTargets (..), TargetFilter (..))
+import Discovery.Filters (
+  AllFilters (AllFilters),
+  Exclude,
+  FilterCombination,
+  Include,
+  applyFilters,
+  comboExclude,
+  comboInclude,
+  pathAllowed,
+  toolAllowed,
+  withToolFilter,
+ )
+import Path (Dir, Path, Rel, mkRelDir)
+import Test.Hspec (
+  Expectation,
+  Spec,
+  describe,
+  expectationFailure,
+  fdescribe,
+  it,
+  shouldBe,
+ )
+import Types (
+  BuildTarget (..),
+  DiscoveredProjectType (..),
+  FoundTargets (..),
+  TargetFilter (..),
+ )
 
 spec :: Spec
 spec = do
@@ -161,7 +187,86 @@ spec = do
         , (mvnQuux, ProjectWithoutTargets, Nothing)
         ]
 
+  describe "Matching primitives" $ do
+    describe "Tool-based matching" $ do
+      it "should exclude tools correctly" $ do
+        toolAllowed (excludeTool CargoProjectType) CargoProjectType `shouldBe` False
+        toolAllowed (excludeTool GomodProjectType) CargoProjectType `shouldBe` True
+      it "should include tools correctly" $ do
+        toolAllowed (includeTool CargoProjectType) CargoProjectType `shouldBe` True
+        toolAllowed (includeTool GomodProjectType) CargoProjectType `shouldBe` False
+      -- Multiple filters
+      it "should include multiple tools correctly" $ do
+        let filts = includeTool CargoProjectType <> includeTool GomodProjectType
+        toolAllowed filts CargoProjectType `shouldBe` True
+        toolAllowed filts GomodProjectType `shouldBe` True
+        toolAllowed filts SetuptoolsProjectType `shouldBe` False
+      it "should exclude multiple tools correctly" $ do
+        let filts = excludeTool CargoProjectType <> excludeTool GomodProjectType
+        toolAllowed filts CargoProjectType `shouldBe` False
+        toolAllowed filts GomodProjectType `shouldBe` False
+        toolAllowed filts SetuptoolsProjectType `shouldBe` True
+      it "should reject conflicted tools" $ do
+        -- Conflicting filters, members of exclude are NEVER allowed
+        toolAllowed (includeTool CargoProjectType <> excludeTool CargoProjectType) CargoProjectType `shouldBe` False
+
+    describe "Path-based matching" $ do
+      it "should include paths correctly" $ do
+        pathAllowed (includePath $(mkRelDir "hello")) $(mkRelDir "hello") `shouldBe` True
+        pathAllowed (includePath $(mkRelDir "NOPE")) $(mkRelDir "Yeah") `shouldBe` False
+      it "should exclude paths correctly" $ do
+        pathAllowed (excludePath $(mkRelDir "Nope")) $(mkRelDir "No") `shouldBe` True
+        pathAllowed (excludePath $(mkRelDir "Bad")) $(mkRelDir "Bad") `shouldBe` False
+      it "should match sub-dir paths correctly" $ do
+        -- Subdir matching
+        pathAllowed (excludePath $(mkRelDir "hello")) $(mkRelDir "hello/world") `shouldBe` False
+      it "should reject conflicted paths" $ do
+        -- Conflicting filters
+        let conflict = $(mkRelDir "conflict")
+        pathAllowed (excludePath conflict <> includePath conflict) conflict `shouldBe` False
+      -- Big tests: multiple filters, subdirectory matching
+      it "should should handle multi-matching with subdirs" $ do
+        let bigFilters = includePath $(mkRelDir "a") <> excludePath $(mkRelDir "a/b/c")
+        pathAllowed bigFilters $(mkRelDir "a/b/c") `shouldBe` False
+        pathAllowed bigFilters $(mkRelDir "a/b/d") `shouldBe` True
+
+  fdescribe "tool filtering helpers" $ do
+    it "should return an empty list when the tool is not allowed" $ do
+      let filters = excludeTool CargoProjectType
+          result = run . runReader filters $ withToolFilter CargoProjectType $ pure [True]
+      if null result
+        then pure ()
+        else expectationFailure "withToolFilter returned non-empty"
+    it "should return the list continuation when the tool is allowed" $ do
+      let filters = excludeTool GomodProjectType
+          result = run . runReader filters $ withToolFilter CargoProjectType $ pure [True]
+      if null result
+        then expectationFailure "withToolFilter returned non-empty"
+        else pure ()
+    it "should return the continuation when the filters are empty" $ do
+      let filters = mempty :: AllFilters
+          result = run . runReader filters $ withToolFilter CargoProjectType $ pure [True]
+      if null result
+        then expectationFailure "withToolFilter returned non-empty"
+        else pure ()
+
 testHarness :: FilterCombination Include -> FilterCombination Exclude -> [((Text.Text, Path Rel Dir), FoundTargets, Maybe FoundTargets)] -> Expectation
 testHarness include exclude = traverse_ testSingle
   where
     testSingle ((buildtool, dir), targets, expected) = applyFilters (AllFilters include exclude) buildtool dir targets `shouldBe` expected
+
+excludePath :: Path Rel Dir -> AllFilters
+excludePath path = AllFilters mempty $ comboExclude mempty [path]
+
+excludeTool :: DiscoveredProjectType -> AllFilters
+excludeTool tool = AllFilters mempty $ comboExclude [TypeTarget $ toText tool] mempty
+
+includePath :: Path Rel Dir -> AllFilters
+includePath path = AllFilters include mempty
+  where
+    include = comboInclude mempty [path]
+
+includeTool :: DiscoveredProjectType -> AllFilters
+includeTool tool = AllFilters include mempty
+  where
+    include = comboInclude [TypeTarget $ toText tool] mempty

--- a/test/Test/Effect.hs
+++ b/test/Test/Effect.hs
@@ -52,12 +52,13 @@ import Test.Hspec (
  )
 import Test.MockApi (FossaApiClientMockC, MockApiC, runApiWithMock, runMockApi)
 import Text.Printf (printf)
+import Type.Operator (type ($))
 
 -- The FossaApiClient must be outside of Diagnostics because it
 -- depends on it.
 -- MockApiC must be inside Diagnostics so its state is not
 -- lost when diagnostics short-circuits on an error.
-type EffectStack = FinallyC (ReaderC AllFilters (ExecIOC (ReadFSIOC (FossaApiClientMockC (DiagnosticsC (MockApiC (IgnoreLoggerC (IgnoreStickyLoggerC (StackC IO)))))))))
+type EffectStack = FinallyC $ ReaderC AllFilters $ ExecIOC $ ReadFSIOC $ FossaApiClientMockC $ DiagnosticsC $ MockApiC $ IgnoreLoggerC $ IgnoreStickyLoggerC $ StackC IO
 
 -- TODO: add useful describe, naive describe' doesn't work.
 


### PR DESCRIPTION
# Overview

Delivers ANE-185

I made a few orthogonal changes to aid in development here:

- `simpleDiscover` - Most of our discovery can be proven to take a simplified form, and `simpleDiscover` helps prove that.  The module includes a comment explaining the difference between simple and non-simple.
- `$` as a type-level operator - Remove parens from big monad stacks.
- Remove `MonadFail` from fused-effect carriers, we don't use them, and trying to use them can cause ambiguous usage.  This is actually one of the bigger reasons for effect systems in general, a `fused-effects` dev did a great talk about this problem [here](https://youtu.be/vfDazZfxlNs). 

## A Caveat of Path Filtering
Note that path filtering is not available for walkers that attempt to collect files from multiple directories, such as maven and nodejs (which both have static-analysis workspace support).  Another way to think of it is that directories emitted by the walk must have a 1:1 relationship with projects emitted by the discovery, and must be independent of each other.  In cases of tool-based workspace support (like cargo), we CAN safely apply path filtering, because the walker does not emit subprojects, it skips them via `WalkSkipSome/WalkSkipAll`.

This is similar to the simple vs non-simple comparison for discovery, except that simple discovery is only determined by the ability to define `mkProject` as `a -> DiscoveredProject a`.

## The Legacy of NodeJS

After reading this PR, you might ask: why isn't the `DiscoveredProjectType` that we pass to `simpleDiscover` inferred from the type of the `a` in `DiscoveredProject a`?  The short answer is that there is not always a single value for all cases of `a`.

During the recent `yarn`/`npm` revamp, nodejs-based discovery became a single process.  However, users' filters still reflected the old model, which used `yarn` and `npm`.  We didn't have a good reason for changing them at the time, so there was no real argument for the breaking change of calling all of these `Node` projects.  However, that has presented us with the problem of not being able make `DiscoveredProjectType` a type-guaranteed match based on the `a` in `DiscoveredProject a`.  Doing this requires a 1:1 relationship between the `DiscoveredProjectType` and the `a`, which is only not true for nodejs, and only because of this exact legacy problem.

While that definitely limits the solution space for this feature, and is fixable, I think it should be in a follow-up discussion/PR.  The addition of `simpleDiscovery` makes this easier to refactor later, as well.  Also, we could probably add this for `simpleDiscover`-eligible projects only, and ship it here, but this PR is already large due to modifying every strategy and affecting tests, so it's a good idea to table it anyway.

## Acceptance criteria

- When a user runs `fossa analyze --exclude-target cabal`, we should not run the `cabal` discovery function.
- When a user runs `fossa analyze --only-target cabal`, we should only run the `cabal` discovery function.
- When a user runs `fossa analyze --only-path hello`, we should not enter any other directory (see caveats above).
- When a user runs `fossa analyze --exclude-path hello`, we should not descend into that directory (see caveats above).

## Testing plan

- unit tests and integration tests must pass
- AC above must be manually tested.

## Risks



## References



## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
