### PR TITLE
[ANE-82]: Native license scan output

### DIFF
--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -21,7 +21,11 @@ import Effect.Exec (runExecIO)
 import Effect.ReadFS (runReadFSIO)
 import Path (reldir, (</>))
 import Path.IO qualified as PIO
-import Srclib.Types (LicenseUnit (licenseUnitFiles, licenseUnitName), emptyLicenseUnit, LicenseSourceUnit (licenseSourceUnitLicenseUnits))
+import Srclib.Types (
+  LicenseSourceUnit (licenseSourceUnitLicenseUnits),
+  LicenseUnit (licenseUnitFiles, licenseUnitName),
+  emptyLicenseUnit,
+ )
 import Test.Hspec (Spec, it, shouldBe)
 
 recursiveArchive :: FixtureArtifact

--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -21,7 +21,7 @@ import Effect.Exec (runExecIO)
 import Effect.ReadFS (runReadFSIO)
 import Path (reldir, (</>))
 import Path.IO qualified as PIO
-import Srclib.Types (LicenseUnit (licenseUnitFiles, licenseUnitName), emptyLicenseUnit)
+import Srclib.Types (LicenseUnit (licenseUnitFiles, licenseUnitName), emptyLicenseUnit, LicenseSourceUnit (licenseSourceUnitLicenseUnits))
 import Test.Hspec (Spec, it, shouldBe)
 
 recursiveArchive :: FixtureArtifact
@@ -61,7 +61,7 @@ spec = do
   it "should find licenses in nested archives" $ do
     extractedDir <- getArtifact recursiveArchive
     let scanDir = extractedDir </> [reldir|cli-license-scan-integration-test-fixtures-main/recursive-archive|]
-    units <- runStack $ runDiagnostics $ ignoreStickyLogger $ runExecIO $ runReadFSIO $ scanVendoredDep scanDir vendoredDep
+    units <- runStack . runDiagnostics . ignoreStickyLogger . runExecIO . runReadFSIO . fmap licenseSourceUnitLicenseUnits $ scanVendoredDep scanDir vendoredDep
     PIO.removeDirRecur extractedDir
     case units of
       Failure ws eg -> fail (show (renderFailure ws eg "An issue occurred"))

--- a/src/App/Fossa/Config/LicenseScan.hs
+++ b/src/App/Fossa/Config/LicenseScan.hs
@@ -74,5 +74,5 @@ cliParser = public <|> private
       command
         "direct"
         ( info (DirectScan <$> baseDirArg) $
-            progDesc "Run a license scan directly only the provided path."
+            progDesc "Run a license scan directly on the provided path."
         )

--- a/src/App/Fossa/Config/LicenseScan.hs
+++ b/src/App/Fossa/Config/LicenseScan.hs
@@ -1,34 +1,48 @@
 module App.Fossa.Config.LicenseScan (
   mkSubCommand,
   LicenseScanConfig (..),
-  LicenseScanOpts,
+  LicenseScanCommand,
 ) where
 
-import App.Fossa.Config.Common (baseDirArg, validateDir)
+import App.Fossa.Config.Common (baseDirArg, collectBaseDir)
 import App.Fossa.Subcommand (EffStack, GetCommonOpts, GetSeverity, SubCommand (SubCommand))
+import App.Types (BaseDir)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Has, Lift)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Options.Applicative (InfoMod, progDesc)
-import Path (Abs, Dir, Path)
+import Options.Applicative (
+  Alternative ((<|>)),
+  InfoMod,
+  Parser,
+  command,
+  hsubparser,
+  info,
+  internal,
+  progDesc,
+  subparser,
+ )
 
 licenseScanInfo :: InfoMod a
-licenseScanInfo = progDesc "Runs license-scanner against a specified path"
+licenseScanInfo = progDesc "Experimental utilities for native license-scanning"
 
-mkSubCommand :: (LicenseScanConfig -> EffStack ()) -> SubCommand LicenseScanOpts LicenseScanConfig
-mkSubCommand = SubCommand "license-scan" licenseScanInfo cliParser noLoadConfig mergeOpts
+mkSubCommand :: (LicenseScanConfig -> EffStack ()) -> SubCommand LicenseScanCommand LicenseScanConfig
+mkSubCommand = SubCommand "experimental-license-scan" licenseScanInfo cliParser noLoadConfig mergeOpts
   where
