### PR TITLE
Converts VSI.IAT.Resolve to FossaApiClient

### DIFF
--- a/src/App/Fossa/VSI/IAT/Resolve.hs
+++ b/src/App/Fossa/VSI/IAT/Resolve.hs
@@ -6,7 +6,6 @@ module App.Fossa.VSI.IAT.Resolve (
   resolveGraph,
 ) where
 
-import App.Fossa.FossaAPIV1 qualified as Fossa
 import App.Fossa.VSI.IAT.Types (
   UserDefinedAssertionMeta (..),
   UserDep,
@@ -15,25 +14,25 @@ import App.Fossa.VSI.IAT.Types qualified as IAT
 import App.Fossa.VSI.Types qualified as VSI
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, context, fatalText, recover)
-import Control.Effect.Lift (Lift)
+import Control.Effect.FossaApiClient (FossaApiClient, resolveProjectDependencies, resolveUserDefinedBinary)
 import Data.Maybe (fromMaybe, isNothing)
 import Data.String.Conversion (toText)
 import Data.Text (Text, intercalate)
-import Fossa.API.Types (ApiOpts)
 import Graphing (Graphing, direct, edges, empty)
 import Srclib.Types (
   SourceUserDefDep (..),
  )
 
-resolveUserDefined :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> [UserDep] -> m (Maybe [SourceUserDefDep])
-resolveUserDefined apiOpts deps = context ("Resolving user defined dependencies " <> toText (show $ map IAT.renderUserDep deps)) $ do
-  assertions <- traverse (Fossa.resolveUserDefinedBinary apiOpts) deps
+resolveUserDefined :: (Has FossaApiClient sig m, Has Diagnostics sig m) => [UserDep] -> m (Maybe [SourceUserDefDep])
+resolveUserDefined deps = context ("Resolving user defined dependencies " <> toText (show $ map IAT.renderUserDep deps)) $ do
+  -- assertions <- traverse ( Fossa.resolveUserDefinedBinary apiOpts) deps
+  assertions <- traverse (resolveUserDefinedBinary) deps
   if null assertions
     then pure Nothing
     else pure . Just $ map toUserDefDep assertions
 
-resolveRevision :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> VSI.Locator -> m (Maybe [VSI.Locator])
-resolveRevision apiOpts locator =
+resolveRevision :: (Has FossaApiClient sig m, Has Diagnostics sig m) => VSI.Locator -> m (Maybe [VSI.Locator])
+resolveRevision locator =
   context ("Resolving dependencies for " <> VSI.renderLocator locator) $
     -- In the future we plan to support either returning a partial graph to the server for resolution there,
     -- or expanding this into a full fledged graph resolver for any dependency using dedicated endpoints.
@@ -41,15 +40,15 @@ resolveRevision apiOpts locator =
     -- Since users may only register revision assertions as a byproduct of running CLI analysis,
     -- revision assertions are always for "custom" projects.
     if VSI.isTopLevelProject locator
-      then recover $ Fossa.resolveProjectDependencies apiOpts locator
+      then recover $ resolveProjectDependencies locator
       else pure . Just $ []
 
-resolveGraph :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> [VSI.Locator] -> VSI.SkipResolution -> m (Graphing VSI.Locator)
-resolveGraph apiOpts locators skipResolving = context ("Resolving graph for " <> toText (show $ fmap VSI.renderLocator locators)) $ do
+resolveGraph :: (Has FossaApiClient sig m, Has Diagnostics sig m) => [VSI.Locator] -> VSI.SkipResolution -> m (Graphing VSI.Locator)
+resolveGraph locators skipResolving = context ("Resolving graph for " <> toText (show $ fmap VSI.renderLocator locators)) $ do
   -- If any of the resulting graphs are Nothing, we failed to fetch the graph from the server.
   -- This typically means that the user doesn't have access to the project, or the project doesn't exist.
   -- Collect failed locators and report them to the user, along with mitigation suggestions.
