### PR TITLE
Rewrites the MockApi docs

### DIFF
--- a/docs/contributing/api-mocking.md
+++ b/docs/contributing/api-mocking.md
@@ -34,7 +34,7 @@ An expectation is considered _satisfied_ when it has been used to fulful the
 minimum number it expects.  An expectation is considered _exhausted_ if has
 fulfulled the maximum number of requests it expects.  At the end of a test all
 expectations should be satisfied, though they need not be exhausted.  Reusing an
-exhaused expectation is an error.
+exhausted expectation is an error.
 
 The helpers are:
 

--- a/docs/contributing/api-mocking.md
+++ b/docs/contributing/api-mocking.md
@@ -1,28 +1,60 @@
 # API Mocking
 
-Testing functions that interact with the API can be complicated because the API can have many different responses or errors, but the behavior is outside the scope of the test.  APIs can have errors, they may be stateful, there may be network instability and a host of other issues that conspire to cause test failures.  Unit tests shouldn't make any API calls because it makes the test slow, brittle and non-determistic which undermines many of the advantages of unit tests such as using them for CI on every change.
+Testing functions that interact with the API can be complicated because the API
+can have many different responses or errors, but the behavior is outside the
+scope of the test.  APIs can have errors, they may be stateful, there may be
+network instability and a host of other issues that conspire to cause test
+failures.  Unit tests shouldn't make any API calls because it makes the test
+slow, brittle and non-determistic which undermines many of the advantages of
+unit tests such as using them for CI on every change.
 
-The code that calls the API still needs to be tested in a predictable and reproducible way.  We need a way to remove all that uncertainty without introducing burdensome complexity in our testing environment such as running an entire application and networking stack.
+The code that calls the API still needs to be tested in a predictable and
+reproducible way.  We need a way to remove all that uncertainty without
+introducing burdensome complexity in our testing environment such as running an
+entire application and networking stack.
 
-The solution is mock the API.  This means that we will tell the test harness how to interpret calls to the API so that the code under test can experience different scenarios.  This is not a fake API, which would seek to mimic the API behavior, but rather a collection of requests and responses.
+The solution is mock the API.  This means that we will tell the test harness how
+to interpret calls to the API so that the code under test can experience
+different scenarios.  This is not a fake API, which would seek to mimic the API
+behavior, but rather a collection of requests and responses.
 
 ## Usage
 
-Using the Mock API is a matter of setting expectations of calls that will be made and at the same time stating what those calls should return.  This lets us tell the test how to handle the expected calls but it also tells the test that anything else is unexpected.  This is important because it guards against accidental calls so you never have to say, "I didn't know that function had stateful behavior!"
+Using the Mock API is a matter of setting expectations of calls that will be
+made and at the same time stating what those calls should return.  This lets us
+tell the test how to handle the expected calls but it also tells the test that
+anything else is unexpected.  This is important because it guards against
+accidental calls so you never have to say, "I didn't know that function had
+stateful behavior!"
 
-Expectations are added through helpers, such as `returnsOnce`.  Each of these take in a request to match against (from the effect) and then a behavior to execute when the request is made.
+Expectations are added through helpers, such as `returnsOnce`.  Each of these
+take in a request to match against (from the effect) and then a behavior to
+execute when the request is made.
 
 The helpers are:
 
 - ``req `returnsOnce` a`` - Expects a request of `req` for which it will return `a`.
-- ``req `alwaysReturns` a`` - Expects zero or requests of `req` for which it will always return `a`.
-- ``req `fails` "Mock Error"`` - Expects exactly one request matching `req` for which it will raise a `Diagnostics` error with the text `"Mock Error"`.
+- ``req `alwaysReturns` a`` - Expects zero or requests of `req` for which it
+  will always return `a`.
+- ``req `fails` "Mock Error"`` - Expects exactly one request matching `req` for
+  which it will raise a `Diagnostics` error with the text `"Mock Error"`.
 
-Expectations are added to the end of a list of expectations that are checked whenever a new request comes in.  That means you can specify a series of values to be returned on subsequent calls, but if you specify that a request should always return the same value it will never reach any expectations you add for the quest after that.
+Expectations are added to the end of a list of expectations that are checked
+whenever a new request comes in.  That means you can specify a series of values
+to be returned on subsequent calls, but if you specify that a request should
+always return the same value it will never reach any expectations you add for
+the quest after that.
 
