### PR TITLE
update the THEMIS_TAG to 2022-04-25-ead2cc3

### DIFF
--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -69,7 +69,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2022-04-14-2ee13e4"
+THEMIS_TAG="2022-04-25-ead2cc3"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

Update the themis release tag to 2022-04-25-ead2cc3.

The Themis release we're updating to includes a fix for [ANE-213](https://fossa.atlassian.net/browse/ANE-213)

## Acceptance criteria

- ANE-213 should be fixed. This will make line numbers output by Themis-cli 1-indexed rather than 0-indexed
- Nothing else should be changed

## Testing plan

Force a download the new version of themis and make sure we are using it when running:

```
rm -rf vendor-bins
cabal clean
```

Analyze the "unarchived-dependencies" example project:

```
cabal run fossa -- analyze --experimental-native-license-scan ~/fossa/example-projects/fossa-deps/unarchived-vendored-dependencies
```

Look at the results for the LICENSE file. The file can be found here: https://github.com/fossas/example-projects/blob/main/fossa-deps/unarchived-vendored-dependencies/vendor/hello-1.0.0.2/LICENSE

<img width="723" alt="Screenshot 2022-04-25 at 3 06 19 PM" src="https://user-images.githubusercontent.com/13045/165182794-52306056-b79f-4537-813c-720d74b18cbb.png">

We match starting on the line that starts with "Redistribution and use in source and binary forms", which should be labelled as line 4. The match continues until the end of the file, line 24.

This is done correcly in this PR:

<img width="761" alt="Screenshot 2022-04-25 at 3 08 10 PM" src="https://user-images.githubusercontent.com/13045/165183022-31d1e411-5fa5-4702-8cdf-b4e74001e00f.png">

On master, it was showing the license being on lines 3-23:

<img width="1252" alt="Screenshot 2022-04-25 at 2 55 54 PM" src="https://user-images.githubusercontent.com/13045/165181622-b2ba16bd-3c3e-4b29-aa9a-7e57c3671ec7.png">

## Risks

None

## References



## Checklist

