### PR TITLE
Don't skip non-included paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## v3.2.8
 
+- Filtering: Don't use included paths for discovery exclusion. ([#907](https://github.com/fossas/fossa-cli/pull/907))
 - Filtering: add `--debug-no-discovery-exclusion` for client-side filter debugging. (#[901](https://github.com/fossas/fossa-cli/pull/901))
 
 ## v3.2.7

--- a/src/Discovery/Filters.hs
+++ b/src/Discovery/Filters.hs
@@ -143,6 +143,8 @@ extractPureTool = \case
 -- During discovery, we cannot use Include filters to reject invalid paths.
 -- Given @include "a/b" && "a/c"@, we will probably try to skip both of them.
 -- Instead, we only skip over Exclude filters.
+-- TODO: we may be able to only allow paths which are proper prefixes of included dirs,
+-- however, this is the safer path.
 pathAllowed :: AllFilters -> Path Rel Dir -> Bool
 pathAllowed AllFilters{..} path = not . any (matchPath path) $ combinedPaths excludeFilters
   where

--- a/test/Discovery/FiltersSpec.hs
+++ b/test/Discovery/FiltersSpec.hs
@@ -221,7 +221,8 @@ spec = do
     describe "Path-based matching" $ do
       it "should include paths correctly" $ do
         pathAllowed (includePath $(mkRelDir "hello")) $(mkRelDir "hello") `shouldBe` True
-        pathAllowed (includePath $(mkRelDir "NOPE")) $(mkRelDir "Yeah") `shouldBe` False
+        -- We never skip non-included paths during discovery, we only skip excluded paths.
+        pathAllowed (includePath $(mkRelDir "NOPE")) $(mkRelDir "Yeah") `shouldBe` True
 
       it "should exclude paths correctly" $ do
         pathAllowed (excludePath $(mkRelDir "Nope")) $(mkRelDir "No") `shouldBe` True


### PR DESCRIPTION
# Overview

Given filters of the shape `include a/b && include a/c`, we would try to skip BOTH directories, because the parent directories wouldn't match the only existing filters.

To fix this, we no longer use `include` paths to do discovery exclusion.  Later, we may be able to limit discovery to paths that are proper prefixes of at least one include filter (if and only if any include filters exist), but for now we just need to fix the bug.

## Acceptance criteria

`--only-path` or `paths.only` does not exclude paths from discovery.

## Testing plan

Given the following folder structure, run `fossa analyze -o /path/to --only-path test-arena/testpy1 --only-path test-arena/testpy2 > /dev/null`.  The scan summary should show that both setuptools projects were found and successfully scanned (there will be warnings, but that's normal for setuptools).

```
/path/to
└── test-arena
    ├── testpy1
    │   └── requirements.txt
    └── testpy2
        └── requirements.txt
```

## Risks

None, this postpones the risky change for later.

## References

https://fossa.zendesk.com/agent/tickets/4194

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
