### PR TITLE
Convert LicenseScanner to FossaApiClient

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -230,6 +230,7 @@ library
     Control.Carrier.Finally
     Control.Carrier.FossaApiClient
     Control.Carrier.FossaApiClient.Internal.Core
+    Control.Carrier.FossaApiClient.Internal.LicenseScanning
     Control.Carrier.FossaApiClient.Internal.ScotlandYard
     Control.Carrier.FossaApiClient.Internal.VSI
     Control.Carrier.Git

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -15,7 +15,7 @@ import Codec.Compression.GZip qualified as GZip
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.StickyLogger (StickyLogger, logSticky)
 import Control.Effect.Diagnostics (context)
-import Control.Effect.FossaApiClient (ArchiveRevision (ArchiveRevision), FossaApiClient, getOrganization, getSignedUploadUrl, queueArchiveBuild, uploadArchive)
+import Control.Effect.FossaApiClient (PackageRevision (PackageRevision), FossaApiClient, getOrganization, getSignedUploadUrl, queueArchiveBuild, uploadArchive)
 import Control.Effect.Lift
 import Control.Effect.Path (withSystemTempDir)
 import Control.Monad (unless)
@@ -90,7 +90,7 @@ compressAndUpload arcDir tmpDir VendoredDependency{..} = context "compressing an
     Nothing -> sendIO $ hashFile compressedFile
     Just version -> pure version
 
-  signedURL <- getSignedUploadUrl $ ArchiveRevision vendoredName depVersion
+  signedURL <- getSignedUploadUrl $ PackageRevision vendoredName depVersion
 
   logSticky $ "Uploading '" <> vendoredName <> "' to secure S3 bucket"
   res <- uploadArchive signedURL compressedFile

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -15,7 +15,7 @@ import Codec.Compression.GZip qualified as GZip
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.StickyLogger (StickyLogger, logSticky)
 import Control.Effect.Diagnostics (context)
-import Control.Effect.FossaApiClient (PackageRevision (PackageRevision), FossaApiClient, getOrganization, getSignedUploadUrl, queueArchiveBuild, uploadArchive)
+import Control.Effect.FossaApiClient (FossaApiClient, PackageRevision (PackageRevision), getOrganization, getSignedUploadUrl, queueArchiveBuild, uploadArchive)
 import Control.Effect.Lift
 import Control.Effect.Path (withSystemTempDir)
 import Control.Monad (unless)

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -17,7 +17,7 @@ import App.Fossa.RunThemis (
  )
 import Control.Carrier.Finally (runFinally)
 import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (renderDiagnostic), context, fatal, fatalText, fromMaybe, recover)
-import Control.Effect.FossaApiClient (FossaApiClient, getOrganization, getSignedLicenseScanUrl, PackageRevision (PackageRevision, packageVersion, packageName), finalizeLicenseScan, uploadLicenseScanResult)
+import Control.Effect.FossaApiClient (FossaApiClient, PackageRevision (PackageRevision, packageName, packageVersion), finalizeLicenseScan, getOrganization, getSignedLicenseScanUrl, uploadLicenseScanResult)
 import Control.Effect.Lift (Lift)
 import Control.Effect.StickyLogger (StickyLogger, logSticky)
 import Control.Monad (unless)
@@ -213,7 +213,7 @@ uploadVendoredDep VendoredDependency{..} themisScanResult = do
     Nothing -> pure . showT . md5 . encodeUtf8 . show . NE.sort $ themisScanResult
     Just version -> pure version
 
-  signedURL <- getSignedLicenseScanUrl $ PackageRevision { packageVersion = depVersion, packageName = vendoredName }
+  signedURL <- getSignedLicenseScanUrl $ PackageRevision{packageVersion = depVersion, packageName = vendoredName}
 
   logSticky $ "Uploading '" <> vendoredName <> "' to secure S3 bucket"
   uploadLicenseScanResult signedURL licenseSourceUnit
