### PR TITLE
Hides FossaAPIV1 inside FossaApiClient.Internal

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -183,7 +183,6 @@ library
     App.Fossa.Container.Test
     App.Fossa.DumpBinaries
     App.Fossa.EmbeddedBinary
-    App.Fossa.FossaAPIV1
     App.Fossa.LicenseScanner
     App.Fossa.ListTargets
     App.Fossa.Main
@@ -230,6 +229,7 @@ library
     Control.Carrier.Finally
     Control.Carrier.FossaApiClient
     Control.Carrier.FossaApiClient.Internal.Core
+    Control.Carrier.FossaApiClient.Internal.FossaAPIV1
     Control.Carrier.FossaApiClient.Internal.LicenseScanning
     Control.Carrier.FossaApiClient.Internal.ScotlandYard
     Control.Carrier.FossaApiClient.Internal.VSI

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -16,9 +16,9 @@ module Control.Carrier.FossaApiClient.Internal.Core (
 
 import App.Fossa.Config.Report (ReportOutputFormat)
 import App.Fossa.Container.Scan (ContainerScan)
-import App.Fossa.FossaAPIV1 qualified as API
 import App.Types (ProjectMetadata, ProjectRevision (..))
 import Control.Algebra (Has)
+import Control.Carrier.FossaApiClient.Internal.FossaAPIV1 qualified as API
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.FossaApiClient (PackageRevision (..))
 import Control.Effect.Lift (Lift)

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module App.Fossa.FossaAPIV1 (
+module Control.Carrier.FossaApiClient.Internal.FossaAPIV1 (
   uploadAnalysis,
   uploadContributors,
   uploadContainerScan,

--- a/src/Control/Carrier/FossaApiClient/Internal/LicenseScanning.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/LicenseScanning.hs
@@ -6,8 +6,8 @@ module Control.Carrier.FossaApiClient.Internal.LicenseScanning (
   uploadLicenseScanResult,
 ) where
 
-import App.Fossa.FossaAPIV1 qualified as API
 import Control.Algebra (Has)
+import Control.Carrier.FossaApiClient.Internal.FossaAPIV1 qualified as API
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.FossaApiClient (PackageRevision (..))
 import Control.Effect.Lift (Lift)

--- a/src/Control/Carrier/FossaApiClient/Internal/ScotlandYard.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/ScotlandYard.hs
@@ -5,9 +5,9 @@ module Control.Carrier.FossaApiClient.Internal.ScotlandYard (
   getLatestScan,
 ) where
 
-import App.Fossa.FossaAPIV1 (getOrganization, renderLocatorUrl)
 import App.Fossa.VPS.Types (runHTTP)
 import App.Types (ProjectRevision (..))
+import Control.Carrier.FossaApiClient.Internal.FossaAPIV1 (getOrganization, renderLocatorUrl)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Lift)
 import Control.Effect.Reader (Reader, ask)

--- a/src/Control/Carrier/FossaApiClient/Internal/VSI.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/VSI.hs
@@ -10,13 +10,13 @@ module Control.Carrier.FossaApiClient.Internal.VSI (
   resolveUserDefinedBinary,
 ) where
 
-import App.Fossa.FossaAPIV1 qualified as API
 import App.Fossa.VSI.Fingerprint (Fingerprint, Raw)
 import App.Fossa.VSI.Fingerprint qualified as Fingerprint
 import App.Fossa.VSI.IAT.Types qualified as IAT
 import App.Fossa.VSI.Types qualified as VSI
 import App.Types (ProjectRevision)
 import Control.Algebra (Has)
+import Control.Carrier.FossaApiClient.Internal.FossaAPIV1 qualified as API
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Lift)
 import Control.Effect.Reader (Reader, ask)


### PR DESCRIPTION
# Overview

As proof that we've cleaned up all the API interactions and to avoid accidentally adding more, this moves the `FossaAPIV1` module into `Control.Carrier.FossaApiClient.Internal`

## Acceptance criteria

`FossaAPIV1` is only used by `FossaApiClient.Internal` modules.

## Testing plan

Since this was just a rename, I just made sure that everything compiles and ran the command once.

## Risks

None

## References

None

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
