### PR TITLE
No discovery filters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.2.8
+
+- Filtering: add `--debug-no-discovery-exclusion` for client-side filter debugging. (#[901](https://github.com/fossas/fossa-cli/pull/901))
+
 ## v3.2.7
 
 - debug: Redact all known API keys from the debug bundle (#[897](https://github.com/fossas/fossa-cli/pull/897))

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -43,9 +43,10 @@ import App.Fossa.Config.Analyze (
   ExperimentalAnalyzeConfig,
   IATAssertion (IATAssertion),
   IncludeAll (IncludeAll),
+  NoDiscoveryExclusion (NoDiscoveryExclusion),
   ScanDestination (..),
   StandardAnalyzeConfig (severity),
-  UnpackArchives (UnpackArchives), NoDiscoveryExclusion (NoDiscoveryExclusion)
+  UnpackArchives (UnpackArchives),
  )
 import App.Fossa.Config.Analyze qualified as Config
 import App.Fossa.ManualDeps (analyzeFossaDepsFile)

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -250,7 +250,7 @@ cliParser =
     <*> flagOpt UnpackArchives (long "unpack-archives" <> help "Recursively unpack and analyze discovered archives")
     <*> flagOpt JsonOutput (long "json" <> help "Output project metadata as json to the console. Useful for communicating with the FOSSA API")
     <*> flagOpt IncludeAll (long "include-unused-deps" <> help "Include all deps found, instead of filtering non-production deps.  Ignored by VSI.")
-    <*> flagOpt NoDiscoveryExclusion (long "debug-no-discovery-exclusion" <> help "Ignore filters during discovery phase.  This is for debugging only and may be removed without warning.")
+    <*> flagOpt NoDiscoveryExclusion (long "debug-no-discovery-exclusion" <> help "Ignore filters during discovery phase.  This is for debugging only and may be removed without warning." <> hidden)
     -- Intentionally hidden until some critical bugs are addressed
     <*> flagOpt AllowNativeLicenseScan (long "experimental-native-license-scan" <> hidden)
     <*> optional (strOption (long "branch" <> short 'b' <> help "this repository's current branch (default: current VCS branch)"))

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -12,6 +12,7 @@ module App.Fossa.Config.Analyze (
   IncludeAll (..),
   JsonOutput (..),
   MonorepoAnalyzeConfig (..),
+  NoDiscoveryExclusion (..),
   ScanDestination (..),
   StandardAnalyzeConfig (..),
   UnpackArchives (..),
@@ -110,6 +111,7 @@ data AllowNativeLicenseScan = AllowNativeLicenseScan deriving (Generic)
 data BinaryDiscovery = BinaryDiscovery deriving (Generic)
 data IncludeAll = IncludeAll deriving (Generic)
 data JsonOutput = JsonOutput deriving (Generic)
+data NoDiscoveryExclusion = NoDiscoveryExclusion deriving (Generic)
 data UnpackArchives = UnpackArchives deriving (Generic)
 data VSIAnalysis = VSIAnalysis deriving (Generic)
 
@@ -123,6 +125,9 @@ instance ToJSON IncludeAll where
   toEncoding = genericToEncoding defaultOptions
 
 instance ToJSON JsonOutput where
+  toEncoding = genericToEncoding defaultOptions
+
+instance ToJSON NoDiscoveryExclusion where
   toEncoding = genericToEncoding defaultOptions
 
 instance ToJSON UnpackArchives where
@@ -155,6 +160,7 @@ data AnalyzeCliOpts = AnalyzeCliOpts
   , analyzeUnpackArchives :: Flag UnpackArchives
   , analyzeJsonOutput :: Flag JsonOutput
   , analyzeIncludeAllDeps :: Flag IncludeAll
+  , analyzeNoDiscoveryExclusion :: Flag NoDiscoveryExclusion
   , analyzeAllowNativeLicenseScan :: Flag AllowNativeLicenseScan
   , analyzeBranch :: Maybe Text
   , analyzeMetadata :: ProjectMetadata
@@ -214,6 +220,7 @@ data StandardAnalyzeConfig = StandardAnalyzeConfig
   , unpackArchives :: Flag UnpackArchives
   , jsonOutput :: Flag JsonOutput
   , includeAllDeps :: Flag IncludeAll
+  , noDiscoveryExclusion :: Flag NoDiscoveryExclusion
   , allowNativeLicenseScan :: Flag AllowNativeLicenseScan
   }
   deriving (Eq, Ord, Show, Generic)
@@ -243,6 +250,7 @@ cliParser =
     <*> flagOpt UnpackArchives (long "unpack-archives" <> help "Recursively unpack and analyze discovered archives")
     <*> flagOpt JsonOutput (long "json" <> help "Output project metadata as json to the console. Useful for communicating with the FOSSA API")
     <*> flagOpt IncludeAll (long "include-unused-deps" <> help "Include all deps found, instead of filtering non-production deps.  Ignored by VSI.")
+    <*> flagOpt NoDiscoveryExclusion (long "debug-no-discovery-exclusion" <> help "Ignore filters during discovery phase.  This is for debugging only and may be removed without warning.")
     -- Intentionally hidden until some critical bugs are addressed
     <*> flagOpt AllowNativeLicenseScan (long "experimental-native-license-scan" <> hidden)
     <*> optional (strOption (long "branch" <> short 'b' <> help "this repository's current branch (default: current VCS branch)"))
@@ -389,6 +397,7 @@ mergeStandardOpts maybeConfig envvars cliOpts@AnalyzeCliOpts{..} = do
     <*> pure analyzeUnpackArchives
     <*> pure analyzeJsonOutput
     <*> pure analyzeIncludeAllDeps
+    <*> pure analyzeNoDiscoveryExclusion
     <*> pure analyzeAllowNativeLicenseScan
 
 collectFilters ::


### PR DESCRIPTION
Turn off discovery filters for debug and unblocking purposes.

The flag has a `debug` prefix, and the help text warns against regular use of this flag.
