### PR TITLE
Adds npm Lockfile v3 support (part A)

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -33,10 +33,10 @@
 - functions:
   - {name: error, within: [Data.String.Conversion, Control.Effect.Replay]}
   - {name: undefined, within: []}
-  - {name: Prelude.head, within: [Control.Effect.Replay.TH, Control.Effect.Record.TH, Node.PackageLockV3Spec], message: "Use Data.List.Extra.head' instead."}
+  - {name: Prelude.head, within: [Control.Effect.*.TH, "**.*Spec"], message: "Use Data.List.Extra.head' instead."}
   - {name: Prelude.tail, within: []}
   - {name: Prelude.init, within: []}
-  - {name: Prelude.last, within: [Node.PackageLockV3Spec]}
+  - {name: Prelude.last, within: ["**.*Spec"]}
   - {name: Data.ByteString.head, within: []}
   - {name: Data.Bytestring.tail, within: []}
   - {name: Data.Bytestring.init, within: []}

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -33,10 +33,10 @@
 - functions:
   - {name: error, within: [Data.String.Conversion, Control.Effect.Replay]}
   - {name: undefined, within: []}
-  - {name: Prelude.head, within: [Control.Effect.Replay.TH, Control.Effect.Record.TH], message: "Use Data.List.Extra.head' instead."}
+  - {name: Prelude.head, within: [Control.Effect.Replay.TH, Control.Effect.Record.TH, Node.PackageLockV3Spec], message: "Use Data.List.Extra.head' instead."}
   - {name: Prelude.tail, within: []}
   - {name: Prelude.init, within: []}
-  - {name: Prelude.last, within: []}
+  - {name: Prelude.last, within: [Node.PackageLockV3Spec]}
   - {name: Data.ByteString.head, within: []}
   - {name: Data.Bytestring.tail, within: []}
   - {name: Data.Bytestring.init, within: []}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,7 @@
 # FOSSA CLI Changelog
 
