### PR TITLE
Pin syft releases to specific tag to avoid broken syft releases

### DIFF
--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -104,16 +104,18 @@ echo "themis index downloaded"
 rm $THEMIS_RELEASE_JSON
 echo
 
+SYFT_TAG="v0.14.0-fossa"
 if $OS_WINDOWS; then
   echo "Skipping syft for Windows builds"
   touch vendor-bins/syft
 else
   echo "Downloading forked syft binary"
+  echo "Using forked syft release: $SYFT_TAG"
   SYFT_RELEASE_JSON=vendor-bins/syft-release.json
   curl -sSL \
       -H "Authorization: token $GITHUB_TOKEN" \
       -H "Accept: application/vnd.github.v3.raw" \
-      api.github.com/repos/fossas/syft/releases/latest > $SYFT_RELEASE_JSON
+      api.github.com/repos/fossas/syft/releases/tags/${SYFT_TAG} > $SYFT_RELEASE_JSON
 
   # Remove leading 'v' from version tag
   # 'v123' -> '123'


### PR DESCRIPTION
# Overview

This PR intends to pin vendored `syft` release, in case we have a broken `syft` release on the latest tag. 

## Acceptance criteria

- Venored Syft releases are pinned to specific version.

## Testing plan

1. Get `GITHUB_TOKEN`
2. execute `GITHUB_TOKEN=<TOKEN> bash vendor_download.sh`
3. Ensure `syft` release works and is of correct version: `cd vendor-bins && ./syft version`

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-220

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