-    cliParser = LicenseScanOpts <$> baseDirArg
     noLoadConfig = const $ pure Nothing
 
-newtype LicenseScanOpts = LicenseScanOpts FilePath
+data LicenseScanCommand
+  = FossaDeps FilePath
+  | DirectScan FilePath
 
-instance GetSeverity LicenseScanOpts
-instance GetCommonOpts LicenseScanOpts
+instance GetSeverity LicenseScanCommand
+instance GetCommonOpts LicenseScanCommand
 
-newtype LicenseScanConfig = LicenseScanConfig (Path Abs Dir) deriving (Show, Generic)
+data LicenseScanConfig
+  = VendoredDepsOutput BaseDir
+  | RawPathScan BaseDir
+  deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON LicenseScanConfig where
   toEncoding = genericToEncoding defaultOptions
@@ -40,6 +54,25 @@ mergeOpts ::
   ) =>
   a ->
   b ->
-  LicenseScanOpts ->
+  LicenseScanCommand ->
   m LicenseScanConfig
-mergeOpts _ _ (LicenseScanOpts path) = LicenseScanConfig <$> validateDir path
+mergeOpts _ _ (DirectScan path) = RawPathScan <$> collectBaseDir path
+mergeOpts _ _ (FossaDeps path) = VendoredDepsOutput <$> collectBaseDir path
+
+cliParser :: Parser LicenseScanCommand
+cliParser = public <|> private
+  where
+    public = hsubparser fossaDepsCommand
+    private = subparser $ internal <> directScanCommand
+    fossaDepsCommand =
+      command
+        "fossa-deps"
+        ( info (FossaDeps <$> baseDirArg) $
+            progDesc "Like `fossa analyze --output`, but only for native scanning of vendored-dependencies."
+        )
+    directScanCommand =
+      command
+        "direct"
+        ( info (DirectScan <$> baseDirArg) $
+            progDesc "Run a license scan directly only the provided path."
+        )

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -3,28 +3,104 @@ module App.Fossa.LicenseScan (
 ) where
 
 import App.Fossa.Config.LicenseScan (
+  LicenseScanCommand,
   LicenseScanConfig (..),
-  LicenseScanOpts,
   mkSubCommand,
  )
 import App.Fossa.EmbeddedBinary (withThemisAndIndex)
+import App.Fossa.LicenseScanner (dedupVendoredDeps, scanVendoredDep)
+import App.Fossa.ManualDeps (
+  ManualDependencies (vendoredDependencies),
+  VendoredDependency (vendoredPath),
+  findFossaDepsFile,
+  readFoundDeps,
+ )
 import App.Fossa.RunThemis (execRawThemis)
 import App.Fossa.Subcommand (SubCommand)
-import Control.Effect.Diagnostics (Diagnostics)
-import Control.Effect.Lift (Has, Lift)
+import App.Types (BaseDir (BaseDir))
+import Control.Carrier.StickyLogger (
+  Has,
+  StickyLogger,
+  runStickyLogger,
+ )
+import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic, fromMaybe)
+import Control.Effect.Lift (Lift)
+import Data.Aeson (KeyValue ((.=)), ToJSON (toJSON), object)
+import Data.Aeson qualified as Aeson
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
 import Data.String.Conversion (decodeUtf8)
+import Data.Traversable (for)
+import Diag.Diagnostic (ToDiagnostic (renderDiagnostic))
 import Effect.Exec (Exec)
-import Effect.Logger (Logger, logStdout)
+import Effect.Logger (Logger, Severity (SevInfo), logStdout)
+import Effect.ReadFS (ReadFS)
+import Path (Abs, Dir, Path)
+import Prettyprinter (vsep)
+import Srclib.Types (LicenseScanType (CliLicenseScanned), LicenseSourceUnit (LicenseSourceUnit))
 
