### PR TITLE
Fix CI (Container Update)

### DIFF
--- a/docs/contributing/STYLE-GUIDE.md
+++ b/docs/contributing/STYLE-GUIDE.md
@@ -134,7 +134,7 @@ to establish a guideline of "There should only be one right and obvious way to
 do something" (which is a loose goal for the codebase).
 
 If your match guards are any less readable than the introductory examples in
-[Learn you a haskell](guards), then you should stick to `case` and `if`
+[Learn you a haskell][guards], then you should stick to `case` and `if`
 expressions within the function body.
 
 [guards]: http://learnyouahaskell.com/syntax-in-functions#guards-guards

--- a/docs/contributing/STYLE-GUIDE.md
+++ b/docs/contributing/STYLE-GUIDE.md
@@ -120,6 +120,25 @@ make sure that you have a solid justification for doing so.
 In almost all cases, `map`, `filter`, `fold`, and the `[]` monad are more
 flexible and readable.
 
+### Do not use match guards
+
+While matching data at the function binding is appealing as an idea, but has
+several drawbacks:
+
+- Match guards in function definitions are adding more info into an area
+that may already be cluttered.
+- Match guards with multiple bindings are essentially the same syntax as list
+comprehensions, which are also forbidden.
+- Match guards offer an alternative to `case` and `if`, which makes it harder
+to establish a guideline of "There should only be one right and obvious way to
+do something" (which is a loose goal for the codebase).
+
+If your match guards are any less readable than the introductory examples in
+[Learn you a haskell](guards), then you should stick to `case` and `if`
+expressions within the function body.
+
+[guards]: http://learnyouahaskell.com/syntax-in-functions#guards-guards
+
 ### Don't go crazy with point-free definitions
 
 Point-free style can help or hinder readability, depending on the context. If a
@@ -339,3 +358,6 @@ Use these instead of `decodeUtf8`/`encodeUTF8`/`Text.pack`
   compiles identically, then remove it.
 - Avoid nested `where` blocks.  If you feel that you need them, rethink your
   design.  Consider making an `Internal` module instead.
+- In do-notation, use `let` bindings, otherwise, use `where` clauses.  Don't
+  use `let` expressions (exammple: `let ... in ...`).
+

--- a/src/App/Fossa/VSI/Fingerprint.hs
+++ b/src/App/Fossa/VSI/Fingerprint.hs
@@ -214,11 +214,11 @@ basicCStyleCommentStripC =
 -- 2. If the substring was not found, the result is @Nothing@,
 -- instead of one of the options being a blank @ByteString@.
 breakSubstringAndRemove :: ByteString -> ByteString -> Maybe (ByteString, ByteString)
-breakSubstringAndRemove needle haystack
-  | (before, after) <- BS.breakSubstring needle haystack
-    , BS.isPrefixOf needle after =
-    Just (before, BS.drop (BS.length needle) after)
-  | otherwise = Nothing
+breakSubstringAndRemove needle haystack = do
+  let (before, after) = BS.breakSubstring needle haystack
+  if needle `BS.isPrefixOf` after
+    then pure (before, BS.drop (BS.length needle) after)
+    else Nothing
 
 -- | Remove leading and trailing spaces.
 stripSpace :: ByteString -> ByteString

--- a/src/Data/Text/Extra.hs
+++ b/src/Data/Text/Extra.hs
@@ -37,11 +37,11 @@ splitOnceOnEnd needle haystack = (strippedInitial, end)
 -- >>> breakOnAndRemove "foo" "bar"
 -- Nothing
 breakOnAndRemove :: Text -> Text -> Maybe (Text, Text)
-breakOnAndRemove needle haystack
-  | (before, after) <- Text.breakOn needle haystack
-    , Text.isPrefixOf needle after =
-    Just (before, Text.drop (Text.length needle) after)
-  | otherwise = Nothing
+breakOnAndRemove needle haystack = do
+  let (before, after) = Text.breakOn needle haystack
+  if needle `Text.isPrefixOf` after
+    then pure (before, Text.drop (Text.length needle) after)
+    else Nothing
 
 underBS :: (ByteString -> ByteString) -> Text -> Text
 underBS f = decodeUtf8 . f . encodeUtf8

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -74,12 +74,12 @@ import Text.Megaparsec (Parsec, runParser)
 import Text.Megaparsec.Error (errorBundlePretty)
 
 data Command = Command
