### PR TITLE
Skip embedding files if FOSSA_SKIP_EMBED_FILE_IN_HLS env var is set

### DIFF
--- a/docs/contributing/HACKING.md
+++ b/docs/contributing/HACKING.md
@@ -89,6 +89,16 @@ In VSCode:
 
 If you installed HLS in the old, complicated way, you can safely remove it.  HLS now bundles all of its needed tools.
 
+You should also set the `FOSSA_SKIP_EMBED_FILE_IN_HLS` environment variable for HLS. This prevents HLS from embedding binaries, which helps to avoid a giant memory footprint for HLS.
+
+In VSCode, this is done by adding this to your `settings.json`:
+
+```json
+    "haskell.serverEnvironment": {
+        "FOSSA_SKIP_EMBED_FILE_IN_HLS": true,
+    },
+```
+
 ## Linting
 
 `hlint` is built into HLS, and is enabled by default. hlint suggestions appear as warnings in the editor.

--- a/src/Data/FileEmbed/Extra.hs
+++ b/src/Data/FileEmbed/Extra.hs
@@ -11,7 +11,7 @@ import Prelude
 
 embedFileIfExists :: FilePath -> Q Exp
 embedFileIfExists inputPath = do
-  skipEmbedEnvVar <- runIO $ lookupEnv "FOSSA_SKIP_EMBEDDED_FILES_IN_HLS"
+  skipEmbedEnvVar <- runIO $ lookupEnv "FOSSA_SKIP_EMBED_FILE_IN_HLS"
   case (skipEmbedEnvVar, parseRelFile inputPath) of
     (Just _, _) -> do
       pure (LitE $ StringL "")

--- a/src/Data/FileEmbed/Extra.hs
+++ b/src/Data/FileEmbed/Extra.hs
@@ -14,7 +14,7 @@ embedFileIfExists inputPath = do
   skipEmbedEnvVar <- runIO $ lookupEnv "FOSSA_SKIP_EMBEDDED_FILES_IN_HLS"
   case (skipEmbedEnvVar, parseRelFile inputPath) of
     (Just _, _) -> do
-      reportWarning $ "FOSSA_SKIP_EMBEDDED_FILES_IN_HLS Environment variable set. Not embedding " <> inputPath
+      -- If you put a warning in here, then you get linter warnings in EmbeddedBinary.hs
       pure (LitE $ StringL "")
     (_, Just path) -> do
       exists <- doesFileExist path

--- a/src/Data/FileEmbed/Extra.hs
+++ b/src/Data/FileEmbed/Extra.hs
@@ -14,7 +14,6 @@ embedFileIfExists inputPath = do
   skipEmbedEnvVar <- runIO $ lookupEnv "FOSSA_SKIP_EMBEDDED_FILES_IN_HLS"
   case (skipEmbedEnvVar, parseRelFile inputPath) of
     (Just _, _) -> do
-      -- If you put a warning in here, then you get linter warnings in EmbeddedBinary.hs
       pure (LitE $ StringL "")
     (_, Just path) -> do
       exists <- doesFileExist path

--- a/src/Data/FileEmbed/Extra.hs
+++ b/src/Data/FileEmbed/Extra.hs
@@ -3,11 +3,10 @@ module Data.FileEmbed.Extra (
 ) where
 
 import Data.FileEmbed (embedFile)
-import Language.Haskell.TH
-import Path
-import Path.IO
+import Language.Haskell.TH (Exp (LitE), Lit (StringL), Q, reportWarning, runIO)
+import Path (parseRelFile)
+import Path.IO (doesFileExist)
 import System.Environment (lookupEnv)
-import Prelude
 
 embedFileIfExists :: FilePath -> Q Exp
 embedFileIfExists inputPath = do


### PR DESCRIPTION
# Overview

HLS's memory usage blows up when it has to open `EmbeddedBinary.hs` or when you compile with a change to that file.

This PR gets rid of that problem by adding an environment variable that, if set, turns off embedding.

You use it by setting the environment variable when running HLS. This is documented in a change to `HACKING.md` in the PR.

## Acceptance criteria

* HLS's memory footprint should stay small, even when you open or change `EmbeddedBinary.hs`
* Nothing else should change

## Testing plan

I tested by making changes to `EmbeddedBinary.hs` with this change and with the environment variable set properly in VS Code. I think it works. HLS's memory usage always stayed below 2 GB, and without this change it can balloon up to > 15 GB.


## Risks


## References


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