-An expectation is considered _satisfied_ when it has been used to fulful the minimum number it expects.  An expectation is considered _exhausted_ if has fulfulled all the requests it can and cannot match any further requests.  `returnsOnce` and `fails` are both satisfied and exhausted after one matching request.  `alwaysReturns` expects zero or more requests so it is always satisfied but never exhausted.
+An expectation is considered _satisfied_ when it has been used to fulful the
+minimum number it expects.  An expectation is considered _exhausted_ if has
+fulfulled all the requests it can and cannot match any further requests.
+`returnsOnce` and `fails` are both satisfied and exhausted after one matching
+request.  `alwaysReturns` expects zero or more requests so it is always
+satisfied but never exhausted.
 
-Any unsatisfied expectations at the end of the test will trigger an assertion error.  Remember that the requests must match exactly (via `Eq`) in order to be satisfied..
+Any unsatisfied expectations at the end of the test will trigger an assertion
+error.  Remember that the requests must match exactly (via `Eq`) in order to be
+satisfied..
 
 ### Examples
 
@@ -45,26 +77,52 @@ GetProject revision `fails` "Mock HTTP error"
 The framework is build around three core parts:
 
 1. Expectations define how to match requests and what to do about them.
-2. The `MockApi` effect and carrier define how the tests can interact with the expectations.
+2. The `MockApi` effect and carrier define how the tests can interact with the
+   expectations.
 3. The `FossaApiClientMock` carrier implements the API against the `MockApi`.
 
-The `MockApi` is separate from the `FossaApiClientMock` for two reasons.  One is that it's clean to have a carrier that just implements the `FossaApiClient` effect against the mock without having any extra state.  More importantly it has to do with the way that errors and state interact.
+The `MockApi` is separate from the `FossaApiClientMock` for two reasons.  One is
+that it's clean to have a carrier that just implements the `FossaApiClient`
+effect against the mock without having any extra state.  More importantly it has
+to do with the way that errors and state interact.
 
-The `FossaApiClient` typically emits errors through `Diagnostics` and so is subject to all the error-recovery semantics therein.  This is used throughout the codebase to implement fall-backs and error-handling.  This means that the `FossaApiClient` implementation needs to be on top of the `Diagnostics` carrier in order to throw those errors.
+The `FossaApiClient` typically emits errors through `Diagnostics` and so is
+subject to all the error-recovery semantics therein.  This is used throughout
+the codebase to implement fall-backs and error-handling.  This means that the
+`FossaApiClient` implementation needs to be on top of the `Diagnostics` carrier
+in order to throw those errors.
 
-However, when `Diagnostics` recovers a branch from an error, the internals of that computation are discarded.  This means that any state tracked in that branch is discarded.  Expectations need to be tracked across calls that are recovered from because otherwise the expectation that caused the failure will not be exhausted for when the request is retried, leading to endless failures and no way to test retry.  It will also maen that we cannot track what calls were made in that branch of code and so satisfy and exhaust those expectations.
+However, when `Diagnostics` recovers a branch from an error, the internals of
+that computation are discarded.  This means that any state tracked in that
+branch is discarded.  Expectations need to be tracked across calls that are
+recovered from because otherwise the expectation that caused the failure will
+not be exhausted for when the request is retried, leading to endless failures
+and no way to test retry.  It will also maen that we cannot track what calls
+were made in that branch of code and so satisfy and exhaust those expectations.
 
-`MockApi` then has to be below `Diagnostics` in the carrier stack.  This allows it to keep track of its state regardless of what errors are thrown, caught or recovered from.
+`MockApi` then has to be below `Diagnostics` in the carrier stack.  This allows
+it to keep track of its state regardless of what errors are thrown, caught or
+recovered from.
 
 ### Expectations
 
-The core of the mocking is `ApiExpectations`.  `ApiExpectations` are both a description of behavior and an assertion about what behavior should occur in the test.  The requests that the expectations match are of type `FossaApiClientF a`, where the return-type, `a`, can be different depending on the type of request.  This leads to an awkward situation where we need to match return types to the request types, but we do not know the actual type of the value.
+The core of the mocking is `ApiExpectations`.  `ApiExpectations` are both a
+description of behavior and an assertion about what behavior should occur in the
+test.  The requests that the expectations match are of type `FossaApiClientF a`,
+where the return-type, `a`, can be different depending on the type of request.
+This leads to an awkward situation where we need to match return types to the
+request types, but we do not know the actual type of the value.
 
