### PR TITLE
Fix/osx vendor downloader

### DIFF
--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -60,7 +60,7 @@ WIGGINS_TAG="2022-01-19-a647d17"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor-bins/wiggins-release.json
-curl -sL \
+curl -sSL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
     https://api.github.com/repos/fossas/basis/releases/tags/$WIGGINS_TAG > $WIGGINS_RELEASE_JSON
@@ -83,7 +83,7 @@ THEMIS_TAG="2022-04-25-ead2cc3"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json
-curl -sL \
+curl -sSL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
     https://api.github.com/repos/fossas/basis/releases/tags/$THEMIS_TAG > $THEMIS_RELEASE_JSON
@@ -138,7 +138,7 @@ else
     OUTPUT=vendor-bins/${NAME%"-$ASSET_POSTFIX"}
 
     echo "Downloading '$NAME' to '$OUTPUT'"
-    curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
+    curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
     echo "Extracting syft binary from tarball"
     tar xzf $OUTPUT fossa-container-scanning
     mv fossa-container-scanning vendor-bins/syft

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -18,6 +18,17 @@ if [ -z "$GITHUB_TOKEN" ]; then
   exit 1
 fi
 
+# Print version of required tools
+echo "curl version"
+echo "------------"
+curl --version
+echo ""
+
+echo "jq version"
+echo "----------"
+jq --version
+echo ""
+
 rm -f vendor-bins/*
 mkdir -p vendor-bins
 
@@ -50,10 +61,10 @@ WIGGINS_TAG="2022-01-19-a647d17"
 echo "Downloading wiggins binary"
 echo "Using wiggins release: $WIGGINS_TAG"
 WIGGINS_RELEASE_JSON=vendor-bins/wiggins-release.json
-curl -sSL \
+curl -sL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
-    api.github.com/repos/fossas/basis/releases/tags/$WIGGINS_TAG > $WIGGINS_RELEASE_JSON
+    https://api.github.com/repos/fossas/basis/releases/tags/$WIGGINS_TAG > $WIGGINS_RELEASE_JSON
 
 cat $WIGGINS_RELEASE_JSON
 WIGGINS_TAG=$(jq -cr ".name" $WIGGINS_RELEASE_JSON)
@@ -74,10 +85,10 @@ THEMIS_TAG="2022-04-25-ead2cc3"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json
-curl -sSL \
+curl -sL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
-    api.github.com/repos/fossas/basis/releases/tags/$THEMIS_TAG > $THEMIS_RELEASE_JSON
+    https://api.github.com/repos/fossas/basis/releases/tags/$THEMIS_TAG > $THEMIS_RELEASE_JSON
 cat $THEMIS_RELEASE_JSON
 
 THEMIS_TAG=$(jq -cr ".name" $THEMIS_RELEASE_JSON)
@@ -114,10 +125,10 @@ else
   echo "Downloading forked syft binary"
   echo "Using forked syft release: $SYFT_TAG"
   SYFT_RELEASE_JSON=vendor-bins/syft-release.json
-  curl -sSL \
+  curl -sL \
       -H "Authorization: token $GITHUB_TOKEN" \
       -H "Accept: application/vnd.github.v3.raw" \
-      api.github.com/repos/fossas/syft/releases/tags/${SYFT_TAG} > $SYFT_RELEASE_JSON
+      https://api.github.com/repos/fossas/syft/releases/tags/${SYFT_TAG} > $SYFT_RELEASE_JSON
   cat $SYFT_RELEASE_JSON
 
   # Remove leading 'v' from version tag

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -55,6 +55,7 @@ curl -sSL \
     -H "Accept: application/vnd.github.v3.raw" \
     api.github.com/repos/fossas/basis/releases/tags/$WIGGINS_TAG > $WIGGINS_RELEASE_JSON
 
+cat $WIGGINS_RELEASE_JSON
 WIGGINS_TAG=$(jq -cr ".name" $WIGGINS_RELEASE_JSON)
 FILTER=".name == \"scotland_yard-wiggins-$BASIS_ASSET_POSTFIX\""
 jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $WIGGINS_RELEASE_JSON | while read ASSET; do
@@ -77,6 +78,7 @@ curl -sSL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
     api.github.com/repos/fossas/basis/releases/tags/$THEMIS_TAG > $THEMIS_RELEASE_JSON
+cat $THEMIS_RELEASE_JSON
 
 THEMIS_TAG=$(jq -cr ".name" $THEMIS_RELEASE_JSON)
 FILTER=".name == \"themis-cli-$BASIS_ASSET_POSTFIX\""
@@ -116,6 +118,7 @@ else
       -H "Authorization: token $GITHUB_TOKEN" \
       -H "Accept: application/vnd.github.v3.raw" \
       api.github.com/repos/fossas/syft/releases/tags/${SYFT_TAG} > $SYFT_RELEASE_JSON
+  cat $SYFT_RELEASE_JSON
 
   # Remove leading 'v' from version tag
   # 'v123' -> '123'

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -18,7 +18,6 @@ if [ -z "$GITHUB_TOKEN" ]; then
   exit 1
 fi
 
-# Print version of required tools
 echo "curl version"
 echo "------------"
 curl --version
@@ -66,7 +65,6 @@ curl -sL \
     -H "Accept: application/vnd.github.v3.raw" \
     https://api.github.com/repos/fossas/basis/releases/tags/$WIGGINS_TAG > $WIGGINS_RELEASE_JSON
 
-cat $WIGGINS_RELEASE_JSON
 WIGGINS_TAG=$(jq -cr ".name" $WIGGINS_RELEASE_JSON)
 FILTER=".name == \"scotland_yard-wiggins-$BASIS_ASSET_POSTFIX\""
 jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $WIGGINS_RELEASE_JSON | while read ASSET; do
@@ -89,7 +87,6 @@ curl -sL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
     https://api.github.com/repos/fossas/basis/releases/tags/$THEMIS_TAG > $THEMIS_RELEASE_JSON
-cat $THEMIS_RELEASE_JSON
 
 THEMIS_TAG=$(jq -cr ".name" $THEMIS_RELEASE_JSON)
 FILTER=".name == \"themis-cli-$BASIS_ASSET_POSTFIX\""
@@ -129,7 +126,6 @@ else
       -H "Authorization: token $GITHUB_TOKEN" \
       -H "Accept: application/vnd.github.v3.raw" \
       https://api.github.com/repos/fossas/syft/releases/tags/${SYFT_TAG} > $SYFT_RELEASE_JSON
-  cat $SYFT_RELEASE_JSON
 
   # Remove leading 'v' from version tag
   # 'v123' -> '123'


### PR DESCRIPTION
Fixes the `vendor_download.sh` for osx, I wasn't sure why this was failing. 

Previous actions (failing in osx):
- https://github.com/fossas/fossa-cli/actions/runs/2272922869
- https://github.com/fossas/fossa-cli/actions/runs/2272209359
- https://github.com/fossas/fossa-cli/actions/runs/2273447666

This action seems to be working: https://github.com/fossas/fossa-cli/runs/6300351000?check_suite_focus=true