@@ -252,7 +252,7 @@ licenseScanSourceUnit baseDir vendoredDeps = do
 
   -- The organizationID is needed to prefix each locator name. The FOSSA API automatically prefixes the locator when queuing the build
   -- but not when reading from a source unit.
-  orgId <- organizationId <$> getOrganization 
+  orgId <- organizationId <$> getOrganization
 
   pure $ NE.map arcToLocator (archivesWithOrganization orgId archives)
   where

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -30,7 +30,7 @@ import Control.Effect.FossaApiClient (
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Path (withSystemTempDir)
 import Control.Effect.StickyLogger (StickyLogger, logSticky)
-import Control.Monad (unless, void)
+import Control.Monad (unless)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes)

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -17,7 +17,14 @@ import App.Fossa.RunThemis (
  )
 import Control.Carrier.Finally (runFinally)
 import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (renderDiagnostic), context, fatal, fatalText, fromMaybe, recover)
-import Control.Effect.FossaApiClient (FossaApiClient, PackageRevision (PackageRevision, packageName, packageVersion), finalizeLicenseScan, getOrganization, getSignedLicenseScanUrl, uploadLicenseScanResult)
+import Control.Effect.FossaApiClient (
+  FossaApiClient,
+  PackageRevision (..),
+  finalizeLicenseScan,
+  getOrganization,
+  getSignedLicenseScanUrl,
+  uploadLicenseScanResult,
+ )
 import Control.Effect.Lift (Lift)
 import Control.Effect.StickyLogger (StickyLogger, logSticky)
 import Control.Monad (unless)

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -4,6 +4,7 @@ module Control.Carrier.FossaApiClient (FossaApiClientC, runFossaApiClient) where
 
 import Control.Algebra (Has)
 import Control.Carrier.FossaApiClient.Internal.Core qualified as Core
+import Control.Carrier.FossaApiClient.Internal.LicenseScanning qualified as LicenseScanning
 import Control.Carrier.FossaApiClient.Internal.ScotlandYard qualified as ScotlandYard
 import Control.Carrier.FossaApiClient.Internal.VSI qualified as VSI
 import Control.Carrier.Reader (ReaderC, runReader)
@@ -12,7 +13,6 @@ import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
 import Control.Effect.Lift (Lift)
 import Fossa.API.Types (ApiOpts)
-import qualified Control.Carrier.FossaApiClient.Internal.LicenseScanning as LicenseScanning
 
 -- | A carrier to run Fossa API functions in the IO monad
 type FossaApiClientC m = SimpleC FossaApiClientF (ReaderC ApiOpts m)

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -31,6 +31,7 @@ runFossaApiClient apiOpts =
       ( \case
           AssertRevisionBinaries locator fingerprints -> VSI.assertRevisionBinaries locator fingerprints
           AssertUserDefinedBinaries meta fingerprints -> VSI.assertUserDefinedBinaries meta fingerprints
+          FinalizeLicenseScan components -> LicenseScanning.finalizeLicenseScan components
           GetApiOpts -> pure apiOpts
           GetAttribution rev format -> Core.getAttribution rev format
           GetIssues rev -> Core.getIssues rev
@@ -39,13 +40,12 @@ runFossaApiClient apiOpts =
           GetOrganization -> Core.getOrganization
           GetProject rev -> Core.getProject rev
           GetScan locator scanId -> ScotlandYard.getScan locator scanId
+          GetSignedLicenseScanUrl rev -> LicenseScanning.getSignedLicenseScanUrl rev
           GetSignedUploadUrl rev -> Core.getSignedUploadUrl rev
           QueueArchiveBuild archive -> Core.queueArchiveBuild archive
           UploadAnalysis rev metadata units -> Core.uploadAnalysis rev metadata units
+          UploadArchive url path -> Core.uploadArchive url path
           UploadContainerScan revision metadata scan -> Core.uploadContainerScan revision metadata scan
           UploadContributors locator contributors -> Core.uploadContributors locator contributors
-          UploadArchive url path -> Core.uploadArchive url path
-          GetSignedLicenseScanUrl rev -> LicenseScanning.getSignedLicenseScanUrl rev
-          FinalizeLicenseScan components -> LicenseScanning.finalizeLicenseScan components
           UploadLicenseScanResult signedUrl licenseSourceUnit -> LicenseScanning.uploadLicenseScanResult signedUrl licenseSourceUnit
       )

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -12,6 +12,7 @@ import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
 import Control.Effect.Lift (Lift)
 import Fossa.API.Types (ApiOpts)