-This leads to creating a heterogeneous list.  We can do that by using a GADT to "erase" the return type.
+This leads to creating a heterogeneous list.  We can do that by using a GADT to
+"erase" the return type.
 
 ```haskell
 data ApiExpectation where
-  ApiExpectation :: ExpectationRepetition -> FossaApiClientF a -> ApiResult a -> ApiExpectation
+  ApiExpectation ::
+    ExpectationRepetition
+    -> FossaApiClientF a
+    -> ApiResult a
+    -> ApiExpectation
 ```
 
 Expectations consist of:
@@ -72,25 +130,46 @@ Expectations consist of:
 1. `FossaApiClientF a`: a request to match against
 1. `ApiResult a`: a behavior such as returning a value or raising an error
 
-The repetition specifies how to exhaust the the expectation.  It's currently only two options, but there is room for expansion.
+The repetition specifies how to exhaust the the expectation.  It's currently
+only two options, but there is room for expansion.
 
 - `Once` means the expectation should be exhausted after one match.
 - `Always` means the expectation should never be exhausted.
 
-The request is used to match incoming requests with `Eq`.  It would be more flexible as a predicate, but this would make error messages harder to write.  A copy of the request is very useful in debugging and writing errors.
+The request is used to match incoming requests with `Eq`.  It would be more
+flexible as a predicate, but this would make error messages harder to write.  A
+copy of the request is very useful in debugging and writing errors.
 
-`ApiResult a` has two modes.  It can be a return value of type `a` that is handed back to the code under test as a successful call.  It can also be `ApiFail` which contains a `Text` message that is raised as a diagnostic failure to represent a failed call.  Further types could be added here such as the ability to specify an ordered list of responses to return one at a time.
+`ApiResult a` has two modes.  It can be a return value of type `a` that is
+handed back to the code under test as a successful call.  It can also be
+`ApiFail` which contains a `Text` message that is raised as a diagnostic failure
+to represent a failed call.  Further types could be added here such as the
+ability to specify an ordered list of responses to return one at a time.
 
 ### MockApi Effect
 
-The expectations are configured through the `MockApi` effect.  It can add expectations, run a request against the expectations or trigger assertions.  These effects aren't intended to be used directly from tests and the helpers should be used instead.
+The expectations are configured through the `MockApi` effect.  It can add
+expectations, run a request against the expectations or trigger assertions.
+These effects aren't intended to be used directly from tests and the helpers
+should be used instead.
 
 ### MockApi Carrier
 
-The `MockApi` is primarily responsible for keeping track of state, but also handles some assertions on that state.  Expectations are added and matched as the test progresses and at some point the test will want to check whether the expectations have been satisfied.  The `MockApi` handles all the logic of what expectations match requests and how they get satisfied or exhausted.
+The `MockApi` is primarily responsible for keeping track of state, but also
+handles some assertions on that state.  Expectations are added and matched as
+the test progresses and at some point the test will want to check whether the
+expectations have been satisfied.  The `MockApi` handles all the logic of what
+expectations match requests and how they get satisfied or exhausted.
 
-The internal state is just a list of expectations in the order in which they should be checked.  The key value of a list is how easy it is to add, traverse and remove elements.  Expectations are removed when they are exhaused so the data structure needs to support that.  The set of expectations is small enough that the performance implications are minor.  The framework should use a more complicated type if the need arrises.
+The internal state is just a list of expectations in the order in which they
+should be checked.  The key value of a list is how easy it is to add, traverse
+and remove elements.  Expectations are removed when they are exhaused so the
+data structure needs to support that.  The set of expectations is small enough
+that the performance implications are minor.  The framework should use a more
+complicated type if the need arrises.
 
 ### FossaApiClientMock
 
-The `FossaApiClientMockC` is the carrier that implements the API in terms of the expectations.  When a request is made it just asks the `MockApi` what to do and lets it check and manage it's own internal expectations.
+The `FossaApiClientMockC` is the carrier that implements the API in terms of the
+expectations.  When a request is made it just asks the `MockApi` what to do and
+lets it check and manage it's own internal expectations.