-## Unreleased
-
-- Archive upload: Fix a bug when trying to tar to a filename that already exists
+## v3.2.17
+- Archive upload: Fix a bug when trying to tar to a filename that already exists. ([#927](https://github.com/fossas/fossa-cli/pull/927))
 - Npm: Supports lockfile v3. ([#932](https://github.com/fossas/fossa-cli/pull/932))
 
 ## v3.2.16

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Archive upload: Fix a bug when trying to tar to a filename that already exists
+- Npm: Supports lockfile v3. ([#932](https://github.com/fossas/fossa-cli/pull/932))
+
 ## v3.2.16
 - Go: When statically analyzing a project, apply reported replacements. ([#926](https://github.com/fossas/fossa-cli/pull/926))
 

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,16 @@ SHELL := bash
 build:
 	cabal build
 
+# Runs units tests.
+# To run a set of unit tests matching a specific value, use ARGS
+# For example, to only run tests whose name matches the wildcard '*fd*':
+# 	make test ARGS="Node.PackageLockV3"
 test:
+ifdef ARGS
+	cabal test unit-tests --test-show-details=streaming --test-option=--format=checks --test-option=--times --test-option=--color --test-option=--match --test-option="$(ARGS)"
+else
 	cabal test unit-tests --test-show-details=streaming --test-option=--format=checks --test-option=--times --test-option=--color
+endif
 
 # Runs an integration test.
 # To run a set of integration tests matching a specific value, use ARGS

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build:
 
 # Runs units tests.
 # To run a set of unit tests matching a specific value, use ARGS
-# For example, to only run tests whose name matches the wildcard '*fd*':
+# For example, to only run tests whose name matches the wildcard '*Node.PackageLockV3*':
 # 	make test ARGS="Node.PackageLockV3"
 test:
 ifdef ARGS

--- a/docs/references/strategies/languages/nodejs/npm-lockfile.md
+++ b/docs/references/strategies/languages/nodejs/npm-lockfile.md
@@ -29,7 +29,7 @@ In `package-lock.json`, `packages` object's key refer to filepath for associated
 
 Generally, we have three types of data shape within `packages` map.
 
-1) Root module
+1) Root module (denoted by having `""` key)
 
 ```json
   "": {
@@ -55,6 +55,8 @@ Generally, we have three types of data shape within `packages` map.
       }
   }
 ```
+
+Workspace module, in essence is type of root module whose parent is top level root module (as shown in (1)).
 
 3) Package Module (these are the dependencies which fossa will report)
 

--- a/docs/references/strategies/languages/nodejs/npm-lockfile.md
+++ b/docs/references/strategies/languages/nodejs/npm-lockfile.md
@@ -18,7 +18,89 @@ Search for files named `package.json` and check for a corresponding
 > will be combined to determine which dependencies are direct and which ones are
 > development.
 
-## Analysis
+## Analysis (for lockFile version 3)
+
+We consider `package-lock.json` to be version 3 compatible, if and only if, 
+
+- `lockFileVersion` field exists, and is of value 3
+- `packages` field exists in the `package-lock.json`.
+
+In `package-lock.json`, `packages` object's key refer to filepath for associated `package.json`.
+
+Generally, we have three types of data shape within `packages` map.
+
+1) Root module
+
+```json
+  "": {
+      "name": "packageLockV3",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+          "foo": "^1.0.0",
+          "boo": "^1.0.0"
+      }
+  }
+```
+
+2) Workspace module
+
+```json
+  "packages/a": {
+      "name": "packageLockV3PkgA",
+      "version": "2.0.0",
+      "license": "ISC",
+      "dependencies": {
+          "foo": "^2.0.0"
+      }
+  }
+```
+
+3) Package Module (these are the dependencies which fossa will report)
+
+```json
+  "node_modules/foo": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/foo/-/foo-1.2.0.tgz"
+  },
+  "node_modules/bar": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bar/-/bar-1.3.0.tgz",
+      "dependencies": {
+          "baz": "^1.0.0"
+      }
+  },
+  "node_modules/baz": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/baz/-/baz-1.9.0.tgz"
+  },
+  "packages/a/node_modules/foo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foo/-/foo-2.0.0.tgz"
+  }
+```
+
+We will attempt infer the resolved version by looking at package's key. 
+
+For instance, to infer resolved version of `foo@^2.0.0` for `packages/a`,
+we will attempt to see if the dependency was resolved at vendored path, 
+or at top level path. 
+
+If we find, `packages/a/node_modules/foo` key in our packages object, we use it's
+resolved version. If this key does not exist we fallback to `node_modules/foo`.
+
+With this approach, for aforementioned example, we will generate following dependency tree:
+
+```text
+-- foo@2.0.0      (via workspace package a)
+-- foo@1.2.0      (via root package.json)
+-- bar@1.3.0      (via root package.json)
+    \- baz@1.9.0  (transitive dep via bar@1.3.0)
+```
+
+We use `dev` field to infer if the dependency is development dependency or not.
+
+## Analysis (for lockFile version 1)
 
 Opening a `package-lock.json` file reveals the project's dependency tree. This
 dependency tree contains information about a dependency's version, its

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -362,6 +362,7 @@ library
     Strategy.Node
     Strategy.Node.Errors
     Strategy.Node.Npm.PackageLock
+    Strategy.Node.Npm.PackageLockV3
     Strategy.Node.PackageJson
     Strategy.Node.YarnV1.YarnLock
     Strategy.Node.YarnV2.Lockfile
@@ -506,6 +507,7 @@ test-suite unit-tests
     Node.NodeSpec
     Node.PackageJsonSpec
     Node.PackageLockSpec
+    Node.PackageLockV3Spec
     NuGet.NuspecSpec
     NuGet.PackageReferenceSpec
     NuGet.PackagesConfigSpec

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -32,7 +32,7 @@ import Data.Glob qualified as Glob
 import Data.List.Extra (singleton)
 import Data.Map (Map, toList)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes, mapMaybe)
+import Data.Maybe (catMaybes, isJust, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String.Conversion (decodeUtf8)
@@ -73,6 +73,7 @@ import Path (
  )
 import Strategy.Node.Errors (CyclicPackageJson (CyclicPackageJson), MissingNodeLockFile (MissingNodeLockFile))
 import Strategy.Node.Npm.PackageLock qualified as PackageLock
+import Strategy.Node.Npm.PackageLockV3 qualified as PackageLockV3
 import Strategy.Node.PackageJson (
   Development,
   FlatDeps (FlatDeps),
@@ -167,9 +168,12 @@ getDeps (NPMLock packageLockFile graph) = analyzeNpmLock packageLockFile graph
 getDeps (NPM graph) = analyzeNpm graph
 
 analyzeNpmLock :: (Has Diagnostics sig m, Has ReadFS sig m) => Manifest -> PkgJsonGraph -> m DependencyResults
-analyzeNpmLock (Manifest file) graph = do
-  result <- PackageLock.analyze file (extractDepLists graph) (findWorkspaceNames graph)
-  pure $ DependencyResults result Complete [file]
+analyzeNpmLock (Manifest npmLockFile) graph = do
+  npmLockVersion <- detectNpmLockVersion npmLockFile
+  result <- case npmLockVersion of
+    NpmLockV3Compatible -> PackageLockV3.analyze npmLockFile
+    NpmLockV1Compatible -> PackageLock.analyze npmLockFile (extractDepLists graph) (findWorkspaceNames graph)
+  pure $ DependencyResults result Complete [npmLockFile]
 
 analyzeNpm :: (Has Diagnostics sig m) => PkgJsonGraph -> m DependencyResults
 analyzeNpm wsGraph = do
@@ -215,6 +219,22 @@ detectYarnVersion yarnfile = do
 data YarnVersion
   = V1
   | V2Compatible
+
+data NpmLockVersion
+  = NpmLockV1Compatible
+  | NpmLockV3Compatible
+
+detectNpmLockVersion ::
+  ( Has Diagnostics sig m
+  , Has ReadFS sig m
+  ) =>
+  Path Abs File ->
+  m NpmLockVersion
+detectNpmLockVersion npmLockFile = do
+  isV3Compatible :: (Maybe PackageLockV3.PackageLockV3) <- recover $ readContentsJson npmLockFile
+  if isJust isV3Compatible
+    then pure NpmLockV3Compatible
+    else pure NpmLockV1Compatible
 
 -- | Find every manifest that is a child of some other package and look
 -- up their @packageName@ in the @jsonLookup@ map.

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -231,7 +231,7 @@ detectNpmLockVersion ::
   Path Abs File ->
   m NpmLockVersion
 detectNpmLockVersion npmLockFile = do
-  isV3Compatible :: (Maybe PackageLockV3.PackageLockV3) <- recover $ readContentsJson npmLockFile
+  isV3Compatible <- recover $ readContentsJson @PackageLockV3.PackageLockV3 npmLockFile
   if isJust isV3Compatible
     then pure NpmLockV3Compatible
     else pure NpmLockV1Compatible

--- a/src/Strategy/Node/Npm/PackageLockV3.hs
+++ b/src/Strategy/Node/Npm/PackageLockV3.hs
@@ -417,7 +417,7 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
         isWorkSpace name pkgPath = pkgPath == PackageLockV3WorkSpace name
 
 analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
-analyze file = context "Analyzing Npm Lockfile" $ do
+analyze file = context "Analyzing Npm Lockfile (v3)" $ do
   packageLockJson <- context "Parsing v3 compatible package-lock.json" $ readContentsJson @PackageLockV3 file
   context "Building dependency graph" $ pure $ buildGraph packageLockJson
 

--- a/src/Strategy/Node/Npm/PackageLockV3.hs
+++ b/src/Strategy/Node/Npm/PackageLockV3.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Strategy.Node.Npm.PackageLockV3 (
   PackageLockV3 (..),

--- a/src/Strategy/Node/Npm/PackageLockV3.hs
+++ b/src/Strategy/Node/Npm/PackageLockV3.hs
@@ -428,4 +428,3 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
 
     isWorkSpace :: Text -> PackagePath -> Bool
     isWorkSpace name pkgPath = pkgPath == PackageLockV3WorkSpace name
-

--- a/src/Strategy/Node/Npm/PackageLockV3.hs
+++ b/src/Strategy/Node/Npm/PackageLockV3.hs
@@ -1,0 +1,448 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Strategy.Node.Npm.PackageLockV3 (
+  PackageLockV3 (..),
+  analyze,
+
+  -- * for testing,
+  PackagePath (..),
+  PackageName (..),
+  PackageLockV3Package (..),
+  NpmLockV3Resolved (..),
+  buildGraph,
+  isV3Compatible,
+  parsePathKey,
+) where
+
+import Control.Algebra (Has)
+import Control.Carrier.Diagnostics (Diagnostics, context)
+import Control.Monad (unless)
+import Data.Aeson (
+  FromJSON (parseJSON),
+  FromJSONKey (fromJSONKey),
+  FromJSONKeyFunction (FromJSONKeyTextParser),
+  Value (Bool, String),
+  withObject,
+  withText,
+  (.!=),
+  (.:),
+  (.:?),
+ )
+import Data.Foldable (for_, traverse_)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
+import Data.Set qualified as Set
+import Data.Text (Text, breakOnEnd)
+import Data.Text qualified as Text
+import DepTypes (
+  DepEnvironment (EnvDevelopment),
+  DepType (NodeJSType),
+  Dependency (..),
+  VerConstraint (CEq),
+ )
+import Effect.Grapher (direct, edge, evalGrapher, run)
+import Effect.ReadFS (ReadFS, readContentsJson)
+import Graphing (Graphing)
+import Path (
+  Abs,
+  File,
+  Path,
+ )
+
+data PackageLockV3 = PackageLockV3
+  { rootPackage :: PackageLockV3Package
+  , packages :: Map PackagePath PackageLockV3Package
+  , lockFileVersion :: Maybe Int
+  }
+  deriving (Show, Eq, Ord)
+
+instance FromJSON PackageLockV3 where
+  parseJSON = withObject "PackageLockV3" $ \obj -> do
+    packages <- obj .: "packages"
+    lockFileVersion <- obj .:? "lockfileVersion"
+
+    -- Ensure it is v3 compatible file
+    -- v2 file by default are v3 compatible
+    -- Refer to: https://docs.npmjs.com/cli/v8/configuring-npm/package-lock-json#lockfileversion
+    unless (isV3Compatible lockFileVersion) $
+      fail "Provided lockfile is not v3 compatible!"
+
+    -- If root package is missing, it is likely
+    -- corrupted package-lock file, fail early.
+    case Map.lookup PackageLockV3Root packages of
+      Nothing -> fail "Could not find root node in package-lock.json! Is this faulty package-lock.json file?"
+      Just rootPackage -> pure $ PackageLockV3 rootPackage packages lockFileVersion
+
+-- | Returns True when provided LockfileVersion is v3 compatible, otherwise returns False.
+-- Although v2 lockfile is forward compatible
+-- We intentionally mark them incompatible for now, give large blast zone.
+-- TODO: make v2 lockfile also compatible with v3 after this analysis has been used in prod for some time.
+isV3Compatible :: Maybe Int -> Bool
+isV3Compatible lockFileVersion =
+  case lockFileVersion of
+    Nothing -> False
+    Just v ->
+      v == 3
+
+-- | Primary identifier in package-lock.json v3 `packages`.
+--
+-- In package-lock v3 file, "packages" key's field value refer to
+-- path in filesystem that points to a package.json file.
+--
+-- * @PackageLockV3Root@ refers to parent package.json file.
+--
+--   project/
+--    + package.json <- PackageLockV3Root
+--
+-- * @PackageLockV3WorkSpace Text@ refers to workspace path of package.json, for example:
+--
+--   project/
+--    + package.json
+--    + workspace-a/
+--    ++ package.json <- PackageLockV3WorkSpace "workspace-a"
+--
+-- * @PackageLockV3PathKey Text PackageName@ refers to dependency's package.json:
+--
+--   project/
+--    + package.json
+--    + node_modules/
+--    ++ a/
+--    +++ package.json <- PackageLockV3PathKey "node_modules" "a"
+--    + workspace-a/
+--    ++ package.json
+data PackagePath
+  = PackageLockV3WorkSpace Text
+  | PackageLockV3Root
+  | PackageLockV3PathKey Text PackageName
+  deriving (Show, Eq, Ord)
+
+instance FromJSONKey PackagePath where
+  fromJSONKey = FromJSONKeyTextParser $ \pkgPathText -> pure $ parsePathKey pkgPathText
+
+instance FromJSON PackagePath where
+  parseJSON = withText "PackageLockV3PackageKey" $ \pkgPathText -> pure $ parsePathKey pkgPathText
+
+-- It is not possible to modify the default vendor dir in npm.
+defaultVendorDir :: Text
+defaultVendorDir = "node_modules/"
+
+-- | Parse a path key to @PackagePath@.
+parsePathKey :: Text -> PackagePath
+parsePathKey t = case (breakOnEnd defaultVendorDir t) of
+  ("", "") -> PackageLockV3Root
+  ("", workspace) -> PackageLockV3WorkSpace workspace
+  (prefix, moduleName) -> PackageLockV3PathKey prefix (PackageName moduleName)
+
+newtype PackageName = PackageName {unPackageName :: Text} deriving (Show, Eq, Ord, FromJSONKey)
+instance FromJSON PackageName where
+  parseJSON = withText "PackageName" $ \pkgName -> pure $ PackageName pkgName
+
+-- | Describes package and it's dependencies.
+data PackageLockV3Package = PackageLockV3Package
+  { plV3PkgVersion :: Maybe Text
+  , plV3PkgResolved :: NpmLockV3Resolved
+  , plV3PkgDependencies :: Map PackageName Text
+  , plV3PkgDevDependencies :: Map PackageName Text
+  , plV3PkgPeerDependencies :: Map PackageName Text
+  , plV3PkgDev :: Bool
+  }
+  deriving (Show, Eq, Ord)
+
+instance FromJSON PackageLockV3Package where
+  parseJSON = withObject "PackageLockV3Package" $ \obj ->
+    PackageLockV3Package
+      <$> obj .:? "version"
+      <*> obj .:? "resolved" .!= (NpmLockV3Resolved Nothing)
+      <*> obj .:? "dependencies" .!= mempty
+      <*> obj .:? "devDependencies" .!= mempty
+      <*> obj .:? "peerDependencies" .!= mempty
+      <*> obj .:? "dev" .!= False -- if 'dev' key is not included, it is presumed to be prod dependency
+
+newtype NpmLockV3Resolved = NpmLockV3Resolved {unNpmLockV3Resolved :: Maybe Text}
+  deriving (Eq, Ord, Show)
+
+instance FromJSON NpmLockV3Resolved where
+  parseJSON (String t) = pure $ NpmLockV3Resolved (Just t)
+  parseJSON (Bool _) = pure $ NpmLockV3Resolved Nothing
+  parseJSON _ = fail "Expected to contain string or boolean value for 'resolved' field!"
+
+-- | Builds a graph for package lock v3.
+--
+-- In summary, when resolving a dependency, npm checks if the version spec of
+-- dependency can be met by storing a dependency at top level, or checking if
+-- existing dependency (at top level) is compatible with the spec. If it finds,
+-- that version spec, cannot be met it vendors this dependency from it's own node_modules
+-- directory.
+--
+--  Consider,
+--
+--  A --> B@^1.0.0
+--  C --> B@^1.0.0
+--  D --> B@^2.0.0
+--
+--  Would yield following file tree,
+--
+--  package.json
+--  package-lock.json
+--  node_modules/
+--    A/
+--    B/ (at 1.0.0) (refer to as top level path)
+--    C/
+--    D/
+--      node_modules/
+--        B@2.0.0 (refer to as vendored path)
+--
+--  And PackageLockV3, packages key reflect filepath of nodule.
+--
+--  So to make a resolution, we work backwards to top level from
+--  a given module,
+--
+--  For package's dependency,
+--    - We associated resolved version to vendored path if present.
+--      If not, we associate it with top-level path if present.
+--      If neither are present, we ignore this edge.
+--
+--  Although, this is not precisely what npm does when loading
+--  package-lock.json, this is good approximation without having
+--  to port npm/cli/arborist/virtualTree.
+--
+--  Since workspaces are considered to a it's own "root", we also
+--  check if package's dependency exists at node_modules of workspace.
+--  in resolution process.
+--
+--  References:
+--    - https://github.com/npm/arborist/blob/main/lib/arborist/load-virtual.js
+--    - https://docs.npmjs.com/cli/v8/using-npm/workspaces
+--    - http://npm.github.io/how-npm-works-docs/npm3/how-npm3-works.html
+--
+--  --
+buildGraph :: PackageLockV3 -> Graphing Dependency
+buildGraph pkgLockV3 = run . evalGrapher $ do
+  for_ (Map.toList $ packages pkgLockV3) $ \(pkgPathKey, pkgMetadata) -> do
+    case pkgPathKey of
+      -- For root package,
+      --
+      -- "": {
+      --   "name": "project-name",
+      --   "version": "1.0.0",
+      --   "dependencies": {
+      --     "someDirectDep": "^1.0.0",
+      --   }
+      --  },
+      --
+      -- Now this, @someDirectDep, will be resolved at:
+      --    - top path: node_modules/someDirectDep
+      --
+      -- "node_modules/someDirectDep": {
+      --       "version": "1.2.3",
+      --       "resolved": "https://registry.npmjs.org/someDirectDep/-/someDirectDep-1.2.3.tgz",
+      --       "dependencies": {
+      --         "someTransitiveDepB": "^1.0.0"
+      --       }
+      --     },
+      --
+      -- We need to resolve dependency from a top path, since we
+      -- want to identify precise version (e.g. 1.2.3) used by project as opposed
+      -- to version spec (e.g. ^1.0.0) provided in 'dependencies' field.
+      --
+      -- Root's direct dependencies are always resolved at top-path.
+      PackageLockV3Root -> do
+        let directDeps :: [PackagePath]
+            directDeps =
+              toTopLevelPackage
+                <$> concatMap
+                  Map.keys
+                  [ plV3PkgDependencies pkgMetadata
+                  , plV3PkgDevDependencies pkgMetadata
+                  , plV3PkgPeerDependencies pkgMetadata
+                  ]
+
+        let resolvedDeps :: [Dependency]
+            resolvedDeps = mapMaybe toDependency directDeps
+
+        traverse_ direct resolvedDeps
+
+      -- For workspace packages, for instance:
+      --
+      -- "workspace-a": {
+      --   "name": "someWorkspacePkgName",
+      --   "version": "1.0.0",
+      --   "dependencies": {
+      --     "someWorkspaceDirectDep": "^1.0.0",
+      --   }
+      --  },
+      --
+      -- Now this, @someWorkspaceDirectDep, might be resolved at:
+      --    - top path: node_modules/someWorkspaceDirectDep
+      --    - vendor path: workspace-a/node_modules/someWorkspaceDirectDep
+      --
+      -- If the @someWorkspaceDirectDep was resolved with top path,
+      -- vendored path (within workspace-a) will not exist. For this reason,
+      -- always prefer vendored path, if such path does not exist fallback to
+      -- top level path.
+      --
+      -- Direct Dependencies within workspace pkg are treated as direct.
+      -- Direct Peer Dependencies within workspace pkg are treated as direct.
+      -- Development Dependencies within workspace pkg are treated as direct development.
+      PackageLockV3WorkSpace workspaceRootPath -> do
+        let directDeps :: [PackagePath]
+            directDeps =
+              (vendoredPathElseTopLevelPath workspaceRootPath)
+                <$> concatMap
+                  Map.keys
+                  [ plV3PkgDependencies pkgMetadata
+                  , plV3PkgDevDependencies pkgMetadata
+                  , plV3PkgPeerDependencies pkgMetadata
+                  ]
+
+        let resolvedDeps :: [Dependency]
+            resolvedDeps = mapMaybe toDependency directDeps
+
+        traverse_ direct resolvedDeps
+
+      -- For typical dependency packages, for instance:
+      --
+      -- "node_module/someDirectDep": {
+      --   "version": "1.2.3",
+      --   "resolved": "https://registry.npmjs.org/someDirectDep/-/someDirectDep-1.2.3.tgz",
+      --   "dependencies": {
+      --     "someTransitiveDepB": "^1.0.0",
+      --   }
+      --  },
+      --
+      -- Now this, @someTransitiveDepB, might be resolved at:
+      --    - top path: node_modules/someTransitiveDepB
+      --    - vendor path: node_modules/a/node_modules/someTransitiveDepB
+      --
+      -- If the @someTransitiveDepB was resolved with top path,
+      -- vendored path (within node_modules/a/) will not exist. For this reason,
+      -- always prefer vendored path, if such path does not exist fallback to
+      -- top level path.
+      --
+      -- Only 'dependencies' field is used to infer transitive dependencies.
+      --
+      -- For each transitive dependency, Adds edge between parent package, and transitive dep.
+      PackageLockV3PathKey prefixPath depPackageName -> do
+        let currentDep :: Maybe Dependency
+            currentDep = toDependency (PackageLockV3PathKey prefixPath depPackageName)
+
+        let vendorPathPrefix :: Text
+            vendorPathPrefix = prefixPath <> (unPackageName depPackageName)
+
+        let deepDeps :: [PackagePath]
+            deepDeps =
+              (vendoredPathElseTopLevelPath vendorPathPrefix)
+                <$> concatMap
+                  Map.keys
+                  [ plV3PkgDependencies pkgMetadata
+                  , plV3PkgPeerDependencies pkgMetadata
+                  ]
+
+        let resolvedDeepDeps :: [Dependency]
+            resolvedDeepDeps = mapMaybe toDependency deepDeps
+
+        case currentDep of
+          Nothing -> pure () -- This will never happen, given that we are iterating on same package path.
+          Just parentDep -> do
+            for_ resolvedDeepDeps $ \resolvedDeepDep -> do
+              edge parentDep resolvedDeepDep
+  where
+    -- Prefer resolution path in following order of precedent:
+    --  1) {prefix}/node_modules/{pkgName}
+    --  2) {root of prefix}/node_modules/{pkgName} (handles workspace root projects)
+    --  3) node_modules/{pkgName}
+    vendoredPathElseTopLevelPath :: Text -> PackageName -> PackagePath
+    vendoredPathElseTopLevelPath prefix pkgName
+      | Map.member (toVendoredPackage prefix pkgName) allDependencyPackages = (toVendoredPackage prefix pkgName)
+      | Map.member (toWorkspaceLevelPackage prefix pkgName) allDependencyPackages = (toWorkspaceLevelPackage prefix pkgName)
+      | otherwise = toTopLevelPackage pkgName
+
+    toDependency :: PackagePath -> Maybe Dependency
+    toDependency pkgPath =
+      case (Map.lookup pkgPath $ packages pkgLockV3) of
+        Just meta -> do
+          case pkgPath of
+            PackageLockV3PathKey _ packageName ->
+              Just $
+                Dependency
+                  { dependencyType = NodeJSType
+                  , dependencyName = unPackageName packageName
+                  , dependencyVersion = CEq <$> (plV3PkgVersion meta)
+                  , dependencyLocations = catMaybes [unNpmLockV3Resolved $ plV3PkgResolved meta]
+                  , dependencyEnvironments =
+                      if plV3PkgDev meta
+                        then Set.singleton EnvDevelopment
+                        else mempty
+                  , dependencyTags = Map.empty
+                  }
+            PackageLockV3WorkSpace _ -> Nothing -- Don't report workspace as dependency!
+            PackageLockV3Root -> Nothing -- Don't report root project as dependency!
+        _ -> Nothing
+
+    allDependencyPackages :: Map PackagePath PackageLockV3Package
+    allDependencyPackages =
+      Map.filterWithKey
+        (\k _ -> isReportableDependencyModule k)
+        (packages pkgLockV3)
+
+    -- True if package path leads to dependency, Otherwise false.
+    isReportableDependencyModule :: PackagePath -> Bool
+    isReportableDependencyModule pkgPath = case pkgPath of
+      PackageLockV3PathKey _ _ -> True
+      _ -> False
+
+    -- Provides candidate path in top level tree
+    -- >> toTopLevelPackage pkgName = PackagePath "node_modules/" pkgName
+    toTopLevelPackage :: PackageName -> PackagePath
+    toTopLevelPackage = PackageLockV3PathKey defaultVendorDir
+
+    -- Provides candidate path in as if the package was vendored
+    -- >> toVendoredPackage "node_module/a" pkgName = PackagePath "node_modules/a/node_modules/" pkgName
+    toVendoredPackage :: Text -> PackageName -> PackagePath
+    toVendoredPackage prefix = PackageLockV3PathKey (prefix <> "/" <> defaultVendorDir)
+
+    -- Provides candidate path in current workspace root, if it contains a workspace root.
+    -- If prefix does not contain workspace root, it mimics @toVendoredPackage.
+    --
+    -- >> toVendoredPackage "myWorkspace/myPkg/node_modules/a" pkgName = PackagePath "myWorkspace/myPkg/node_modules/" pkgName
+    -- >> toVendoredPackage "myWorkspace/myPkg/node_modules/a/node_modules/b" pkgName = PackagePath "myWorkspace/myPkg/node_modules/" pkgName
+    -- >> toVendoredPackage "node_modules/a" pkgName = PackagePath "node_modules/a/node_modules/" pkgName
+    toWorkspaceLevelPackage :: Text -> PackageName -> PackagePath
+    toWorkspaceLevelPackage prefix = PackageLockV3PathKey (rootWorkspace <> "/" <> defaultVendorDir)
+      where
+        rootWorkspace :: Text
+        rootWorkspace = fromMaybe prefix (getRootWorkspace prefix)
+
+        getRootWorkspace :: Text -> Maybe Text
+        getRootWorkspace pkgPath = case Text.breakOn "/node_modules" pkgPath of
+          ("", "") -> Nothing
+          (firstModule, _) ->
+            if firstModule == pkgPath
+              then Nothing
+              else
+                if (Map.size (Map.filterWithKey (\k _ -> isWorkSpace firstModule k) (packages pkgLockV3)) > 0)
+                  then Just firstModule
+                  else Nothing
+
+        isWorkSpace :: Text -> PackagePath -> Bool
+        isWorkSpace name pkgPath = pkgPath == PackageLockV3WorkSpace name
+
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
+analyze file = context "Analyzing Npm Lockfile" $ do
+  packageLockJson <- context "Parsing v3 compatible package-lock.json" $ readContentsJson @PackageLockV3 file
+  context "Building dependency graph" $ pure $ buildGraph packageLockJson
+
+-- | Keeping repl'ble function in tactic for rapid debugging
+-- --
+-- main :: IO ()
+-- main = do
+--   currentDir <- getCurrentDir
+--   let pkgLockV3Path = currentDir </> $(mkRelFile "test/Node/testdata/lockfileV3/graphing/simple-package-lock.json")
+--   maybePkgLockV3 <- eitherDecodeFileStrict' (toString pkgLockV3Path)
+--   case maybePkgLockV3 of
+--     Left err -> print err
+--     Right (g :: PackageLockV3) -> do
+--       print $ "parsed packageLock at: " <> (toString pkgLockV3Path)
+--       print g

--- a/test/GraphUtil.hs
+++ b/test/GraphUtil.hs
@@ -3,6 +3,7 @@ module GraphUtil (
   expectDeps',
   expectDep,
   expectDep',
+  expectEdge,
   expectEdges,
   expectEdges',
   expectDirect,
@@ -58,3 +59,6 @@ expectDirect expected graph = Graphing.directList graph `shouldMatchList` expect
 
 expectDirect' :: (Ord a, Show a, Has (Lift IO) sig m) => [a] -> Graphing a -> m ()
 expectDirect' expected graph = sendIO $ expectDirect expected graph
+
+expectEdge :: (Ord a, Show a) => Graphing a -> a -> a -> Expectation
+expectEdge graph expectedFrom expectedTo = Graphing.edgesList graph `shouldContain` [(expectedFrom, expectedTo)]

--- a/test/GraphUtil.hs
+++ b/test/GraphUtil.hs
@@ -4,6 +4,7 @@ module GraphUtil (
   expectDep,
   expectDep',
   expectEdge,
+  expectEdge',
   expectEdges,
   expectEdges',
   expectDirect,
@@ -62,3 +63,6 @@ expectDirect' expected graph = sendIO $ expectDirect expected graph
 
 expectEdge :: (Ord a, Show a) => Graphing a -> a -> a -> Expectation
 expectEdge graph expectedFrom expectedTo = Graphing.edgesList graph `shouldContain` [(expectedFrom, expectedTo)]
+
+expectEdge' :: (Ord a, Show a, Has (Lift IO) sig m) => Graphing a -> a -> a -> m ()
+expectEdge' graph expectedFrom expectedTo = sendIO $ expectEdge graph expectedFrom expectedTo

--- a/test/Node/PackageLockV3Spec.hs
+++ b/test/Node/PackageLockV3Spec.hs
@@ -11,7 +11,7 @@ import Data.String.Conversion (toString)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import DepTypes (
-  DepEnvironment (EnvDevelopment),
+  DepEnvironment (EnvDevelopment, EnvProduction),
   DepType (NodeJSType),
   Dependency (..),
   VerConstraint (CEq),
@@ -305,7 +305,7 @@ buildGraphSpec graph = do
       hasEdge (mkProdDep "xml2js@0.4.19") (mkProdDep "xmlbuilder@9.0.7")
 
 mkProdDep :: Text -> Dependency
-mkProdDep nameAtVersion = mkDep nameAtVersion Nothing
+mkProdDep nameAtVersion = mkDep nameAtVersion (Just EnvProduction)
 
 mkDevDep :: Text -> Dependency
 mkDevDep nameAtVersion = mkDep nameAtVersion (Just EnvDevelopment)

--- a/test/Node/PackageLockV3Spec.hs
+++ b/test/Node/PackageLockV3Spec.hs
@@ -1,0 +1,327 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Node.PackageLockV3Spec (
+  spec,
+) where
+
+import Data.Aeson (eitherDecodeFileStrict')
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.String.Conversion (toString)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import DepTypes (
+  DepEnvironment (EnvDevelopment),
+  DepType (NodeJSType),
+  Dependency (..),
+  VerConstraint (CEq),
+ )
+import Effect.ReadFS (readContentsJson)
+import GraphUtil (
+  expectDep,
+  expectDirect,
+  expectEdge,
+ )
+import Graphing (Graphing)
+import Path (Abs, Dir, File, Path, Rel, mkRelDir, mkRelFile, (</>))
+import Path.IO (getCurrentDir)
+import Strategy.Node.Npm.PackageLockV3 (
+  NpmLockV3Resolved (unNpmLockV3Resolved),
+  PackageLockV3 (packages),
+  PackageLockV3Package (plV3PkgResolved),
+  PackageName (PackageName),
+  PackagePath (PackageLockV3PathKey, PackageLockV3Root, PackageLockV3WorkSpace),
+  buildGraph,
+  isV3Compatible,
+  parsePathKey,
+ )
+import Test.Effect (it', shouldBe')
+import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, runIO, shouldBe)
+
+fixturePackageLockPath :: Path Rel File
+fixturePackageLockPath = $(mkRelFile "simple-package-lock.json")
+
+spec :: Spec
+spec = do
+  currentDir <- runIO getCurrentDir
+  let parsingFixtureDir = currentDir </> $(mkRelDir "test/Node/testdata/lockfileV3/parsing/")
+  let graphingFixtureDir = currentDir </> $(mkRelDir "test/Node/testdata/lockfileV3/graphing/")
+
+  -- Resolved Field
+  packageLockParseSpec parsingFixtureDir
+
+  -- Helpers
+  isV3CompatibleSpec
+  parsePathKeySpec
+
+  -- Parse and Validate Graphing
+  let filePathToFixture = (graphingFixtureDir </> fixturePackageLockPath)
+  maybePkgLockV3 <- runIO $ eitherDecodeFileStrict' (toString filePathToFixture)
+  case maybePkgLockV3 of
+    Left errMsg -> alwaysFailSpec "should parse fixture" errMsg
+    Right pkgLockV3 -> do
+      buildGraphSpec (buildGraph pkgLockV3)
+
+isV3CompatibleSpec :: Spec
+isV3CompatibleSpec = do
+  describe "isV3Compatible" $ do
+    it "should return false for version 1" $
+      isV3Compatible (Just 1) `shouldBe` False
+
+    it "should return false for version 2" $
+      isV3Compatible (Just 2) `shouldBe` False
+
+    it "should return true for version 3" $
+      isV3Compatible (Just 3) `shouldBe` True
+
+    it "should return false for version 4" $
+      isV3Compatible (Just 4) `shouldBe` False
+
+    it "should return false for when version is not discoverd" $
+      isV3Compatible Nothing `shouldBe` False
+
+parsePathKeySpec :: Spec
+parsePathKeySpec = do
+  describe "parsePathKey" $ do
+    describe "parse root" $
+      it "should parse for root package path" $
+        parsePathKey "" `shouldBe` PackageLockV3Root
+
+    describe "parse package module" $ do
+      it "should parse for top level path" $
+        parsePathKey "node_modules/pkg"
+          `shouldBe` PackageLockV3PathKey "node_modules/" (PackageName "pkg")
+
+      it "should parse for vendor path" $
+        parsePathKey "node_modules/pkg/node_modules/pkgDeep"
+          `shouldBe` PackageLockV3PathKey "node_modules/pkg/node_modules/" (PackageName "pkgDeep")
+
+      it "should parse for nested vendor path" $
+        parsePathKey "node_modules/pkg/node_modules/pkgDeep/node_modules/pkgDeepLevel2"
+          `shouldBe` PackageLockV3PathKey "node_modules/pkg/node_modules/pkgDeep/node_modules/" (PackageName "pkgDeepLevel2")
+
+      it "should parse for vendor path in workspace" $
+        parsePathKey "myWorkspace/node_modules/pkg"
+          `shouldBe` PackageLockV3PathKey "myWorkspace/node_modules/" (PackageName "pkg")
+
+      it "should parse for nested vendor path in workspace" $
+        parsePathKey "myWorkspace/node_modules/pkg/node_modules/pkgDeep"
+          `shouldBe` PackageLockV3PathKey "myWorkspace/node_modules/pkg/node_modules/" (PackageName "pkgDeep")
+
+      it "should parse for org scoped packages" $
+        parsePathKey "node_modules/@myOrg/pkg"
+          `shouldBe` PackageLockV3PathKey "node_modules/" (PackageName "@myOrg/pkg")
+
+    describe "parse workspace" $
+      it "should parse for top level workspace" $
+        parsePathKey "myWorkspace" `shouldBe` PackageLockV3WorkSpace "myWorkspace"
+
+packageLockParseSpec :: Path Abs Dir -> Spec
+packageLockParseSpec testDir =
+  describe "parsing package-json.lock's resolved field" $ do
+    it' "Should ignore \"resolved\": <bool> in package-lock.json" $ do
+      let packageLock = testDir </> $(mkRelFile "boolean-resolved-package-lock.json")
+      pkgLockV3 <- readContentsJson packageLock
+      let foo =
+            unNpmLockV3Resolved . plV3PkgResolved
+              =<< Map.lookup
+                (PackageLockV3PathKey "node_modules/" $ PackageName "foo")
+                (packages pkgLockV3)
+      foo `shouldBe'` Nothing
+
+    it' "Should parse \"resolved\": <string> in package-lock.json" $ do
+      let packageLock = testDir </> $(mkRelFile "string-resolved-package-lock.json")
+      pkgLockV3 <- readContentsJson packageLock
+      let foo =
+            unNpmLockV3Resolved . plV3PkgResolved
+              =<< Map.lookup
+                (PackageLockV3PathKey "node_modules/" $ PackageName "foo")
+                (packages pkgLockV3)
+      foo `shouldBe'` Just "https://bar.npmjs.org/foo/-/foo-1.0.0.tgz"
+
+    it' "Should parse dependency with no \"resolved\" key in package-lock.json" $ do
+      let packageLock = testDir </> $(mkRelFile "absent-resolved-package-lock.json")
+      pkgLockV3 <- readContentsJson packageLock
+      let foo =
+            unNpmLockV3Resolved . plV3PkgResolved
+              =<< Map.lookup
+                (PackageLockV3PathKey "node_modules/" $ PackageName "foo")
+                (packages pkgLockV3)
+      foo `shouldBe'` Nothing
+
+buildGraphSpec :: Graphing Dependency -> Spec
+buildGraphSpec graph = do
+  let hasEdge :: Dependency -> Dependency -> Expectation
+      hasEdge = expectEdge graph
+
+  let hasDep :: Dependency -> Expectation
+      hasDep dep = expectDep dep graph
+
+  describe "buildGraph" $ do
+    it "should include dependencies of root and workspace package as direct" $ do
+      -- npm list --depth 0
+
+      -- ├── 3@2.1.0
+      -- ├── aws-sdk@2.1134.0
+      -- ├── chalk@5.0.1
+      -- ├── mocha@10.0.0
+      -- ├── react@18.1.0
+      -- └─┬ workspace-a-name@2.0.0 -> ./packages/a
+      --   ├── aws-sdk@1.0.0
+      --   └── commander@9.2.0
+
+      expectDirect
+        [ mkProdDep "3@2.1.0"
+        , mkProdDep "aws-sdk@2.1134.0"
+        , mkProdDep "react@18.1.0"
+        , -- peer dep
+          mkProdDep "chalk@5.0.1"
+        , -- development dep
+          mkDevDep "mocha@10.0.0"
+        , -- from workspaces
+          mkProdDep "aws-sdk@1.0.0"
+        , mkProdDep "commander@9.2.0"
+        ]
+        graph
+
+    it "should graph edge via top level path" $ do
+      hasEdge (mkProdDep "3@2.1.0") (mkProdDep "2@1.0.2")
+
+    it "should graph edge via vendored level path" $ do
+      hasEdge (mkDevDep "log-symbols@4.1.0") (mkDevDep "chalk@4.1.2")
+      hasEdge (mkProdDep "aws-sdk@1.0.0") (mkProdDep "xml2js@0.2.4")
+      hasEdge (mkProdDep "xml2js@0.2.4") (mkProdDep "sax@1.2.1")
+
+    it "should correctly graph workspace a's dependencies" $ do
+      -- npm list --all --package-lock-only -- inspecting ./packages/a
+
+      -- └─┬ workspace-a-name@2.0.0 -> ./packages/a
+      --   ├─┬ aws-sdk@1.0.0
+      --   │ ├─┬ xml2js@0.2.4
+      --   │ │ └── sax@1.2.1 deduped
+      --   │ └── xmlbuilder@9.0.7 deduped
+      --   └── commander@9.2.0
+
+      hasDep (mkProdDep "commander@9.2.0")
+      hasDep (mkProdDep "aws-sdk@1.0.0")
+      hasDep (mkProdDep "xml2js@0.2.4")
+      hasDep (mkProdDep "xmlbuilder@9.0.7")
+      hasDep (mkProdDep "sax@1.2.1")
+
+      hasEdge (mkProdDep "aws-sdk@1.0.0") (mkProdDep "xml2js@0.2.4")
+      hasEdge (mkProdDep "aws-sdk@1.0.0") (mkProdDep "xmlbuilder@9.0.7")
+      hasEdge (mkProdDep "xml2js@0.2.4") (mkProdDep "sax@1.2.1")
+
+    it "should correctly graph react's dependencies" $ do
+      -- npm list --all --package-lock-only -- inspecting react
+
+      -- ├─┬ react@18.1.0
+      -- │ └─┬ loose-envify@1.4.0
+      -- │   └── js-tokens@4.0.0
+
+      expectDep (mkProdDep "react@18.1.0") graph
+      expectDep (mkProdDep "loose-envify@1.4.0") graph
+      expectDep (mkProdDep "js-tokens@4.0.0") graph
+
+      hasEdge (mkProdDep "react@18.1.0") $ mkProdDep "loose-envify@1.4.0"
+      hasEdge (mkProdDep "loose-envify@1.4.0") $ mkProdDep "js-tokens@4.0.0"
+
+    it "should correctly graph 3's dependencies" $ do
+      -- npm list --all --package-lock-only -- inspecting 3
+
+      -- ├─┬ 3@2.1.0
+      -- │ ├── 2@1.0.2
+      -- │ ├── chunk-array@1.0.2
+      -- │ └─┬ enforce-range@1.0.0
+      -- │   └── 2@1.0.2 deduped
+
+      hasDep (mkProdDep "3@2.1.0")
+      hasDep (mkProdDep "2@1.0.2")
+      hasDep (mkProdDep "chunk-array@1.0.2")
+      hasDep (mkProdDep "enforce-range@1.0.0")
+
+      hasEdge (mkProdDep "3@2.1.0") (mkProdDep "2@1.0.2")
+      hasEdge (mkProdDep "3@2.1.0") (mkProdDep "chunk-array@1.0.2")
+      hasEdge (mkProdDep "3@2.1.0") (mkProdDep "enforce-range@1.0.0")
+      hasEdge (mkProdDep "enforce-range@1.0.0") (mkProdDep "2@1.0.2")
+
+    it "should correctly graph aws-sdk@2.1134.0's dependencies" $ do
+      -- npm list --all --package-lock-only -- inspecting aws-sdk@2.1124.0
+
+      -- ├─┬ aws-sdk@2.1134.0
+      -- │ ├─┬ buffer@4.9.2
+      -- │ │ ├── base64-js@1.5.1
+      -- │ │ ├── ieee754@1.1.13 deduped
+      -- │ │ └── isarray@1.0.0
+      -- │ ├── events@1.1.1
+      -- │ ├── ieee754@1.1.13
+      -- │ ├── jmespath@0.16.0
+      -- │ ├── querystring@0.2.0
+      -- │ ├── sax@1.2.1
+      -- │ ├─┬ url@0.10.3
+      -- │ │ ├── punycode@1.3.2
+      -- │ │ └── querystring@0.2.0 deduped
+      -- │ ├── uuid@3.3.2
+      -- │ └─┬ xml2js@0.4.19
+      -- │   ├── sax@1.2.1 deduped
+      -- │   └── xmlbuilder@9.0.7
+
+      hasDep (mkProdDep "aws-sdk@2.1134.0")
+      hasDep (mkProdDep "buffer@4.9.2")
+      hasDep (mkProdDep "base64-js@1.5.1")
+      hasDep (mkProdDep "ieee754@1.1.13")
+      hasDep (mkProdDep "isarray@1.0.0")
+
+      hasEdge (mkProdDep "aws-sdk@2.1134.0") (mkProdDep "buffer@4.9.2")
+      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "base64-js@1.5.1")
+      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "ieee754@1.1.13")
+      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "isarray@1.0.0")
+
+      hasDep (mkProdDep "events@1.1.1")
+      hasDep (mkProdDep "jmespath@0.16.0")
+      hasDep (mkProdDep "querystring@0.2.0")
+      hasDep (mkProdDep "sax@1.2.1")
+
+      hasEdge (mkProdDep "aws-sdk@2.1134.0") (mkProdDep "events@1.1.1")
+      hasEdge (mkProdDep "aws-sdk@2.1134.0") (mkProdDep "ieee754@1.1.13")
+      hasEdge (mkProdDep "aws-sdk@2.1134.0") (mkProdDep "jmespath@0.16.0")
+      hasEdge (mkProdDep "aws-sdk@2.1134.0") (mkProdDep "querystring@0.2.0")
+      hasEdge (mkProdDep "aws-sdk@2.1134.0") (mkProdDep "sax@1.2.1")
+
+      hasDep (mkProdDep "url@0.10.3")
+      hasDep (mkProdDep "punycode@1.3.2")
+      hasDep (mkProdDep "querystring@0.2.0")
+
+      hasEdge (mkProdDep "aws-sdk@2.1134.0") (mkProdDep "url@0.10.3")
+      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "punycode@1.3.2")
+      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "querystring@0.2.0")
+
+      hasDep (mkProdDep "uuid@3.3.2")
+      hasDep (mkProdDep "xml2js@0.4.19")
+      hasDep (mkProdDep "xmlbuilder@9.0.7")
+
+      hasEdge (mkProdDep "aws-sdk@2.1134.0") (mkProdDep "xml2js@0.4.19")
+      hasEdge (mkProdDep "xml2js@0.4.19") (mkProdDep "sax@1.2.1")
+      hasEdge (mkProdDep "xml2js@0.4.19") (mkProdDep "xmlbuilder@9.0.7")
+
+mkProdDep :: Text -> Dependency
+mkProdDep nameAtVersion = mkDep nameAtVersion Nothing
+
+mkDevDep :: Text -> Dependency
+mkDevDep nameAtVersion = mkDep nameAtVersion (Just EnvDevelopment)
+
+mkDep :: Text -> Maybe DepEnvironment -> Dependency
+mkDep nameAtVersion env = do
+  let nameAndVersionSplit = Text.splitOn "@" nameAtVersion
+      name = head nameAndVersionSplit
+      version = last nameAndVersionSplit
+  Dependency
+    NodeJSType
+    name
+    (CEq <$> (Just version))
+    ["https://registry.npmjs.org/" <> name <> "/-/" <> name <> "-" <> version <> ".tgz"]
+    (maybe mempty Set.singleton env)
+    mempty
+
+alwaysFailSpec :: String -> String -> Spec
+alwaysFailSpec testMsg errMsg = describe "packageLockV3" $ it testMsg $ expectationFailure errMsg