+import qualified Control.Carrier.FossaApiClient.Internal.LicenseScanning as LicenseScanning
 
 -- | A carrier to run Fossa API functions in the IO monad
 type FossaApiClientC m = SimpleC FossaApiClientF (ReaderC ApiOpts m)
@@ -44,4 +45,7 @@ runFossaApiClient apiOpts =
           UploadContainerScan revision metadata scan -> Core.uploadContainerScan revision metadata scan
           UploadContributors locator contributors -> Core.uploadContributors locator contributors
           UploadArchive url path -> Core.uploadArchive url path
+          GetSignedLicenseScanUrl rev -> LicenseScanning.getSignedLicenseScanUrl rev
+          FinalizeLicenseScan components -> LicenseScanning.finalizeLicenseScan components
+          UploadLicenseScanResult signedUrl licenseSourceUnit -> LicenseScanning.uploadLicenseScanResult signedUrl licenseSourceUnit
       )

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -20,7 +20,7 @@ import App.Fossa.FossaAPIV1 qualified as API
 import App.Types (ProjectMetadata, ProjectRevision (..))
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics)
-import Control.Effect.FossaApiClient (ArchiveRevision (..))
+import Control.Effect.FossaApiClient (PackageRevision (..))
 import Control.Effect.Lift (Lift)
 import Control.Effect.Reader (Reader, ask)
 import Data.ByteString.Char8 qualified as C8
@@ -141,11 +141,11 @@ getSignedUploadUrl ::
   , Has Diagnostics sig m
   , Has (Reader ApiOpts) sig m
   ) =>
-  ArchiveRevision ->
+  PackageRevision ->
   m SignedURL
-getSignedUploadUrl ArchiveRevision{..} = do
+getSignedUploadUrl PackageRevision{..} = do
   apiOpts <- ask
-  API.getSignedURL apiOpts archiveRevision archiveName
+  API.getSignedURL apiOpts packageVersion packageName
 
 queueArchiveBuild ::
   ( Has (Lift IO) sig m

--- a/src/Control/Carrier/FossaApiClient/Internal/LicenseScanning.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/LicenseScanning.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE RecordWildCards #-}
+module Control.Carrier.FossaApiClient.Internal.LicenseScanning (
+  getSignedLicenseScanUrl, finalizeLicenseScan, uploadLicenseScanResult
+  ) where
+
+import Control.Effect.FossaApiClient (PackageRevision (..))
+import Fossa.API.Types (SignedURL, ApiOpts, ArchiveComponents)
+import Control.Effect.Reader (Reader, ask)
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Lift)
+import Srclib.Types (LicenseSourceUnit)
+import qualified App.Fossa.FossaAPIV1 as API
+import Control.Monad (void)
+
+
+getSignedLicenseScanUrl ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has (Reader ApiOpts) sig m
+  ) =>
+  PackageRevision -> m SignedURL
+getSignedLicenseScanUrl PackageRevision{..} = do
+  apiOpts <- ask
+  API.getSignedLicenseScanURL apiOpts packageVersion packageName
+
+finalizeLicenseScan ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has (Reader ApiOpts) sig m
+  ) =>
+  ArchiveComponents -> m ()
+finalizeLicenseScan components = do
+  apiOpts <- ask
+  void $ API.licenseScanFinalize apiOpts components
+
+uploadLicenseScanResult ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  ) =>
+  SignedURL -> LicenseSourceUnit -> m ()
+uploadLicenseScanResult signedUrl licenseSourceUnit = do
+  void $ API.licenseScanResultUpload signedUrl licenseSourceUnit

