### PR TITLE
Pull out shared archive uploader functions

### DIFF
--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -7,8 +7,8 @@ import Analysis.FixtureUtils (
   FixtureArtifact (FixtureArtifact),
   getArtifact,
  )
-import App.Fossa.ArchiveUploader (VendoredDependency (VendoredDependency))
 import App.Fossa.LicenseScanner (scanVendoredDep)
+import App.Fossa.VendoredDependency (VendoredDependency (VendoredDependency))
 import Control.Carrier.Diagnostics (runDiagnostics)
 import Control.Carrier.Stack (runStack)
 import Control.Carrier.StickyLogger (ignoreStickyLogger)

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -436,7 +436,7 @@ test-suite unit-tests
     App.Fossa.AnalyzeSpec
     App.Fossa.API.BuildLinkSpec
     App.Fossa.API.BuildWaitSpec
-    App.Fossa.ArchiveUploaderSpec
+    App.Fossa.VendoredDependencySpec
     App.Fossa.BinaryDeps.JarSpec
     App.Fossa.Config.AnalyzeSpec
     App.Fossa.Config.TestSpec

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -196,6 +196,7 @@ library
     App.Fossa.RunThemis
     App.Fossa.Subcommand
     App.Fossa.Test
+    App.Fossa.VendoredDependency
     App.Fossa.VPS.Scan.RunWiggins
     App.Fossa.VPS.Types
     App.Fossa.VSI.Analyze

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -435,6 +435,7 @@ test-suite unit-tests
     App.Fossa.AnalyzeSpec
     App.Fossa.API.BuildLinkSpec
     App.Fossa.API.BuildWaitSpec
+    App.Fossa.ArchiveUploaderSpec
     App.Fossa.BinaryDeps.JarSpec
     App.Fossa.Config.AnalyzeSpec
     App.Fossa.Config.TestSpec

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -436,7 +436,6 @@ test-suite unit-tests
     App.Fossa.AnalyzeSpec
     App.Fossa.API.BuildLinkSpec
     App.Fossa.API.BuildWaitSpec
-    App.Fossa.VendoredDependencySpec
     App.Fossa.BinaryDeps.JarSpec
     App.Fossa.Config.AnalyzeSpec
     App.Fossa.Config.TestSpec
@@ -448,6 +447,7 @@ test-suite unit-tests
     App.Fossa.Report.AttributionSpec
     App.Fossa.Report.Log4jReportSpec
     App.Fossa.ReportSpec
+    App.Fossa.VendoredDependencySpec
     App.Fossa.VSI.DynLinked.Internal.BinarySpec
     App.Fossa.VSI.DynLinked.Internal.Lookup.DEBSpec
     App.Fossa.VSI.DynLinked.Internal.Lookup.RPMSpec

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -2,17 +2,16 @@
 
 module App.Fossa.ArchiveUploader (
   archiveUploadSourceUnit,
+) where
+
+import App.Fossa.VendoredDependency (
+  VendoredDependency (..),
   arcToLocator,
   compressFile,
-  forceVendoredToArchive,
   duplicateFailureBundle,
   duplicateNames,
   hashFile,
-) where
-
-import App.Fossa.VendoredDependency (VendoredDependency (..))
-import Codec.Archive.Tar qualified as Tar
-import Codec.Compression.GZip qualified as GZip
+ )
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.StickyLogger (StickyLogger, logSticky)
 import Control.Effect.Diagnostics (context)