--- a/test/Node/testdata/lockfileV3/graphing/simple-package-lock.json
+++ b/test/Node/testdata/lockfileV3/graphing/simple-package-lock.json
@@ -1,0 +1,1176 @@
+{
+    "name": "lockv3",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "lockv3",
+            "version": "1.0.0",
+            "license": "ISC",
+            "workspaces": [
+                "packages/a"
+            ],
+            "dependencies": {
+                "3": "^2.1.0",
+                "aws-sdk": "^2.0.0",
+                "react": "^18.1.0"
+            },
+            "devDependencies": {
+                "mocha": "*"
+            },
+            "peerDependencies": {
+                "chalk": "*"
+            }
+        },
+        "node_modules/@ungap/promise-all-settled": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+            "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+            "dev": true
+        },
+        "node_modules/2": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/2/-/2-1.0.2.tgz",
+            "integrity": "sha512-G0Eca6Fz2qJKvjM9/niouz5kWTZy7pm+LRAMXir5v+DOt4bMszVlfIYKy2T+TPKnGxpp236pzK7/chNuToWlnQ==",
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/3": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/3/-/3-2.1.0.tgz",
+            "integrity": "sha512-rEoeK/qBZCLzqt9a3Q3Dnb5TUyXnZlxVaWr9ZXBV65Ppzcz59dx3Ik5YUxtni+36CtZgJdhQaYkLgHBdqjxjoA==",
+            "dependencies": {
+                "2": "^1.0.2",
+                "chunk-array": "^1.0.2",
+                "enforce-range": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/anymatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+            "dev": true,
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "node_modules/aws-sdk": {
+            "version": "2.1134.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1134.0.tgz",
+            "integrity": "sha512-CvIcPSDzKFn4LRmk6GcQZYWtCxD/FwbbC1yaslvmpOYP8CndCmdz1MHMOPy/QyUyrH2WnUrVTAP2WdWqq6oCjQ==",
+            "dependencies": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.16.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/binary-extensions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "dependencies": {
+                "fill-range": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
+        },
+        "node_modules/buffer": {
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "dependencies": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+            "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+            "peer": true,
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/chunk-array": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/chunk-array/-/chunk-array-1.0.2.tgz",
+            "integrity": "sha1-eCEf9VArxXtsdgQ9jMYGpEI7ee8="
+        },
+        "node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/commander": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+            "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+            "engines": {
+                "node": "^12.20.0 || >=14"
+            }
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/debug/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "node_modules/decamelize": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/diff": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/enforce-range": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/enforce-range/-/enforce-range-1.0.0.tgz",
+            "integrity": "sha1-8QzMA5biNoS0E9c2YdAg0ZLlunA=",
+            "dependencies": {
+                "2": "^1.0.2"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true,
+            "bin": {
+                "flat": "cli.js"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/glob": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
+            "bin": {
+                "he": "bin/he"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "node_modules/jmespath": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-symbols/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/log-symbols/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+            "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/mocha": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
+            "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+            "dev": true,
+            "dependencies": {
+                "@ungap/promise-all-settled": "1.1.2",
+                "ansi-colors": "4.1.1",
+                "browser-stdout": "1.3.1",
+                "chokidar": "3.5.3",
+                "debug": "4.3.4",
+                "diff": "5.0.0",
+                "escape-string-regexp": "4.0.0",
+                "find-up": "5.0.0",
+                "glob": "7.2.0",
+                "he": "1.2.0",
+                "js-yaml": "4.1.0",
+                "log-symbols": "4.1.0",
+                "minimatch": "5.0.1",
+                "ms": "2.1.3",
+                "nanoid": "3.3.3",
+                "serialize-javascript": "6.0.0",
+                "strip-json-comments": "3.1.1",
+                "supports-color": "8.1.1",
+                "workerpool": "6.2.1",
+                "yargs": "16.2.0",
+                "yargs-parser": "20.2.4",
+                "yargs-unparser": "2.0.0"
+            },
+            "bin": {
+                "_mocha": "bin/_mocha",
+                "mocha": "bin/mocha.js"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mochajs"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+            "dev": true,
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/react": {
+            "version": "18.1.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
+            "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "node_modules/serialize-javascript": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+            "dev": true,
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/workerpool": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+            "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+            "dev": true
+        },
+        "node_modules/workspace-a-name": {
+            "resolved": "packages/a",
+            "link": true
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "node_modules/xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "20.2.4",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+            "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs-unparser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+            "dev": true,
+            "dependencies": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/a": {
+            "name": "workspace-a-name",
+            "version": "2.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "aws-sdk": "1.0.0",
+                "commander": "9.2.0"
+            }
+        },
+        "packages/a/node_modules/aws-sdk": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-1.0.0.tgz",
+            "integrity": "sha1-HiWXRu0lSGeP+wDjngUImMUGtn4=",
+            "dependencies": {
+                "xml2js": "0.2.4",
+                "xmlbuilder": "latest"
+            },
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "packages/a/node_modules/xml2js": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.4.tgz",
+            "integrity": "sha1-mltXf6HmzfiSPV4TcvejGIQ25E0=",
+            "dependencies": {
+                "sax": ">=0.4.2"
+            }
+        }
+    }
+}