-  subgraphs <- traverseZip (resolveSubgraph apiOpts skipResolving) locators
+  subgraphs <- traverseZipM (resolveSubgraph skipResolving) locators
   if any resolutionFailed subgraphs
     then fatalText $ resolveGraphFailureBundle subgraphs
     else pure . mconcat $ fmap unwrap subgraphs
@@ -71,18 +70,15 @@ resolveGraphFailureBundle subgraphs =
       Nothing -> VSI.renderLocator a : renderFailed xs
 
 -- | Given a traverseable list and a monadic function that resolves them to b, traverse and zip the list into a pair of (a, b)
-traverseZip :: (Has (Lift IO) sig m, Traversable t) => (a -> m b) -> t a -> m (t (a, b))
-traverseZip f = traverse (pairM f)
-  where
-    pairM :: Has (Lift IO) sig m => (a -> m b) -> a -> m (a, b)
-    pairM transform a = transform a >>= (\b -> pure (a, b))
+traverseZipM :: (Traversable t, Applicative m) => (a -> m b) -> t a -> m (t (a, b))
+traverseZipM f = traverse (\a -> (a,) <$> f a)
 
 -- Pass through the list of skipped locators all the way here:
 -- we want to still record the direct dependency, we just don't want to resolve it.
-resolveSubgraph :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> VSI.SkipResolution -> VSI.Locator -> m (Maybe (Graphing VSI.Locator))
-resolveSubgraph _ skip locator | VSI.shouldSkipResolving skip locator = pure . Just $ direct locator
-resolveSubgraph apiOpts _ locator = do
-  resolved <- resolveRevision apiOpts locator
+resolveSubgraph :: (Has FossaApiClient sig m, Has Diagnostics sig m) => VSI.SkipResolution -> VSI.Locator -> m (Maybe (Graphing VSI.Locator))
+resolveSubgraph skip locator | VSI.shouldSkipResolving skip locator = pure . Just $ direct locator
+resolveSubgraph _ locator = do
+  resolved <- resolveRevision locator
   case resolved of
     Just deps -> pure . Just $ direct locator <> edges (map edge deps)
     Nothing -> pure Nothing

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -38,6 +38,8 @@ runFossaApiClient apiOpts =
           GetProject rev -> Core.getProject rev
           GetScan locator scanId -> ScotlandYard.getScan locator scanId
           GetSignedUploadUrl rev -> Core.getSignedUploadUrl rev
+          ResolveProjectDependencies locator -> VSI.resolveProjectDependencies locator
+          ResolveUserDefinedBinary deps -> VSI.resolveUserDefinedBinary deps
           QueueArchiveBuild archive -> Core.queueArchiveBuild archive
           UploadAnalysis rev metadata units -> Core.uploadAnalysis rev metadata units
           UploadContainerScan revision metadata scan -> Core.uploadContainerScan revision metadata scan

--- a/src/Control/Carrier/FossaApiClient/Internal/VSI.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/VSI.hs
@@ -1,8 +1,13 @@
-module Control.Carrier.FossaApiClient.Internal.VSI (assertUserDefinedBinaries) where
+module Control.Carrier.FossaApiClient.Internal.VSI (
+  assertUserDefinedBinaries,
+  resolveUserDefinedBinary,
+  resolveProjectDependencies,
+) where
 
 import App.Fossa.FossaAPIV1 qualified as API
 import App.Fossa.VSI.Fingerprint (Fingerprint, Raw)
 import App.Fossa.VSI.IAT.Types qualified as IAT
+import App.Fossa.VSI.Types qualified as VSI
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Lift)
@@ -20,3 +25,25 @@ assertUserDefinedBinaries ::
 assertUserDefinedBinaries meta fingerprints = do
   apiOpts <- ask
   API.assertUserDefinedBinaries apiOpts meta fingerprints