-licenseScanSubCommand :: SubCommand LicenseScanOpts LicenseScanConfig
+data MissingFossaDepsFile = MissingFossaDepsFile
+data NoVendoredDeps = NoVendoredDeps
+
+instance ToDiagnostic MissingFossaDepsFile where
+  renderDiagnostic _ =
+    vsep
+      [ "'fossa experimental-license-scan fossa-deps' requires pointing to a directory with a fossa-deps file."
+      , "The file can have one of the extensions: .yaml .yml .json"
+      ]
+
+instance ToDiagnostic NoVendoredDeps where
+  renderDiagnostic _ = "The 'vendored-dependencies' section of the fossa deps file is empty or missing."
+
+newtype UploadUnits = UploadUnits (NonEmpty LicenseSourceUnit)
+
+instance ToJSON UploadUnits where
+  toJSON (UploadUnits units) = object ["uploadUnits" .= units]
+
+licenseScanSubCommand :: SubCommand LicenseScanCommand LicenseScanConfig
 licenseScanSubCommand = mkSubCommand licenseScanMain
 
 licenseScanMain ::
   ( Has (Lift IO) sig m
   , Has Exec sig m
   , Has Diagnostics sig m
+  , Has ReadFS sig m
   , Has Logger sig m
   ) =>
   LicenseScanConfig ->
   m ()
-licenseScanMain (LicenseScanConfig dir) = logStdout . decodeUtf8 =<< withThemisAndIndex (`execRawThemis` dir)
+licenseScanMain = \case
+  RawPathScan (BaseDir dir) -> logStdout . decodeUtf8 =<< withThemisAndIndex (`execRawThemis` dir)
+  VendoredDepsOutput basedir -> outputVendoredDeps basedir
+
+outputVendoredDeps ::
+  ( Has Diagnostics sig m
+  , Has ReadFS sig m
+  , Has Logger sig m
+  , Has (Lift IO) sig m
+  , Has Exec sig m
+  ) =>
+  BaseDir ->
+  m ()
+outputVendoredDeps (BaseDir dir) = runStickyLogger SevInfo $ do
+  manualDepsFile <- fromMaybe MissingFossaDepsFile =<< findFossaDepsFile dir
+  manualDeps <- readFoundDeps manualDepsFile
+  vendoredDeps <- fromMaybe NoVendoredDeps $ NE.nonEmpty $ vendoredDependencies manualDeps
+  resultMap <- UploadUnits <$> runLicenseScan dir vendoredDeps
+  logStdout . decodeUtf8 $ Aeson.encode resultMap
+
+runLicenseScan ::
+  ( Has Diagnostics sig m
+  , Has ReadFS sig m
+  , Has StickyLogger sig m
+  , Has (Lift IO) sig m
+  , Has Exec sig m
+  ) =>
+  Path Abs Dir ->
+  NonEmpty VendoredDependency ->
+  m (NonEmpty LicenseSourceUnit)
+runLicenseScan basedir vdeps = do
+  uniqDeps <- dedupVendoredDeps vdeps
+  for uniqDeps $ \dep ->
+    LicenseSourceUnit (vendoredPath dep) CliLicenseScanned
+      <$> scanVendoredDep basedir dep

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -11,7 +11,7 @@ import App.Fossa.EmbeddedBinary (withThemisAndIndex)
 import App.Fossa.LicenseScanner (dedupVendoredDeps, scanVendoredDep)
 import App.Fossa.ManualDeps (
   ManualDependencies (vendoredDependencies),
-  VendoredDependency (vendoredPath),
+  VendoredDependency,
   findFossaDepsFile,
   readFoundDeps,
  )
@@ -30,14 +30,13 @@ import Data.Aeson qualified as Aeson
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.String.Conversion (decodeUtf8)
-import Data.Traversable (for)
 import Diag.Diagnostic (ToDiagnostic (renderDiagnostic))
 import Effect.Exec (Exec)
 import Effect.Logger (Logger, Severity (SevInfo), logStdout)
 import Effect.ReadFS (ReadFS)
 import Path (Abs, Dir, Path)
 import Prettyprinter (vsep)
-import Srclib.Types (LicenseScanType (CliLicenseScanned), LicenseSourceUnit (LicenseSourceUnit))
+import Srclib.Types (LicenseSourceUnit)
 
 data MissingFossaDepsFile = MissingFossaDepsFile
 data NoVendoredDeps = NoVendoredDeps