--- a/src/Control/Carrier/FossaApiClient/Internal/LicenseScanning.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/LicenseScanning.hs
@@ -1,25 +1,28 @@
 {-# LANGUAGE RecordWildCards #-}
-module Control.Carrier.FossaApiClient.Internal.LicenseScanning (
-  getSignedLicenseScanUrl, finalizeLicenseScan, uploadLicenseScanResult
-  ) where
 
-import Control.Effect.FossaApiClient (PackageRevision (..))
-import Fossa.API.Types (SignedURL, ApiOpts, ArchiveComponents)
-import Control.Effect.Reader (Reader, ask)
+module Control.Carrier.FossaApiClient.Internal.LicenseScanning (
+  getSignedLicenseScanUrl,
+  finalizeLicenseScan,
+  uploadLicenseScanResult,
+) where
+
+import App.Fossa.FossaAPIV1 qualified as API
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.FossaApiClient (PackageRevision (..))
 import Control.Effect.Lift (Lift)
-import Srclib.Types (LicenseSourceUnit)
-import qualified App.Fossa.FossaAPIV1 as API
+import Control.Effect.Reader (Reader, ask)
 import Control.Monad (void)
-
+import Fossa.API.Types (ApiOpts, ArchiveComponents, SignedURL)
+import Srclib.Types (LicenseSourceUnit)
 
 getSignedLicenseScanUrl ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
   , Has (Reader ApiOpts) sig m
   ) =>
-  PackageRevision -> m SignedURL
+  PackageRevision ->
+  m SignedURL
 getSignedLicenseScanUrl PackageRevision{..} = do
   apiOpts <- ask
   API.getSignedLicenseScanURL apiOpts packageVersion packageName
@@ -29,7 +32,8 @@ finalizeLicenseScan ::
   , Has Diagnostics sig m
   , Has (Reader ApiOpts) sig m
   ) =>
-  ArchiveComponents -> m ()
+  ArchiveComponents ->
+  m ()
 finalizeLicenseScan components = do
   apiOpts <- ask
   void $ API.licenseScanFinalize apiOpts components
@@ -38,6 +42,8 @@ uploadLicenseScanResult ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
   ) =>
