### PR TITLE
Discovery exclusion reads target filters wrong

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -96,7 +96,7 @@ data DiscoveredProjectType
   | SwiftProjectType
   | VsiProjectType
   | YarnProjectType
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Enum, Bounded)
 
 projectTypeToText :: DiscoveredProjectType -> Text
 projectTypeToText = \case

--- a/test/Discovery/FiltersSpec.hs
+++ b/test/Discovery/FiltersSpec.hs
@@ -29,7 +29,7 @@ import Test.Hspec (
   describe,
   expectationFailure,
   it,
-  shouldBe,
+  shouldBe, fdescribe
  )
 import Types (
   BuildTarget (..),
@@ -186,7 +186,7 @@ spec = do
         , (mvnQuux, ProjectWithoutTargets, Nothing)
         ]
 
-  describe "Matching primitives" $ do
+  fdescribe "Matching primitives" $ do
     describe "Tool-based matching" $ do
       it "should exclude tools correctly" $ do
         toolAllowed (excludeTool CargoProjectType) CargoProjectType `shouldBe` False

--- a/test/Discovery/FiltersSpec.hs
+++ b/test/Discovery/FiltersSpec.hs
@@ -213,6 +213,11 @@ spec = do
         -- Conflicting filters, members of exclude are NEVER allowed
         toolAllowed (includeTool CargoProjectType <> excludeTool CargoProjectType) CargoProjectType `shouldBe` False
 
+      it "should not exclude tools present only in project filters" $ do
+        let filters = excludeProject CargoProjectType $(mkRelDir "no-go") <> excludeTool GomodProjectType
+        toolAllowed filters CargoProjectType `shouldBe` True
+        toolAllowed filters GomodProjectType `shouldBe` False
+
     describe "Path-based matching" $ do
       it "should include paths correctly" $ do
         pathAllowed (includePath $(mkRelDir "hello")) $(mkRelDir "hello") `shouldBe` True
@@ -269,6 +274,9 @@ excludePath path = AllFilters mempty $ comboExclude mempty [path]
 
 excludeTool :: DiscoveredProjectType -> AllFilters
 excludeTool tool = AllFilters mempty $ comboExclude [TypeTarget $ toText tool] mempty
+
+excludeProject :: DiscoveredProjectType -> Path Rel Dir -> AllFilters
+excludeProject ty path = AllFilters mempty $ comboExclude [TypeDirTarget (toText ty) path] mempty
 
 includePath :: Path Rel Dir -> AllFilters
 includePath path = AllFilters include mempty

--- a/test/Discovery/FiltersSpec.hs
+++ b/test/Discovery/FiltersSpec.hs
@@ -29,7 +29,7 @@ import Test.Hspec (
   describe,
   expectationFailure,
   it,
-  shouldBe, fdescribe
+  shouldBe,
  )
 import Types (
   BuildTarget (..),
@@ -186,7 +186,7 @@ spec = do
         , (mvnQuux, ProjectWithoutTargets, Nothing)
         ]
 
-  fdescribe "Matching primitives" $ do
+  describe "Matching primitives" $ do
     describe "Tool-based matching" $ do
       it "should exclude tools correctly" $ do
         toolAllowed (excludeTool CargoProjectType) CargoProjectType `shouldBe` False


### PR DESCRIPTION
# Overview

When a user has 2 project of the same type, and explicitly excludes only one of them with `tool@path/`, discovery exclusion should not treat that tool as forbidden.  

See new unit test for a clearer example