### PR TITLE
Runs integration test daily

### DIFF
--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -59,4 +59,4 @@ jobs:
 
     - name: Run all integration tests
       run: |
-        cabal test --project-file=cabal.project.ci.linux integration-tests --test-show-details=direct --test-option=--times --test-option=--match --test-option="absinthe"
+        cabal test --project-file=cabal.project.ci.linux integration-tests --test-show-details=direct --test-option=--times

--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -5,7 +5,7 @@ name: Integration Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 8 * * *" # At 08:00 on every day. 
+    - cron: "0 5 * * *" # At 05:00 on every day. 
 
 jobs:
   integration-test:
@@ -20,7 +20,7 @@ jobs:
         apk add bash xz-dev bzip2-dev bzip2-static upx curl jq
 
     - uses: actions/checkout@v3
-    - name: Ensures git ownership check does not lead to compile error
+    - name: Ensures git ownership check does not lead to compile error (we run git during compile for version tagging, etc.)
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - uses: cachix/install-nix-action@v17
@@ -59,4 +59,4 @@ jobs:
 
     - name: Run all integration tests
       run: |
-        cabal test --project-file=cabal.project.ci.linux integration-tests --test-show-details=direct --test-option=--times
+        cabal test --project-file=cabal.project.ci.linux integration-tests --test-show-details=direct --test-option=--times --test-option=--match --test-option="absinthe"

--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -4,6 +4,8 @@ name: Integration Tests
 # Refer to https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_dispatch
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *" # At 08:00 on every day. 
 
 jobs:
   integration-test:
@@ -12,12 +14,14 @@ jobs:
     container: fossa/haskell-static-alpine:ghc-9.0.2
 
     steps:
-    - uses: actions/checkout@v2
-
     - name: Install alpine binary dependencies
       shell: sh
       run: |
         apk add bash xz-dev bzip2-dev bzip2-static upx curl jq
+
+    - uses: actions/checkout@v3
+    - name: Ensures git ownership check does not lead to compile error
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - uses: cachix/install-nix-action@v17
       with:

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,10 @@ build:
 test:
 	cabal test unit-tests --test-show-details=streaming --test-option=--format=checks --test-option=--times --test-option=--color
 
-# Runs a integeration test.
-# To run a set of integeration spec matching specific value, use ARGS
-# 	Example: make integeration-test-for ARGS="fd"
+# Runs an integration test.
+# To run a set of integration tests matching a specific value, use ARGS
+# For example, to only run tests whose name matches the wildcard '*fd*':
+# 	make integration-test ARGS="fd"
 integeration-test:
 ifdef ARGS
 	cabal test integration-tests --test-show-details=streaming --test-option=--format=checks --test-option=--match --test-option="$(ARGS)"

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,16 @@ build:
 test:
 	cabal test unit-tests --test-show-details=streaming --test-option=--format=checks --test-option=--times --test-option=--color
 
-integration-test:
-	cabal test integration-tests --test-show-details=streaming --test-option=--format=checks --test-option=--times --test-option=--color
-
+# Runs a integeration test.
+# To run a set of integeration spec matching specific value, use ARGS
+# 	Example: make integeration-test-for ARGS="fd"
+integeration-test:
+ifdef ARGS
+	cabal test integration-tests --test-show-details=streaming --test-option=--format=checks --test-option=--match --test-option="$(ARGS)"
+else
+	cabal test integration-tests --test-show-details=streaming --test-option=--format=checks
+endif
+	
 test-all:
 	cabal test
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test:
 # To run a set of integration tests matching a specific value, use ARGS
 # For example, to only run tests whose name matches the wildcard '*fd*':
 # 	make integration-test ARGS="fd"
-integeration-test:
+integration-test:
 ifdef ARGS
 	cabal test integration-tests --test-show-details=streaming --test-option=--format=checks --test-option=--match --test-option="$(ARGS)"
 else

--- a/integration-test/Analysis/ElixirSpec.hs
+++ b/integration-test/Analysis/ElixirSpec.hs
@@ -12,7 +12,7 @@ import Test.Hspec
 import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 elixirEnv :: FixtureEnvironment
-elixirEnv = NixEnv ["elixir"]
+elixirEnv = NixEnv ["elixir", "rebar3"]
 
 mixBuildProjectCmd :: Command
 mixBuildProjectCmd = Command "mix" ["local.hex", "--force", "--if-missing", "&&", "mix deps.get", "&&", "mix deps.compile"] Never

--- a/integration-test/Analysis/ElixirSpec.hs
+++ b/integration-test/Analysis/ElixirSpec.hs
@@ -15,7 +15,18 @@ elixirEnv :: FixtureEnvironment
 elixirEnv = NixEnv ["elixir"]
 
 mixBuildProjectCmd :: Command
