### PR TITLE
[ANE-208] Adds hidden license-scan sub command

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -173,6 +173,7 @@ library
     App.Fossa.Config.Container.Test
     App.Fossa.Config.DumpBinaries
     App.Fossa.Config.EnvironmentVars
+    App.Fossa.Config.LicenseScan
     App.Fossa.Config.LinkUserBinaries
     App.Fossa.Config.ListTargets
     App.Fossa.Config.Report
@@ -183,6 +184,7 @@ library
     App.Fossa.Container.Test
     App.Fossa.DumpBinaries
     App.Fossa.EmbeddedBinary
+    App.Fossa.LicenseScan
     App.Fossa.LicenseScanner
     App.Fossa.ListTargets
     App.Fossa.Main

--- a/src/App/Fossa/Config/LicenseScan.hs
+++ b/src/App/Fossa/Config/LicenseScan.hs
@@ -1,0 +1,45 @@
+module App.Fossa.Config.LicenseScan (
+  mkSubCommand,
+  LicenseScanConfig (..),
+  LicenseScanOpts,
+) where
+
+import App.Fossa.Config.Common (baseDirArg, validateDir)
+import App.Fossa.Subcommand (EffStack, GetCommonOpts, GetSeverity, SubCommand (SubCommand))
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Has, Lift)
+import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
+import Effect.ReadFS (ReadFS)
+import GHC.Generics (Generic)
+import Options.Applicative (InfoMod, progDesc)
+import Path (Abs, Dir, Path)
+
+licenseScanInfo :: InfoMod a
+licenseScanInfo = progDesc "Runs license-scanner against a specified path"
+
+mkSubCommand :: (LicenseScanConfig -> EffStack ()) -> SubCommand LicenseScanOpts LicenseScanConfig
+mkSubCommand = SubCommand "license-scan" licenseScanInfo cliParser noLoadConfig mergeOpts
+  where
+    cliParser = LicenseScanOpts <$> baseDirArg
+    noLoadConfig = const $ pure Nothing
+
+newtype LicenseScanOpts = LicenseScanOpts FilePath
+
+instance GetSeverity LicenseScanOpts
+instance GetCommonOpts LicenseScanOpts
+
+newtype LicenseScanConfig = LicenseScanConfig (Path Abs Dir) deriving (Show, Generic)
+
+instance ToJSON LicenseScanConfig where
+  toEncoding = genericToEncoding defaultOptions
+
+mergeOpts ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has ReadFS sig m
+  ) =>
+  a ->
+  b ->
+  LicenseScanOpts ->
+  m LicenseScanConfig
+mergeOpts _ _ (LicenseScanOpts path) = LicenseScanConfig <$> validateDir path

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -1,0 +1,30 @@
+module App.Fossa.LicenseScan (
+  licenseScanSubCommand,
+) where
+
+import App.Fossa.Config.LicenseScan (
+  LicenseScanConfig (..),
+  LicenseScanOpts,
+  mkSubCommand,
+ )
+import App.Fossa.EmbeddedBinary (withThemisAndIndex)
+import App.Fossa.RunThemis (execRawThemis)
+import App.Fossa.Subcommand (SubCommand)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Has, Lift)
+import Data.String.Conversion (decodeUtf8)
+import Effect.Exec (Exec)
+import Effect.Logger (Logger, logStdout)
+
+licenseScanSubCommand :: SubCommand LicenseScanOpts LicenseScanConfig
+licenseScanSubCommand = mkSubCommand licenseScanMain
+
+licenseScanMain ::
+  ( Has (Lift IO) sig m
+  , Has Exec sig m
+  , Has Diagnostics sig m
+  , Has Logger sig m
+  ) =>
+  LicenseScanConfig ->
+  m ()
+licenseScanMain (LicenseScanConfig dir) = logStdout . decodeUtf8 =<< withThemisAndIndex (`execRawThemis` dir)

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -6,6 +6,7 @@ import App.Fossa.Analyze qualified as Analyze
 import App.Fossa.Analyze.Log4jReport qualified as Log4j
 import App.Fossa.Container qualified as Container
 import App.Fossa.DumpBinaries qualified as Dump
+import App.Fossa.LicenseScan qualified as LicenseScan (licenseScanSubCommand)
 import App.Fossa.ListTargets qualified as ListTargets
 import App.Fossa.Report qualified as Report
 import App.Fossa.Subcommand (GetCommonOpts, GetSeverity, SubCommand (..), runSubCommand)
@@ -69,6 +70,7 @@ subcommands = public <|> private
           , initCommand
           , decodeSubCommand Dump.dumpSubCommand
           , decodeSubCommand Log4j.log4jSubCommand
+          , decodeSubCommand LicenseScan.licenseScanSubCommand
           ]
     public =
       hsubparser $

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -2,6 +2,7 @@
 
 module App.Fossa.RunThemis (
   execThemis,
+  execRawThemis,
 ) where
 
 import App.Fossa.EmbeddedBinary (
@@ -11,6 +12,7 @@ import App.Fossa.EmbeddedBinary (
   toPath,
  )
 import Control.Effect.Diagnostics (Diagnostics, Has)
+import Data.ByteString.Lazy qualified as BL
 import Data.String.Conversion (toText)
 import Data.Tagged (Tagged, unTag)
 import Data.Text (Text)
@@ -19,9 +21,13 @@ import Effect.Exec (
   Command (..),
   Exec,
   execJson,
+  execThrow,
  )
 import Path (Abs, Dir, Path, parent)
 import Srclib.Types (LicenseUnit)
+
+execRawThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> m BL.ByteString
+execRawThemis themisBins scanDir = execThrow scanDir $ themisCommand themisBins
 
 -- TODO: We should log the themis version and index version
 execThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> m [LicenseUnit]


### PR DESCRIPTION
# Overview

This PR adds the following hidden subcommand, which will log stdout of raw themis scan.

```
fossa license-scan <path>
```

This is so post-sales, and on-duty engineers can quickly diagnose issues related to unlicensed dependency and license scanning. I wanted to get this small change in so, I can wrap up my guide to triaging analysis doc. 

## Out of Scope

- themis uses `--debug` flag
- also output stderr from themis scanner

## Acceptance criteria

- sub command `license-scan` is hidden
- executing `fossa license-scan <path>`, runs themis against <path>

## Testing plan

0. `bash vendor_download.sh`
1. `make install-dev`
2. `fossa-dev license-scan docs` (you should see raw themis output)

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-208
