### PR TITLE
Ane 183 gomod respect vendored replacements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.2.16
+- Go: When statically analyzing a project, apply reported replacements. ([#926](https://github.com/fossas/fossa-cli/pull/926))
+
 ## v3.2.15
 
 - Update Maven depGraph plugin to 4.0.1 and add a fallback ot the legacy 3.3.0 plugin ([#895](https://github.com/fossas/fossa-cli/pull/895))

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -109,6 +109,26 @@ analyze' dir = do
         pure ()
   pure (graph, Complete)
   where
+    -- TODO: Do we need this? It's for modules we receive from go list -m -json
+    -- all. Maybe need a test for output from that command to verify that it
+    -- NOTE: maybe it's necessary for replacements of direct deps
+    -- handle replacements
+    -- modToRequire :: GoListModule -> Require
+    -- modToRequire m =
+    --   let r =
+    --         Require
+    --           (maybe (path m) pathReplacement (moduleReplacement m))
+    --           ( fromMaybe
+    --               "LATEST"
+    --               ( fmap versionReplacement (moduleReplacement m)
+    --                   <|> version m
+    --               )
+    --           )
+    --           (not $ isIndirect m)
+    --    in pTraceShowId r
+
+    -- toRequires src = map modToRequire (withoutMain src)
+
     toRequires :: [GoListModule] -> [Require]
     toRequires src = map (\m -> Require (path m) (fromMaybe "LATEST" $ version m) (not $ isIndirect m)) (withoutMain src)
 

--- a/src/Strategy/Go/GoList.hs
+++ b/src/Strategy/Go/GoList.hs
@@ -109,26 +109,6 @@ analyze' dir = do
         pure ()
   pure (graph, Complete)
   where
-    -- TODO: Do we need this? It's for modules we receive from go list -m -json
-    -- all. Maybe need a test for output from that command to verify that it
-    -- NOTE: maybe it's necessary for replacements of direct deps
-    -- handle replacements
-    -- modToRequire :: GoListModule -> Require
-    -- modToRequire m =
-    --   let r =
-    --         Require
-    --           (maybe (path m) pathReplacement (moduleReplacement m))
-    --           ( fromMaybe
-    --               "LATEST"
-    --               ( fmap versionReplacement (moduleReplacement m)
-    --                   <|> version m
-    --               )
-    --           )
-    --           (not $ isIndirect m)
-    --    in pTraceShowId r
-
-    -- toRequires src = map modToRequire (withoutMain src)
-
     toRequires :: [GoListModule] -> [Require]
     toRequires src = map (\m -> Require (path m) (fromMaybe "LATEST" $ version m) (not $ isIndirect m)) (withoutMain src)
 

--- a/src/Strategy/Go/Transitive.hs
+++ b/src/Strategy/Go/Transitive.hs
@@ -179,19 +179,16 @@ normalizeImportPathsToModules packages = map normalizeSingle packages
     normalizeSingle :: Package -> Package
     normalizeSingle package =
       package
-        { packageImports = map replaceImport <$> packageImports package
+        { packageImports = map normalizeImportPath <$> packageImports package
         , -- when a gomod field is present, use that or the module replacement
           -- for the package import path otherwise use the top-level package
           -- import path
-          packageImportPath = normalizeImportPath package
+          packageImportPath = normalizeImportPath . packageImportPath $ package
         }
 
-    normalizeImportPath :: Package -> Text
-    normalizeImportPath Package{packageImportPath} = Maybe.fromMaybe packageImportPath (Map.lookup packageImportPath packageNameToModule)
-
     -- If a package doesn't have an associated module, use the package name instead
-    replaceImport :: Text -> Text
-    replaceImport packageName = Maybe.fromMaybe packageName (Map.lookup packageName packageNameToModule)
+    normalizeImportPath :: Text -> Text
+    normalizeImportPath packageImportPath = Maybe.fromMaybe packageImportPath (Map.lookup packageImportPath packageNameToModule)
 
     normalizedImportPath :: Module -> Text
     normalizedImportPath m = maybe (modPath m) pathReplacement (modReplacement m)

--- a/test/Go/GomodSpec.hs
+++ b/test/Go/GomodSpec.hs
@@ -168,7 +168,7 @@ spec = do
 spec_buildGraph :: Spec
 spec_buildGraph =
   describe "buildGraph" $ do
-    it "constructs a trivial graph and respects overrides" $ do
+    it "constructs a trivial graph and performs overrides" $ do
       let result = buildGraph trivialGomod & graphingGolang & run
       result `shouldBe` trivialGraph
 

--- a/test/Go/GomodSpec.hs
+++ b/test/Go/GomodSpec.hs
@@ -168,7 +168,7 @@ spec = do
 spec_buildGraph :: Spec
 spec_buildGraph =
   describe "buildGraph" $ do
-    it "constructs a trivial graph" $ do
+    it "constructs a trivial graph and respects overrides" $ do
       let result = buildGraph trivialGomod & graphingGolang & run
       result `shouldBe` trivialGraph
 

--- a/test/Go/TransitiveSpec.hs
+++ b/test/Go/TransitiveSpec.hs
@@ -8,7 +8,7 @@ import Strategy.Go.Transitive as Transitive (
   Module (Module, modPath, modReplacement, modVersion),
   Package (..),
   graphTransitive,
-  normalizeImportsToModules,
+  normalizeImportPathsToModules,
  )
 
 import Strategy.Go.Types (graphingGolang)
@@ -23,13 +23,13 @@ performsPackageReplacementSpec :: Spec
 performsPackageReplacementSpec =
   describe "Package list module replacements" $ do
     it "It replaces module name and version when the replacement is a parent" $ do
-      let normalized = normalizeImportsToModules replacedParentPackages
+      let normalized = normalizeImportPathsToModules replacedParentPackages
           graph = run $ graphingGolang (graphTransitive normalized)
       expectDeps [replacedModuleDep, nonReplacedPackageDep] graph
       expectEdges [(replacedModuleDep, nonReplacedPackageDep)] graph
 
     it "It replaces module name and version when the replacement is a child" $ do
-      let normalized = normalizeImportsToModules replacedChildPackages
+      let normalized = normalizeImportPathsToModules replacedChildPackages
           graph = run $ graphingGolang (graphTransitive normalized)
       expectDeps [replacedModuleDep, nonReplacedPackageDep] graph
       expectEdges [(nonReplacedPackageDep, replacedModuleDep)] graph
@@ -116,18 +116,18 @@ replacedChildPackages =
 -- aren't dropped from the dependency graph
 spec_packageToModule :: Spec
 spec_packageToModule =
-  describe "normalizeImportsToModules" $ do
+  describe "normalizeImportPathsToModules" $ do
     it "should map package imports to their modules" $ do
-      let result = normalizeImportsToModules testPackages
+      let result = normalizeImportPathsToModules testPackages
       result `shouldBe` normalizedPackages
 
     it "should prevent packages from appearing in the final graph" $ do
-      let graph = run $ graphingGolang (graphTransitive (normalizeImportsToModules testPackages))
+      let graph = run $ graphingGolang (graphTransitive (normalizeImportPathsToModules testPackages))
       expectDeps [fooDep, barDep, bazDep] graph
       expectEdges [(fooDep, barDep), (barDep, bazDep)] graph
 
     it "should be a no-op for non-module packages" $ do
-      normalizeImportsToModules nonModulePackages `shouldBe` nonModulePackages
+      normalizeImportPathsToModules nonModulePackages `shouldBe` nonModulePackages
 
 nonModulePackages :: [Package]
 nonModulePackages =
@@ -213,7 +213,7 @@ normalizedPackages =
       , packageSystem = Nothing
       }
   , Package
-      { packageImportPath = "github.com/example/bar/some/package"
+      { packageImportPath = "github.com/example/bar"
       , packageModule =
           Just
             Module
@@ -229,7 +229,7 @@ normalizedPackages =
       , packageSystem = Nothing
       }
   , Package
-      { packageImportPath = "github.com/example/baz/other"
+      { packageImportPath = "github.com/example/baz"
       , packageModule =
           Just
             Module

--- a/test/Go/TransitiveSpec.hs
+++ b/test/Go/TransitiveSpec.hs
@@ -4,13 +4,16 @@ import Control.Algebra (run)
 import DepTypes (DepType (GoType), Dependency (..), VerConstraint (CEq))
 import GraphUtil (expectDeps, expectEdges)
 import Strategy.Go.Transitive as Transitive (
+  GoListPkgImportPath (GoListPkgImportPath),
   GoPackageReplacement (..),
   Module (Module, modPath, modReplacement, modVersion),
+  NormalizedImportPath (NormalizedImportPath),
   Package (..),
   graphTransitive,
   normalizeImportPathsToModules,
  )
 
+import Data.Coerce (coerce)
 import Strategy.Go.Types (graphingGolang)
 import Test.Hspec (Spec, describe, it, shouldBe)
 
@@ -56,7 +59,7 @@ nonReplacedPackageDep =
     , dependencyTags = mempty
     }
 
-replacedParentPackages :: [Package]
+replacedParentPackages :: [Package GoListPkgImportPath]
 replacedParentPackages =
   [ Package
       { packageImportPath = "github.com/example/foo/inner-package"
@@ -83,7 +86,7 @@ replacedParentPackages =
       }
   ]
 
-replacedChildPackages :: [Package]
+replacedChildPackages :: [Package GoListPkgImportPath]
 replacedChildPackages =
   [ Package
       { packageImportPath = "github.com/example/foo/inner-package"
@@ -127,9 +130,9 @@ spec_packageToModule =
       expectEdges [(fooDep, barDep), (barDep, bazDep)] graph
 
     it "should be a no-op for non-module packages" $ do
-      normalizeImportPathsToModules nonModulePackages `shouldBe` nonModulePackages
+      normalizeImportPathsToModules nonModulePackages `shouldBe` coerce nonModulePackages
 
-nonModulePackages :: [Package]
+nonModulePackages :: [Package GoListPkgImportPath]
 nonModulePackages =
   [ Package
       { packageImportPath = "github.com/example/foo"
@@ -148,7 +151,7 @@ nonModulePackages =
       }
   ]
 
-testPackages :: [Package]
+testPackages :: [Package GoListPkgImportPath]
 testPackages =
   [ Package
       { packageImportPath = "github.com/example/foo"
@@ -201,7 +204,7 @@ testPackages =
       }
   ]
 
-normalizedPackages :: [Package]
+normalizedPackages :: [Package NormalizedImportPath]
 normalizedPackages =
   [ Package
       { packageImportPath = "github.com/example/foo"

--- a/test/Go/TransitiveSpec.hs
+++ b/test/Go/TransitiveSpec.hs
@@ -66,6 +66,7 @@ testPackages =
             Module
               { modPath = "github.com/example/bar"
               , modVersion = Nothing
+              , modReplacement = Nothing
               }
       , packageImports =
           Just
@@ -81,6 +82,7 @@ testPackages =
             Module
               { modPath = "github.com/example/baz"
               , modVersion = Nothing
+              , modReplacement = Nothing
               }
       , packageImports = Nothing
       , packageSystem = Nothing
@@ -92,6 +94,7 @@ testPackages =
             Module
               { modPath = "github.com/example/baz"
               , modVersion = Nothing
+              , modReplacement = Nothing
               }
       , packageImports = Nothing
       , packageSystem = Nothing
@@ -116,6 +119,7 @@ normalizedPackages =
             Module
               { modPath = "github.com/example/bar"
               , modVersion = Nothing
+              , modReplacement = Nothing
               }
       , packageImports =
           Just
@@ -131,6 +135,7 @@ normalizedPackages =
             Module
               { modPath = "github.com/example/baz"
               , modVersion = Nothing
+              , modReplacement = Nothing
               }
       , packageImports = Nothing
       , packageSystem = Nothing
@@ -142,6 +147,7 @@ normalizedPackages =
             Module
               { modPath = "github.com/example/baz"
               , modVersion = Nothing
+              , modReplacement = Nothing
               }
       , packageImports = Nothing
       , packageSystem = Nothing

--- a/test/Go/TransitiveSpec.hs
+++ b/test/Go/TransitiveSpec.hs
@@ -25,13 +25,13 @@ spec = do
 performsPackageReplacementSpec :: Spec
 performsPackageReplacementSpec =
   describe "Package list module replacements" $ do
-    it "It replaces module name and version when the replacement isn't in an import list" $ do
+    it "replaces module name and version when the replacement isn't in an import list" $ do
       let normalized = normalizeImportPaths unimportedPackageReplacement
           graph = run $ graphingGolang (graphTransitive normalized)
       expectDeps [replacedModuleDep, nonReplacedPackageDep] graph
       expectEdges [(replacedModuleDep, nonReplacedPackageDep)] graph
 
-    it "It replaces module name and version when the replacement is in an import list" $ do
+    it "replaces module name and version when the replacement is in an import list" $ do
       let normalized = normalizeImportPaths importedPackageReplacement
           graph = run $ graphingGolang (graphTransitive normalized)
       expectDeps [replacedModuleDep, nonReplacedPackageDep] graph


### PR DESCRIPTION
# Overview

During static analysis of Go we try to map go packages to go modules. We were failing to apply `go.mod` replacements to that were reported by `go list -json all` when building a graph from these. This change is to apply those replacements.

## Acceptance criteria

When users analyze a go project and we perform static analysis we will apply any replacements we found in `go.mod`. 

## Testing plan

To test, you can copy this go source file into `main.go`:
```go
package main

import ("fmt"
	_ "google.golang.org/grpc")

func main() {
	fmt.Println("Hello, world!")
}
```
and this `go.mod` file:
```go
module foo.com/test

go 1.15

replace golang.org/x/text v0.3.3 => golang.org/x/text v0.3.6

replace golang.org/x/text v0.3.0 => golang.org/x/text v0.3.6
```
into a directory. Then run the following commands:

```
> go get google.golang.org/grpc@v1.40.0
> go mod vendor
```

If you analyze it with the cli on master, you'll see that `golang.org/x/text` version 0.3.0 appears as a dependency. On this branch, the replacement specified in `go.mod` is applied. 

## Risks

I added some additional types to `Transitive.hs` in order to try and make it clearer that we are potentially replacing import paths and to track where/when that happens. Please evaluate if it feels like overkill or if it doesn't seem useful. As always, please let me know if there are automated tests that seem worth adding that I've missed.

## References

- [ANE-183](https://fossa.atlassian.net/browse/ANE-183)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
