### PR TITLE
Label require'd deps of dev dependencies as development.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.2.4
+- nodejs: Fixed a bug where dev deps that only appear in requires were considered production dependencies. ([#884](https://github.com/fossas/fossa-cli/pull/884))
+
 ## v3.2.3
 - nodejs: Fixed a bug where some dev dependencies weren't removed during shrinking. ([#859](https://github.com/fossas/fossa-cli/pull/859))
 


### PR DESCRIPTION
# Overview

Some `package-lock.json` files will have dependencies in a dev dep's 'required' field, but those dependencies won't be recorded in that deps `dependencies` field or in the top-level `dependencies` field. When this happens the required dep gets added to the graph but never gets labeled as `EnvDevelopment` because fossa-cli waits to label things until it gets to a full dependency object - which in this case doesn't exist. These extra dep vertices are then included in graph at the end. 

This change eagerly labels required dependencies of dev deps as `EnvDevelopment` so that dev deps don't appear in fossa-cli's output.

## Acceptance criteria

Don't include development dependencies that only appear in a `requires` field as production dependencies.

## Testing plan

I've created a unit test. Additionally you can use the following package.json:

```json
{
  "name": "fake",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "devDependencies": {
    "chalk-pipe": "^5.1.1"
  },
  "dependencies": {
    "underscore": "^1.13.2"
  }
}
```
and package-lock.json:

```json
{
  "name": "foo",
  "version": "1.0.0",
  "lockfileVersion": 2,
  "requires": true,
    "dependencies": {
        "chalk-pipe": {
            "version": "5.1.1",
            "resolved": "https://registry.npmjs.org/chalk-pipe/-/chalk-pipe-5.1.1.tgz",
            "integrity": "sha512-rtJvGrqUKNDyJ/8AfqVo1WGRX2yT9/f5lCyh6aZzrltz7j9QrbJN6xwds7PRFRqanpKmDKjkwKQtCflrUgf4RA==",
            "dev": true,
            "requires": {
                "chalk": "^4.1.0"
            }
        },
        "underscore": {
            "version": "1.13.2",
            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
            "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
        }
    }
}
```

To see the problem and differences between master and this branch.


## Risks

If you can think of any unintended consequences of this solution, let me know. Packages marked as both prod and dev are treated as prod when we prune the graph so I don't think there's any issue.

## References

[ANE-212](https://fossa.atlassian.net/browse/ANE-212)
Partially fixes [ANE-121](https://fossa.atlassian.net/browse/ANE-121)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