-  SignedURL -> LicenseSourceUnit -> m ()
+  SignedURL ->
+  LicenseSourceUnit ->
+  m ()
 uploadLicenseScanResult signedUrl licenseSourceUnit = do
   void $ API.licenseScanResultUpload signedUrl licenseSourceUnit

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -6,6 +6,7 @@ module Control.Effect.FossaApiClient (
   FossaApiClient,
   assertRevisionBinaries,
   assertUserDefinedBinaries,
+  finalizeLicenseScan,
   getApiOpts,
   getAttribution,
   getIssues,
@@ -14,15 +15,14 @@ module Control.Effect.FossaApiClient (
   getOrganization,
   getProject,
   getScan,
+  getSignedLicenseScanUrl,
   getSignedUploadUrl,
   queueArchiveBuild,
   uploadAnalysis,
   uploadArchive,
   uploadContainerScan,
   uploadContributors,
-  getSignedLicenseScanUrl,
   uploadLicenseScanResult,
-  finalizeLicenseScan,
 ) where
 
 import App.Fossa.Config.Report (ReportOutputFormat)
@@ -62,6 +62,7 @@ data PackageRevision = PackageRevision
 data FossaApiClientF a where
   AssertRevisionBinaries :: Locator -> [Fingerprint Raw] -> FossaApiClientF ()
   AssertUserDefinedBinaries :: IAT.UserDefinedAssertionMeta -> [Fingerprint Raw] -> FossaApiClientF ()
+  FinalizeLicenseScan :: ArchiveComponents -> FossaApiClientF ()
   GetApiOpts :: FossaApiClientF ApiOpts
   GetAttribution :: ProjectRevision -> ReportOutputFormat -> FossaApiClientF Text
   GetIssues :: ProjectRevision -> FossaApiClientF Issues
@@ -70,6 +71,7 @@ data FossaApiClientF a where
   GetOrganization :: FossaApiClientF Organization
   GetProject :: ProjectRevision -> FossaApiClientF Project
   GetScan :: Locator -> ScanId -> FossaApiClientF ScanResponse
+  GetSignedLicenseScanUrl :: PackageRevision -> FossaApiClientF SignedURL
   GetSignedUploadUrl :: PackageRevision -> FossaApiClientF SignedURL
   QueueArchiveBuild :: Archive -> FossaApiClientF (Maybe C8.ByteString)
   UploadAnalysis ::
@@ -87,8 +89,6 @@ data FossaApiClientF a where
     Locator ->
     Contributors ->
     FossaApiClientF ()
-  GetSignedLicenseScanUrl :: PackageRevision -> FossaApiClientF SignedURL
-  FinalizeLicenseScan :: ArchiveComponents -> FossaApiClientF ()
   UploadLicenseScanResult :: SignedURL -> LicenseSourceUnit -> FossaApiClientF ()
 
 deriving instance Show (FossaApiClientF a)

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -20,7 +20,10 @@ module Control.Effect.FossaApiClient (
   uploadArchive,
   uploadContainerScan,
   uploadContributors,
-getSignedLicenseScanUrl, uploadLicenseScanResult, finalizeLicenseScan) where
+  getSignedLicenseScanUrl,
+  uploadLicenseScanResult,
+  finalizeLicenseScan,
+) where
 
 import App.Fossa.Config.Report (ReportOutputFormat)
 import App.Fossa.Container.Scan (ContainerScan (..))
