### PR TITLE
[CLI License Scan] Calculate the version from a hash of the vendored deps contents

### DIFF
--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -3,6 +3,7 @@
 module App.Fossa.ArchiveUploader (
   archiveUploadSourceUnit,
   arcToLocator,
+  compressFile,
   forceVendoredToArchive,
   duplicateFailureBundle,
   duplicateNames,


### PR DESCRIPTION
# Overview

This PR changes how we calculate the version of a vendored dependency when the version is not supplied in `fossa-deps.yml`.

This is the first requirement for implementing [avoiding rescanning vendored deps](https://fossa.atlassian.net/browse/ANE-190).

Previously we got the version of a vendored dependecy by calculating the hash of the results of the license scan. This was bad for two reasons. First, it meant we always had to license scan.

Second, it meant that we got different versions for cli-side license scans and archive uploads.

This PR fixes both of those problems by calculating the version of a cli-side license scanned vendored dependency in the same way that we calculate it for an archive-uploaded vendored dependency: by archiving the directory and calculating a hash of its contents.

## Acceptance criteria

- The version should be calculated using the directory contents
- The version calculated should be exactly the same as the version calculated by an archive upload for both archived vendored deps and unarchived vendored deps.

## Testing plan

clone the https://github.com/fossas/example-projects repo.

We are going to run `fossa analyze` on the `fossa-deps/vendored-dependencies` and `fossa-deps/unarchived-vendored-dependencies` projects, with and without the `--experimental-native-license-scan` flag.

Remove the version field from `fossa-deps/vendored-dependencies/fossa-deps.yml` and `fossa-deps/unarchived-vendored-dependencies/fossa-deps.yml`

```
cabal run fossa -- analyze -e http://localhost:9578 ~/fossa/example-projects/fossa-deps/vendored-dependencies
```

Note the version of the `Hello-Vendored` dependency.

Now re-scan with the `--experimental-native-license-scan` flag:

```
cabal run fossa -- analyze -e http://localhost:9578 --experimental-native-license-scan ~/fossa/example-projects/fossa-deps/vendored-dependencies
```

The version of the two `Hello-Vendored` revisions should be the same. For me it was `aeee3b54f8f3917e504b566cfc2a910e`.

<img width="587" alt="Screenshot 2022-04-08 at 4 22 40 PM" src="https://user-images.githubusercontent.com/13045/162545859-09de0a82-40eb-46d1-9497-0f0a5f2c192b.png">

<img width="578" alt="Screenshot 2022-04-08 at 4 22 54 PM" src="https://user-images.githubusercontent.com/13045/162545882-a5d148ad-8ab4-4078-9cc4-abeb640efb3f.png">

Do the same thing for an unarchived vendored dependency:

```
cabal run fossa -- analyze -e http://localhost:9578 ~/fossa/example-projects/fossa-deps/unarchived-vendored-dependencies
cabal run fossa -- analyze -e http://localhost:9578 --experimental-native-license-scan ~/fossa/example-projects/fossa-deps/unarchived-vendored-dependencies
```

Those analyses should both result in the same revision for the `Hello-Vendored-Unarchived` dependency.

<img width="657" alt="Screenshot 2022-04-08 at 4 32 19 PM" src="https://user-images.githubusercontent.com/13045/162546424-b5d31125-96f2-4f06-b73b-33b81b14acce.png">

<img width="661" alt="Screenshot 2022-04-08 at 4 32 32 PM" src="https://user-images.githubusercontent.com/13045/162546433-df8a4bff-c0a2-4171-b006-dedda82332c1.png">


Change the contents of the `vendored/hello-1.0.0.2` directory and scan again:

```
echo hello > unarchived-vendored-dependencies/vendor/hello-1.0.0.2/hello.txt   
```

Then re-run the analyses:

```
cabal run fossa -- analyze -e http://localhost:9578 ~/fossa/example-projects/fossa-deps/unarchived-vendored-dependencies
cabal run fossa -- analyze -e http://localhost:9578 --experimental-native-license-scan ~/fossa/example-projects/fossa-deps/unarchived-vendored-dependencies
```

The revision for the `Hello-Vendored-Unarchived` dependency should change from your previous scans, but it should be the same for the archive-upload and the cli-side license scan.

<img width="647" alt="Screenshot 2022-04-08 at 4 40 13 PM" src="https://user-images.githubusercontent.com/13045/162546877-c3afb6c8-bb72-42e4-9874-aa1423c38ee0.png">

<img width="652" alt="Screenshot 2022-04-08 at 4 40 29 PM" src="https://user-images.githubusercontent.com/13045/162546893-f920b070-6262-4a11-8a20-1d91f73c6703.png">

## Risks

_Highlight any areas that you're unsure of, want feedback on, or want reviewers to pay particular attention to._

_Example: I'm not sure I did X correctly, can reviewers please double-check that for me?_

## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
