### PR TITLE
[ANE-211] Missing peer deps of namespaced packages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## v3.2.7
 
 - debug: Redact all known API keys from the debug bundle (#[897](https://github.com/fossas/fossa-cli/pull/897))
+- nodejs: Discover peer deps and transitive deps for name-spaced packages in package-lock.json. ([#882](https://github.com/fossas/fossa-cli/pull/882))
 
 ## v3.2.6
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -299,6 +299,7 @@ library
     Fossa.API.Types
     Graphing
     Graphing.Hydrate
+    Graphing.Trace
     Network.HTTP.Req.Extra
     Parse.XML
     Path.Extra

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -298,8 +298,8 @@ library
     Effect.ReadFS
     Fossa.API.Types
     Graphing
+    Graphing.Debug
     Graphing.Hydrate
-    Graphing.Trace
     Network.HTTP.Req.Extra
     Parse.XML
     Path.Extra

--- a/src/Graphing/Trace.hs
+++ b/src/Graphing/Trace.hs
@@ -14,7 +14,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String (IsString)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Data.Text.Extra (showT)
 import Data.Text.IO qualified as TIO
 import DepTypes (DepEnvironment, Dependency (..), VerConstraint (..))
@@ -31,13 +31,13 @@ instance GraphTrace a => GraphTrace (Node a) where
   toTrace (Node a) = toTrace a
 
 instance GraphTrace Dependency where
-  toTrace Dependency{..} = T.unwords [dependencyName, version, envs]
+  toTrace Dependency{..} = Text.unwords [dependencyName, version, envs]
     where
       version = maybe "*" versionTxt dependencyVersion
       envs = "[" <> envsToText dependencyEnvironments <> "]"
 
 envsToText :: Set DepEnvironment -> Text
-envsToText = T.intercalate ", " . map showT . Set.toList
+envsToText = Text.intercalate ", " . map showT . Set.toList
 
 versionTxt :: VerConstraint -> Text
 versionTxt = \case
@@ -71,8 +71,8 @@ renderGvFile gr = emit graphEdges
       Just ac -> emitDiGraphEdges ac
 
 emit :: EmittedGraph -> Text
-emit (Cyclic edges) = T.unlines (["graph G {"] <> map (indent 4) edges <> ["}"])
-emit (Acyclic edges) = T.unlines (["digraph G {"] <> map (indent 4) edges <> ["}"])
+emit (Cyclic edges) = Text.unlines (["graph G {"] <> map (indent 4) edges <> ["}"])
+emit (Acyclic edges) = Text.unlines (["digraph G {"] <> map (indent 4) edges <> ["}"])
 
 emitDiGraphEdges :: GraphTrace a => Acyclic.AdjacencyMap a -> EmittedGraph
 emitDiGraphEdges = Acyclic . edgesToTexts (Icon "->") . Acyclic.edgeList
@@ -91,7 +91,7 @@ traceTuple = bimap toTrace toTrace
 newtype Icon = Icon Text
 
 renderEdge :: Icon -> (Text, Text) -> Text
-renderEdge (Icon icon) (parent, child) = terminated $ T.unwords [quoted parent, icon, quoted child]
+renderEdge (Icon icon) (parent, child) = terminated $ Text.unwords [quoted parent, icon, quoted child]
 
 quoted :: Text -> Text
 quoted item = "\"" <> item <> "\""
@@ -100,4 +100,4 @@ terminated :: Text -> Text
 terminated = (<> ";")
 
 indent :: Int -> Text -> Text
-indent count txt = T.replicate count " " <> txt
+indent count txt = Text.replicate count " " <> txt

--- a/src/Graphing/Trace.hs
+++ b/src/Graphing/Trace.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Graphing.Trace (
+  GraphTrace (toTrace),
+  traceGraph,
+  renderGvFile,
+) where
+
+import Algebra.Graph.Acyclic.AdjacencyMap qualified as Acyclic
+import Algebra.Graph.AdjacencyMap qualified as Cyclic
+import Control.Effect.Lift (Has, Lift, sendIO)
+import Data.Bifunctor (Bifunctor (bimap))
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.String (IsString)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Extra (showT)
+import Data.Text.IO qualified as TIO
+import DepTypes (DepEnvironment, Dependency (..), VerConstraint (..))
+import Graphing (Graphing (unGraphing), Node (..))
+
+gvFileName :: (IsString a) => a
+gvFileName = "./fossa.debug.gv"
+
+class Ord a => GraphTrace a where
+  toTrace :: a -> Text
+
+instance GraphTrace a => GraphTrace (Node a) where
+  toTrace Root = "ROOT"
+  toTrace (Node a) = toTrace a
+
+instance GraphTrace Dependency where
+  toTrace Dependency{..} = T.unwords [dependencyName, version, envs]
+    where
+      version = maybe "*" versionTxt dependencyVersion
+      envs = "[" <> envsToText dependencyEnvironments <> "]"
+
+envsToText :: Set DepEnvironment -> Text
+envsToText = T.intercalate ", " . map showT . Set.toList
+
+versionTxt :: VerConstraint -> Text
+versionTxt = \case
+  CEq txt -> txt
+  CURI txt -> txt
+  CCompatible txt -> txt
+  CAnd vc vc' -> versionTxt vc <> "AND" <> versionTxt vc'
+  COr vc vc' -> versionTxt vc <> "OR" <> versionTxt vc'
+  CLess txt -> txt
+  CLessOrEq txt -> txt
+  CGreater txt -> txt
+  CGreaterOrEq txt -> txt
+  CNot txt -> txt
+
+data EmittedGraph
+  = Cyclic [Text]
+  | Acyclic [Text]
+
+traceGraph :: Has (Lift IO) sig m => GraphTrace a => Graphing a -> m ()
+traceGraph gr = sendIO $ do
+  let graphTxt = renderGvFile gr
+  TIO.writeFile gvFileName graphTxt
+{-# WARNING traceGraph "This function is for debug purposes only and should not be used in production." #-}
+
+renderGvFile :: GraphTrace a => Graphing a -> Text
+renderGvFile gr = emit graphEdges
+  where
+    adjMap = unGraphing gr
+    graphEdges = case Acyclic.toAcyclic adjMap of
+      Nothing -> emitGraphEdges adjMap
+      Just ac -> emitDiGraphEdges ac
+
+emit :: EmittedGraph -> Text
+emit (Cyclic edges) = T.unlines (["graph G {"] <> map (indent 4) edges <> ["}"])
+emit (Acyclic edges) = T.unlines (["digraph G {"] <> map (indent 4) edges <> ["}"])
+
+emitDiGraphEdges :: GraphTrace a => Acyclic.AdjacencyMap a -> EmittedGraph
+emitDiGraphEdges = Acyclic . edgesToTexts (Icon "->") . Acyclic.edgeList
+
+emitGraphEdges :: GraphTrace a => Cyclic.AdjacencyMap a -> EmittedGraph
+emitGraphEdges = Cyclic . edgesToTexts (Icon "--") . Cyclic.edgeList
+
+edgesToTexts :: GraphTrace a => Icon -> [(a, a)] -> [Text]
+edgesToTexts icon = map (renderEdge icon . traceTuple)
+
+traceTuple :: GraphTrace a => (a, a) -> (Text, Text)
+traceTuple = bimap toTrace toTrace
+
+---------------------- HELPERS ------------------------
+
+newtype Icon = Icon Text
+
+renderEdge :: Icon -> (Text, Text) -> Text
+renderEdge (Icon icon) (parent, child) = terminated $ T.unwords [quoted parent, icon, quoted child]
+
+quoted :: Text -> Text
+quoted item = "\"" <> item <> "\""
+
+terminated :: Text -> Text
+terminated = (<> ";")
+
+indent :: Int -> Text -> Text
+indent count txt = T.replicate count " " <> txt

--- a/src/Strategy/Node/Npm/PackageLock.hs
+++ b/src/Strategy/Node/Npm/PackageLock.hs
@@ -133,7 +133,7 @@ data NpmDepVertexLabel = NpmDepVertexEnv DepEnvironment | NpmDepVertexLocation T
 -- downloaded to @node_modules@. This function will adjust map keys to be names
 -- like in the @dependencies@ key by stripping out path components besides the final one..
 --
--- When 
+-- When
 packagePathsToNames :: Map Text a -> Map Text a
 packagePathsToNames = Map.mapKeys (TE.dropPrefix "node_modules/")
 

--- a/src/Strategy/Node/Npm/PackageLock.hs
+++ b/src/Strategy/Node/Npm/PackageLock.hs
@@ -133,7 +133,10 @@ data NpmDepVertexLabel = NpmDepVertexEnv DepEnvironment | NpmDepVertexLocation T
 -- downloaded to @node_modules@. This function will adjust map keys to be names
 -- like in the @dependencies@ key by stripping out path components besides the final one..
 --
--- When
+-- When npm installs a dep inside of another dep (for version conflicts) we get the string
+-- @node_modules/a/node_modules/b@.  We actually don't want to do sub-package matching here,
+-- so we only drop the first @node_modules/@, and if it has a sub-package, then we just
+-- won't ever query for that key.
 packagePathsToNames :: Map Text a -> Map Text a
 packagePathsToNames = Map.mapKeys (TE.dropPrefix "node_modules/")
 


### PR DESCRIPTION
# Overview

I wrote `Graphing.Trace` to debug this problem, and solved the problem to prove that the tracing module worked.

`package-lock.json` take the following rough form (simplified for explanation):
```json
{
  ...,
  "packages": {
    "node_modules/foo": {
      "peerDeps": [ ... ]
    },
    "node_modules/@org/bar": {
      "peerDeps": [ ... ]
    },
    "node_modules/baz/node_modules/quux": {
      "peerDeps": [ ... ]
    }
  },
  "dependencies": {
    "foo": { ... },
    "@org/bar": { ... },
    "baz": {
      "dependencies": {
        "quux": { ... }
      }
    }
  }
}
```

To understand the problem, you must know two things about the file:

- Most relevant dependency info is in the top-level `dependencies` field, or in one of the sub-`dependencies` fields, (see `baz -> quux`).  Peer dependencies info is only available in `packages`.
- The link between keys in `packages`/`dependencies` is not explicitly specified, and must be manually constructed.

## The Actual Problem

When traversing the `dependencies` field, we query the associated item on the `packages` field for peer dep info.  To make the names match, we mangle the key from the `dependencies` field.  However, the mangling process was doing a string split on `/` characters, which would screw with namespaced packages (like `@org/bar` in the above example).  This caused us to miss peer deps for ALL namespaced packages.  If a dependency was only brought in via the peer deps of a namespaced package, we would miss it.

JIRA: [ANE-211](https://fossa.atlassian.net/browse/ANE-211)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
