### PR TITLE
Add text format for report

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.2.12
+
+- Adds `text` as an option to `fossa report attribution --format`. ([#921](https://github.com/fossas/fossa-cli/pull/921))
+
 ## v3.2.11
 
 - nodejs: Refine how workspace packages are recognized/skipped. ([#916](https://github.com/fossas/fossa-cli/pull/916))

--- a/src/App/Fossa/Config/Report.hs
+++ b/src/App/Fossa/Config/Report.hs
@@ -61,12 +61,14 @@ data ReportOutputFormat
   = ReportJson
   | ReportMarkdown
   | ReportSpdx
+  | ReportPlainText
   deriving (Eq, Ord, Enum, Bounded, Generic)
 
 parseReportOutputFormat :: String -> Maybe ReportOutputFormat
 parseReportOutputFormat s | s == show ReportJson = Just ReportJson
 parseReportOutputFormat s | s == show ReportSpdx = Just ReportSpdx
 parseReportOutputFormat s | s == show ReportMarkdown = Just ReportMarkdown
+parseReportOutputFormat s | s == show ReportPlainText = Just ReportPlainText
 parseReportOutputFormat _ = Nothing
 
 instance ToText ReportOutputFormat where
@@ -76,6 +78,7 @@ instance Show ReportOutputFormat where
   show ReportJson = "json"
   show ReportMarkdown = "markdown"
   show ReportSpdx = "spdx"
+  show ReportPlainText = "text"
 
 reportOutputFormatList :: String
 reportOutputFormatList = intercalate ", " $ map show allFormats

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -10,7 +10,7 @@ import App.Fossa.API.BuildWait (
   waitForIssues,
   waitForScanCompletion,
  )
-import App.Fossa.Config.Report (ReportCliOptions, ReportConfig (..), mkSubCommand)
+import App.Fossa.Config.Report (ReportCliOptions, ReportConfig (..), ReportOutputFormat (ReportJson), mkSubCommand)
 import App.Fossa.Subcommand (SubCommand)
 import App.Types (ProjectRevision (..))
 import Control.Carrier.FossaApiClient (runFossaApiClient)
@@ -18,7 +18,9 @@ import Control.Carrier.StickyLogger (StickyLogger, logSticky, runStickyLogger)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.FossaApiClient (FossaApiClient, getAttribution)
 import Control.Effect.Lift (Has, Lift)
+import Control.Monad (when)
 import Control.Timeout (timeout')
+import Data.String.Conversion (toText)
 import Data.Text.Extra (showT)
 import Effect.Logger (
   Logger,
@@ -26,6 +28,7 @@ import Effect.Logger (
   Severity (SevInfo),
   logInfo,
   logStdout,
+  logWarn,
  )
 
 reportSubCommand :: SubCommand ReportCliOptions ReportConfig
@@ -67,6 +70,8 @@ fetchReport ReportConfig{..} =
       logInfo ""
       logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
       logInfo ("Using revision: `" <> pretty (projectRevision revision) <> "`")
+      when (outputFormat /= ReportJson) $
+        logWarn (pretty $ toText outputFormat <> " format is not guaranteed to be stable and may change without notice.")
 
       logSticky "[ Waiting for build completion... ]"
 

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -71,7 +71,7 @@ fetchReport ReportConfig{..} =
       logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
       logInfo ("Using revision: `" <> pretty (projectRevision revision) <> "`")
       when (outputFormat /= ReportJson) $
-        logWarn (pretty $ toText outputFormat <> " format is not guaranteed to be stable and may change without notice.")
+        logWarn (pretty $ "\"" <> toText outputFormat <> "\" format may change independent of CLI version: it is sourced from the FOSSA service.")
 
       logSticky "[ Waiting for build completion... ]"
 

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -560,6 +560,7 @@ attributionEndpoint baseurl orgId locator format = appendSegment format $ baseur
     appendSegment ReportJson input = input /: "json"
     appendSegment ReportMarkdown input = input /: "full" /: "MD"
     appendSegment ReportSpdx input = input /: "full" /: "spdx"
+    appendSegment ReportPlainText input = input /: "full" /: "TXT"
 
 getAttributionJson ::
   (Has (Lift IO) sig m, Has Diagnostics sig m) =>


### PR DESCRIPTION
# Overview

Adds `text` as an option to `fossa report attribution --format`.
Renders the text report in the same format as FOSSA Cloud.

## Acceptance criteria

* Running `fossa report attribution -h` displays `text` as a valid option for `--format`:
* Running `fossa report attribution --format text` renders the text report.

## Testing plan

I used github.com/kitified/faktory-rs as an example project. The below has been edited for brevity:
```
; cabal run fossa -- analyze ~/projects/faktory-rs
Up to date
[ INFO] Analyzing cargo project at /Users/kit/projects/faktory-rs/
[ INFO]
[ INFO] Scan Summary
[ INFO] ------------
[ INFO] fossa-cli branch plain-text-report (revision 1e947c4505af (dirty) compiled with ghc-9.0)
[ INFO]
[ INFO] 1 projects scanned;  0 skipped,  1 succeeded,  0 failed,  0 analysis warnings
[ INFO]
[ INFO] * cargo project in "/Users/kit/projects/faktory-rs/": succeeded
[ INFO] -
[ INFO]
[ INFO]   Some projects may not appear in the summary if they were filtered during discovery.
[ INFO]   You can run `fossa list-targets` to see all discoverable projects.
[ INFO]
[ INFO] You can pass `--debug` option to eagerly show all warning and failure messages.
[ INFO] You can also view analysis summary with warning and error messages at: "/private/var/folders/q7/3nvvpy0d6js28m8lypw3tcx80000gn/T/fossa-analyze-scan-summary.txt"
[ INFO] ------------
[ INFO]
[ INFO] Using project name: `git@github.com:kitified/faktory-rs.git`
[ INFO] Using revision: `65082b9ad86cabb20834873aee966ee6ecb84c14`
[ INFO] Using branch: `master`
[ INFO] ============================================================
[ INFO]
[ INFO]     View FOSSA Report:
[ INFO]     https://app.fossa.com/projects/custom%2b24357%2fgit%40github.com%3akitified%2ffaktory-rs.git/refs/branch/master/65082b9ad86cabb20834873aee966ee6ecb84c14
[ INFO]
[ INFO] ============================================================

; cabal run fossa -- report attribution ~/projects/faktory-rs
Up to date
[ERROR] ----------
  An issue occurred

  >>> Relevant errors

    Error

      Provide a format option via '--format' to render this report. Supported formats: json, markdown, spdx, text

      Traceback:
        - Validating configuration


; cabal run fossa -- report attribution ~/projects/faktory-rs --format text
Up to date
[ INFO]
[ INFO] Using project name: `git@github.com:kitified/faktory-rs.git`
[ INFO] Using revision: `65082b9ad86cabb20834873aee966ee6ecb84c14`
================================================================================
================================================================================

        Third-Party Software for git@github.com:kitified/faktory-rs.git

--------------------------------------------------------------------------------

The following 3rd-party software packages may be used by or distributed with git@github.com:kitified/faktory-rs.git. Any information relevant to third-party vendors listed below are collected using common, reasonable means.

Date generated: 2022-4-28

Revision ID: 65082b9ad86cabb20834873aee966ee6ecb84c14

{ ... report contents snipped ... }
```

## Risks

I don't think this is risky, it's literally just an additional format.

## References

[ZD 4251](https://fossa.zendesk.com/agent/tickets/4251)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).

I didn't add tests for this because this is one of those super trivial areas of the code that don't really have tests, because they can't really do the wrong thing.

- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