--- a/docs/contributing/api-mocking.md
+++ b/docs/contributing/api-mocking.md
@@ -1,34 +1,30 @@
 # API Mocking
 
-Testing functions that interact with the API can be complicated because the API can have many different responses or errors, but the behavior is defined outside this app.  The code that calls the API needs to be tested in a predictable and reproducible way.
+Testing functions that interact with the API can be complicated because the API can have many different responses or errors, but the behavior is outside the scope of the test.  APIs can have errors, they may be stateful, there may be network instability and a host of other issues that conspire to cause test failures.  Unit tests shouldn't make any API calls because it makes the test slow, brittle and non-determistic which undermines many of the advantages of unit tests such as using them for CI on every change.
+
+The code that calls the API still needs to be tested in a predictable and reproducible way.  We need a way to remove all that uncertainty without introducing burdensome complexity in our testing environment such as running an entire application and networking stack.
 
 The solution is mock the API.  This means that we will tell the test harness how to interpret calls to the API so that the code under test can experience different scenarios.  This is not a fake API, which would seek to mimic the API behavior, but rather a collection of requests and responses.
 
-The framework is build around two core parts:
+## Usage
 
-1. Expectations
-2. Mock Effects
+Using the Mock API is a matter of setting expectations of calls that will be made and at the same time stating what those calls should return.  This lets us tell the test how to handle the expected calls but it also tells the test that anything else is unexpected.  This is important because it guards against accidental calls so you never have to say, "I didn't know that function had stateful behavior!"
 
-## Expectations
+Expectations are added through helpers, such as `returnsOnce`.  Each of these take in a request to match against (from the effect) and then a behavior to execute when the request is made.
 
-The core of the mocking is `ApiExpectations`.  `ApiExpectations` are both a description of behavior and an assertion about what behavior should occur in the test.
+The helpers are:
 
-Expectations are added through helpers, such as `returnsOnce`.  These are added to the end of a list of expectations that are checked whenever a new request comes in.
+- ``req `returnsOnce` a`` - Expects a request of `req` for which it will return `a`.
+- ``req `alwaysReturns` a`` - Expects zero or requests of `req` for which it will always return `a`.
+- ``req `fails` "Mock Error"`` - Expects exactly one request matching `req` for which it will raise a `Diagnostics` error with the text `"Mock Error"`.
 
-Expectations consist of:
-1. `FossaApiClientF a`: a request to match against
-2. `ApiResult a`: a behavior such as returning a value or raising an error
-3. `ExpectationRepetition`: a repetition specification
+Expectations are added to the end of a list of expectations that are checked whenever a new request comes in.  That means you can specify a series of values to be returned on subsequent calls, but if you specify that a request should always return the same value it will never reach any expectations you add for the quest after that.
 
-`ApiResult a` has two modes.  It can be a return value of type `a` that is handed back to the code under test as a successful call.  It can also be `ApiFail` which contains a `Text` message that is raised as a diagnostic failure to represent a failed call.
+An expectation is considered _satisfied_ when it has been used to fulful the minimum number it expects.  An expectation is considered _exhausted_ if has fulfulled all the requests it can and cannot match any further requests.  `returnsOnce` and `fails` are both satisfied and exhausted after one matching request.  `alwaysReturns` expects zero or more requests so it is always satisfied but never exhausted.
 
-`ExpectationRepetition` can be `Once` or `Always`.  An expectation that is set up with `Once` will be invoked the first time it matches a request.  It will expire and be considered satisfied after that call.  An expectation set up with `Always` can be invoked many times and is always considered satisfied.
+Any unsatisfied expectations at the end of the test will trigger an assertion error.  Remember that the requests must match exactly (via `Eq`) in order to be satisfied..
 
-Expectations are checked and matched in the order in which they are added.
-
-Any unsatisfied expectations at the end of the test will trigger an assertion error.  Remember that the requests must match exactly (via `Eq`).
-
-Examples:
+### Examples
 
 ```haskell
 -- return the same value every time a call is made.
@@ -44,10 +40,57 @@ GetProject revision `fails` "Mock HTTP error"
   `alwaysReturns` Fixtures.scanResponse{responseScanStatus = Just "Available"}
 ```
 
