### PR TITLE
Makes GetCurrendDir into a ReadFS effect

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -433,6 +433,9 @@ test-suite unit-tests
     App.Fossa.API.BuildLinkSpec
     App.Fossa.API.BuildWaitSpec
     App.Fossa.BinaryDeps.JarSpec
+    App.Fossa.Config.AnalyzeSpec
+    App.Fossa.Config.TestSpec
+    App.Fossa.Config.Utils
     App.Fossa.Configuration.ConfigurationSpec
     App.Fossa.Configuration.TelemetryConfigSpec
     App.Fossa.ManualDepsSpec

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -199,6 +199,7 @@ readFSToDebug = interpret $ \case
   cons@ReadContentsBSLimit'{} -> ignoring cons
   cons@ListDir{} -> ignoring cons
   cons@GetIdentifier{} -> ignoring cons
+  cons@GetCurrentDir{} -> ignoring cons
 
 -----------------------------------------------
 

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -3,7 +3,7 @@
 
 module App.Fossa.Config.Analyze (
   AllowNativeLicenseScan (..),
-  AnalyzeCliOpts,
+  AnalyzeCliOpts (..),
   AnalyzeConfig (..),
   BinaryDiscovery (..),
   ExperimentalAnalyzeConfig (..),
@@ -18,6 +18,8 @@ module App.Fossa.Config.Analyze (
   VSIAnalysis (..),
   VSIModeOptions (..),
   mkSubCommand,
+  loadConfig,
+  cliParser,
 ) where
 
 import App.Fossa.Config.Common (
@@ -61,7 +63,7 @@ import Control.Effect.Diagnostics (
   Has,
   fatalText,
  )
-import Control.Effect.Lift (Lift, sendIO)
+import Control.Effect.Lift (Lift)
 import Control.Monad (when)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.Flag (Flag, flagOpt)
@@ -78,8 +80,8 @@ import Discovery.Filters (AllFilters (AllFilters), comboExclude, comboInclude)
 import Effect.Exec (
   Exec,
  )
-import Effect.Logger (Logger, Severity (SevDebug, SevInfo), logDebug, logWarn, pretty)
-import Effect.ReadFS (ReadFS, resolveDir)
+import Effect.Logger (Logger, Severity (SevDebug, SevInfo), logWarn)
+import Effect.ReadFS (ReadFS, getCurrentDir, resolveDir)
 import Fossa.API.Types (ApiOpts)
 import GHC.Generics (Generic)
 import Options.Applicative (
@@ -100,7 +102,6 @@ import Options.Applicative (
   (<|>),
  )
 import Path (Abs, Dir, File, Path, Rel)
-import Path.IO (getCurrentDir)
 import System.Info qualified as SysInfo
 import Types (TargetFilter)
 
@@ -293,9 +294,8 @@ loadConfig ::
   AnalyzeCliOpts ->
   m (Maybe ConfigFile)
 loadConfig AnalyzeCliOpts{analyzeBaseDir, commons = CommonOpts{optConfig}} = do
-  cwd <- sendIO getCurrentDir
+  cwd <- getCurrentDir
   configBaseDir <- resolveDir cwd (toText analyzeBaseDir)
-  logDebug $ "Loading configuration file from " <> pretty (show configBaseDir)
   resolveConfigFile configBaseDir optConfig
 
 mergeOpts ::

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -51,6 +51,7 @@ import Effect.Logger (
   Pretty (pretty),
   logDebug,
   logWarn,
+  viaShow,
   vsep,
  )
 import Effect.ReadFS (ReadFS, doesFileExist, getCurrentDir, readContentsYaml)
@@ -101,7 +102,7 @@ resolveConfigFile ::
   Maybe FilePath ->
   m (Maybe ConfigFile)
 resolveConfigFile base path = do
-  logDebug $ "Loading configuration file from " <> pretty (show base)
+  logDebug $ "Loading configuration file from " <> viaShow base
   loc <- resolveLocation base path
   case loc of
     DefaultConfigLocation dir -> do

--- a/src/App/Fossa/Config/Container.hs
+++ b/src/App/Fossa/Config/Container.hs
@@ -76,8 +76,7 @@ loadConfig = \case
   ContainerParseFile _ -> pure Nothing
   ContainerDumpScan _ -> pure Nothing
   -- Only parse config file if we're running analyze or test
-  cmd -> do
-    resolveLocalConfigFile $ getCfgFilePath cmd
+  cmd -> resolveLocalConfigFile $ getCfgFilePath cmd
 
 getCfgFilePath :: ContainerCommand -> Maybe FilePath
 getCfgFilePath = \case

--- a/src/App/Fossa/Config/Container.hs
+++ b/src/App/Fossa/Config/Container.hs
@@ -15,7 +15,7 @@ import App.Fossa.Config.Common (
  )
 import App.Fossa.Config.ConfigFile (
   ConfigFile,
-  resolveConfigFile,
+  resolveLocalConfigFile,
  )
 import App.Fossa.Config.Container.Analyze (ContainerAnalyzeConfig, ContainerAnalyzeOptions (..))
 import App.Fossa.Config.Container.Analyze qualified as Analyze
@@ -29,7 +29,7 @@ import App.Fossa.Config.Container.Test qualified as Test
 import App.Fossa.Config.EnvironmentVars (EnvVars)
 import App.Fossa.Subcommand (EffStack, GetCommonOpts (getCommonOpts), GetSeverity (getSeverity), SubCommand (SubCommand))
 import Control.Effect.Diagnostics (Diagnostics)
-import Control.Effect.Lift (Has, Lift, sendIO)
+import Control.Effect.Lift (Has, Lift)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Effect.Logger (Logger, Severity (SevDebug, SevInfo))
 import Effect.ReadFS (ReadFS)
@@ -43,7 +43,6 @@ import Options.Applicative (
   subparser,
   (<|>),
  )
-import Path.IO (getCurrentDir)
 
 containerCmdInfo :: InfoMod a
 containerCmdInfo = progDesc "Run in container-scanning mode"
@@ -78,8 +77,7 @@ loadConfig = \case
   ContainerDumpScan _ -> pure Nothing
   -- Only parse config file if we're running analyze or test
   cmd -> do
-    curdir <- sendIO getCurrentDir
-    resolveConfigFile curdir $ getCfgFilePath cmd
+    resolveLocalConfigFile $ getCfgFilePath cmd
 
 getCfgFilePath :: ContainerCommand -> Maybe FilePath
 getCfgFilePath = \case

--- a/src/App/Fossa/Config/LinkUserBinaries.hs
+++ b/src/App/Fossa/Config/LinkUserBinaries.hs
@@ -12,7 +12,7 @@ import App.Fossa.Config.Common (
   collectBaseDir,
   commonOpts,
  )
-import App.Fossa.Config.ConfigFile (ConfigFile, resolveConfigFile)
+import App.Fossa.Config.ConfigFile (ConfigFile, resolveLocalConfigFile)
 import App.Fossa.Config.EnvironmentVars (EnvVars)
 import App.Fossa.Subcommand (
   EffStack,
@@ -28,7 +28,7 @@ import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
  )
-import Control.Effect.Lift (Lift, sendIO)
+import Control.Effect.Lift (Lift)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Effect.Logger (Logger, Severity (SevDebug, SevInfo))
 import Effect.ReadFS (ReadFS)
@@ -47,7 +47,6 @@ import Options.Applicative (
   strOption,
   value,
  )
-import Path.IO (getCurrentDir)
 
 cmdName :: String
 cmdName = "experimental-link-user-defined-dependency-binary"
@@ -94,9 +93,8 @@ loadConfig ::
   ) =>
   LinkUserBinsOpts ->
   m (Maybe ConfigFile)
-loadConfig LinkUserBinsOpts{..} = do
-  curdir <- sendIO getCurrentDir
-  resolveConfigFile curdir $ optConfig commons
+loadConfig =
+  resolveLocalConfigFile . optConfig . commons
 
 data LinkUserBinsOpts = LinkUserBinsOpts
   { commons :: CommonOpts

--- a/src/App/Fossa/Config/LinkUserBinaries.hs
+++ b/src/App/Fossa/Config/LinkUserBinaries.hs
@@ -93,8 +93,7 @@ loadConfig ::
   ) =>
   LinkUserBinsOpts ->
   m (Maybe ConfigFile)
-loadConfig =
-  resolveLocalConfigFile . optConfig . commons
+loadConfig = resolveLocalConfigFile . optConfig . commons
 
 data LinkUserBinsOpts = LinkUserBinsOpts
   { commons :: CommonOpts

--- a/src/App/Fossa/Config/ListTargets.hs
+++ b/src/App/Fossa/Config/ListTargets.hs
@@ -42,8 +42,7 @@ loadConfig ::
   ) =>
   ListTargetsCliOpts ->
   m (Maybe ConfigFile)
-loadConfig =
-  resolveLocalConfigFile . optConfig . commons
+loadConfig = resolveLocalConfigFile . optConfig . commons
 
 listTargetsInfo :: InfoMod a
 listTargetsInfo = progDesc "List available analysis-targets in a directory (projects and sub-projects)"

--- a/src/App/Fossa/Config/ListTargets.hs
+++ b/src/App/Fossa/Config/ListTargets.hs
@@ -19,18 +19,17 @@ import App.Fossa.Config.ConfigFile (
   ConfigFile (configExperimental),
   ExperimentalConfigs (gradle),
   ExperimentalGradleConfigs (gradleConfigsOnly),
-  resolveConfigFile,
+  resolveLocalConfigFile,
  )
 import App.Fossa.Subcommand (EffStack, GetCommonOpts (getCommonOpts), GetSeverity (getSeverity), SubCommand (SubCommand))
 import App.Types (BaseDir)
 import Control.Effect.Diagnostics (Diagnostics)
-import Control.Effect.Lift (Lift, sendIO)
+import Control.Effect.Lift (Lift)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Effect.Logger (Has, Logger, Severity (SevDebug, SevInfo))
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
 import Options.Applicative (InfoMod, Parser, progDesc)
-import Path.IO (getCurrentDir)
 
 mkSubCommand :: (ListTargetsConfig -> EffStack ()) -> SubCommand ListTargetsCliOpts ListTargetsConfig
 mkSubCommand = SubCommand "list-targets" listTargetsInfo parser loadConfig mergeOpts
@@ -43,9 +42,8 @@ loadConfig ::
   ) =>
   ListTargetsCliOpts ->
   m (Maybe ConfigFile)
-loadConfig ListTargetsCliOpts{..} = do
-  curdir <- sendIO getCurrentDir
-  resolveConfigFile curdir $ optConfig commons
+loadConfig =
+  resolveLocalConfigFile . optConfig . commons
 
 listTargetsInfo :: InfoMod a
 listTargetsInfo = progDesc "List available analysis-targets in a directory (projects and sub-projects)"

--- a/src/App/Fossa/Config/Report.hs
+++ b/src/App/Fossa/Config/Report.hs
@@ -142,8 +142,7 @@ loadConfig ::
   ) =>
   ReportCliOptions ->
   m (Maybe ConfigFile)
