### PR TITLE
Add text format to report documentation

### DIFF
--- a/docs/references/subcommands/report.md
+++ b/docs/references/subcommands/report.md
@@ -31,6 +31,7 @@ Available options are:
 - `json`
 - `markdown`
 - `spdx`
+- `text`
 
 For example, to render the report in JSON format, use `fossa report attribution --format json`.
 


### PR DESCRIPTION
# Overview

As a follow up to https://github.com/fossas/fossa-cli/pull/921, now that we support plain text format for report generation via the CLI, this small PR adds `text` to the doc as one of the formats support.

## Acceptance criteria

When users click on the `fossa report` [documentation](https://github.com/fossas/fossa-cli/blob/master/docs/references/subcommands/report.md), if they actually read it they will see that `text` is a supported format.

## Testing plan

I made sure the markdown can be previewed properly.

## Risks

No risks

## References

https://github.com/fossas/fossa-cli/pull/921

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
