### PR TITLE
Updates AssertUserDefinedBinary to use FossaApiClient

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -231,6 +231,7 @@ library
     Control.Carrier.FossaApiClient
     Control.Carrier.FossaApiClient.Internal.Core
     Control.Carrier.FossaApiClient.Internal.ScotlandYard
+    Control.Carrier.FossaApiClient.Internal.VSI
     Control.Carrier.Git
     Control.Carrier.Output.IO
     Control.Carrier.Simple

--- a/src/App/Fossa/VSI/Fingerprint.hs
+++ b/src/App/Fossa/VSI/Fingerprint.hs
@@ -37,7 +37,7 @@ import Path (Abs, Dir, File, Path, toFilePath)
 --   @k@ - Kind, the kind of fingerprint computed.
 --
 -- For ease of implementation, the backing representation of a @Fingerprint@ instance is a @Base16@ encoded @Text@.
-newtype Fingerprint k = Fingerprint Text deriving (ToJSON)
+newtype Fingerprint k = Fingerprint Text deriving (Show, Eq, ToJSON)
 
 type role Fingerprint nominal
 

--- a/src/App/Fossa/VSI/IAT/AssertUserDefinedBinaries.hs
+++ b/src/App/Fossa/VSI/IAT/AssertUserDefinedBinaries.hs
@@ -9,12 +9,13 @@ import App.Fossa.Config.LinkUserBinaries (
   LinkUserBinsOpts,
   mkSubCommand,
  )
-import App.Fossa.FossaAPIV1 qualified as Fossa
 import App.Fossa.Subcommand (SubCommand)
 import App.Fossa.VSI.Fingerprint (fingerprintContentsRaw)
 import App.Types (BaseDir (..))
 import Control.Algebra (Has)
+import Control.Carrier.FossaApiClient (runFossaApiClient)
 import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.FossaApiClient qualified as API
 import Control.Effect.Lift (Lift)
 import Effect.Logger (Logger, logInfo)
 import Effect.ReadFS (ReadFS)
@@ -35,4 +36,4 @@ assertUserDefinedBinaries LinkUserBinsConfig{..} = do
   fingerprints <- fingerprintContentsRaw $ unBaseDir baseDir
 
   logInfo "Uploading assertion to FOSSA"
-  Fossa.assertUserDefinedBinaries apiOpts binMetadata fingerprints
+  runFossaApiClient apiOpts $ API.assertUserDefinedBinaries binMetadata fingerprints

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -5,6 +5,7 @@ module Control.Carrier.FossaApiClient (FossaApiClientC, runFossaApiClient) where
 import Control.Algebra (Has)
 import Control.Carrier.FossaApiClient.Internal.Core qualified as Core
 import Control.Carrier.FossaApiClient.Internal.ScotlandYard qualified as ScotlandYard
+import Control.Carrier.FossaApiClient.Internal.VSI qualified as VSI
 import Control.Carrier.Reader (ReaderC, runReader)
 import Control.Carrier.Simple (SimpleC, interpret)
 import Control.Effect.Diagnostics (Diagnostics)
@@ -27,6 +28,7 @@ runFossaApiClient apiOpts =
   runReader apiOpts
     . interpret
       ( \case
+          AssertUserDefinedBinaries meta fingerprints -> VSI.assertUserDefinedBinaries meta fingerprints
           GetApiOpts -> pure apiOpts
           GetIssues rev -> Core.getIssues rev
           GetLatestBuild rev -> Core.getLatestBuild rev

--- a/src/Control/Carrier/FossaApiClient/Internal/VSI.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/VSI.hs
@@ -1,0 +1,22 @@
+module Control.Carrier.FossaApiClient.Internal.VSI (assertUserDefinedBinaries) where
+
+import App.Fossa.FossaAPIV1 qualified as API
+import App.Fossa.VSI.Fingerprint (Fingerprint, Raw)
+import App.Fossa.VSI.IAT.Types qualified as IAT
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Lift)
+import Control.Effect.Reader (Reader, ask)
+import Fossa.API.Types (ApiOpts)
+
+assertUserDefinedBinaries ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has (Reader ApiOpts) sig m
+  ) =>
+  IAT.UserDefinedAssertionMeta ->
+  [Fingerprint Raw] ->
+  m ()
+assertUserDefinedBinaries meta fingerprints = do
+  apiOpts <- ask
+  API.assertUserDefinedBinaries apiOpts meta fingerprints

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -17,9 +17,12 @@ module Control.Effect.FossaApiClient (
   uploadArchive,
   uploadContainerScan,
   uploadContributors,
+  assertUserDefinedBinaries,
 ) where
 
 import App.Fossa.Container.Scan (ContainerScan (..))
+import App.Fossa.VSI.Fingerprint (Fingerprint, Raw)
+import App.Fossa.VSI.IAT.Types qualified as IAT
 import App.Types (ProjectMetadata, ProjectRevision)
 import Control.Algebra (Has)
 import Control.Carrier.Simple (Simple, sendSimple)
@@ -49,6 +52,7 @@ data ArchiveRevision = ArchiveRevision
   deriving (Show, Eq, Ord)
 
 data FossaApiClientF a where
+  AssertUserDefinedBinaries :: IAT.UserDefinedAssertionMeta -> [Fingerprint Raw] -> FossaApiClientF ()
   GetApiOpts :: FossaApiClientF ApiOpts
   GetIssues :: ProjectRevision -> FossaApiClientF Issues
   GetLatestBuild :: ProjectRevision -> FossaApiClientF Build
@@ -124,3 +128,6 @@ uploadArchive dest path = sendSimple (UploadArchive dest path)
 
 queueArchiveBuild :: Has FossaApiClient sig m => Archive -> m (Maybe C8.ByteString)
 queueArchiveBuild = sendSimple . QueueArchiveBuild
+
+assertUserDefinedBinaries :: Has FossaApiClient sig m => IAT.UserDefinedAssertionMeta -> [Fingerprint Raw] -> m ()
+assertUserDefinedBinaries meta fprints = sendSimple (AssertUserDefinedBinaries meta fprints)


### PR DESCRIPTION
# Overview

This is a relatively small change to convert `AssertUserDefinedBinary` to use `FossaApiClient`.

I opted to start putting VSI endpoints in their own file because there are a lot of them and the `Core` file was big enough already.

## Acceptance criteria

`AssertUserDefinedBinary` doesn't use IO to make requests!

Unfortunately, fingerprinting still dips into IO instead of just using `ReadFS`.

## Testing plan

Due to all the IO, I just tested this locally using our [VSI Demo repo]( https://github.com/fossas/cpp-vsi-demo).

1. I started by setting up the repo and verifying it worked.
2. Then I refactored everything except the implementation of `Control.Carrier.FossaApiClient.Internal.VSI.assertUserDefinedBinary` which I filled with `undefined`.
3. I verified that when I ran the command I got an undefined error.
    ```haskell
    fossa experimental-link-user-defined-dependency-binary bin/libauth_internal \
        -e "$ENDPOINT" --fossa-api-key** "$API_KEY" \
        --name libauth_internal  \
        --version 1.0  \
        --license 'BSD-3-Clause'  \
        --description 'Internal authentication library'
    ```
4. I updated that to call the actual endpoint.
5. Reran the command in #3 and verified success.

## Risks

Without great tests we have to rely on my manual testing.  Thankfully, the change is very minor.

## References

- [ANE-134](https://fossa.atlassian.net/browse/ANE-134): Convert App.Fossa.VSI.IAT.AssertUserDefinedBinaries to use API Effects

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
