### PR TITLE
Cabal build all

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.2.10
+
+- Haskell: Generate build plan properly for multi-home Cabal projects (h/t [@jmickelin](https://github.com/jmickelin))
+
 ## v3.2.9
 
 - Container Scanning: supports rpm databases using `ndb` or `sqlite` backend. ([#894](https://github.com/fossas/fossa-cli/pull/894))

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## v3.2.10
 
-- Haskell: Generate build plan properly for multi-home Cabal projects (h/t [@jmickelin](https://github.com/jmickelin))
+- Haskell: Generate build plan properly for multi-home Cabal projects (h/t [@jmickelin](https://github.com/jmickelin)) ([#910](https://github.com/fossas/fossa-cli/pull/910))
 
 ## v3.2.9
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## v3.2.10
 
-- Haskell: Generate build plan properly for multi-home Cabal projects (h/t [@jmickelin](https://github.com/jmickelin)) ([#910](https://github.com/fossas/fossa-cli/pull/910))
+- Haskell: Generates build plan properly for multi-home Cabal projects (h/t [@jmickelin](https://github.com/jmickelin)) ([#910](https://github.com/fossas/fossa-cli/pull/910))
 
 ## v3.2.9
 

--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -145,7 +145,7 @@ cabalGenPlanCmd :: Command
 cabalGenPlanCmd =
   Command
     { cmdName = "cabal"
-    , cmdArgs = ["v2-build", "--dry-run"]
+    , cmdArgs = ["v2-build", "all", "--dry-run"]
     , cmdAllowErr = Never
     }
 


### PR DESCRIPTION
# Overview

Modifies the command for generating the `plan.json` file for `Cabal` projects to use the target `all`. 
Running `v2-build` without a target, as was done previously, only works for projects that have a package in their top-level directory. Using target `all` should work for all projects and behave identically as before for projects with a top-level package.

## Acceptance criteria

`fossa analyze` should now work for both simple project layouts (a directory with a top-level `.cabal` file with a single target) and more complex ones (multiple packages, with no "top-level" package).

## Testing plan

Tested against `fossa-cli`:
```shell
; git checkout master
; cabal run fossa -v0 -- analyze -o | jq > master.json
; git checkout cabal-build-all
; cabal run fossa -v0 -- analyze -o | jq > cabal-build-all.json
; diff master.json cabal-build-all.json
; echo $?
0
```

Tested against https://github.com/jmickelin/multi-home-cabal-example:
```shell
; fossa -V
fossa-cli version 3.2.9 (revision 2e79a284caee compiled with ghc-8.10)
; fossa analyze ~/projects/multi-home-cabal-example -o
[ INFO] Analyzing cabal project at /Users/kit/projects/multi-home-cabal-example/
[ERROR] ----------
  An issue occurred

  >>> Details

    We could not dry run cabal build for dependency analysis.

  >>> Relevant errors

    Error

      Command execution failed:
          command: Command {cmdName = "cabal", cmdArgs = ["v2-build","--dry-run"], cmdAllowErr = Never}
          dir: /Users/kit/projects/multi-home-cabal-example/
          exit: ExitFailure 1
          stdout:

          stderr:
            Cloning into '/Users/kit/projects/multi-home-cabal-example/dist-newstyle/src/hedgehog-_-98a7a40dab91621e'...
            HEAD is now at 9d79ccf Update Char.json
            cabal: No targets given and there is no package in the current directory. Use
            the target 'all' for all packages in the project or specify packages or
            components by name or location. See 'cabal build --help' for more details on
            target options.


      If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com/hc/en-us

      Traceback:
        - Running command 'cabal'
        - Dynamic analysis
        - Cabal
        - Project Analysis

; cabal run fossa -v0 -- analyze ~/projects/multi-home-cabal-example -o | jq
# status messages elided...
[ INFO] Scan Summary
[ INFO] ------------
[ INFO] fossa-cli branch cabal-build-all (revision d96d2baca618 (dirty) compiled with ghc-8.10)
[ INFO]
[ INFO] 1 projects scanned;  0 skipped,  1 succeeded,  0 failed,  0 analysis warnings
[ INFO]
[ INFO] * cabal project in "/Users/kit/projects/multi-home-cabal-example/": succeeded
# json output elided, but it looked correct
```

## Risks

This doesn't seem super risky; it looks like we just would now properly support more complex projects.

## References

Originally PR'd by @jmickelin in https://github.com/fossas/fossa-cli/pull/909.

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