@@ -35,6 +38,7 @@ import Data.Text (Text)
 import Fossa.API.Types (
   ApiOpts,
   Archive,
+  ArchiveComponents,
   Build,
   Contributors,
   Issues,
@@ -43,10 +47,10 @@ import Fossa.API.Types (
   ScanId,
   ScanResponse,
   SignedURL,
-  UploadResponse, ArchiveComponents
+  UploadResponse,
  )
 import Network.HTTP.Req (LbsResponse)
-import Srclib.Types (Locator, SourceUnit, LicenseSourceUnit)
+import Srclib.Types (LicenseSourceUnit, Locator, SourceUnit)
 
 -- | PackageRevisions are like ProjectRevisions, but they never have a branch.
 data PackageRevision = PackageRevision

--- a/test/Test/MockApi.hs
+++ b/test/Test/MockApi.hs
@@ -167,6 +167,9 @@ isSingular (ApiExpectation Always _ _) = False
 -- extract and compare the runtime constructor of the two arguments so that
 -- arbitrary ones can be compared even if the types wouldn't match.
 matchExpectation :: FossaApiClientF a -> ApiExpectation -> Maybe (ApiResult a)
+matchExpectation a@(AssertRevisionBinaries{}) (ApiExpectation _ b@(AssertRevisionBinaries{}) resp) = resp <$ guard (a == b)
+matchExpectation a@(AssertUserDefinedBinaries{}) (ApiExpectation _ b@(AssertUserDefinedBinaries{}) resp) = resp <$ guard (a == b)
+matchExpectation a@(FinalizeLicenseScan{}) (ApiExpectation _ b@(FinalizeLicenseScan{}) resp) = resp <$ guard (a == b)
 matchExpectation a@(GetApiOpts) (ApiExpectation _ b@(GetApiOpts) resp) = resp <$ guard (a == b)
 matchExpectation a@(GetAttribution{}) (ApiExpectation _ b@(GetAttribution{}) resp) = resp <$ guard (a == b)
 matchExpectation a@(GetIssues{}) (ApiExpectation _ b@(GetIssues{}) resp) = resp <$ guard (a == b)
@@ -175,8 +178,14 @@ matchExpectation a@(GetLatestScan{}) (ApiExpectation _ b@(GetLatestScan{}) resp)
 matchExpectation a@(GetOrganization) (ApiExpectation _ b@(GetOrganization) resp) = resp <$ guard (a == b)
 matchExpectation a@(GetProject{}) (ApiExpectation _ b@(GetProject{}) resp) = resp <$ guard (a == b)
 matchExpectation a@(GetScan{}) (ApiExpectation _ b@(GetScan{}) resp) = resp <$ guard (a == b)
+matchExpectation a@(GetSignedLicenseScanUrl{}) (ApiExpectation _ b@(GetSignedLicenseScanUrl{}) resp) = resp <$ guard (a == b)
+matchExpectation a@(GetSignedUploadUrl{}) (ApiExpectation _ b@(GetSignedUploadUrl{}) resp) = resp <$ guard (a == b)
+matchExpectation a@(QueueArchiveBuild{}) (ApiExpectation _ b@(QueueArchiveBuild{}) resp) = resp <$ guard (a == b)
 matchExpectation a@(UploadAnalysis{}) (ApiExpectation _ b@(UploadAnalysis{}) resp) = resp <$ guard (a == b)
+matchExpectation a@(UploadArchive{}) (ApiExpectation _ b@(UploadArchive{}) resp) = resp <$ guard (a == b)
+matchExpectation a@(UploadContainerScan{}) (ApiExpectation _ b@(UploadContainerScan{}) resp) = resp <$ guard (a == b)
 matchExpectation a@(UploadContributors{}) (ApiExpectation _ b@(UploadContributors{}) resp) = resp <$ guard (a == b)
+matchExpectation a@(UploadLicenseScanResult{}) (ApiExpectation _ b@(UploadLicenseScanResult{}) resp) = resp <$ guard (a == b)
 matchExpectation _ _ = Nothing
 
 -- | Handles a request in the context of the mock API.


### PR DESCRIPTION
# Overview

Converts `LicenceScanning` to use `FossaApiClient`.

Also, I had a structured called `ArchiveRevision` which I renamed to `PackageRevision`.  It captures the notion of an external dependency that will never have a branch and so `ProjectRevision` is not appropriate.  I'm not sure if this is the best naming, but it makes the API clearer to bundle these instead of passing around pairs of `Text` values.  I welcome discussion on this.

I also noticed there were two places where we were ignoring the value of the call, so I converted those to just return unit.

## Acceptance criteria

- All of `LicenceScanning` uses `FossaApiClient`.
- Tests added where feasible

## Testing plan

The function exposed by `LicenseScanner` actually executes Themis.  Our test harnesses don't seem to have mock execution set up.  This makes testing hard because I'd need to create and run against a fake dependency.  That feels out of scope for this PR, so I didn't create any unit tests.

I tested by incrementally implementing the endpoints to ensure everything was working.

1. First, set up my local core to do local license scanning.
2. Run the CLI with local scanning against a vendored dep and observe the behavior, verifying it invoked local scanning.
3. Refactor the code up to the point that it would invoke the legacy API functions. 
 Those are replaced with dummy implementations using `fatalText`.
4. Run the CLI and observe the dummy errors, updating the triggered dummy implementation with a pass-through to the API V1 implementation.
5. Repeat until license scanning succeeds.
6. Double-check that all expected end-points were invoked to ensure I have full coverage.

Future testing is just to run a local licence scan and observe that it works.


## References

- [ANE-217](https://fossa.atlassian.net/browse/ANE-217): Convert License Scanning to use FossaApiClient

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