-## MockApi Effect
+## Implementation
 
-The `FossaApiClient` effects needs to have a carrier in order for the tests to run.  This is provided by the `FossaApiClientMockC` carrier in `MockApi.hs`.  This is a special carrier that implements the API using the expectations.
+The framework is build around three core parts:
 
-The expectations are configured through the `MockApi` effect.  It can add expectations, run a request against the expectations or trigger assertions.  These should not be used directly.  The exported helpers should be used instead.
+1. Expectations define how to match requests and what to do about them.
+2. The `MockApi` effect and carrier define how the tests can interact with the expectations.
+3. The `FossaApiClientMock` carrier implements the API against the `MockApi`.
 
-Internally the `MockApiC` carrier keeps track of the expectations and provides an interface to them that `FossaApiClientMockC` can use to implement `FossaApiClient` effects against the expectations.  These are already configured in `Test.Effect`, so you should not need to set them up manually.  If you do, for some reason, make sure that the `MockApiC` is inside the `Diagnostics` effect so that its state is not lost when `recover` is used.
+The `MockApi` is separate from the `FossaApiClientMock` for two reasons.  One is that it's clean to have a carrier that just implements the `FossaApiClient` effect against the mock without having any extra state.  More importantly it has to do with the way that errors and state interact.
+
+The `FossaApiClient` typically emits errors through `Diagnostics` and so is subject to all the error-recovery semantics therein.  This is used throughout the codebase to implement fall-backs and error-handling.  This means that the `FossaApiClient` implementation needs to be on top of the `Diagnostics` carrier in order to throw those errors.
+
+However, when `Diagnostics` recovers a branch from an error, the internals of that computation are discarded.  This means that any state tracked in that branch is discarded.  Expectations need to be tracked across calls that are recovered from because otherwise the expectation that caused the failure will not be exhausted for when the request is retried, leading to endless failures and no way to test retry.  It will also maen that we cannot track what calls were made in that branch of code and so satisfy and exhaust those expectations.
+
+`MockApi` then has to be below `Diagnostics` in the carrier stack.  This allows it to keep track of its state regardless of what errors are thrown, caught or recovered from.
+
+### Expectations
+
+The core of the mocking is `ApiExpectations`.  `ApiExpectations` are both a description of behavior and an assertion about what behavior should occur in the test.  The requests that the expectations match are of type `FossaApiClientF a`, where the return-type, `a`, can be different depending on the type of request.  This leads to an awkward situation where we need to match return types to the request types, but we do not know the actual type of the value.
+
+This leads to creating a heterogeneous list.  We can do that by using a GADT to "erase" the return type.
+
+```haskell
+data ApiExpectation where
+  ApiExpectation :: ExpectationRepetition -> FossaApiClientF a -> ApiResult a -> ApiExpectation
+```
+
+Expectations consist of:
+1. `ExpectationRepetition`: a repetition specification
+1. `FossaApiClientF a`: a request to match against
+1. `ApiResult a`: a behavior such as returning a value or raising an error
+
+The repetition specifies how to exhaust the the expectation.  It's currently only two options, but there is room for expansion.
+
+- `Once` means the expectation should be exhausted after one match.
+- `Always` means the expectation should never be exhausted.
+
+The request is used to match incoming requests with `Eq`.  It would be more flexible as a predicate, but this would make error messages harder to write.  A copy of the request is very useful in debugging and writing errors.
+
+`ApiResult a` has two modes.  It can be a return value of type `a` that is handed back to the code under test as a successful call.  It can also be `ApiFail` which contains a `Text` message that is raised as a diagnostic failure to represent a failed call.  Further types could be added here such as the ability to specify an ordered list of responses to return one at a time.
+
+### MockApi Effect
+
+The expectations are configured through the `MockApi` effect.  It can add expectations, run a request against the expectations or trigger assertions.  These effects aren't intended to be used directly from tests and the helpers should be used instead.
+
+### MockApi Carrier
+
+The `MockApi` is primarily responsible for keeping track of state, but also handles some assertions on that state.  Expectations are added and matched as the test progresses and at some point the test will want to check whether the expectations have been satisfied.  The `MockApi` handles all the logic of what expectations match requests and how they get satisfied or exhausted.
+
+The internal state is just a list of expectations in the order in which they should be checked.  The key value of a list is how easy it is to add, traverse and remove elements.  Expectations are removed when they are exhaused so the data structure needs to support that.  The set of expectations is small enough that the performance implications are minor.  The framework should use a more complicated type if the need arrises.
+
+### FossaApiClientMock
+
+The `FossaApiClientMockC` is the carrier that implements the API in terms of the expectations.  When a request is made it just asks the `MockApi` what to do and lets it check and manage it's own internal expectations.

