### PR TITLE
Don't leak API keys in Show instances

### DIFF
--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -86,7 +86,7 @@ data ApiOpts = ApiOpts
   deriving (Eq, Ord, Show)
 
 instance ToJSON ApiOpts where
-  toJSON ApiOpts {..} =
+  toJSON ApiOpts{..} =
     object
       [ "uri" .= show apiOptsUri
       , "apiKey" .= apiOptsApiKey


### PR DESCRIPTION
We should try really hard to NEVER print out the API key.