### PR TITLE
Don't record `GetIdentifier` calls

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.2.5
+
+- debug: Reduce the size of debug bundles. ([#890](https://github.com/fossas/fossa-cli/pull/890))
+
 ## v3.2.4
 - nodejs: Fixed a bug where dev deps that only appear in requires were considered production dependencies. ([#884](https://github.com/fossas/fossa-cli/pull/884))
 

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -176,20 +176,20 @@ diagToDebug = runDiagDebugC
 
 type ReadFSDebugC = SimpleC ReadFSF
 
--- | Record most ReadFS constructors, ignoring ListDir because it explodes the
--- size of the debug bundle
+-- | Record ReadFS constructors which are relevant for debugging.
 readFSToDebug :: (Has ReadFS sig m, Has Debug sig m) => ReadFSDebugC m a -> m a
 readFSToDebug = interpret $ \case
   cons@ReadContentsBS'{} -> recording cons
-  cons@ReadContentsBSLimit'{} -> ignoring cons
   cons@ReadContentsText'{} -> recording cons
   cons@DoesFileExist{} -> recording cons
   cons@DoesDirExist{} -> recording cons
   cons@ResolveFile'{} -> recording cons
   cons@ResolveDir'{} -> recording cons
   cons@ResolvePath{} -> recording cons
+  -- Unneeded or excessive for debug bundles
+  cons@ReadContentsBSLimit'{} -> ignoring cons
   cons@ListDir{} -> ignoring cons
-  cons@GetIdentifier{} -> recording cons
+  cons@GetIdentifier{} -> ignoring cons
 
 -----------------------------------------------
 


### PR DESCRIPTION
# Overview

In debug bundles, we ignore `ReadFS` operations the explode the size of the bundles, like `ListDir`.  This PR adds `GetIdentifier` to that list.