-loadConfig =
-  resolveLocalConfigFile . optConfig . commons
+loadConfig = resolveLocalConfigFile . optConfig . commons
 
 mergeOpts ::
   ( Has (Lift IO) sig m

--- a/src/App/Fossa/Config/Report.hs
+++ b/src/App/Fossa/Config/Report.hs
@@ -18,12 +18,12 @@ import App.Fossa.Config.Common (
   commonOpts,
   defaultTimeoutDuration,
  )
-import App.Fossa.Config.ConfigFile (ConfigFile, resolveConfigFile)
+import App.Fossa.Config.ConfigFile (ConfigFile, resolveLocalConfigFile)
 import App.Fossa.Config.EnvironmentVars (EnvVars)
 import App.Fossa.Subcommand (EffStack, GetCommonOpts (getCommonOpts), GetSeverity (getSeverity), SubCommand (SubCommand))
 import App.Types (BaseDir, OverrideProject (OverrideProject), ProjectRevision)
 import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (renderDiagnostic), fatal, fromMaybe)
-import Control.Effect.Lift (Has, Lift, sendIO)
+import Control.Effect.Lift (Has, Lift)
 import Control.Timeout (Duration (Seconds))
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.List (intercalate)
@@ -48,7 +48,6 @@ import Options.Applicative (
   strOption,
   switch,
  )