--- a/docs/contributing/api-mocking.md
+++ b/docs/contributing/api-mocking.md
@@ -1,12 +1,12 @@
 # API Mocking
 
-Testing functions that interact with the API can be complicated because the API
-can have many different responses or errors, but the behavior is outside the
-scope of the test.  APIs can have errors, they may be stateful, there may be
-network instability and a host of other issues that conspire to cause test
-failures.  Unit tests shouldn't make any API calls because it makes the test
-slow, brittle and non-determistic which undermines many of the advantages of
-unit tests such as using them for CI on every change.
+API testing can be complicated because the API can have many different responses
+or errors. Additionally the API behavior is generally outside the scope of the
+test.  APIs can have errors, they may be stateful, there may be network
+instability and a host of other issues that conspire to cause test failures.
+Unit tests shouldn't make any API calls because it makes the test slow, brittle
+and non-determistic which undermines many of the advantages of unit tests such
+as using them for CI on every change.
 
 The code that calls the API still needs to be tested in a predictable and
 reproducible way.  We need a way to remove all that uncertainty without
@@ -16,45 +16,45 @@ entire application and networking stack.
 The solution is mock the API.  This means that we will tell the test harness how
 to interpret calls to the API so that the code under test can experience
 different scenarios.  This is not a fake API, which would seek to mimic the API
-behavior, but rather a collection of requests and responses.
+behavior, but rather a collection of expected requests and responses.
 
 ## Usage
 
-Using the Mock API is a matter of setting expectations of calls that will be
-made and at the same time stating what those calls should return.  This lets us
-tell the test how to handle the expected calls but it also tells the test that
-anything else is unexpected.  This is important because it guards against
-accidental calls so you never have to say, "I didn't know that function had
-stateful behavior!"
+Mock API usage is a matter of setting expectations of calls that will be made
+and stating what those calls should return.  This tells the test how to handle
+the expected calls and that anything else is unexpected.  This is important to
+guard against accidental calls so you never have to say, "I didn't know that
+function had stateful behavior!"
 
 Expectations are added through helpers, such as `returnsOnce`.  Each of these
 take in a request to match against (from the effect) and then a behavior to
 execute when the request is made.
 
-The helpers are:
-
-- ``req `returnsOnce` a`` - Expects a request of `req` for which it will return `a`.
-- ``req `alwaysReturns` a`` - Expects zero or requests of `req` for which it
-  will always return `a`.
-- ``req `fails` "Mock Error"`` - Expects exactly one request matching `req` for
-  which it will raise a `Diagnostics` error with the text `"Mock Error"`.
-
-Expectations are added to the end of a list of expectations that are checked
-whenever a new request comes in.  That means you can specify a series of values
-to be returned on subsequent calls, but if you specify that a request should
-always return the same value it will never reach any expectations you add for
-the quest after that.
-
 An expectation is considered _satisfied_ when it has been used to fulful the
 minimum number it expects.  An expectation is considered _exhausted_ if has
-fulfulled all the requests it can and cannot match any further requests.
+fulfulled the maximum number of requests it expects.
 `returnsOnce` and `fails` are both satisfied and exhausted after one matching
 request.  `alwaysReturns` expects zero or more requests so it is always
 satisfied but never exhausted.
 
+The helpers are:
+
+- ``req `returnsOnce` a`` - Expects a request of `req` for which it will return
+  `a`.  This is both fulfilled and exhausted after one request.
+- ``req `alwaysReturns` a`` - Expects zero or more requests of `req` for which it
+  will always return `a`.  This is always satisfied and never exhausted.
+- ``req `fails` "Mock Error"`` - Expects exactly one request matching `req` for
+  which it will raise a `Diagnostics` error with the text `"Mock Error"`.  This is both fulfilled and exhausted after one request.
+
+Expectations are added to the end of a list of expectations that are checked
+whenever a new request comes in.  That means you can specify a series of values
+to be returned on subsequent calls by specifying multiple expectations. Note
+that if you specify that a request should always return the same value it will
+never reach any expectations you add for the request after that.
+
 Any unsatisfied expectations at the end of the test will trigger an assertion
 error.  Remember that the requests must match exactly (via `Eq`) in order to be