--- a/test/Node/testdata/lockfileV3/graphing/ws-nested-module-package-lock.json
+++ b/test/Node/testdata/lockfileV3/graphing/ws-nested-module-package-lock.json
@@ -1,0 +1,43 @@
+{
+    "name": "lockv3NestedPkgInWorkspace",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "lockv3",
+            "version": "1.0.0",
+            "license": "ISC",
+            "workspaces": [
+                "packages/a"
+            ]
+        },
+        "packages/a": {
+            "name": "workspace-a-name",
+            "version": "2.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "b": "^2.0.0",
+                "c": "^2.0.0"
+            }
+        },
+        "packages/a/node_modules/b": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/b/-/b-2.0.0.tgz",
+            "integrity": "sha1-HiWXRu0lSGeP+wDjngUImMUGtn4=",
+            "dependencies": {
+                "c": "1.0.0"
+            }
+        },
+        "packages/a/node_modules/b/node_modules/c": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/c/-/c-1.0.0.tgz",
+            "integrity": "sha1-HiWXRu0lSGeP+wDjngUImMUGtn4="
+        },
+        "packages/a/node_modules/c": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/c/-/c-2.0.0.tgz",
+            "integrity": "sha1-mltXf6HmzfiSPV4TcvejGIQ25E0="
+        }
+    }
+}