@@ -99,8 +98,4 @@ runLicenseScan ::
   Path Abs Dir ->
   NonEmpty VendoredDependency ->
   m (NonEmpty LicenseSourceUnit)
-runLicenseScan basedir vdeps = do
-  uniqDeps <- dedupVendoredDeps vdeps
-  for uniqDeps $ \dep ->
-    LicenseSourceUnit (vendoredPath dep) CliLicenseScanned
-      <$> scanVendoredDep basedir dep
+runLicenseScan basedir vdeps = dedupVendoredDeps vdeps >>= traverse (scanVendoredDep basedir)

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -200,7 +200,7 @@ scanVendoredDep baseDir VendoredDependency{..} = context "Scanning vendored deps
     SomeFile (Rel path) -> scanArchive baseDir . ScannableArchive $ baseDir </> path
     SomeDir (Abs path) -> scanDirectory Nothing (getPathPrefix baseDir path) path
     SomeDir (Rel path) -> scanDirectory Nothing (toText path) (baseDir </> path)
-  pure $ LicenseSourceUnit vendoredPath CliLicenseScanned  licenseUnits
+  pure $ LicenseSourceUnit vendoredPath CliLicenseScanned licenseUnits
 
 getPathPrefix :: Path Abs Dir -> Path Abs t -> Text
 getPathPrefix baseDir scanPath = do

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -192,7 +192,7 @@ scanVendoredDep ::
   ) =>
   Path Abs Dir ->
   VendoredDependency ->
-  m LicenseSourceUnit 
+  m LicenseSourceUnit
 scanVendoredDep baseDir VendoredDependency{..} = context "Scanning vendored deps for license data" $ do
   logSticky $ "License Scanning '" <> vendoredName <> "' at '" <> vendoredPath <> "'"
   scanPath <- resolvePath' baseDir $ toString vendoredPath

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -4,6 +4,7 @@
 module App.Fossa.LicenseScanner (
   licenseScanSourceUnit,
   combineLicenseUnits,
+  dedupVendoredDeps,
   scanVendoredDep,
 ) where
 

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -33,7 +33,6 @@ import Control.Effect.FossaApiClient (
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Path (withSystemTempDir)
 import Control.Effect.StickyLogger (StickyLogger, logSticky)
-import Control.Monad (unless)
 import Data.HashMap.Strict qualified as HM
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeApplications #-}
 
 module App.Fossa.ManualDeps (
   ReferencedDependency (..),

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -10,6 +10,8 @@ module App.Fossa.ManualDeps (
   ManualDependencies (..),
   FoundDepsFile (..),
   analyzeFossaDepsFile,
+  findFossaDepsFile,
+  readFoundDeps,
 ) where
 
 import App.Fossa.ArchiveUploader (VendoredDependency (..), arcToLocator, archiveUploadSourceUnit, forceVendoredToArchive)


### PR DESCRIPTION
# Overview

Provide an analog to `fossa analyze --output`, but for the results that we upload during native license scanning.

We did not add this as part of the existing `fossa analyze --output` mechanism because the existing pipeline of `fossa analyze` assumes that in output mode, we don't run the license scan at all.  Also, the existing license scan pipeline is heavily tied to the upload process.  Instead, we make a new pipeline entirely out of the existing license scan primitives (with a tiny refactor to give us access to the primitives).

## Acceptance criteria

The output of `fossa experimental-license-scan fossa-deps /path/to/dir/with/fossa-deps/file/` should be a collection of all of the uploads from running `fossa analyze` against that same directory.

Note that because the actual uploads are entirely separate, we cannot match the format of one JSON blob to many, but the output format should be a thin wrapper around the data, and the data within should match perfectly.

## Testing plan

Run `fossa experimental-license-scan fossa-deps` on a directory with a `fossa-deps` file that has the following `vendored-dependencies` (these will probably have to be separate runs):

- One local directory
- One archive
- 2+ local directories
- 2+ archive
- One or more of each

## Risks

Please check that the refactor does not affect the upload of the actual `fossa analyze` process.  You can check this locally with minio.

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