-  { -- | Command name to use. E.g., "pip", "pip3", "./gradlew".
-    cmdName :: Text
-  , -- | Arguments for the command
-    cmdArgs :: [Text]
-  , -- | Error (i.e. non-zero exit code) tolerance policy for running commands. This is helpful for commands like @npm@, that nonsensically return non-zero exit codes when a command succeeds
-    cmdAllowErr :: AllowErr
+  { cmdName :: Text
+  -- ^ Command name to use. E.g., "pip", "pip3", "./gradlew".
+  , cmdArgs :: [Text]
+  -- ^ Arguments for the command
+  , cmdAllowErr :: AllowErr
+  -- ^ Error (i.e. non-zero exit code) tolerance policy for running commands. This is helpful for commands like @npm@, that nonsensically return non-zero exit codes when a command succeeds
   }
   deriving (Eq, Ord, Show, Generic)
 

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -180,8 +180,8 @@ instance FromJSON LicenseUnitMatchData where
 data SourceUnit = SourceUnit
   { sourceUnitName :: Text
   , sourceUnitType :: Text
-  , -- | path to manifest file
-    sourceUnitManifest :: Text
+  , sourceUnitManifest :: Text
+  -- ^ path to manifest file
   , sourceUnitBuild :: Maybe SourceUnitBuild
   , sourceUnitGraphBreadth :: GraphBreadth
   , sourceUnitOriginPaths :: [SomeBase File]
@@ -190,10 +190,10 @@ data SourceUnit = SourceUnit
   deriving (Eq, Ord, Show)
 
 data SourceUnitBuild = SourceUnitBuild
-  { -- | always "default"
-    buildArtifact :: Text
-  , -- | always true
-    buildSucceeded :: Bool
+  { buildArtifact :: Text
+  -- ^ always "default"
+  , buildSucceeded :: Bool
+  -- ^ always true
   , buildImports :: [Locator]
   , buildDependencies :: [SourceUnitDependency]
   }

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -210,8 +210,8 @@ instance AnalyzeProject CargoProject where
 
 data CargoPackage = CargoPackage
   { license :: Maybe Text.Text
-  , -- | Path relative to Cargo.toml containing the license
-    cargoLicenseFile :: Maybe FilePath
+  , cargoLicenseFile :: Maybe FilePath
+  -- ^ Path relative to Cargo.toml containing the license
   }
   deriving (Eq, Show)
 

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -135,8 +135,8 @@ data ComposerLock = ComposerLock
 data CompDep = CompDep
   { depName :: Text
   , depVersion :: Text
-  , -- | name to version spec
-    depRequire :: Maybe (Map Text Text)
+  , depRequire :: Maybe (Map Text Text)
+  -- ^ name to version spec
   , depRequireDev :: Maybe (Map Text Text)
   }
   deriving (Eq, Ord, Show)

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -38,7 +38,7 @@ import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
 import Data.FileEmbed (embedFile)
-import Data.Foldable (find)
+import Data.Foldable (find, traverse_)
 import Data.List (isPrefixOf)
 import Data.Maybe (mapMaybe)
 import Data.Set (Set)
@@ -296,6 +296,6 @@ analyze foundTargets dir = withSystemTempDir "fossa-gradle" $ \tmpDir -> do
   let graphFromResolutionApi = ResolutionApi.buildGraph resolvedProjects (onlyConfigurations)
 
   -- Log debug messages as seen in gradle script
-  sequence_ $ logDebug . pretty <$> (getDebugMessages text)
+  traverse_ (logDebug . pretty) (getDebugMessages text)
 
   context "Building dependency graph" $ pure graphFromResolutionApi

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -241,12 +241,13 @@ ednVecToMap :: EDN.EDNVec -> Parser EDN.EDNMap
 ednVecToMap = go Map.empty
   where
     go :: EDN.EDNMap -> EDN.EDNVec -> Parser EDN.EDNMap
+    -- TODO: refactor this to not use match guards
     go m vec
       | V.null vec = pure m
       | otherwise = do
-        key <- EDN.vecGet 0 vec
-        value <- EDN.vecGet 1 vec
-        go (Map.insert key value m) (V.drop 2 vec)
+          key <- EDN.vecGet 0 vec
+          value <- EDN.vecGet 1 vec
+          go (Map.insert key value m) (V.drop 2 vec)
 
 -- | The FromEDN type for lein deps output
 newtype Deps = Deps

--- a/src/Strategy/Maven/Pom.hs
+++ b/src/Strategy/Maven/Pom.hs
@@ -191,8 +191,7 @@ interpolate properties text =
 -- find the first maven property in the string, e.g., `${foo}`, returning text
 -- before the property, the property, and the text after the property
 splitMavenProperty :: Text -> Maybe (Text, Text, Text)
-splitMavenProperty text
-  | Just (beforeBegin, afterBegin) <- breakOnAndRemove "${" text
-    , Just (property, afterEnd) <- breakOnAndRemove "}" afterBegin =
-    Just (beforeBegin, property, afterEnd)
-  | otherwise = Nothing
+splitMavenProperty text = do
+  (beforeBegin, afterBegin) <- breakOnAndRemove "${" text
+  (property, afterEnd) <- breakOnAndRemove "}" afterBegin
+  pure (beforeBegin, property, afterEnd)

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -99,10 +99,10 @@ determineProjectRoots rootDir closure = go . Set.fromList
         frontier = Set.unions $ Set.map (\coord -> AM.postSet coord (globalGraph closure)) remainingCoords
 
 data MavenProjectClosure = MavenProjectClosure
-  { -- | the root of global fossa-analyze analysis; needed for pathfinder license scan
-    closureAnalysisRoot :: Path Abs Dir
-  , -- | path of the pom file used as the root of this project closure
-    closurePath :: Path Abs File
+  { closureAnalysisRoot :: Path Abs Dir
+  -- ^ the root of global fossa-analyze analysis; needed for pathfinder license scan
+  , closurePath :: Path Abs File
+  -- ^ path of the pom file used as the root of this project closure
   , closureRootCoord :: MavenCoordinate
   , closureRootPom :: Pom
   , closureGraph :: AM.AdjacencyMap MavenCoordinate

--- a/src/Strategy/Nim/NimbleLock.hs
+++ b/src/Strategy/Nim/NimbleLock.hs
@@ -142,7 +142,7 @@ buildGraph lockFile nimbleDump =
     applyDirect :: Graphing NimPackage -> Graphing NimPackage
     applyDirect gr = case nimbleDump of
       Nothing -> Graphing.directs (getVerticesWithoutPredecessors gr) <> gr
-      Just nd -> Graphing.directs (catMaybes $ (`Map.lookup` pkgRegistry) <$> map nameOf (requires nd)) <> gr
+      Just nd -> Graphing.directs (mapMaybe ((`Map.lookup` pkgRegistry) . nameOf) (requires nd)) <> gr
 
     toDependency :: NimPackage -> Maybe Dependency
     toDependency nimPkg = case downloadMethod nimPkg of

--- a/src/Strategy/Nim/NimbleLock.hs
+++ b/src/Strategy/Nim/NimbleLock.hs
@@ -14,8 +14,14 @@ module Strategy.Nim.NimbleLock (
 ) where
 
 import Algebra.Graph.AdjacencyMap qualified as AM
-import Control.Carrier.Diagnostics (ToDiagnostic, errCtx, warnOnErr)
-import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (renderDiagnostic), context, recover)
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  ToDiagnostic (renderDiagnostic),
+  context,
+  errCtx,
+  recover,
+  warnOnErr,
+ )
 import Data.Aeson (
   FromJSON (parseJSON),
   FromJSONKey,
@@ -28,7 +34,7 @@ import Data.Aeson.Types (Parser)
 import Data.HashMap.Strict qualified as HM
 import Data.Map (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes, mapMaybe)
+import Data.Maybe (mapMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Traversable (for)
@@ -48,7 +54,7 @@ import Graphing (
   toAdjacencyMap,
   unfoldDeep,
  )
-import Path
+import Path (Abs, Dir, File, Path)
 import Types (GraphBreadth (..))
 
 -- | Represents nimble lock file.

--- a/src/Strategy/Node/Npm/PackageLock.hs
+++ b/src/Strategy/Node/Npm/PackageLock.hs
@@ -85,8 +85,8 @@ data PkgLockDependency = PkgLockDependency
   { depVersion :: Text
   , depDev :: Bool
   , depResolved :: NpmResolved
-  , -- | name to version spec
-    depRequires :: Map Text Text
+  , depRequires :: Map Text Text
+  -- ^ name to version spec
   , depDependencies :: Map Text PkgLockDependency
   }
   deriving (Eq, Ord, Show)

--- a/src/Strategy/Node/YarnV2/Resolvers.hs
+++ b/src/Strategy/Node/YarnV2/Resolvers.hs
@@ -39,12 +39,12 @@ import Strategy.Node.YarnV2.Lockfile
 import Text.Megaparsec
 
 data Resolver = Resolver
-  { -- | Used for error messages
-    resolverName :: Text
-  , -- | Does this resolver support the locator?
-    resolverSupportsLocator :: Locator -> Bool
-  , -- | Convert this locator to a yarn package
-    resolverLocatorToPackage :: Locator -> Either Text Package
+  { resolverName :: Text
+  -- ^ Used for error messages
+  , resolverSupportsLocator :: Locator -> Bool
+  -- ^ Does this resolver support the locator?
+  , resolverLocatorToPackage :: Locator -> Either Text Package
+  -- ^ Convert this locator to a yarn package
   }
 
 data Package

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -215,7 +215,11 @@ graphOfFramework projectFrameworkDeps (targetFramework, targetFrameworkDeps) = d
     isDirectDep d = depName d `elem` (getProjectDirectDepsByFramework)
 
     getTransitiveDeps :: NuGetDep -> [NuGetDep]
-    getTransitiveDeps nugetDep = concat $ (\(name, _) -> filter (\d -> depName d == name) allResolvedDeps) <$> Map.toList (completeDeepDeps nugetDep)
+    getTransitiveDeps nugetDep =
+      concatMap
+        (\(name, _) -> filter (\d -> depName d == name) allResolvedDeps)
+        . Map.toList
+        $ completeDeepDeps nugetDep
 
     allResolvedDeps :: [NuGetDep]
     allResolvedDeps = map toNugetDep $ Map.toList targetFrameworkDeps

--- a/src/Strategy/Swift/Xcode/Pbxproj.hs
+++ b/src/Strategy/Swift/Xcode/Pbxproj.hs
@@ -32,10 +32,10 @@ import Strategy.Swift.Xcode.PbxprojParser (AsciiValue (..), PbxProj (..), lookup
 
 -- | Represents the version rules for a Swift Package as defined in Xcode project file.
 data XCRemoteSwiftPackageReference = XCRemoteSwiftPackageReference
-  { -- | Represents repositoryURL field from project file.
-    urlOf :: Text
-  , -- | Represents requirement field from project file.
-    requirementOf :: SwiftPackageGitDepRequirement
+  { urlOf :: Text
+  -- ^ Represents repositoryURL field from project file.
+  , requirementOf :: SwiftPackageGitDepRequirement
+  -- ^ Represents requirement field from project file.
   }
   deriving (Show, Eq, Ord)
 


### PR DESCRIPTION
# Overview

Updates the codebase to `hlint 3.4` and `fourmolu 0.6.0.0`.

The `hlint` issues came from using `<$>` for the list monad, instead of using `map`.  I believe each instance predated that section of the style guide, so this is just cleaning up old stuff we didn't know was old.

Some formatting issues came from using function guards, those have refactored out into simpler, but equivalent code.  One guard was left alone with a TODO, since it was trivial and the formatter did not clobber it.  The style guide has been updated to forbid match guards in new code.

The bulk of formatting changes came from `fourmolu` preferring trailing haddocks when using leading commas, in `[v0.5.0.0](https://github.com/fourmolu/fourmolu/blob/master/CHANGELOG.md#fourmolu-0500).

## Acceptance criteria

- `make lint` passes using `hlint` 3.4, and `make check-fmt` passes using `fourmolu 0.6.0.0` (check locally with `make check-ci`, and confirm the versions in CI logs.)

## Testing plan

Ran `make check-ci` and ran CI tests.

## Risks

No known risks, the type system validates the updated areas, and the tests confirm the guard refactors.

## References
`hlint` and `fourmolu` changelogs:
https://github.com/fourmolu/fourmolu/blob/master/CHANGELOG.md
https://github.com/ndmitchell/hlint/blob/master/CHANGES.txt