--- a/test/Node/testdata/lockfileV3/parsing/absent-resolved-package-lock.json
+++ b/test/Node/testdata/lockfileV3/parsing/absent-resolved-package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "packagelock-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "packagelock-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+          "foo": "^1.0.0"
+      }
+    },
+      "node_modules/foo": {
+          "version": "1.0.0",
+          "integrity": "sha512-bar"
+      }
+  }
+}

--- a/test/Node/testdata/lockfileV3/parsing/boolean-resolved-package-lock.json
+++ b/test/Node/testdata/lockfileV3/parsing/boolean-resolved-package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "packagelock-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "packagelock-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+          "foo": "^1.0.0"
+      }
+    },
+      "node_modules/foo": {
+          "version": "1.0.0",
+          "resolved": true,
+          "integrity": "sha512-bar"
+      }
+  }
+}

--- a/test/Node/testdata/lockfileV3/parsing/string-resolved-package-lock.json
+++ b/test/Node/testdata/lockfileV3/parsing/string-resolved-package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "packagelock-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "packagelock-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+          "foo": "^1.0.0"
+      }
+    },
+      "node_modules/foo": {
+          "version": "1.0.0",
+          "resolved": "https://bar.npmjs.org/foo/-/foo-1.0.0.tgz",
+          "integrity": "sha512-bar"
+      }
+  }
+}


