### PR TITLE
Allow linting modified files only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ FMT_OPTS := -co -XTypeApplications -o -XImportQualifiedPost
 FIND_OPTS := src test integration-test -type f -name '*.hs'
 GHC_VERSION := 9.0.2
 DEV_TOOLS := ghcr.io/fossas/haskell-dev-tools:${GHC_VERSION}
-MOUNTED_DEV_TOOLS := docker run
-MOUNTED_DEV_TOOLS += --rm
-MOUNTED_DEV_TOOLS += --mount "type=bind,source=${current_dir},target=/fossa-cli"
-MOUNTED_DEV_TOOLS += --workdir "/fossa-cli"
-MOUNTED_DEV_TOOLS += ${DEV_TOOLS}
+MOUNTED_DEV_TOOLS_OPTS := --rm
+MOUNTED_DEV_TOOLS_OPTS += --mount "type=bind,source=${current_dir},target=/fossa-cli"
+MOUNTED_DEV_TOOLS_OPTS += --workdir "/fossa-cli"
+MOUNTED_DEV_TOOLS := ${MOUNTED_DEV_TOOLS_OPTS} ${DEV_TOOLS}
+SHELL := bash
 
 build:
 	cabal build
@@ -64,7 +64,7 @@ fmt:
 # Run the formatter from within a docker image, with the project mounted as a volume
 fmt-ci:
 	docker pull ${DEV_TOOLS}
-	${MOUNTED_DEV_TOOLS} make fmt
+	docker run ${MOUNTED_DEV_TOOLS} make fmt
 
 # Confirm everything is formatted without changing anything
 check-fmt:
@@ -94,6 +94,6 @@ check-links:
 # that we always have the latest.
 check-ci:
 	docker pull ${DEV_TOOLS}
-	${MOUNTED_DEV_TOOLS} make check
+	docker run ${MOUNTED_DEV_TOOLS} make check
 
 .PHONY: build test integration-test analyze install-local fmt check check-fmt lint check-ci fmt-ci build-test-data clean-test-data install-dev test-all

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,6 @@ fmt:
 	@echo "Running cabal-fmt"
 	@cabal-fmt spectrometer.cabal --inplace
 
-# Run the formatter from within a docker image, with the project mounted as a volume
-fmt-ci:
-	docker pull ${DEV_TOOLS}
-	docker run ${MOUNTED_DEV_TOOLS} make fmt
-
 # Confirm everything is formatted without changing anything
 check-fmt:
 	@echo "Running fourmolu"
@@ -112,6 +107,11 @@ check-links:
 	find ./docs/ -name \*.md -exec markdown-link-check {} \;
 	@echo "Running markdown-link-check for README.md"
 	markdown-link-check README.md
+
+# Run the formatter from within a docker image, with the project mounted as a volume
+fmt-ci:
+	docker pull ${DEV_TOOLS}
+	docker run ${MOUNTED_DEV_TOOLS} make fmt
 
 fast-lint-ci:
 	docker pull ${DEV_TOOLS}

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ install-dev: build
 
 check: check-fmt lint
 
+fast-check: check-fmt fast-lint
+
 # Run any build scripts required for test data to be generated.
 build-test-data:
 	./test/App/Fossa/VSI/DynLinked/testdata/build.sh
@@ -120,6 +122,10 @@ fast-lint-ci:
 check-ci:
 	docker pull ${DEV_TOOLS}
 	docker run ${MOUNTED_DEV_TOOLS} make check
+
+fast-check-ci:
+	docker pull ${DEV_TOOLS}
+	docker run ${MOUNTED_DEV_TOOLS} make fast-check
 
 ci-shell:
 	docker pull ${DEV_TOOLS}

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ check-fmt:
 lint:
 	@echo "Running hlint"
 	@hlint --version
-	@hlint src test integration-test
+	@hlint src test integration-test --cross --timing -vj
 	@echo "No linter errors found"
 
 # Performs markdown lint checks for dead links

--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,8 @@ check-ci:
 	docker pull ${DEV_TOOLS}
 	docker run ${MOUNTED_DEV_TOOLS} make check
 
+ci-shell:
+	docker pull ${DEV_TOOLS}
+	docker run -it ${MOUNTED_DEV_TOOLS} bash
+
 .PHONY: build test integration-test analyze install-local fmt check check-fmt lint check-ci fmt-ci build-test-data clean-test-data install-dev test-all

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ fmt-ci:
 	docker pull ${DEV_TOOLS}
 	docker run ${MOUNTED_DEV_TOOLS} make fmt
 
+# Run the fast-lint target with the CI docker container
 fast-lint-ci:
 	docker pull ${DEV_TOOLS}
 	docker run ${MOUNTED_DEV_TOOLS} make fast-lint
@@ -123,10 +124,12 @@ check-ci:
 	docker pull ${DEV_TOOLS}
 	docker run ${MOUNTED_DEV_TOOLS} make check
 
+# Run the fast-check target with the CI docker container
 fast-check-ci:
 	docker pull ${DEV_TOOLS}
 	docker run ${MOUNTED_DEV_TOOLS} make fast-check
 
+# Run bash in the CI edocker container.  Useful for debugging make with CI tools.
 ci-shell:
 	docker pull ${DEV_TOOLS}
 	docker run -it ${MOUNTED_DEV_TOOLS} bash


### PR DESCRIPTION
# Overview

When running linting locally, it can take a few minutes to complete, due to the fact that it always scans the whole codebase.  This PR adds linting targets for only checking files which have been modified (according to `git`).  This provides massive speedups when then number of changed files is very low, improving the developer experience.

Additional targets for working with the CI docker container locally have been added as well:

- `fast-lint` - Lint only modified files, using the locally-installed `hlint`
- `fast-check` - Check formatting, then run `fast-lint`, using local `hlint`/`fourmolu`/`cabal-fmt`
- `fast-lint-ci` - `fast-lint`, but run with the CI docker image, mounting the local checkout into the container
- `fast-check-ci` - `fast-check`, but run with the CI docker image, mounting the local checkout into the container
- `ci-shell` - interactive `bash` session into the CI docker image, mounting the local checkout into the container

## Acceptance criteria

Nothing should break

## Testing plan

Manually testing the make targets

## Risks

No risk if CI passes

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