-mixBuildProjectCmd = Command "mix" ["local.hex --force --if-missing", "&&", "mix local.rebar --force", "&&", "mix deps.get", "&&", "mix deps.compile"] Never
+mixBuildProjectCmd =
+  Command
+    "mix"
+    [ "local.hex --force --if-missing" -- install hex package manager
+    , "&&"
+    , "mix local.rebar --force" -- project requires rebar3
+    , "&&"
+    , "mix deps.get"
+    , "&&"
+    , "mix deps.compile"
+    ]
+    Never
 
 absinthe :: AnalysisTestFixture (Mix.MixProject)
 absinthe =

--- a/integration-test/Analysis/ElixirSpec.hs
+++ b/integration-test/Analysis/ElixirSpec.hs
@@ -15,7 +15,7 @@ elixirEnv :: FixtureEnvironment
 elixirEnv = NixEnv ["elixir"]
 
 mixBuildProjectCmd :: Command
-mixBuildProjectCmd = Command "mix" ["deps.get", "&&", "mix deps.compile"] Never
+mixBuildProjectCmd = Command "mix" ["local.hex", "--force", "--if-missing", "&&", "mix deps.get", "&&", "mix deps.compile"] Never
 
 absinthe :: AnalysisTestFixture (Mix.MixProject)
 absinthe =

--- a/integration-test/Analysis/ElixirSpec.hs
+++ b/integration-test/Analysis/ElixirSpec.hs
@@ -12,10 +12,10 @@ import Test.Hspec
 import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 elixirEnv :: FixtureEnvironment
-elixirEnv = NixEnv ["elixir", "rebar3"]
+elixirEnv = NixEnv ["elixir"]
 
 mixBuildProjectCmd :: Command
-mixBuildProjectCmd = Command "mix" ["local.hex", "--force", "--if-missing", "&&", "mix deps.get", "&&", "mix deps.compile"] Never
+mixBuildProjectCmd = Command "mix" ["local.hex --force --if-missing", "&&", "mix local.rebar --force", "&&", "mix deps.get", "&&", "mix deps.compile"] Never
 
 absinthe :: AnalysisTestFixture (Mix.MixProject)
 absinthe =

--- a/integration-test/Analysis/FixtureUtils.hs
+++ b/integration-test/Analysis/FixtureUtils.hs
@@ -43,7 +43,7 @@ import Effect.Exec (
   exec,
   runExecIO,
  )
-import Effect.Logger (LoggerC, Severity (SevDebug), withDefaultLogger)
+import Effect.Logger (LoggerC, Severity (SevWarn), withDefaultLogger)
 import Effect.ReadFS (ReadFSIOC, runReadFSIO)
 import Network.HTTP.Req (
   GET (GET),
@@ -109,7 +109,7 @@ testRunnerWithLogger f env =
     & runExecIOWithinEnv env
     & runReadFSIO
     & runDiagnostics
-    & withDefaultLogger SevDebug
+    & withDefaultLogger SevWarn
     & runReader mempty
     & runReader (ExperimentalAnalyzeConfig Nothing)
     & runFinally

--- a/integration-test/Analysis/RustSpec.hs
+++ b/integration-test/Analysis/RustSpec.hs
@@ -39,5 +39,5 @@ fd =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary bat CargoProjectType (DependencyResultsSummary 146 29 269 1 Complete)
-  testSuiteDepResultSummary fd CargoProjectType (DependencyResultsSummary 71 25 137 1 Complete)
+  testSuiteDepResultSummary bat CargoProjectType (DependencyResultsSummary 146 29 270 1 Complete)
+  testSuiteDepResultSummary fd CargoProjectType (DependencyResultsSummary 73 25 142 1 Complete)

--- a/integration-test/Analysis/RustSpec.hs
+++ b/integration-test/Analysis/RustSpec.hs
@@ -40,4 +40,4 @@ fd =
 spec :: Spec
 spec = do
   testSuiteDepResultSummary bat CargoProjectType (DependencyResultsSummary 146 29 270 1 Complete)
-  testSuiteDepResultSummary fd CargoProjectType (DependencyResultsSummary 73 25 142 1 Complete)
+  testSuiteDepResultSummary fd CargoProjectType (DependencyResultsSummary 74 25 145 1 Complete)


### PR DESCRIPTION
# Overview

This PR, 
- Fixes broken integration tests. 
- Runs CI integration test on week

From our discussion, we wanted to start running this daily at the start, instead of every push (if I'm remembering correctly). 

## Acceptance criteria

- CI integration tests are run on a daily cadence
- CI integration test pass

## Testing plan

You can manually run this workflow, by
1. Going to Actions
2. Selecting 'Integration Test' and dispatching workflow on this branch. 

Here is the CI run: https://github.com/fossas/fossa-cli/actions/runs/2204419218

## Risks

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