### PR DESCRIPTION
# Overview

This PR adds initial lockfile v3 support. 
- We only apply this new tactic when we are confident that provided lockfile is v3 (we can parse, and lockFileVersion is explicitly 3)

Out of Scope:
- Nested workspaces (hope to address with part b of pr chain)
- Other resolutions work as before

## Acceptance criteria

- Npm lockfile v3 is supported

## Testing plan

1) Create an example: `package.json`

```
{
    "name": "lockv3",
    "version": "1.0.0",
    "description": "",
    "main": "index.js",
    "scripts": {
        "test": "echo \"Error: no test specified\" && exit 1"
    },
    "devDependencies": {
        "mocha": "*"
    },
    "peerDependencies": {
        "chalk": "*"
    },
    "dependencies": {
        "3": "^2.1.0",
        "aws-sdk": "^2.0.0",
        "react": "^18.1.0"
    },
    "author": "",
    "license": "ISC"
}

```

2) Execute: `npm i --lockfile-version=3`
3) Run `fossa-dev analyze -o` and confirm we analyzed it successfully.

## Manual Testing plan
- [x] compare v2 and v3 analysis for a complicated project
- [x] test against symbolic linked package

## To Dos
- [x] Update Changelog.md 


## Risks

Since lockFile v3 is not used by npm's default configs. This change has very low risk profile.

## References

https://fossa.atlassian.net/browse/ANE-109

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
