### PR TITLE
Improve debug bundles.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.2.7
+
+- debug: Redact all known API keys from the debug bundle (#[897](https://github.com/fossas/fossa-cli/pull/897))
+
 ## v3.2.6
 
 - Filters: Apply filters during the discvoery phase, reducing end-to-end runtime. ([#877](https://github.com/fossas/fossa-cli/pull/877))

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -394,6 +394,7 @@ library
     Strategy.Swift.Xcode.Pbxproj
     Strategy.Swift.Xcode.PbxprojParser
     Strategy.SwiftPM
+    System.Args
     Text.URI.Builder
     Type.Operator
     Types
@@ -457,7 +458,6 @@ test-suite unit-tests
     Conda.CondaListSpec
     Conda.EnvironmentYmlSpec
     Control.Carrier.DiagnosticsSpec
-    Control.Carrier.Telemetry.UtilSpec
     Control.Carrier.TelemetrySpec
     Control.TimeoutSpec
     Dart.PubDepsSpec
@@ -519,6 +519,7 @@ test-suite unit-tests
     Swift.PackageSwiftSpec
     Swift.Xcode.PbxprojParserSpec
     Swift.Xcode.PbxprojSpec
+    System.ArgsSpec
     Test.Effect
     Test.Fixtures
     Test.MockApi

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -155,7 +155,7 @@ analyzeMain ::
   m ()
 analyzeMain cfg = case Config.severity cfg of
   SevDebug -> do
-    (scope, res) <- collectDebugBundle $ Diag.errorBoundaryIO $ analyze cfg
+    (scope, res) <- collectDebugBundle cfg $ Diag.errorBoundaryIO $ analyze cfg
     sendIO . BL.writeFile debugBundlePath . GZip.compress $ Aeson.encode scope
     Diag.rethrow res
   _ -> ignoreDebug $ analyze cfg

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -20,28 +20,39 @@ module App.Fossa.Analyze.Debug (
   debugEverything,
 ) where
 
-import Control.Carrier.Debug
-import Control.Carrier.Diagnostics (Diag (Fatal), Diagnostics)
+import Control.Carrier.Debug (
+  Algebra (..),
+  Debug,
+  DebugC,
+  Has,
+  Scope,
+  debugError,
+  debugLog,
+  debugScope,
+  ignoring,
+  recording,
+  runDebug,
+  type (:+:) (..),
+ )
 import Control.Carrier.Lift (sendIO)
 import Control.Carrier.Simple (SimpleC, interpret, sendSimple)
-import Control.Carrier.Stack (Stack (Context))
+import Control.Effect.Diagnostics (Diag (Fatal), Diagnostics)
 import Control.Effect.Lift (Lift)
 import Control.Effect.Record (Journal, RecordC, runRecord)
+import Control.Effect.Stack (Stack (Context))
 import Control.Effect.Sum (Member, inj)
-import Control.Exception (IOException, try)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text.IO qualified as TIO
 import Data.Word (Word64)
 import Effect.Exec (Exec, ExecF (..))
 import Effect.Logger (Logger, LoggerF (..))
 import Effect.ReadFS (ReadFS, ReadFSF (..))
 import GHC.Conc qualified as Conc
-import GHC.Environment qualified as Environment
 import GHC.Generics (Generic)
 import GHC.Stats qualified as Stats
+import System.Args (getCommandArgs)
 import System.Info qualified as Info
 
 collectDebugBundle ::
@@ -51,21 +62,19 @@ collectDebugBundle ::
   , Has Logger sig m
   , Has (Lift IO) sig m
   ) =>
+  cfg ->
   DebugEverythingC (RecordC ReadFSF (RecordC ExecF (DebugC m))) a ->
-  m (DebugBundle, a)
-collectDebugBundle act = do
+  m (DebugBundle cfg, a)
+collectDebugBundle cfg act = do
   (scope, (execJournal, (readFSJournal, res))) <- runDebug . runRecord @ExecF . runRecord @ReadFSF . debugEverything $ act
   sysInfo <- sendIO collectSystemInfo
-  -- TODO: collect the config file in command entrypoint and emit "effective
-  -- config", which is config overlayed with CLI options
-  fossaYml <- eitherToMaybe <$> sendIO (try @IOException (TIO.readFile ".fossa.yml"))
-  args <- sendIO Environment.getFullArgs
+  args <- sendIO getCommandArgs
   let bundle =
         DebugBundle
           { bundleScope = scope
           , bundleSystem = sysInfo
           , bundleArgs = args
-          , bundleFossaYml = fossaYml
+          , bundleConfig = cfg
           , bundleJournals =
               BundleJournals
                 { bundleJournalReadFS = readFSJournal
@@ -73,9 +82,6 @@ collectDebugBundle act = do
                 }
           }
   pure (bundle, res)
-
-eitherToMaybe :: Either e a -> Maybe a
-eitherToMaybe = either (const Nothing) Just
 
 collectSystemInfo :: IO SystemInfo
 collectSystemInfo = do
@@ -96,16 +102,16 @@ collectSystemInfo = do
       processors
       systemMemory
 
-data DebugBundle = DebugBundle
+data DebugBundle cfg = DebugBundle
   { bundleScope :: Scope
   , bundleSystem :: SystemInfo
-  , bundleArgs :: [String]
-  , bundleFossaYml :: Maybe Text
+  , bundleArgs :: [Text]
+  , bundleConfig :: cfg
   , bundleJournals :: BundleJournals
   }
   deriving (Show, Generic)
 
-instance ToJSON DebugBundle where
+instance ToJSON cfg => ToJSON (DebugBundle cfg) where
   toEncoding = genericToEncoding defaultOptions
 
 data SystemInfo = SystemInfo

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -20,6 +20,7 @@ module App.Fossa.Analyze.Debug (
   debugEverything,
 ) where
 
+import App.Version (fullVersionDescription)
 import Control.Carrier.Debug (
   Algebra (..),
   Debug,
@@ -73,6 +74,7 @@ collectDebugBundle cfg act = do
         DebugBundle
           { bundleScope = scope
           , bundleSystem = sysInfo
+          , bundleCLIVersion = fullVersionDescription
           , bundleArgs = args
           , bundleConfig = cfg
           , bundleJournals =
@@ -105,6 +107,7 @@ collectSystemInfo = do
 data DebugBundle cfg = DebugBundle
   { bundleScope :: Scope
   , bundleSystem :: SystemInfo
+  , bundleCLIVersion :: Text
   , bundleArgs :: [Text]
   , bundleConfig :: cfg
   , bundleJournals :: BundleJournals

--- a/src/Control/Carrier/Telemetry/Utils.hs
+++ b/src/Control/Carrier/Telemetry/Utils.hs
@@ -2,14 +2,11 @@ module Control.Carrier.Telemetry.Utils (
   getCurrentCliEnvironment,
   getCurrentCliVersion,
   getSystemInfo,
-  getCommandArgs,
   mkTelemetryCtx,
   mkTelemetryRecord,
   -- for testing
-  redactApiKeyFromCmdArgs,
 ) where
 
-import App.Fossa.Config.Common (fossaApiKeyCmdText)
 import App.Version (isDirty, versionOrBranch)
 import Control.Algebra (Has)
 import Control.Carrier.Lift (Lift, sendIO)
@@ -23,10 +20,8 @@ import Control.Carrier.Telemetry.Types (
 import Control.Concurrent.STM (STM, atomically, newEmptyTMVarIO, tryReadTMVar)
 import Control.Concurrent.STM.TBMQueue (TBMQueue, newTBMQueueIO, tryReadTBMQueue)
 import Control.Monad (join, replicateM)
-import Data.List (elemIndex)
 import Data.Maybe (catMaybes)
-import Data.String.Conversion (toText)
-import Data.Text (Text, isPrefixOf)
+import Data.Text (Text)
 import Data.Time (diffUTCTime, getCurrentTime, nominalDiffTimeToSeconds)
 import Data.Tracing.Instrument (
   getCounterRegistry,
@@ -34,7 +29,7 @@ import Data.Tracing.Instrument (
  )
 import Data.UUID.V4 (nextRandom)
 import GHC.Conc.Sync qualified as Conc
-import GHC.Environment qualified as Environment
+import System.Args (getCommandArgs)
 import System.Info qualified as Info
 
 maxQueueSize :: Int
@@ -88,35 +83,6 @@ getCurrentCliEnvironment =
   if isDirty
     then CliDevelopmentEnvironment
     else CliProductionEnvironment
-
-getCommandArgs :: IO [Text]
-getCommandArgs = redactApiKeyFromCmdArgs . map toText <$> Environment.getFullArgs
-
--- | Redacts Api Key from raw command args.
-redactApiKeyFromCmdArgs :: [Text] -> [Text]
-redactApiKeyFromCmdArgs = redactApiKeyWhenDirectlySupplied . redactApiKeyWhenPassedAsArg
-  where
-    -- When provided with --fossa-api-key=someKey
-    redactApiKeyWhenDirectlySupplied :: [Text] -> [Text]
-    redactApiKeyWhenDirectlySupplied =
-      map
-        ( \arg ->
-            if ("--" <> fossaApiKeyCmdText <> "=") `isPrefixOf` arg
-              then ("--" <> fossaApiKeyCmdText <> "=<REDACTED>")
-              else arg
-        )
-
-    -- When provided with --fossa-api-key someKey
-    redactApiKeyWhenPassedAsArg :: [Text] -> [Text]
-    redactApiKeyWhenPassedAsArg args =
-      case elemIndex ("--" <> fossaApiKeyCmdText) args of
-        Nothing -> args
-        Just i -> replaceAtWith args (i + 1) "<REDACTED>"
-
-    replaceAtWith :: [Text] -> Int -> Text -> [Text]
-    replaceAtWith args replaceAt replaceWith = case splitAt replaceAt args of
-      (start, _ : end) -> start ++ replaceWith : end
-      _ -> args
 
 getSystemInfo :: IO SystemInfo
 getSystemInfo =

--- a/src/System/Args.hs
+++ b/src/System/Args.hs
@@ -1,0 +1,39 @@
+module System.Args (
+  redactApiKeyFromCmdArgs,
+  getCommandArgs,
+) where
+
+import App.Fossa.Config.Common (fossaApiKeyCmdText)
+import Data.List (elemIndex)
+import Data.String.Conversion (ToText (toText))
+import Data.Text (Text, isPrefixOf)
+import GHC.Environment qualified as Environment
+
+getCommandArgs :: IO [Text]
+getCommandArgs = redactApiKeyFromCmdArgs . map toText <$> Environment.getFullArgs
+
+-- | Redacts Api Key from raw command args.
+redactApiKeyFromCmdArgs :: [Text] -> [Text]
+redactApiKeyFromCmdArgs = redactApiKeyWhenDirectlySupplied . redactApiKeyWhenPassedAsArg
+  where
+    -- When provided with --fossa-api-key=someKey
+    redactApiKeyWhenDirectlySupplied :: [Text] -> [Text]
+    redactApiKeyWhenDirectlySupplied =
+      map
+        ( \arg ->
+            if ("--" <> fossaApiKeyCmdText <> "=") `isPrefixOf` arg
+              then ("--" <> fossaApiKeyCmdText <> "=<REDACTED>")
+              else arg
+        )
+
+    -- When provided with --fossa-api-key someKey
+    redactApiKeyWhenPassedAsArg :: [Text] -> [Text]
+    redactApiKeyWhenPassedAsArg args =
+      case elemIndex ("--" <> fossaApiKeyCmdText) args of
+        Nothing -> args
+        Just i -> replaceAtWith args (i + 1) "<REDACTED>"
+
+    replaceAtWith :: [Text] -> Int -> Text -> [Text]
+    replaceAtWith args replaceAt replaceWith = case splitAt replaceAt args of
+      (start, _ : end) -> start ++ replaceWith : end
+      _ -> args

--- a/test/System/ArgsSpec.hs
+++ b/test/System/ArgsSpec.hs
@@ -1,6 +1,6 @@
-module Control.Carrier.Telemetry.UtilSpec (spec) where
+module System.ArgsSpec (spec) where
 
-import Control.Carrier.Telemetry.Utils (redactApiKeyFromCmdArgs)
+import System.Args (redactApiKeyFromCmdArgs)
 import Test.Hspec (Spec, describe, it, shouldBe)
 
 spec :: Spec


### PR DESCRIPTION
# Overview

We currently leak API keys in debug bundles if the key is in the config file or the CLI args.  We also do not capture the CLI version in the debug bundle.  This resolves both of those problems with the following changes

- We no longer capture the config file text, only the resolved configuration settings.
- We redact the api key from the command line using the same util as telemetry
- We add the version text to the debug bundle.