-satisfied..
+satisfied.
 
 ### Examples
 
@@ -89,16 +89,16 @@ to do with the way that errors and state interact.
 The `FossaApiClient` typically emits errors through `Diagnostics` and so is
 subject to all the error-recovery semantics therein.  This is used throughout
 the codebase to implement fall-backs and error-handling.  This means that the
-`FossaApiClient` implementation needs to be on top of the `Diagnostics` carrier
+`FossaApiClient` carrier needs to be on top of the `Diagnostics` carrier
 in order to throw those errors.
 
 However, when `Diagnostics` recovers a branch from an error, the internals of
 that computation are discarded.  This means that any state tracked in that
-branch is discarded.  Expectations need to be tracked across calls that are
-recovered from because otherwise the expectation that caused the failure will
-not be exhausted for when the request is retried, leading to endless failures
-and no way to test retry.  It will also maen that we cannot track what calls
-were made in that branch of code and so satisfy and exhaust those expectations.
+branch is discarded and so the mock would have no way to know what calls were
+made and which expectations to exhaust.  This would mean that we could not
+create a situation where a request fails, the failure is recovered from and then
+the request retries and succeeds because the mock would never remember if it had
+made the failing call or not.
 
 `MockApi` then has to be below `Diagnostics` in the carrier stack.  This allows
 it to keep track of its state regardless of what errors are thrown, caught or
@@ -110,11 +110,12 @@ The core of the mocking is `ApiExpectations`.  `ApiExpectations` are both a
 description of behavior and an assertion about what behavior should occur in the
 test.  The requests that the expectations match are of type `FossaApiClientF a`,
 where the return-type, `a`, can be different depending on the type of request.
-This leads to an awkward situation where we need to match return types to the
-request types, but we do not know the actual type of the value.
+This leads to an awkward situation of matching return types to the request types
+without knowing the actual type of the value.
 
-This leads to creating a heterogeneous list.  We can do that by using a GADT to
-"erase" the return type.
+The expectations need to ensure that request and return types match, but
+otherwise can "forget" the type.  This can be achieved with a GADT to "erase"
+the return type.
 
 ```haskell
 data ApiExpectation where
@@ -126,7 +127,8 @@ data ApiExpectation where
 ```
 
 Expectations consist of:
-1. `ExpectationRepetition`: a repetition specification
+1. `ExpectationRepetition`: a repetition specification used to track when it is
+   exhausted
 1. `FossaApiClientF a`: a request to match against
 1. `ApiResult a`: a behavior such as returning a value or raising an error
 
@@ -162,11 +164,10 @@ expectations have been satisfied.  The `MockApi` handles all the logic of what
 expectations match requests and how they get satisfied or exhausted.
 
 The internal state is just a list of expectations in the order in which they
-should be checked.  The key value of a list is how easy it is to add, traverse
-and remove elements.  Expectations are removed when they are exhaused so the
-data structure needs to support that.  The set of expectations is small enough
-that the performance implications are minor.  The framework should use a more
-complicated type if the need arrises.
+should be checked.  Expectations are removed when they are exhaused so the data
+structure needs to support that.  The set of expectations is small enough that
+the performance implications of using a list are minor.  The framework should
+use a more complicated type if the need arrises.
 
 ### FossaApiClientMock
 


### PR DESCRIPTION
# Overview

Rewrites the `MockApi` docs to be a bit clearer about usage and implementation.

@scruffystuffs and I had a conversation about making the docs both a good source of usage and of design for this module.  I've attempted to make the docs useful for consumers of the interface as well as anyone who might want to contribute to the interface or understand it more deeply.

## Acceptance criteria

- Drew and Wes have a common understanding of the purposes and audiences of this doc.
- The doc satisfies that purposes for those audiences.

## References

_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

_Example:_

- [ANE-188](https://fossa.atlassian.net/browse/ANE-188): Create contributor docs for API effects/mocking

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