@@ -20,23 +19,15 @@ import Control.Effect.FossaApiClient (FossaApiClient, PackageRevision (PackageRe
 import Control.Effect.Lift
 import Control.Effect.Path (withSystemTempDir)
 import Control.Monad (unless)
-import Crypto.Hash
-import Data.ByteString.Lazy qualified as BS
-import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
-import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe)
 import Data.String.Conversion
 import Data.Text (Text)
-import Data.Text qualified as Text
-import Data.UUID.V4 (nextRandom)
 import Effect.Logger (Logger, logDebug)
 import Fossa.API.Types
 import Path hiding ((</>))
 import Prettyprinter (Pretty (pretty))
 import Srclib.Types (Locator (..))
-import System.FilePath.Posix
 
 uploadArchives ::
   ( Has Diag.Diagnostics sig m
@@ -119,51 +110,3 @@ archiveUploadSourceUnit baseDir vendoredDeps = do
       archivesWithOrganization = updateArcName (toText $ show orgId) <$> archives
 
   pure $ arcToLocator <$> archivesWithOrganization
-
--- | List of names that occur more than once in a list of vendored dependencies.
-duplicateNames :: NonEmpty VendoredDependency -> [Text]
-duplicateNames = Map.keys . Map.filter (> 1) . Map.fromListWith (+) . map pair . NonEmpty.toList
-  where
-    pair :: VendoredDependency -> (Text, Int)
-    pair VendoredDependency{vendoredName} = (vendoredName, 1)
-
-duplicateFailureBundle :: [Text] -> Text
-duplicateFailureBundle names =
-  "The provided vendored dependencies contain the following duplicate names:\n\t"
-    <> Text.intercalate "\n\t" names
-    <> "\n\n"
-    <> "Vendored dependency entries may not specify duplicate names.\n"
-    <> "Please ensure that each vendored dependency entry has a unique name."
-
-forceVendoredToArchive :: VendoredDependency -> Archive
-forceVendoredToArchive dep = Archive (vendoredName dep) (fromMaybe "" $ vendoredVersion dep)
-
-arcToLocator :: Archive -> Locator
-arcToLocator arc =
-  Locator
-    { locatorFetcher = "archive"
-    , locatorProject = archiveName arc
-    , locatorRevision = Just $ archiveVersion arc
-    }
-
-compressFile :: Path Abs Dir -> Path Abs Dir -> FilePath -> IO FilePath
-compressFile outputDir directory fileToTar = do
-  -- We are adding the suffix to avoid errors when we compress to a path that already exists
-  -- This is most likely to happen if `fileToTar` is "."
-  suffix <- nextRandom
-  let finalFilename = fileToTar ++ show suffix
-  let finalFile = toString outputDir </> safeSeparators finalFilename
-  entries <- Tar.pack (toString directory) [fileToTar]
-  BS.writeFile finalFile $ GZip.compress $ Tar.write entries
-  pure finalFile
-
-md5 :: BS.ByteString -> Digest MD5
-md5 = hashlazy
-
-hashFile :: FilePath -> IO Text
-hashFile fileToHash = do
-  fileContent <- BS.readFile fileToHash
-  pure . toText . show $ md5 fileContent
-
-safeSeparators :: FilePath -> FilePath
-safeSeparators = intercalate "_" . splitDirectories

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -38,6 +38,7 @@ import Data.Maybe (fromMaybe)
 import Data.String.Conversion
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.UUID.V4 (nextRandom)
 import Effect.Logger (Logger, logDebug)
 import Fossa.API.Types
 import Path hiding ((</>))
@@ -169,7 +170,9 @@ arcToLocator arc =
 
 compressFile :: Path Abs Dir -> Path Abs Dir -> FilePath -> IO FilePath
 compressFile outputDir directory fileToTar = do
-  let finalFile = toString outputDir </> safeSeparators fileToTar
+  suffix <- nextRandom
+  let finalFilename = fileToTar ++ show suffix
+  let finalFile = toString outputDir </> safeSeparators finalFilename
   entries <- Tar.pack (toString directory) [fileToTar]
   BS.writeFile finalFile $ GZip.compress $ Tar.write entries
   pure finalFile

--- a/src/App/Fossa/ArchiveUploader.hs
+++ b/src/App/Fossa/ArchiveUploader.hs
@@ -8,9 +8,9 @@ module App.Fossa.ArchiveUploader (
   duplicateFailureBundle,
   duplicateNames,
   hashFile,
-  VendoredDependency (..),
 ) where
 
+import App.Fossa.VendoredDependency (VendoredDependency (..))
 import Codec.Archive.Tar qualified as Tar
 import Codec.Compression.GZip qualified as GZip
 import Control.Carrier.Diagnostics qualified as Diag
@@ -21,15 +21,7 @@ import Control.Effect.Lift
 import Control.Effect.Path (withSystemTempDir)
 import Control.Monad (unless)
 import Crypto.Hash
-import Data.Aeson (
-  FromJSON (parseJSON),
-  withObject,
-  (.:),
-  (.:?),
- )
-import Data.Aeson.Extra
 import Data.ByteString.Lazy qualified as BS
-import Data.Functor.Extra ((<$$>))
 import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
@@ -45,20 +37,6 @@ import Path hiding ((</>))
 import Prettyprinter (Pretty (pretty))
 import Srclib.Types (Locator (..))
 import System.FilePath.Posix
-
-data VendoredDependency = VendoredDependency
-  { vendoredName :: Text
-  , vendoredPath :: Text
-  , vendoredVersion :: Maybe Text
-  }
-  deriving (Eq, Ord, Show)
-
-instance FromJSON VendoredDependency where
-  parseJSON = withObject "VendoredDependency" $ \obj ->
-    VendoredDependency <$> obj .: "name"
-      <*> obj .: "path"
-      <*> (unTextLike <$$> obj .:? "version")
-      <* forbidMembers "vendored dependencies" ["type", "license", "url", "description"] obj
 
 uploadArchives ::
   ( Has Diag.Diagnostics sig m

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -8,7 +8,7 @@ import App.Fossa.Config.LicenseScan (
   mkSubCommand,
  )
 import App.Fossa.EmbeddedBinary (withThemisAndIndex)
-import App.Fossa.LicenseScanner (dedupVendoredDeps, scanVendoredDep)
+import App.Fossa.LicenseScanner (scanVendoredDep)
 import App.Fossa.ManualDeps (
   ManualDependencies (vendoredDependencies),
   findFossaDepsFile,
@@ -18,6 +18,7 @@ import App.Fossa.RunThemis (execRawThemis)
 import App.Fossa.Subcommand (SubCommand)
 import App.Fossa.VendoredDependency (
   VendoredDependency,
+  dedupVendoredDeps,
  )
 import App.Types (BaseDir (BaseDir))
 import Control.Carrier.StickyLogger (

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -11,12 +11,14 @@ import App.Fossa.EmbeddedBinary (withThemisAndIndex)
 import App.Fossa.LicenseScanner (dedupVendoredDeps, scanVendoredDep)
 import App.Fossa.ManualDeps (
   ManualDependencies (vendoredDependencies),
-  VendoredDependency,
   findFossaDepsFile,
   readFoundDeps,
  )
 import App.Fossa.RunThemis (execRawThemis)
 import App.Fossa.Subcommand (SubCommand)
+import App.Fossa.VendoredDependency (
+  VendoredDependency,
+ )
 import App.Types (BaseDir (BaseDir))
 import Control.Carrier.StickyLogger (
   Has,

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -8,19 +8,17 @@ module App.Fossa.LicenseScanner (
   scanVendoredDep,
 ) where
 
-import App.Fossa.ArchiveUploader (
-  arcToLocator,
-  compressFile,
-  duplicateFailureBundle,
-  duplicateNames,
-  hashFile,
- )
 import App.Fossa.EmbeddedBinary (ThemisBins, withThemisAndIndex)
 import App.Fossa.RunThemis (
   execThemis,
  )
 import App.Fossa.VendoredDependency (
   VendoredDependency (..),
+  arcToLocator,
+  compressFile,
+  duplicateFailureBundle,
+  duplicateNames,
+  hashFile,
  )
 import Control.Carrier.Finally (Finally, runFinally)
 import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (renderDiagnostic), context, fatal, fatalText, fromMaybe, recover)

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -9,7 +9,6 @@ module App.Fossa.LicenseScanner (
 ) where
 
 import App.Fossa.ArchiveUploader (
-  VendoredDependency (..),
   arcToLocator,
   compressFile,
   duplicateFailureBundle,
@@ -19,6 +18,9 @@ import App.Fossa.ArchiveUploader (
 import App.Fossa.EmbeddedBinary (ThemisBins, withThemisAndIndex)
 import App.Fossa.RunThemis (
   execThemis,
+ )
+import App.Fossa.VendoredDependency (
+  VendoredDependency (..),
  )
 import Control.Carrier.Finally (Finally, runFinally)
 import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (renderDiagnostic), context, fatal, fatalText, fromMaybe, recover)

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -14,9 +14,12 @@ module App.Fossa.ManualDeps (
   readFoundDeps,
 ) where
 
-import App.Fossa.ArchiveUploader (VendoredDependency (..), arcToLocator, archiveUploadSourceUnit, forceVendoredToArchive)
+import App.Fossa.ArchiveUploader (arcToLocator, archiveUploadSourceUnit, forceVendoredToArchive)
 import App.Fossa.Config.Analyze (AllowNativeLicenseScan (AllowNativeLicenseScan))
 import App.Fossa.LicenseScanner (licenseScanSourceUnit)
+import App.Fossa.VendoredDependency (
+  VendoredDependency (..),
+ )
 import Control.Carrier.FossaApiClient (runFossaApiClient)
 import Control.Effect.Diagnostics (Diagnostics, context, fatalText)
 import Control.Effect.FossaApiClient (FossaApiClient, getOrganization)

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -14,11 +14,13 @@ module App.Fossa.ManualDeps (
   readFoundDeps,
 ) where
 
-import App.Fossa.ArchiveUploader (arcToLocator, archiveUploadSourceUnit, forceVendoredToArchive)
+import App.Fossa.ArchiveUploader (archiveUploadSourceUnit)
 import App.Fossa.Config.Analyze (AllowNativeLicenseScan (AllowNativeLicenseScan))
 import App.Fossa.LicenseScanner (licenseScanSourceUnit)
 import App.Fossa.VendoredDependency (
   VendoredDependency (..),
+  arcToLocator,
+  forceVendoredToArchive,
  )
 import Control.Carrier.FossaApiClient (runFossaApiClient)
 import Control.Effect.Diagnostics (Diagnostics, context, fatalText)

--- a/src/App/Fossa/VendoredDependency.hs
+++ b/src/App/Fossa/VendoredDependency.hs
@@ -1,0 +1,22 @@
+module App.Fossa.VendoredDependency (
+  VendoredDependency (..),
+) where
+
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
+import Data.Aeson.Extra (TextLike (unTextLike), forbidMembers)
+import Data.Functor.Extra ((<$$>))
+import Data.Text (Text)
+
+data VendoredDependency = VendoredDependency
+  { vendoredName :: Text
+  , vendoredPath :: Text
+  , vendoredVersion :: Maybe Text
+  }
+  deriving (Eq, Ord, Show)
+
+instance FromJSON VendoredDependency where
+  parseJSON = withObject "VendoredDependency" $ \obj ->
+    VendoredDependency <$> obj .: "name"
+      <*> obj .: "path"
+      <*> (unTextLike <$$> obj .:? "version")
+      <* forbidMembers "vendored dependencies" ["type", "license", "url", "description"] obj

--- a/src/App/Fossa/VendoredDependency.hs
+++ b/src/App/Fossa/VendoredDependency.hs
@@ -30,7 +30,7 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.UUID.V4 (nextRandom)
 import Fossa.API.Types (Archive (..))
-import Path.Posix (Abs, Dir, Path)
+import Path (Abs, Dir, Path)
 import Srclib.Types (Locator (..))
 import System.FilePath.Posix (splitDirectories, (</>))
 

--- a/src/App/Fossa/VendoredDependency.hs
+++ b/src/App/Fossa/VendoredDependency.hs
@@ -1,11 +1,36 @@
 module App.Fossa.VendoredDependency (
   VendoredDependency (..),
+  arcToLocator,
+  forceVendoredToArchive,
+  compressFile,
+  duplicateFailureBundle,
+  duplicateNames,
+  hashFile,
 ) where
 
+import Codec.Archive.Tar qualified as Tar
+import Codec.Compression.GZip qualified as GZip
+import Crypto.Hash (Digest, MD5, hashlazy)
 import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
 import Data.Aeson.Extra (TextLike (unTextLike), forbidMembers)
+import Data.ByteString.Lazy qualified as BS
 import Data.Functor.Extra ((<$$>))
+import Data.List (intercalate)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.String.Conversion (
+  ToString (toString),
+  ToText (toText),
+ )
 import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.UUID.V4 (nextRandom)
+import Fossa.API.Types (Archive (..))
+import Path.Posix (Abs, Dir, Path)
+import Srclib.Types (Locator (..))
+import System.FilePath.Posix (splitDirectories, (</>))
 
 data VendoredDependency = VendoredDependency
   { vendoredName :: Text
@@ -20,3 +45,51 @@ instance FromJSON VendoredDependency where
       <*> obj .: "path"
       <*> (unTextLike <$$> obj .:? "version")
       <* forbidMembers "vendored dependencies" ["type", "license", "url", "description"] obj
+
+-- | List of names that occur more than once in a list of vendored dependencies.
+duplicateNames :: NonEmpty VendoredDependency -> [Text]
+duplicateNames = Map.keys . Map.filter (> 1) . Map.fromListWith (+) . map pair . NonEmpty.toList
+  where
+    pair :: VendoredDependency -> (Text, Int)
+    pair VendoredDependency{vendoredName} = (vendoredName, 1)
+
+duplicateFailureBundle :: [Text] -> Text
+duplicateFailureBundle names =
+  "The provided vendored dependencies contain the following duplicate names:\n\t"
+    <> Text.intercalate "\n\t" names
+    <> "\n\n"
+    <> "Vendored dependency entries may not specify duplicate names.\n"
+    <> "Please ensure that each vendored dependency entry has a unique name."
+
+forceVendoredToArchive :: VendoredDependency -> Archive
+forceVendoredToArchive dep = Archive (vendoredName dep) (fromMaybe "" $ vendoredVersion dep)
+
+arcToLocator :: Archive -> Locator
+arcToLocator arc =
+  Locator
+    { locatorFetcher = "archive"
+    , locatorProject = archiveName arc
+    , locatorRevision = Just $ archiveVersion arc
+    }
+
+compressFile :: Path Abs Dir -> Path Abs Dir -> FilePath -> IO FilePath
+compressFile outputDir directory fileToTar = do
+  -- We are adding the suffix to avoid errors when we compress to a path that already exists
+  -- This is most likely to happen if `fileToTar` is "."
+  suffix <- nextRandom
+  let finalFilename = fileToTar ++ show suffix
+  let finalFile = toString outputDir </> safeSeparators finalFilename
+  entries <- Tar.pack (toString directory) [fileToTar]
+  BS.writeFile finalFile $ GZip.compress $ Tar.write entries
+  pure finalFile
+
+md5 :: BS.ByteString -> Digest MD5
+md5 = hashlazy
+
+hashFile :: FilePath -> IO Text
+hashFile fileToHash = do
+  fileContent <- BS.readFile fileToHash
+  pure . toText . show $ md5 fileContent
+
+safeSeparators :: FilePath -> FilePath
+safeSeparators = intercalate "_" . splitDirectories

--- a/src/App/Fossa/VendoredDependency.hs
+++ b/src/App/Fossa/VendoredDependency.hs
@@ -3,8 +3,6 @@ module App.Fossa.VendoredDependency (
   arcToLocator,
   forceVendoredToArchive,
   compressFile,
-  duplicateFailureBundle,
-  duplicateNames,
   hashFile,
   dedupVendoredDeps,
 ) where

--- a/test/App/Fossa/ArchiveUploaderSpec.hs
+++ b/test/App/Fossa/ArchiveUploaderSpec.hs
@@ -4,7 +4,7 @@ module App.Fossa.ArchiveUploaderSpec (
   spec,
 ) where
 
-import App.Fossa.ArchiveUploader (
+import App.Fossa.VendoredDependency (
   compressFile,
  )
 import Control.Carrier.Lift (sendIO)

--- a/test/App/Fossa/ArchiveUploaderSpec.hs
+++ b/test/App/Fossa/ArchiveUploaderSpec.hs
@@ -12,7 +12,7 @@ import Control.Carrier.Lift (sendIO)
 import Control.Effect.Path (withSystemTempDir)
 import Path (Abs, Dir, Path, mkRelDir, (</>))
 import Path.IO (getCurrentDir)
-import Test.Effect (it', shouldBe', shouldContain')
+import Test.Effect (it', shouldContain')
 import Test.Hspec (Spec, describe, runIO)
 
 spec :: Spec

--- a/test/App/Fossa/ArchiveUploaderSpec.hs
+++ b/test/App/Fossa/ArchiveUploaderSpec.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.Fossa.ArchiveUploaderSpec
+  ( spec,
+  )
+where
+
+import App.Fossa.ArchiveUploader
+  ( compressFile,
+  )
+import Control.Carrier.Lift (sendIO)
+import Control.Effect.Path (withSystemTempDir)
+import Path (Abs, Dir, Path, mkRelDir, (</>))
+import Path.IO (getCurrentDir)
+import Test.Effect (it', shouldBe', shouldContain')
+import Test.Hspec (Spec, describe, runIO)
+
+spec :: Spec
+spec = do
+  currDir <- runIO getCurrentDir
+  describe "compressFile" $ do
+    it' "should compress a file" $
+      do
+        let fileToTar = "foo"
+        let specDir = currDir </> $(mkRelDir "test/ArchiveUploader/normal")
+        compressedFilePath <- sendIO $ withSystemTempDir "fossa-temp" (flippedCompressFile specDir fileToTar)
+        compressedFilePath `shouldContain'` fileToTar
+
+    -- We are mostly testing that this does not raise an exception
+    it' "should compress a directory called '.' without throwing" $
+      do
+        let fileToTar = "."
+        let specDir = currDir </> $(mkRelDir "test/ArchiveUploader/normal")
+        compressedFilePath <- sendIO $ withSystemTempDir "fossa-temp" (flippedCompressFile specDir fileToTar)
+        compressedFilePath `shouldContain'` fileToTar
+  where
+    flippedCompressFile :: Path Abs Dir -> FilePath -> Path Abs Dir -> IO FilePath
+    flippedCompressFile directory fileToTar outputDir = compressFile outputDir directory fileToTar

--- a/test/App/Fossa/ArchiveUploaderSpec.hs
+++ b/test/App/Fossa/ArchiveUploaderSpec.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module App.Fossa.ArchiveUploaderSpec
-  ( spec,
-  )
-where
+module App.Fossa.ArchiveUploaderSpec (
+  spec,
+) where
 
-import App.Fossa.ArchiveUploader
-  ( compressFile,
-  )
+import App.Fossa.ArchiveUploader (
+  compressFile,
+ )
 import Control.Carrier.Lift (sendIO)
 import Control.Effect.Path (withSystemTempDir)
 import Path (Abs, Dir, Path, mkRelDir, (</>))

--- a/test/App/Fossa/VendoredDependencySpec.hs
+++ b/test/App/Fossa/VendoredDependencySpec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module App.Fossa.ArchiveUploaderSpec (
+module App.Fossa.VendoredDependencySpec (
   spec,
 ) where
 


### PR DESCRIPTION
# Overview

Refactors `App.Fossa.ArchiveUploader` by pulling some of its shared functionality into `App.Fossa.VendoredDependency`.

The functions pulled out are used in `App.Fossa.LicenseScanner` and a few other places.

I also replaced some duplicated code in `archiveUploadSourceUnit` with a call to `dedupVendoredDeps`.

## Acceptance criteria

This is a refactor, so there should be no changes in behavior.

## Testing plan

I sanity checked by running an archive upload and a cli-side license scan against the sample "unarchived-vendored-dependencies" project.

```
cd ~/fossa/license-scan-dirs
cp -r ~/fossa/example-projects/fossa-deps/unarchived-vendored-dependencies .
```

I edited fossa-deps.yml to remove the version. It now looks like this:

```
vendored-dependencies:
  - name: Hello-Vendored-Unarchived
    path: vendor/hello-1.0.0.2
```

Now run scans on it, changing the files slightly each time so you get different versions:

```
uuidgen > ~/fossa/license-scan-dirs/unarchived-vendored-dependencies/vendor/hello-1.0.0.2/VERSION
cabal run fossa -- analyze ~/fossa/license-scan-dirs/unarchived-vendored-dependencies
```

```
uuidgen > ~/fossa/license-scan-dirs/unarchived-vendored-dependencies/vendor/hello-1.0.0.2/VERSION
cabal run fossa -- analyze --experimental-native-license-scan ~/fossa/license-scan-dirs/unarchived-vendored-dependencies
```
## Risks

None

## References

None

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
