### PR TITLE
Removes CLI 1.x install docs from main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ scoop install fossa
 
 ### Installing manually
 
-You can install the FOSSA CLI releases manually by downloading the latest release from [GitHub Releases](https://github.com/fossas/fossa-cli/releases) and extracting the binary to your `$PATH`. 
+You can install the FOSSA CLI releases manually by downloading the latest release from [GitHub Releases](https://github.com/fossas/fossa-cli/releases) and extracting the binary to your `$PATH`.
 
 To install FOSSA CLI 1.x with install script please refer to: [installing 1.x guide](./docs/install-v1.md) 
 

--- a/README.md
+++ b/README.md
@@ -51,23 +51,10 @@ scoop install fossa
 
 ### Installing manually
 
-You can install the FOSSA CLI releases manually by downloading the latest release from [GitHub Releases](https://github.com/fossas/fossa-cli/releases) and extracting the binary to your `$PATH`.
+You can install the FOSSA CLI releases manually by downloading the latest release from [GitHub Releases](https://github.com/fossas/fossa-cli/releases) and extracting the binary to your `$PATH`. 
 
-## Installing CLI 1.x
+To install FOSSA CLI 1.x with install script please refer to: [installing 1.x guide](./docs/install-v1.md) 
 
-You can install FOSSA CLI 1.x with installation script for macOS or 64-bit Linux using:
-
-```bash
-curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-v1.sh | bash
-```
-
-And for windows:
-
-```powershell
-Set-ExecutionPolicy Bypass -Scope Process -Force; iex  ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fossas/fossa-cli/master/install-v1.ps1'))
-```
-
-It is recommended that you migrate to CLI 3.x. Please read the [migration guide](./docs/differences-from-v1.md) for more details.
 ## Getting Started
 
 ### Integrating your project with FOSSA

--- a/docs/install-v1.md
+++ b/docs/install-v1.md
@@ -1,3 +1,5 @@
+> As of now, there is no development work being done on CLI 1.x. Likewise, support for CLI 1.x is deprecated. If there is a defect with CLI 1.x, we will not make patches to CLI 1.x anymore but instead will ask you to migrate to 3.x, and make necessary patches to CLI 3.x
+
 ## Installing CLI 1.x
 
 You can install FOSSA CLI 1.x with installation script for macOS or 64-bit Linux using:

--- a/docs/install-v1.md
+++ b/docs/install-v1.md
@@ -1,0 +1,15 @@
+## Installing CLI 1.x
+
+You can install FOSSA CLI 1.x with installation script for macOS or 64-bit Linux using:
+
+```bash
+curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-v1.sh | bash
+```
+
+And for windows:
+
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex  ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fossas/fossa-cli/master/install-v1.ps1'))
+```
+
+It is recommended that you migrate to CLI 3.x. Please read the [migration guide](./differences-from-v1.md) for more details.


### PR DESCRIPTION
# Overview

We've had a few users who mistakenly integrated with CLI 1.x, instead of CLI 3.x (by copy-pasting install code). 
This can happen by mistake, as our readme includes an install snippet for both 3.x and 1.x. 

This PR, 
- moves install 1.x instruction to its own document and leaves a reference on the main readme.

## Acceptance criteria

- Primary readme does not have install instructions for 1.X  

## Testing plan

N/A

## Risks

N/A

## References

Works on https://fossa.atlassian.net/browse/ANE-115

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