+
+resolveUserDefinedBinary ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has (Reader ApiOpts) sig m
+  ) =>
+  IAT.UserDep ->
+  m IAT.UserDefinedAssertionMeta
+resolveUserDefinedBinary dep = do
+  apiOpts <- ask
+  API.resolveUserDefinedBinary apiOpts dep
+
+resolveProjectDependencies ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has (Reader ApiOpts) sig m
+  ) =>
+  VSI.Locator ->
+  m [VSI.Locator]
+resolveProjectDependencies locator = do
+  apiOpts <- ask
+  API.resolveProjectDependencies apiOpts locator

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -19,12 +19,15 @@ module Control.Effect.FossaApiClient (
   uploadContainerScan,
   uploadContributors,
   assertUserDefinedBinaries,
+  resolveUserDefinedBinary,
+  resolveProjectDependencies,
 ) where
 
 import App.Fossa.Config.Report (ReportOutputFormat)
 import App.Fossa.Container.Scan (ContainerScan (..))
 import App.Fossa.VSI.Fingerprint (Fingerprint, Raw)
 import App.Fossa.VSI.IAT.Types qualified as IAT
+import App.Fossa.VSI.Types qualified as VSI
 import App.Types (ProjectMetadata, ProjectRevision)
 import Control.Algebra (Has)
 import Control.Carrier.Simple (Simple, sendSimple)
@@ -65,6 +68,8 @@ data FossaApiClientF a where
   GetScan :: Locator -> ScanId -> FossaApiClientF ScanResponse
   GetSignedUploadUrl :: ArchiveRevision -> FossaApiClientF SignedURL
   QueueArchiveBuild :: Archive -> FossaApiClientF (Maybe C8.ByteString)
+  ResolveProjectDependencies :: VSI.Locator -> FossaApiClientF [VSI.Locator]
+  ResolveUserDefinedBinary :: IAT.UserDep -> FossaApiClientF IAT.UserDefinedAssertionMeta
   UploadAnalysis ::
     ProjectRevision ->
     ProjectMetadata ->
@@ -137,3 +142,9 @@ queueArchiveBuild = sendSimple . QueueArchiveBuild
 
 assertUserDefinedBinaries :: Has FossaApiClient sig m => IAT.UserDefinedAssertionMeta -> [Fingerprint Raw] -> m ()
 assertUserDefinedBinaries meta fprints = sendSimple (AssertUserDefinedBinaries meta fprints)
+
+resolveUserDefinedBinary :: Has FossaApiClient sig m => IAT.UserDep -> m IAT.UserDefinedAssertionMeta
+resolveUserDefinedBinary = sendSimple . ResolveUserDefinedBinary
+
+resolveProjectDependencies :: Has FossaApiClient sig m => VSI.Locator -> m [VSI.Locator]
+resolveProjectDependencies = sendSimple . ResolveProjectDependencies


### PR DESCRIPTION
# Overview

Converts both `resolveUserDefinedBinary` and `resolveProjectDependencies` to use `FossaApiClient`.

## Acceptance criteria

- Both functions should be exclusively accessed through effects.
- Unit tests where possible.

## Testing plan

In addition to any unit tests, I did manual testing.

1. Set up both functions to trigger a fatal diagnostic error in the carrier implementation.
2. Linked a project binary
    ```sh
    fossa analyze internal-json-parser \    
      -e "$ENDPOINT" --fossa-api-key "$API_KEY" \
      --project internal-json-parser --revision $(date +%s) \
      --experimental-link-project-binary bin/libjson_internal \
      --enable-vsi --debug
    ```
3. Observed the diagnostic error for `resolveUserDefinedBinary` in the output.
4. Implemented the function as a pass-through to the old API function.
5. Re-ran and observed the error disappeared and the command was successful.
6. Ran analysis on the project
    ```sh
fossa analyze example-internal-project \
  -e "$ENDPOINT" --fossa-api-key "$API_KEY" \
  --project internal-project --revision $(date +%s) \
  --enable-vsi --debug
    ````
7. Observed the error for `resolveProjectDependencies` in the output.
8. Implemented the function as a pass-through to the old API function
9. Re-ran and observed the error disappeared and the command was successful

## References

_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

_Example:_

- [ANE-136](https://fossa.atlassian.net/browse/ANE-136): Convert App.Fossa.VSI.IAT.Resolve to use API Effects

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).