-import Path.IO (getCurrentDir)
 
 data ReportType = Attribution deriving (Eq, Ord, Enum, Bounded, Generic)
 
@@ -143,9 +142,8 @@ loadConfig ::
   ) =>
   ReportCliOptions ->
   m (Maybe ConfigFile)
-loadConfig ReportCliOptions{commons = CommonOpts{optConfig}} = do
-  configRelBase <- sendIO getCurrentDir
-  resolveConfigFile configRelBase optConfig
+loadConfig =
+  resolveLocalConfigFile . optConfig . commons
 
 mergeOpts ::
   ( Has (Lift IO) sig m

--- a/src/App/Fossa/Container/Analyze.hs
+++ b/src/App/Fossa/Container/Analyze.hs
@@ -27,6 +27,7 @@ import Data.Foldable (traverse_)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (decodeUtf8)
 import Data.Text (Text)
+import Effect.Exec (Exec)
 import Effect.Logger (
   AnsiStyle,
   Has,
@@ -38,6 +39,7 @@ import Effect.Logger (
   logStdout,
   viaShow,
  )
+import Effect.ReadFS (ReadFS)
 import Fossa.API.Types (UploadResponse (uploadError, uploadLocator))
 import Prettyprinter (Doc, indent, vsep)
 
@@ -45,6 +47,8 @@ analyze ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
   , Has Logger sig m
+  , Has Exec sig m
+  , Has ReadFS sig m
   ) =>
   ContainerAnalyzeConfig ->
   m ()

--- a/src/App/Fossa/Container/Test.hs
+++ b/src/App/Fossa/Container/Test.hs
@@ -27,6 +27,7 @@ import Control.Effect.Lift (Has, Lift, sendIO)
 import Control.Timeout (timeout')
 import Data.Aeson qualified as Aeson
 import Data.String.Conversion (decodeUtf8)
+import Effect.Exec (Exec)
 import Effect.Logger (
   Logger,
   Pretty (pretty),
@@ -35,6 +36,7 @@ import Effect.Logger (
   logInfo,
   logStdout,
  )
+import Effect.ReadFS (ReadFS)
 import Fossa.API.Types (Issues (..))
 import System.Exit (exitFailure)
 
@@ -42,6 +44,8 @@ test ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
   , Has Logger sig m
+  , Has Exec sig m
+  , Has ReadFS sig m
   ) =>
   ContainerTestConfig ->
   m ()

--- a/src/Control/Effect/Replay/TH.hs
+++ b/src/Control/Effect/Replay/TH.hs
@@ -73,15 +73,24 @@ decodeSingle keyVal valVal con = do
       constructorTupleP :: PatQ
       constructorTupleP = tupP (constructorNameP : constructorArgsP)
 
+  let argBindingsE :: [StmtQ]
+      argBindingsE =
+        if null constructorArgsP
+          then -- No-arg constructors are meaningless to match
+            []
+          else -- (("MyGadt.Bar" :: String), a, b) <- fromRecordedValue keyVal
+            [bindS constructorTupleP [e|fromRecordedValue $(varE keyVal)|]]
+
   -- do
   doE
-    -- (("MyGadt.Bar" :: String), a, b) <- fromRecordedValue keyVal
-    [ bindS constructorTupleP [e|fromRecordedValue $(varE keyVal)|]
-    , -- decodedResultValue <- fromRecordedValue valVal
-      bindS (sigP (varP resultNm) (getGadtTy con)) [e|fromRecordedValue $(varE valVal)|]
-    , -- pure (EffectResult (Bar a b) decodedResultValue)
-      noBindS [e|pure (EffectResult $(conAppliedE) $(varE resultNm))|]
-    ]
+    ( argBindingsE
+        <> [
+             -- decodedResultValue <- fromRecordedValue valVal
+             bindS (sigP (varP resultNm) (getGadtTy con)) [e|fromRecordedValue $(varE valVal)|]
+           , -- pure (EffectResult (Bar a b) decodedResultValue)
+             noBindS [e|pure (EffectResult $(conAppliedE) $(varE resultNm))|]
+           ]
+    )
 
 -- | Get the Name of a data constructor
 conNm :: Con -> Name

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -18,21 +18,39 @@ module Effect.Exec (
   runExecIO,
   renderCommand,
   module System.Exit,
-  module X,
   execThrow',
+  Has,
 ) where
 
 import App.Support (reportDefectMsg)
-import Control.Algebra as X
-import Control.Carrier.Simple
-import Control.Effect.Diagnostics
+import Control.Algebra (Has)
+import Control.Carrier.Simple (
+  Simple,
+  SimpleC,
+  interpret,
+  sendSimple,
+ )
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  ToDiagnostic (..),
+  context,
+  fatal,
+ )
 import Control.Effect.Lift (Lift, sendIO)
-import Control.Effect.Record
+import Control.Effect.Record (RecordableValue (..))
 import Control.Effect.Record.TH (deriveRecordable)
-import Control.Effect.Replay
+import Control.Effect.Replay (ReplayableValue (..))
 import Control.Effect.Replay.TH (deriveReplayable)
 import Control.Exception (IOException, try)
-import Data.Aeson
+import Data.Aeson (
+  FromJSON (parseJSON),
+  KeyValue ((.=)),
+  ToJSON (toJSON),
+  eitherDecode,
+  object,
+  withObject,
+  (.:),
+ )
 import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as BL
 import Data.String (fromString)
@@ -42,12 +60,16 @@ import Data.Text qualified as Text
 import Data.Void (Void)
 import Effect.ReadFS (ReadFS, getCurrentDir)
 import GHC.Generics (Generic)
-import Path
+import Path (Abs, Dir, Path, SomeBase (..), fromAbsDir)
 import Path.IO (AnyPath (makeAbsolute))
 import Prettyprinter (Doc, indent, line, pretty, viaShow, vsep)
 import Prettyprinter.Render.Terminal (AnsiStyle)
 import System.Exit (ExitCode (..))
-import System.Process.Typed
+import System.Process.Typed (
+  proc,
+  readProcess,
+  setWorkingDir,
+ )
 import Text.Megaparsec (Parsec, runParser)
 import Text.Megaparsec.Error (errorBundlePretty)
 

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -220,14 +220,11 @@ execThrow dir cmd = context ("Running command '" <> cmdName cmd <> "'") $ do
     Left failure -> fatal (CommandFailed failure)
     Right stdout -> pure stdout
 
--- | A variant of 'execThrow' that runs the command in the currend directory
+-- | A variant of 'execThrow' that runs the command in the current directory
 execThrow' :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => Command -> m BL.ByteString
 execThrow' cmd = context ("Running command '" <> cmdName cmd <> "'") $ do
   dir <- getCurrentDir
-  result <- exec dir cmd
-  case result of
-    Left failure -> fatal (CommandFailed failure)
-    Right stdout -> pure stdout
+  execThrow dir cmd
 
 type ExecIOC = SimpleC ExecF
 

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -364,12 +364,12 @@ runReadFSIO = interpret $ \case
     let fullpath = toString root FP.</> path
     stat <- Posix.getFileStatus fullpath `catchingIO` ResolveError (toString root) path
     pure (stat >>= identifyPath fullpath)
-  -- NB: these never throw
-  DoesFileExist file -> sendIO (Directory.doesFileExist (fromSomeFile file))
-  DoesDirExist dir -> sendIO (Directory.doesDirectoryExist (fromSomeDir dir))
   GetCurrentDir -> do
     PIO.getCurrentDir
       `catchingIO` CurrentDirError
+  -- NB: these never throw
+  DoesFileExist file -> sendIO (Directory.doesFileExist (fromSomeFile file))
+  DoesDirExist dir -> sendIO (Directory.doesDirectoryExist (fromSomeDir dir))
 
 identifyPath :: FilePath -> Posix.FileStatus -> Either ReadFSErr SomePath
 identifyPath path stat = case (isDirectory stat, isRegularFile stat) of

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -72,7 +72,6 @@ import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Record (RecordableValue)
 import Control.Effect.Record.TH (deriveRecordable)
 import Control.Effect.Replay (ReplayableValue)
-import Control.Effect.Replay.TH (deriveReplayable)
 import Control.Exception qualified as E
 import Control.Exception.Extra (safeCatch)
 import Control.Monad ((<=<))
@@ -166,7 +165,6 @@ instance RecordableValue ReadFSErr
 instance FromJSON ReadFSErr
 instance ReplayableValue ReadFSErr
 $(deriveRecordable ''ReadFSF)
-$(deriveReplayable ''ReadFSF)
 
 deriving instance Show (ReadFSF a)
 deriving instance Eq (ReadFSF a)

--- a/test/App/Fossa/Config/AnalyzeSpec.hs
+++ b/test/App/Fossa/Config/AnalyzeSpec.hs
@@ -1,0 +1,13 @@
+module App.Fossa.Config.AnalyzeSpec (spec) where
+
+import App.Fossa.Config.Analyze (
+  cliParser,
+  loadConfig,
+ )
+import App.Fossa.Config.Utils (itShouldLoadFromTheConfiguredBaseDir)
+import Test.Hspec (Spec, describe)
+
+spec :: Spec
+spec = do
+  describe "loadConfig" $ do
+    itShouldLoadFromTheConfiguredBaseDir cliParser loadConfig

--- a/test/App/Fossa/Config/TestSpec.hs
+++ b/test/App/Fossa/Config/TestSpec.hs
@@ -1,0 +1,13 @@
+module App.Fossa.Config.TestSpec (spec) where
+
+import App.Fossa.Config.Test (
+  loadConfig,
+  parser,
+ )
+import App.Fossa.Config.Utils (itShouldLoadFromTheConfiguredBaseDir)
+import Test.Hspec (Spec, describe)
+
+spec :: Spec
+spec = do
+  describe "loadConfig" $ do
+    itShouldLoadFromTheConfiguredBaseDir parser loadConfig

--- a/test/App/Fossa/Config/Utils.hs
+++ b/test/App/Fossa/Config/Utils.hs
@@ -7,7 +7,7 @@ import Control.Algebra (Has)
 import Control.Effect.Lift (Lift, sendIO)
 import Data.ByteString qualified as BS
 import Options.Applicative (Parser, execParserPure, handleParseResult, header, info, prefs)
-import Path.Posix (mkRelFile, toFilePath, (</>))
+import Path (mkRelFile, toFilePath, (</>))
 import Test.Effect (EffectStack, it', shouldBe', withTempDir)
 import Test.Hspec (Spec)
 

--- a/test/App/Fossa/Config/Utils.hs
+++ b/test/App/Fossa/Config/Utils.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.Fossa.Config.Utils (parseArgString, itShouldLoadFromTheConfiguredBaseDir) where
+
+import App.Fossa.Config.ConfigFile (ConfigFile (..))
+import Control.Algebra (Has)
+import Control.Effect.Lift (Lift, sendIO)
+import Data.ByteString qualified as BS
+import Options.Applicative (Parser, execParserPure, handleParseResult, header, info, prefs)
+import Path.Posix (mkRelFile, toFilePath, (</>))
+import Test.Effect (EffectStack, it', shouldBe', withTempDir)
+import Test.Hspec (Spec)
+
+-- | Parses an arg string or raises an error
+parseArgString :: (Has (Lift IO) sig m) => Parser a -> String -> m a
+parseArgString parser = sendIO . handleParseResult . execParserPure (prefs mempty) (info parser progInfo) . words
+  where
+    progInfo =
+      header "Test Arg Parser"
+
+-- | Tests that the config loader uses the directory set in the arguments
+itShouldLoadFromTheConfiguredBaseDir ::
+  Parser opts -> (opts -> EffectStack (Maybe ConfigFile)) -> Spec
+itShouldLoadFromTheConfiguredBaseDir parser loadConfig =
+  it' "should load from the configured base dir"
+    . withTempDir "AnalyzeSpec"
+    $ \tempDir ->
+      do
+        sendIO $ BS.writeFile (toFilePath (tempDir </> $(mkRelFile ".fossa.yml"))) "version: 42\n"
+        options <- sendIO $ parseArgString parser (toFilePath tempDir)
+        let configFile =
+              ConfigFile
+                { configVersion = 42
+                , configServer = Nothing
+                , configApiKey = Nothing
+                , configProject = Nothing
+                , configRevision = Nothing
+                , configTargets = Nothing
+                , configPaths = Nothing
+                , configExperimental = Nothing
+                , configTelemetry = Nothing
+                }
+        maybeConfigFile <- loadConfig options
+        maybeConfigFile `shouldBe'` Just configFile

--- a/test/Googlesource/RepoManifestSpec.hs
+++ b/test/Googlesource/RepoManifestSpec.hs
@@ -12,7 +12,7 @@ import Data.Set qualified as Set
 import Data.String.Conversion (toString)
 import Data.Text.IO qualified as TIO
 import DepTypes
-import Effect.ReadFS
+import Effect.ReadFS (runReadFSIO)
 import GraphUtil
 import Parse.XML
 import Path

--- a/test/Test/Effect.hs
+++ b/test/Test/Effect.hs
@@ -1,4 +1,5 @@
 module Test.Effect (
+  EffectStack,
   expectationFailure',
   expectFailure',
   expectFatal',


### PR DESCRIPTION
# Overview

This makes an effect for `GetCurrentDir` as part of `ReadFS`.  This was one of the simplest changes identified in an inventory of our `sendIO` usage.

The main target here is config-file loading, which I standardized a bit so that each file wasn't reading in the directory independently.  For that I introduced a function to load the config file with the current dir as the default, which most commands use.

Other than that there was some usage for finding the directory to run Syft.

## Acceptance criteria

- There are fewer usages of `getCurrentDir` in the codebase.
- Other places we get the current dir are updated to use `ReadFS`

## Testing plan

One change here is that we now always print the config file as debug information for all the commands, instead of just a few.  This made it easy to run various comnmands and make sure that it was working in the new common code path.

I also added unit tests for `analyze` and `test` config loading.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
