### PR TITLE
update basis release tag for themis

### DIFF
--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -79,7 +79,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2022-04-25-ead2cc3"
+THEMIS_TAG="2022-05-12-3332fcd"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

Updates the basis tag to the latest release, 2022-05-12-3332fcd

This pulls in the following PRs:

Four performance PRs:
https://github.com/fossas/basis/pull/1732
https://github.com/fossas/basis/pull/1733
https://github.com/fossas/basis/pull/1734
https://github.com/fossas/basis/pull/1737

Two copyright fixes:
https://github.com/fossas/basis/pull/1739
https://github.com/fossas/basis/pull/1740

And some license improvements:
https://github.com/fossas/basis/pull/1741


## Acceptance criteria

Themis should still work and be faster

## Testing plan

```
./vendor_download.sh
cabal clean
cabal run fossa -- analyze --experimental-native-license-scan -e http://localhost:9578 ~/fossa/license-scan-dirs/archive-upload-with-target
```

Verify that the results still show the proper licenses

<img width="1523" alt="Screenshot 2022-05-12 at 2 39 20 PM" src="https://user-images.githubusercontent.com/13045/168172455-3589d45e-7365-4074-80ab-970b7776d4a2.png">

## Risks

None

## References

None

## Checklist

