### PR TITLE
[ANE-283] Adds sbt dependency tree strategy

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,10 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## v3.3.1
 - Vendor Dependencies: Considers `licence` and `license` equivalent when performing native license scan ([#939](https://github.com/fossas/fossa-cli/pull/939)).
 - Vendor Dependencies: Native license scanning works in alpine linux without additional dependencies ([#949](https://github.com/fossas/fossa-cli/pull/949)).
-- Adds copyright information to attribution reports in the JSON output.
+- Adds copyright information to attribution reports in the JSON output ([#945](https://github.com/fossas/fossa-cli/pull/945)). 
+- Scala: non-multi sbt projects include deep dependencies ([#942](https://github.com/fossas/fossa-cli/pull/942)).
 
 ## v3.3.0
 - Telemetry: CLI collects telemetry by default. ([#936](https://github.com/fossas/fossa-cli/pull/936))

--- a/docs/references/strategies/languages/scala/sbt.md
+++ b/docs/references/strategies/languages/scala/sbt.md
@@ -2,14 +2,15 @@
 
 While the other analysis strategies for `gradle` and `maven` offer some scala project coverage, scala projects overwhelmingly use the build tool `sbt`.
 
-| Strategy           | Direct Deps        | Deep Deps          | Edges              | Other Limitations                                                 |
-| ------------------ | ------------------ | ------------------ | ------------------ | ----------------------------------------------------------------- |
-| sbt dependencyTree | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | Requires sbt v1.4 or greater. Versions do not include classifiers |
-| pom                | :heavy_check_mark: | :x:                | :x:                |                                                                   |
+| Strategy           | Direct Deps        | Deep Deps          | Edges              | Other Limitations                                                                                       |
+| ------------------ | ------------------ | ------------------ | ------------------ | ------------------------------------------------------------------------------------------------------- |
+| sbt dependencyTree | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | Requires sbt v1.4 or greater. Versions do not include classifiers. Does not support multi-project build |
+| pom                | :heavy_check_mark: | :x:                | :x:                |                                                                                                         |
 
  # Requirements
 
 - A locally-installed `sbt`
+- Ensure project is compiled with `sbt compile` or equivalent
 
 ## Project Discovery
 
@@ -32,6 +33,9 @@ For sbt < 1.3:
 # in project/plugins.sbt
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 ```
+
+> Unfortunately, `sbt dependencyTree` command does not include version classifier in it's output. Further, 
+> currently we do not support this strategy for multi-project builds due [inconsistent reporting defect in sbt](https://github.com/sbt/sbt/issues/6905)
 
 ## Strategy: `pom`
 

--- a/docs/references/strategies/languages/scala/sbt.md
+++ b/docs/references/strategies/languages/scala/sbt.md
@@ -2,11 +2,12 @@
 
 While the other analysis strategies for `gradle` and `maven` offer some scala project coverage, scala projects overwhelmingly use the build tool `sbt`.
 
-| Strategy   | Direct Deps | Deep Deps | Edges | Tags |
-| ---        | ---         | ---       | ---   | ---  |
-| sbt        | ✅          | ✅        | ✅    |      |
+| Strategy           | Direct Deps        | Deep Deps          | Edges              | Other Limitations                                                 |
+| ------------------ | ------------------ | ------------------ | ------------------ | ----------------------------------------------------------------- |
+| sbt dependencyTree | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | Requires sbt v1.4 or greater. Versions do not include classifiers |
+| pom                | :heavy_check_mark: | :x:                | :x:                |                                                                   |
 
-## Requirements
+ # Requirements
 
 - A locally-installed `sbt`
 
@@ -17,4 +18,37 @@ Directories that contain `build.sbt` files are treated as sbt projects
 ## Analysis
 
 1. Run `sbt makePom` to generate pom files
-2. Use the pom.xml maven strategy to "link together" related poms into projects, and extract a dependency graph
+
+## Strategy: `sbt dependencyTree`
+
+1. From generated pom file, identify project name via, `<name>` attribute.
+2. Perform `sbt $project/dependencyTree` and parse it's output to create dependency graph
+
+With [sbt 1.4.0 release](https://www.scala-sbt.org/1.x/docs/sbt-1.4-Release-Notes.html#sbt-dependency-graph+is+in-sourced), `dependencyTree` command is available by default. If you are using
+older sbt version, you can install following plugin: https://github.com/sbt/sbt-dependency-graph, which will also enable fossa-cli to work with `dependencyTree` task.
+
+For sbt < 1.3:
+```
+# in project/plugins.sbt
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+```
+
+## Strategy: `pom`
+
+1. From generated pom.xml, use maven strategy to "link together" related poms into projects, and extract a dependency graph
+
+## FAQ
+
+### How do I *only* analyze scala projects?
+
+You can explicitly specify analyses target in `.fossa.yml` file. 
+Example below, will exclude all analyses targets except scala. 
+
+```yaml
+# .fossa.yml 
+
+version: 3
+targets:
+  only:
+    - type: scala
+```

--- a/docs/references/strategies/languages/scala/sbt.md
+++ b/docs/references/strategies/languages/scala/sbt.md
@@ -22,11 +22,11 @@ Directories that contain `build.sbt` files are treated as sbt projects
 
 ## Strategy: `sbt dependencyTree`
 
-1. From generated pom file, identify project name via, `<name>` attribute.
-2. Perform `sbt $project/dependencyTree` and parse it's output to create dependency graph
+1. From the generated pom file, identify the project name via the `<name>` attribute.
+2. Perform `sbt $project/dependencyTree` and parse its output to create a dependency graph
 
-With [sbt 1.4.0 release](https://www.scala-sbt.org/1.x/docs/sbt-1.4-Release-Notes.html#sbt-dependency-graph+is+in-sourced), `dependencyTree` command is available by default. If you are using
-older sbt version, you can install following plugin: https://github.com/sbt/sbt-dependency-graph, which will also enable fossa-cli to work with `dependencyTree` task.
+With [sbt 1.4.0 release](https://www.scala-sbt.org/1.x/docs/sbt-1.4-Release-Notes.html#sbt-dependency-graph+is+in-sourced), the `dependencyTree` command is available by default. If you are using
+an older sbt version, you can install the following plugin: https://github.com/sbt/sbt-dependency-graph. This will also enable fossa-cli to work with the `dependencyTree` task.
 
 For sbt < 1.3:
 ```

--- a/docs/references/strategies/languages/scala/sbt.md
+++ b/docs/references/strategies/languages/scala/sbt.md
@@ -34,8 +34,8 @@ For sbt < 1.3:
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 ```
 
-> Unfortunately, `sbt dependencyTree` command does not include version classifier in it's output. Further, 
-> currently we do not support this strategy for multi-project builds due [inconsistent reporting defect in sbt](https://github.com/sbt/sbt/issues/6905)
+> Unfortunately, the `sbt dependencyTree` command does not include version classifier in its output. Further, 
+> currently we do not support this strategy for multi-project builds due an [inconsistent reporting defect in sbt](https://github.com/sbt/sbt/issues/6905).
 
 ## Strategy: `pom`
 

--- a/docs/references/strategies/languages/scala/sbt.md
+++ b/docs/references/strategies/languages/scala/sbt.md
@@ -2,10 +2,10 @@
 
 While the other analysis strategies for `gradle` and `maven` offer some scala project coverage, scala projects overwhelmingly use the build tool `sbt`.
 
-| Strategy           | Direct Deps        | Deep Deps          | Edges              | Other Limitations                                                                                       |
-| ------------------ | ------------------ | ------------------ | ------------------ | ------------------------------------------------------------------------------------------------------- |
-| sbt dependencyTree | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | Requires sbt v1.4 or greater. Versions do not include classifiers. Does not support multi-project build |
-| pom                | :heavy_check_mark: | :x:                | :x:                |                                                                                                         |
+| Strategy           | Direct Deps        | Deep Deps          | Edges              | Other Limitations                                                                                                                                      |
+| ------------------ | ------------------ | ------------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| sbt dependencyTree | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | Requires sbt version greater than v1.3.13 or `sbt-dependency-graph` plugin. Versions do not include classifiers. Does not support multi-project build. |
+| pom                | :heavy_check_mark: | :x:                | :x:                |                                                                                                                                                        |
 
  # Requirements
 

--- a/integration-test/Analysis/ScalaSpec.hs
+++ b/integration-test/Analysis/ScalaSpec.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.ScalaSpec (spec) where
+
+import Analysis.FixtureExpectationUtils (
+  DependencyResultsSummary (DependencyResultsSummary),
+  testSuiteDepResultSummary,
+ )
+import Analysis.FixtureUtils (
+  AnalysisTestFixture (AnalysisTestFixture),
+  FixtureArtifact (FixtureArtifact),
+  FixtureEnvironment (NixEnv),
+ )
+import Path (reldir)
+import Strategy.Scala qualified as Scala
+import Test.Hspec (Spec)
+import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
+
+scalaEnv :: FixtureEnvironment
+scalaEnv = NixEnv ["scala", "sbt"]
+
+scalaExampleProject :: AnalysisTestFixture (Scala.ScalaProject)
+scalaExampleProject =
+  AnalysisTestFixture
+    "scalaExampleProject"
+    Scala.discover
+    scalaEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/fossas/scala3-example-project/archive/refs/heads/main.tar.gz"
+      [reldir|scala/scala-3-ex-project/|]
+      [reldir|scala3-example-project-main/target/scala-3.1.2/|]
+
+spec :: Spec
+spec = do
+  testSuiteDepResultSummary scalaExampleProject ScalaProjectType (DependencyResultsSummary 3 2 1 1 Complete)

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -394,6 +394,7 @@ library
     Strategy.Ruby.GemfileLock
     Strategy.Ruby.Parse
     Strategy.Scala
+    Strategy.Scala.Common
     Strategy.Scala.Errors
     Strategy.Scala.SbtDependencyTree
     Strategy.Swift.Errors
@@ -532,6 +533,7 @@ test-suite unit-tests
     Ruby.BundleShowSpec
     Ruby.GemfileLockSpec
     Ruby.ParseSpec
+    Scala.CommonSpec
     Scala.SbtDependencyTreeParsingSpec
     Scala.SbtDependencyTreeSpec
     Swift.PackageResolvedSpec
@@ -582,6 +584,7 @@ test-suite integration-tests
     Analysis.Python.SetuptoolsSpec
     Analysis.RubySpec
     Analysis.RustSpec
+    Analysis.ScalaSpec
 
   build-tool-depends: hspec-discover:hspec-discover ^>=2.8.2
   build-depends:

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -394,6 +394,8 @@ library
     Strategy.Ruby.GemfileLock
     Strategy.Ruby.Parse
     Strategy.Scala
+    Strategy.Scala.Errors
+    Strategy.Scala.SbtDependencyTree
     Strategy.Swift.Errors
     Strategy.Swift.PackageResolved
     Strategy.Swift.PackageSwift
@@ -530,6 +532,8 @@ test-suite unit-tests
     Ruby.BundleShowSpec
     Ruby.GemfileLockSpec
     Ruby.ParseSpec
+    Scala.SbtDependencyTreeParsingSpec
+    Scala.SbtDependencyTreeSpec
     Swift.PackageResolvedSpec
     Swift.PackageSwiftSpec
     Swift.Xcode.PbxprojParserSpec

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -47,6 +47,7 @@ module Graphing (
   stripRoot,
   promoteToDirect,
   shrinkRoots,
+  subGraphOf,
 
   -- * Conversions
   fromAdjacencyMap,
@@ -366,3 +367,31 @@ hasPredecessors (Graphing gr) from = not $ Set.null $ Set.filter (withoutRoots) 
     withoutRoots :: Node a -> Bool
     withoutRoots (Node _) = True
     withoutRoots (Root) = False
+
+-- | Keeps children of provided node in graph
+--
+-- Example:
+--
+--   1 -> 2 -> 5 -> 6
+--        \       \
+--         \       7
+--          4
+--
+--  subGraphOf 5 gr =
+--
+--   5 -> 6
+--        \
+--         7
+subGraphOf :: forall ty. Ord ty => ty -> Graphing ty -> Graphing ty
+subGraphOf n (Graphing gr) =
+  Graphing (AM.induce keepPredicate gr)
+  where
+    nodes :: [Node ty]
+    nodes = Prelude.filter (== Node n) $ AM.vertexList gr
+
+    reachableNodes :: Set.Set (Node ty)
+    reachableNodes = Set.fromList $ AMA.dfs nodes gr
+
+    keepPredicate :: Node ty -> Bool
+    keepPredicate Root = True
+    keepPredicate (Node ty) = Set.member (Node ty) reachableNodes

--- a/src/Strategy/Maven/Pom/PomFile.hs
+++ b/src/Strategy/Maven/Pom/PomFile.hs
@@ -145,6 +145,7 @@ data RawPom = RawPom
   , rawPomGroup :: Maybe Text
   , rawPomArtifact :: Text
   , rawPomVersion :: Maybe Text
+  , rawPomName :: Maybe Text
   , rawPomProperties :: Map Text Text
   , rawPomModules :: [Text]
   , rawPomDependencyManagement :: [RawDependency]
@@ -185,6 +186,7 @@ instance FromXML RawPom where
       <*> optional (child "groupId" el)
       <*> child "artifactId" el
       <*> optional (child "version" el)
+      <*> optional (child "name" el)
       <*> optional (child "properties" el) `defaultsTo` Map.empty
       <*> optional (child "modules" el >>= children "module") `defaultsTo` []
       <*> optional (child "dependencyManagement" el >>= children "dependency") `defaultsTo` []

--- a/src/Strategy/Scala/Common.hs
+++ b/src/Strategy/Scala/Common.hs
@@ -19,11 +19,15 @@ data SbtArtifact = SbtArtifact
 removeLogPrefixes :: Text -> Text
 removeLogPrefixes content = Text.unlines . map removePrefix $ Text.lines content
   where
+    removePrefix :: Text -> Text
     removePrefix candidate
-      | Text.isPrefixOf "[debug]" candidate = fromMaybe candidate $ Text.stripPrefix "[debug] " candidate
-      | Text.isPrefixOf "[info]" candidate = fromMaybe candidate $ Text.stripPrefix "[info] " candidate
-      | Text.isPrefixOf "[warn]" candidate = fromMaybe candidate $ Text.stripPrefix "[warn] " candidate
-      | Text.isPrefixOf "[success]" candidate = fromMaybe candidate $ Text.stripPrefix "[success] " candidate
-      | Text.isPrefixOf "[error]" candidate = fromMaybe candidate $ Text.stripPrefix "[error] " candidate
-      | Text.isPrefixOf "[trace]" candidate = fromMaybe candidate $ Text.stripPrefix "[trace] " candidate
+      | Text.isPrefixOf "[debug]" candidate = maybeRemovePrefix "[debug]" candidate
+      | Text.isPrefixOf "[info]" candidate = maybeRemovePrefix "[info]" candidate
+      | Text.isPrefixOf "[warn]" candidate = maybeRemovePrefix "[warn]" candidate
+      | Text.isPrefixOf "[success]" candidate = maybeRemovePrefix "[success]" candidate
+      | Text.isPrefixOf "[error]" candidate = maybeRemovePrefix "[error]" candidate
+      | Text.isPrefixOf "[trace]" candidate = maybeRemovePrefix "[trace]" candidate
       | otherwise = candidate
+
+    maybeRemovePrefix :: Text -> Text -> Text
+    maybeRemovePrefix prefix candidate = fromMaybe candidate $ Text.stripPrefix (prefix <> " ") candidate

--- a/src/Strategy/Scala/Common.hs
+++ b/src/Strategy/Scala/Common.hs
@@ -1,0 +1,29 @@
+module Strategy.Scala.Common (
+  removeLogPrefixes,
+  SbtArtifact (..),
+) where
+
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as Text
+
+data SbtArtifact = SbtArtifact
+  { groupId :: Text
+  , artifactId :: Text
+  , version :: Text
+  }
+  deriving (Eq, Ord, Show)
+
+-- | Removes log prefix from the log.
+-- >> removeLogPrefixes "[info] someInfo" = "someInfo"
+removeLogPrefixes :: Text -> Text
+removeLogPrefixes content = Text.unlines . map removePrefix $ Text.lines content
+  where
+    removePrefix candidate
+      | Text.isPrefixOf "[debug]" candidate = fromMaybe candidate $ Text.stripPrefix "[debug] " candidate
+      | Text.isPrefixOf "[info]" candidate = fromMaybe candidate $ Text.stripPrefix "[info] " candidate
+      | Text.isPrefixOf "[warn]" candidate = fromMaybe candidate $ Text.stripPrefix "[warn] " candidate
+      | Text.isPrefixOf "[success]" candidate = fromMaybe candidate $ Text.stripPrefix "[success] " candidate
+      | Text.isPrefixOf "[error]" candidate = fromMaybe candidate $ Text.stripPrefix "[error] " candidate
+      | Text.isPrefixOf "[trace]" candidate = fromMaybe candidate $ Text.stripPrefix "[trace] " candidate
+      | otherwise = candidate

--- a/src/Strategy/Scala/Errors.hs
+++ b/src/Strategy/Scala/Errors.hs
@@ -1,0 +1,37 @@
+module Strategy.Scala.Errors (
+  MaybeWithoutDependencyTreeTask (..),
+
+  -- * docs
+  scalaFossaDocUrl,
+  sbtDepsGraphPluginUrl,
+) where
+
+import App.Docs (strategyLangDocUrl)
+import Data.Text (Text)
+import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
+import Prettyprinter (Pretty (pretty), indent, viaShow, vsep)
+
+scalaFossaDocUrl :: Text
+scalaFossaDocUrl = strategyLangDocUrl "scala/sbt.md"
+
+sbtDepsGraphPluginUrl :: Text
+sbtDepsGraphPluginUrl = "https://github.com/sbt/sbt-dependency-graph"
+
+newtype MaybeWithoutDependencyTreeTask = MaybeWithoutDependencyTreeTask (Text)
+
+instance ToDiagnostic MaybeWithoutDependencyTreeTask where
+  renderDiagnostic (MaybeWithoutDependencyTreeTask project) =
+    vsep
+      [ "We could not perform dynamic sbt analysis for: " <> viaShow project
+      , ""
+      , indent 2 $
+          vsep
+            [ "Ensure you can run sbt dependencyTree. If you are using sbt v1.4.0 or older"
+            , "please install following plugin prior to running fossa:"
+            , indent 2 $ pretty sbtDepsGraphPluginUrl
+            , ""
+            ]
+      , ""
+      , "Refer to:"
+      , indent 2 $ pretty $ "- " <> scalaFossaDocUrl
+      ]

--- a/src/Strategy/Scala/Errors.hs
+++ b/src/Strategy/Scala/Errors.hs
@@ -19,13 +19,12 @@ scalaFossaDocUrl = strategyLangDocUrl "scala/sbt.md"
 sbtDepsGraphPluginUrl :: Text
 sbtDepsGraphPluginUrl = "https://github.com/sbt/sbt-dependency-graph"
 
-newtype MaybeWithoutDependencyTreeTask = MaybeWithoutDependencyTreeTask (Text)
+data MaybeWithoutDependencyTreeTask = MaybeWithoutDependencyTreeTask
 
 instance ToDiagnostic MaybeWithoutDependencyTreeTask where
-  renderDiagnostic (MaybeWithoutDependencyTreeTask project) =
+  renderDiagnostic (MaybeWithoutDependencyTreeTask) =
     vsep
-      [ "We could not perform dynamic sbt analysis for: " <> viaShow project
-      , ""
+      [ "We could not perform dynamic sbt analysis via sbt dependencyTree"
       , indent 2 $
           vsep
             [ "Ensure you can run sbt dependencyTree. If you are using sbt v1.4.0 or older"

--- a/src/Strategy/Scala/Errors.hs
+++ b/src/Strategy/Scala/Errors.hs
@@ -27,7 +27,7 @@ instance ToDiagnostic MaybeWithoutDependencyTreeTask where
       [ "We could not perform dynamic sbt analysis via sbt dependencyTree"
       , indent 2 $
           vsep
-            [ "Ensure you can run sbt dependencyTree. If you are using sbt v1.4.0 or older"
+            [ "Ensure you can run sbt dependencyTree. If you are using older version than sbt v1.4.0 (e.g. v1.3.13)"
             , "please install following plugin prior to running fossa:"
             , indent 2 $ pretty sbtDepsGraphPluginUrl
             , ""

--- a/src/Strategy/Scala/Errors.hs
+++ b/src/Strategy/Scala/Errors.hs
@@ -1,5 +1,6 @@
 module Strategy.Scala.Errors (
   MaybeWithoutDependencyTreeTask (..),
+  FailedToListProjects (..),
 
   -- * docs
   scalaFossaDocUrl,
@@ -9,6 +10,7 @@ module Strategy.Scala.Errors (
 import App.Docs (strategyLangDocUrl)
 import Data.Text (Text)
 import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
+import Path (Abs, Dir, Path)
 import Prettyprinter (Pretty (pretty), indent, viaShow, vsep)
 
 scalaFossaDocUrl :: Text
@@ -35,3 +37,9 @@ instance ToDiagnostic MaybeWithoutDependencyTreeTask where
       , "Refer to:"
       , indent 2 $ pretty $ "- " <> scalaFossaDocUrl
       ]
+
+newtype FailedToListProjects = FailedToListProjects (Path Abs Dir)
+  deriving (Eq, Ord, Show)
+
+instance ToDiagnostic FailedToListProjects where
+  renderDiagnostic (FailedToListProjects dir) = "Failed to discover and analyze sbt projects, for sbt build manifest at:" <> viaShow dir

--- a/src/Strategy/Scala/SbtDependencyTree.hs
+++ b/src/Strategy/Scala/SbtDependencyTree.hs
@@ -14,7 +14,7 @@ module Strategy.Scala.SbtDependencyTree (
 ) where
 
 import Control.Carrier.Simple (Has)
-import Control.Effect.Diagnostics (Diagnostics, context, errCtx, fatal, fromMaybeText)
+import Control.Effect.Diagnostics (Diagnostics, context, errCtx, fatal)
 import Control.Monad (guard, void)
 import Data.Functor (($>))
 import Data.Maybe qualified as DMaybe

--- a/src/Strategy/Scala/SbtDependencyTree.hs
+++ b/src/Strategy/Scala/SbtDependencyTree.hs
@@ -1,0 +1,239 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Strategy.Scala.SbtDependencyTree (
+  analyze,
+
+  -- * for testing
+  SbtArtifact (..),
+  SbtDep (..),
+  parseSbtArtifact,
+  parseEviction,
+  sbtTreeParser,
+  removeLogPrefixes,
+  buildGraph,
+) where
+
+import Control.Carrier.Simple (Has)
+import Control.Effect.Diagnostics (Diagnostics, context, errCtx, fatal, fromMaybeText)
+import Control.Monad (guard, void)
+import Data.Functor (($>))
+import Data.Maybe qualified as DMaybe
+import Data.Set qualified as Set
+import Data.String.Conversion (ConvertUtf8 (decodeUtf8), toText)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Void (Void)
+import DepTypes (
+  DepEnvironment (EnvProduction),
+  DepType (MavenType),
+  Dependency (..),
+  VerConstraint (CEq),
+ )
+import Effect.Exec (
+  AllowErr (Never),
+  Command (..),
+  Exec,
+  ExecErr (CommandParseError),
+  execThrow,
+ )
+import Graphing (Graphing, shrinkRoots, unfold)
+import Path (Abs, Dir, Path)
+import Strategy.Scala.Errors (MaybeWithoutDependencyTreeTask (MaybeWithoutDependencyTreeTask))
+import Text.Megaparsec (
+  MonadParsec (eof, takeWhileP, try),
+  Parsec,
+  chunk,
+  empty,
+  errorBundlePretty,
+  many,
+  optional,
+  runParser,
+  sepBy,
+  some,
+  (<|>),
+ )
+import Text.Megaparsec.Char (alphaNumChar, char, eol)
+import Text.Megaparsec.Char.Lexer qualified as Lexer
+
+-- | Sbt Dependency Ascii tree task
+-- This only works with sbt v1.4.0 greater, or with sbt which has DependencyTreePlugin.
+-- Ref: https://www.scala-sbt.org/1.x/docs/sbt-1.4-Release-Notes.html#sbt-dependency-graph+is+in-sourced
+sbtDepTreeCmd :: Text -> Command
+sbtDepTreeCmd projectName =
+  Command
+    { cmdName = "sbt"
+    , cmdArgs =
+        [ "--batch" -- ensure sbt does not enter repl mode!
+        , "--no-colors"
+        , projectName <> "/dependencyTree"
+        ]
+    , cmdAllowErr = Never
+    }
+
+data SbtArtifact = SbtArtifact
+  { groupId :: Text
+  , artifactId :: Text
+  , version :: Text
+  }
+  deriving (Eq, Ord, Show)
+
+data SbtDep = SbtDep
+  { artifact :: SbtArtifact
+  , requires :: [SbtDep]
+  }
+  deriving (Eq, Ord, Show)
+
+type Parser = Parsec Void Text
+
+sc :: Parser ()
+sc = Lexer.space (void $ some $ char ' ' <|> char '\t') empty empty
+
+lexeme :: Parser a -> Parser a
+lexeme = Lexer.lexeme sc
+
+symbol :: Text -> Parser Text
+symbol = Lexer.symbol sc
+
+-- | Parses package identifier.
+--
+-- @Examples:
+-- >> parseTest parseValidProjectIdentifier "org.a.b" = "org.a.b"
+-- >> parseTest parseValidProjectIdentifier "org.a.b-c" = "org.a.b-c"
+-- >> parseTest parseValidProjectIdentifier "org.a.b:" = "org.a.b"
+-- >> parseTest parseValidProjectIdentifier "org.a.b " = "org.a.b"
+parseValidProjectIdentifier :: Parser Text
+parseValidProjectIdentifier = toText <$> some (alphaNumChar <|> char '.' <|> char '-' <|> char '_')
+
+-- | Parses Sbt Artifact
+--
+-- @Example:
+-- >> parseTest parseSbtArtifact "com.typesafe:config:1.3.1" = SbtArtifact "com.typesafe" "config" "1.3.1"
+-- >> parseTest parseSbtArtifact "com.typesafe:config:1.3.1 [S]" = SbtArtifact "com.typesafe" "config" "1.3.1"
+parseSbtArtifact :: Parser SbtArtifact
+parseSbtArtifact =
+  SbtArtifact
+    <$> parseValidProjectIdentifier
+    <*> (":" >> parseValidProjectIdentifier)
+    <*> (":" >> parseValidProjectIdentifier)
+
+-- | Parses chars used for ascii graphing layout.
+parseAsciiGraphLayoutChars :: Parser Text
+parseAsciiGraphLayoutChars =
+  toText
+    <$> many
+      ( char ' '
+          <|> char '|'
+          <|> char '+'
+          <|> char '-'
+          <|> char '#'
+      )
+
+-- | Parses evicted version identifier
+-- >> parseEviction "(evicted by: 2.0)" = "2.0"
+parseEviction :: Parser (Text)
+parseEviction = symbol "(evicted by:" *> parseValidProjectIdentifier <* symbol ")"
+
+-- | Parses ASCII tree
+--
+-- parent
+--   +-childA
+--   +-childB
+--   |   +-childC
+--   |
+--   +-childD
+--
+-- Reference: https://github.com/sbt/sbt/blob/develop/main/src/main/scala/sbt/internal/SettingGraph.scala#L84
+sbtTreeParser :: Parser [SbtDep]
+sbtTreeParser = concat <$> ((try (parseDeps 0) <|> ignoredLine) `sepBy` eol) <* eof
+  where
+    isEndLine :: Char -> Bool
+    isEndLine '\n' = True
+    isEndLine '\r' = True
+    isEndLine _ = False
+
+    ignoredLine :: Parser [SbtDep]
+    ignoredLine = void (takeWhileP (Just "ignored") (not . isEndLine)) $> mempty
+
+    parseDeps :: Int -> Parser [SbtDep]
+    parseDeps depth = do
+      prefixes <- parseAsciiGraphLayoutChars
+      guard (Text.length prefixes == expectedSpacing depth)
+      parseDep depth <|> emptyLineBreakInGraph
+
+    -- Refer to: https://github.com/sbt/sbt/blob/develop/main/src/main/scala/sbt/internal/SettingGraph.scala#L107
+    expectedSpacing :: Int -> Int
+    expectedSpacing currentDepth =
+      if currentDepth <= 0
+        then 0
+        else 2 + currentDepth * 2
+
+    parseDep :: Int -> Parser [SbtDep]
+    parseDep depth = do
+      depArtifact <- lexeme parseSbtArtifact
+
+      -- Sbt may choose different version of dependency than specified
+      -- if there are version conflicts!
+      -- Ref: https://www.scala-sbt.org/0.13/docs/Library-Management.html#Eviction+warning
+      evictedVersion <- optional . try $ parseEviction
+      void $ takeWhileP (Just "ignored") (not . isEndLine)
+
+      deepDependencies <- many $ try (sbtRecurse (depth + 1))
+
+      case evictedVersion of
+        Nothing -> pure [SbtDep depArtifact (concat deepDependencies)]
+        Just ev -> pure [SbtDep depArtifact{version = ev} (concat deepDependencies)]
+
+    -- Used to handles scenarios like,
+    --
+    --   +-childB
+    --   |   +-childC
+    --   |            <- emptyLineBreakInGraph
+    --   +-childD
+    --
+    emptyLineBreakInGraph :: Parser [SbtDep]
+    emptyLineBreakInGraph = mempty
+
+    sbtRecurse :: Int -> Parser [SbtDep]
+    sbtRecurse depth = chunk "\n" *> parseDeps depth
+
+-- | Removes log prefix from the log.
+-- >> removeLogPrefixes "[info] someInfo" = "someInfo"
+removeLogPrefixes :: Text -> Text
+removeLogPrefixes content = Text.unlines . map removePrefix $ Text.lines content
+  where
+    removePrefix candidate
+      | Text.isPrefixOf "[debug]" candidate = DMaybe.fromMaybe candidate $ Text.stripPrefix "[debug] " candidate
+      | Text.isPrefixOf "[info]" candidate = DMaybe.fromMaybe candidate $ Text.stripPrefix "[info] " candidate
+      | Text.isPrefixOf "[warn]" candidate = DMaybe.fromMaybe candidate $ Text.stripPrefix "[warn] " candidate
+      | Text.isPrefixOf "[success]" candidate = DMaybe.fromMaybe candidate $ Text.stripPrefix "[success] " candidate
+      | Text.isPrefixOf "[error]" candidate = DMaybe.fromMaybe candidate $ Text.stripPrefix "[error] " candidate
+      | Text.isPrefixOf "[trace]" candidate = DMaybe.fromMaybe candidate $ Text.stripPrefix "[trace] " candidate
+      | otherwise = candidate
+
+buildGraph :: [SbtDep] -> Graphing Dependency
+buildGraph dependencies = unfold dependencies requires toDependency
+  where
+    toDependency SbtDep{..} =
+      Dependency
+        { dependencyType = MavenType
+        , dependencyName = toText (groupId artifact) <> ":" <> toText (artifactId artifact)
+        , dependencyVersion = Just (CEq $ version artifact)
+        , dependencyLocations = mempty
+        , dependencyEnvironments = Set.singleton EnvProduction
+        , dependencyTags = mempty
+        }
+
+analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> Text -> m (Graphing Dependency)
+analyze buildSbtDir projectName = do
+  let sbtCmd = sbtDepTreeCmd projectName
+
+  rawSbtDepTreeStdout <-
+    context ("inferring dependencies for project: " <> projectName) $
+      errCtx (MaybeWithoutDependencyTreeTask projectName) $
+        execThrow buildSbtDir sbtCmd
+
+  case runParser sbtTreeParser "" (removeLogPrefixes $ decodeUtf8 rawSbtDepTreeStdout) of
+    Right parsedDeps -> pure $ shrinkRoots $ buildGraph parsedDeps
+    Left err ->
+      fatal $
+        CommandParseError sbtCmd (toText $ errorBundlePretty err)

--- a/src/Strategy/Scala/SbtDependencyTree.hs
+++ b/src/Strategy/Scala/SbtDependencyTree.hs
@@ -185,7 +185,7 @@ sbtTreeParser = concat <$> ((try (parseDeps 0) <|> ignoredLine) `sepBy` eol) <* 
     emptyLineBreakInGraph = mempty
 
     sbtRecurse :: Int -> Parser [SbtDep]
-    sbtRecurse depth = chunk "\n" *> parseDeps depth
+    sbtRecurse depth = (chunk "\n" <|> chunk "\r\n") *> parseDeps depth
 
 -- | Builds graph with scoped to @SbtArtifact
 --
@@ -220,7 +220,7 @@ toDependency :: SbtArtifact -> Dependency
 toDependency SbtArtifact{..} =
   Dependency
     { dependencyType = MavenType
-    , dependencyName = toText (groupId) <> ":" <> toText (artifactId)
+    , dependencyName = toText groupId <> ":" <> toText artifactId
     , dependencyVersion = Just (CEq version)
     , dependencyLocations = mempty
     , dependencyEnvironments = Set.singleton EnvProduction

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -36,6 +36,7 @@ import Strategy.Swift.Errors (
  )
 import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 import Text.URI (mkURI)
+import Strategy.Scala.Errors (scalaFossaDocUrl, sbtDepsGraphPluginUrl)
 
 shouldRespondToGETWithHttpCode :: Text -> Int -> Expectation
 shouldRespondToGETWithHttpCode uri expected = do
@@ -62,6 +63,8 @@ urlsToCheck =
   , refPodDocUrl
   , refGradleDocUrl
   , containerScanningDocUrl
+  , scalaFossaDocUrl
+  , sbtDepsGraphPluginUrl
   ]
 
 spec :: Spec

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -29,6 +29,7 @@ import Strategy.Node.Errors (
  )
 import Strategy.Python.Errors (commitPoetryLockToVCS)
 import Strategy.Ruby.Errors (bundlerLockFileRationaleUrl, rubyFossaDocUrl)
+import Strategy.Scala.Errors (sbtDepsGraphPluginUrl, scalaFossaDocUrl)
 import Strategy.Swift.Errors (
   swiftFossaDocUrl,
   swiftPackageResolvedRef,
@@ -36,7 +37,6 @@ import Strategy.Swift.Errors (
  )
 import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 import Text.URI (mkURI)
-import Strategy.Scala.Errors (scalaFossaDocUrl, sbtDepsGraphPluginUrl)
 
 shouldRespondToGETWithHttpCode :: Text -> Int -> Expectation
 shouldRespondToGETWithHttpCode uri expected = do

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -366,43 +366,44 @@ hasPredecessorsSpec = do
 
 subGraphOfSpec :: Spec
 subGraphOfSpec = do
-  describe "subGraphOf" $
-    it "should return graph of children including the node" $ do
-      --   1 -> 2
-      --    \    \
-      --     3    \
-      --      \    4
-      --       6
-      let graph :: Graphing Int = Graphing.directs [1, 2] <> Graphing.edges [(1, 2), (1, 3), (2, 4), (3, 6)]
+  --   1 -> 2
+  --    \    \
+  --     3    \
+  --      \    4
+  --       6
+  let graph1 :: Graphing Int = Graphing.directs [1, 2] <> Graphing.edges [(1, 2), (1, 3), (2, 4), (3, 6)]
 
-      let graphSub0 = subGraphOf 0 graph
-          graphSub1 = subGraphOf 1 graph
-          graphSub2 = subGraphOf 2 graph
-          graphSub3 = subGraphOf 3 graph
+  --     -- 1 -> 2 -> 5 -> 6
+  --     --      \    \
+  --     --       \    7
+  --     -- 3 ----> 4
+  let graph2 :: Graphing Int = Graphing.edges [(1, 2), (3, 4), (2, 4), (2, 5), (5, 7), (5, 6)] <> Graphing.directs [1, 3]
 
+  describe "subGraphOf" $ do
+    it "should return subGraph of 0 for graph1 correctly" $ do
+      let graphSub0 = subGraphOf 0 graph1
       expectEdges [] graphSub0
       expectDeps [] graphSub0
       expectDirect [] graphSub0
 
-      graphSub1 `shouldBe` graph
+    it "should return subGraph of 1 for graph1 correctly" $ do
+      let graphSub1 = subGraphOf 1 graph1
+      graphSub1 `shouldBe` graph1
 
+    it "should return subGraph of 2 for graph1 correctly" $ do
+      let graphSub2 = subGraphOf 2 graph1
       expectEdges [(2, 4)] graphSub2
       expectDeps [2, 4] graphSub2
       expectDirect [2] graphSub2
 
+    it "should return subGraph of 3 for graph1 correctly" $ do
+      let graphSub3 = subGraphOf 3 graph1
       expectEdges [(3, 6)] graphSub3
       expectDeps [3, 6] graphSub3
       expectDirect [] graphSub3
 
-      -- 1 -> 2 -> 5 -> 6
-      --      \    \
-      --       \    7
-      -- 3 ----> 4
-
-      let graph2 :: Graphing Int
-          graph2 = Graphing.edges [(1, 2), (3, 4), (2, 4), (2, 5), (5, 7), (5, 6)] <> Graphing.directs [1, 3]
-          graph2Sub5 = subGraphOf 5 graph2
-
+    it "should return subGraph of 5 for graph2 correctly" $ do
+      let graph2Sub5 = subGraphOf 5 graph2
       expectEdges [(5, 7), (5, 6)] graph2Sub5
       expectDeps [5, 6, 7] graph2Sub5
       expectDirect [] graph2Sub5

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -24,6 +24,7 @@ import Graphing (
   shrinkSingle,
   shrinkWithoutPromotionToDirect,
   stripRoot,
+  subGraphOf,
   toAdjacencyMap,
   unfold,
   unfoldDeep,
@@ -363,6 +364,49 @@ hasPredecessorsSpec = do
       let graph :: Graphing Int = Graphing.directs [1, 2] <> Graphing.edges [(1, 2), (2, 3), (3, 4)]
       hasPredecessors graph 2 `shouldBe` True
 
+subGraphOfSpec :: Spec
+subGraphOfSpec = do
+  describe "subGraphOf" $
+    it "should return graph of children including the node" $ do
+      --   1 -> 2
+      --    \    \
+      --     3    \
+      --      \    4
+      --       6
+      let graph :: Graphing Int = Graphing.directs [1, 2] <> Graphing.edges [(1, 2), (1, 3), (2, 4), (3, 6)]
+
+      let graphSub0 = subGraphOf 0 graph
+          graphSub1 = subGraphOf 1 graph
+          graphSub2 = subGraphOf 2 graph
+          graphSub3 = subGraphOf 3 graph
+
+      expectEdges [] graphSub0
+      expectDeps [] graphSub0
+      expectDirect [] graphSub0
+
+      graphSub1 `shouldBe` graph
+
+      expectEdges [(2, 4)] graphSub2
+      expectDeps [2, 4] graphSub2
+      expectDirect [2] graphSub2
+
+      expectEdges [(3, 6)] graphSub3
+      expectDeps [3, 6] graphSub3
+      expectDirect [] graphSub3
+
+      -- 1 -> 2 -> 5 -> 6
+      --      \    \
+      --       \    7
+      -- 3 ----> 4
+
+      let graph2 :: Graphing Int
+          graph2 = Graphing.edges [(1, 2), (3, 4), (2, 4), (2, 5), (5, 7), (5, 6)] <> Graphing.directs [1, 3]
+          graph2Sub5 = subGraphOf 5 graph2
+
+      expectEdges [(5, 7), (5, 6)] graph2Sub5
+      expectDeps [5, 6, 7] graph2Sub5
+      expectDirect [] graph2Sub5
+
 spec :: Spec
 spec = do
   unfoldSpec
@@ -386,3 +430,5 @@ spec = do
   promoteToDirectSpec
 
   hasPredecessorsSpec
+
+  subGraphOfSpec

--- a/test/Scala/CommonSpec.hs
+++ b/test/Scala/CommonSpec.hs
@@ -31,4 +31,6 @@ spec = do
       removeLogPrefixes "[warn] pineapples!\n" `shouldBe` "pineapples!\n"
       removeLogPrefixes "[error] pineapples!\n" `shouldBe` "pineapples!\n"
       removeLogPrefixes "[debug] pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes "[success] pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes "[trace] pineapples!\n" `shouldBe` "pineapples!\n"
       removeLogPrefixes stdoutFromSbt `shouldBe` "truth\nis\nout\nthere!\n"

--- a/test/Scala/CommonSpec.hs
+++ b/test/Scala/CommonSpec.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Scala.CommonSpec (
+  spec,
+) where
+
+import Data.Text (Text)
+import Strategy.Scala.Common (removeLogPrefixes)
+import Test.Hspec (
+  Spec,
+  describe,
+  it,
+  shouldBe,
+ )
+import Text.RawString.QQ (r)
+
+stdoutFromSbt :: Text
+stdoutFromSbt =
+  [r|[info] truth
+[info] is
+[warn] out
+[error] there!
+|]
+
+spec :: Spec
+spec = do
+  describe "removeLogPrefixes" $ do
+    it "should parse sbt artifact" $ do
+      removeLogPrefixes "pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes "[info] pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes "[warn] pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes "[error] pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes "[debug] pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes stdoutFromSbt `shouldBe` "truth\nis\nout\nthere!\n"

--- a/test/Scala/SbtDependencyTreeParsingSpec.hs
+++ b/test/Scala/SbtDependencyTreeParsingSpec.hs
@@ -7,7 +7,14 @@ module Scala.SbtDependencyTreeParsingSpec (
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Void (Void)
-import Strategy.Scala.SbtDependencyTree (SbtArtifact (SbtArtifact), SbtDep (SbtDep), parseEviction, parseSbtArtifact, removeLogPrefixes, sbtTreeParser)
+import Strategy.Scala.SbtDependencyTree (
+  SbtArtifact (SbtArtifact),
+  SbtDep (SbtDep),
+  parseEviction,
+  parseSbtArtifact,
+  removeLogPrefixes,
+  sbtTreeParser,
+ )
 import Test.Hspec (
   Expectation,
   Spec,

--- a/test/Scala/SbtDependencyTreeParsingSpec.hs
+++ b/test/Scala/SbtDependencyTreeParsingSpec.hs
@@ -12,7 +12,6 @@ import Strategy.Scala.SbtDependencyTree (
   SbtDep (SbtDep),
   parseEviction,
   parseSbtArtifact,
-  removeLogPrefixes,
   sbtTreeParser,
  )
 import Test.Hspec (
@@ -20,7 +19,6 @@ import Test.Hspec (
   Spec,
   describe,
   it,
-  shouldBe,
  )
 import Test.Hspec.Megaparsec (shouldParse)
 import Text.Megaparsec (
@@ -31,14 +29,6 @@ import Text.RawString.QQ (r)
 
 parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
 parseMatch parser input expected = parse parser "" input `shouldParse` expected
-
-stdoutFromSbt :: Text
-stdoutFromSbt =
-  [r|[info] truth
-[info] is
-[warn] out
-[error] there!
-|]
 
 spec :: Spec
 spec = do
@@ -54,15 +44,6 @@ spec = do
       "a:b.c:1.0" `shouldParseInto` SbtArtifact "a" "b.c" "1.0"
       "a:b.c:1.0.0" `shouldParseInto` SbtArtifact "a" "b.c" "1.0.0"
       "a:b.c:1.0.0-SNAPSHOT" `shouldParseInto` SbtArtifact "a" "b.c" "1.0.0-SNAPSHOT"
-
-  describe "removeLogPrefixes" $ do
-    it "should parse sbt artifact" $ do
-      removeLogPrefixes "pineapples!\n" `shouldBe` "pineapples!\n"
-      removeLogPrefixes "[info] pineapples!\n" `shouldBe` "pineapples!\n"
-      removeLogPrefixes "[warn] pineapples!\n" `shouldBe` "pineapples!\n"
-      removeLogPrefixes "[error] pineapples!\n" `shouldBe` "pineapples!\n"
-      removeLogPrefixes "[debug] pineapples!\n" `shouldBe` "pineapples!\n"
-      removeLogPrefixes stdoutFromSbt `shouldBe` "truth\nis\nout\nthere!\n"
 
   describe "parseEviction" $ do
     let shouldParseInto = parseMatch parseEviction

--- a/test/Scala/SbtDependencyTreeParsingSpec.hs
+++ b/test/Scala/SbtDependencyTreeParsingSpec.hs
@@ -67,8 +67,8 @@ org:project:1.0.0-snapshot
   +-org:childA:1.0
 |]
 
-treeWithOneDepWithEvication :: Text
-treeWithOneDepWithEvication =
+treeWithOneDepWithEviction :: Text
+treeWithOneDepWithEviction =
   [r|
 org:project:1.0.0-snapshot
   +-org:childA:1.0 (evicted by: 2.0)
@@ -81,6 +81,9 @@ org:project:1.0.0-snapshot
   +-org:childA:1.0
     +-org:grandChildA:2.0
 |]
+
+treeWithNestedDepWithWindowsLineBreak :: Text
+treeWithNestedDepWithWindowsLineBreak = "org:project:1.0.0-snapshot\r\n  +-org:childA:1.0\r\n    +-org:grandChildA:2.0\r\n"
 
 treeWithMultipleNestedDep :: Text
 treeWithMultipleNestedDep =
@@ -132,7 +135,7 @@ parsesTreeSpec = do
                           ]
 
     it "should parse tree with one dep" $
-      treeWithOneDepWithEvication
+      treeWithOneDepWithEviction
         `shouldParseInto` [ SbtDep
                               (mkArtifact "project@1.0.0-snapshot")
                               [ SbtDep (mkArtifact "childA@2.0") []
@@ -141,6 +144,17 @@ parsesTreeSpec = do
 
     it "should parse tree with nested dep" $
       treeWithNestedDep
+        `shouldParseInto` [ SbtDep
+                              (mkArtifact "project@1.0.0-snapshot")
+                              [ SbtDep
+                                  (mkArtifact "childA@1.0")
+                                  [ SbtDep (mkArtifact "grandChildA@2.0") mempty
+                                  ]
+                              ]
+                          ]
+
+    it "should parse tree with nested dep with windows line break" $
+      treeWithNestedDepWithWindowsLineBreak
         `shouldParseInto` [ SbtDep
                               (mkArtifact "project@1.0.0-snapshot")
                               [ SbtDep

--- a/test/Scala/SbtDependencyTreeParsingSpec.hs
+++ b/test/Scala/SbtDependencyTreeParsingSpec.hs
@@ -1,0 +1,199 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Scala.SbtDependencyTreeParsingSpec (
+  spec,
+) where
+
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Void (Void)
+import Strategy.Scala.SbtDependencyTree (SbtArtifact (SbtArtifact), SbtDep (SbtDep), parseEviction, parseSbtArtifact, removeLogPrefixes, sbtTreeParser)
+import Test.Hspec (
+  Expectation,
+  Spec,
+  describe,
+  it,
+  shouldBe,
+ )
+import Test.Hspec.Megaparsec (shouldParse)
+import Text.Megaparsec (
+  Parsec,
+  parse,
+ )
+import Text.RawString.QQ (r)
+
+parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
+parseMatch parser input expected = parse parser "" input `shouldParse` expected
+
+stdoutFromSbt :: Text
+stdoutFromSbt =
+  [r|[info] truth
+[info] is
+[warn] out
+[error] there!
+|]
+
+spec :: Spec
+spec = do
+  describe "parseValidProjectIdentifier" $ do
+    let shouldParseInto = parseMatch parseSbtArtifact
+
+    it "should parse sbt artifact" $ do
+      "a:b:c" `shouldParseInto` SbtArtifact "a" "b" "c"
+      "a.b:c:d" `shouldParseInto` SbtArtifact "a.b" "c" "d"
+      "a.b-c:d:e" `shouldParseInto` SbtArtifact "a.b-c" "d" "e"
+      "a:b-c:d" `shouldParseInto` SbtArtifact "a" "b-c" "d"
+      "a:b.c:d" `shouldParseInto` SbtArtifact "a" "b.c" "d"
+      "a:b.c:1.0" `shouldParseInto` SbtArtifact "a" "b.c" "1.0"
+      "a:b.c:1.0.0" `shouldParseInto` SbtArtifact "a" "b.c" "1.0.0"
+      "a:b.c:1.0.0-SNAPSHOT" `shouldParseInto` SbtArtifact "a" "b.c" "1.0.0-SNAPSHOT"
+
+  describe "removeLogPrefixes" $ do
+    it "should parse sbt artifact" $ do
+      removeLogPrefixes "pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes "[info] pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes "[warn] pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes "[error] pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes "[debug] pineapples!\n" `shouldBe` "pineapples!\n"
+      removeLogPrefixes stdoutFromSbt `shouldBe` "truth\nis\nout\nthere!\n"
+
+  describe "parseEviction" $ do
+    let shouldParseInto = parseMatch parseEviction
+    it "should parse sbt dependency eviction" $ do
+      "(evicted by: 1.0)" `shouldParseInto` "1.0"
+      "(evicted by: 1.0.0)" `shouldParseInto` "1.0.0"
+      "(evicted by: 1.0.0-SNAPSHOT)" `shouldParseInto` "1.0.0-SNAPSHOT"
+
+  parsesTreeSpec
+
+treeWithNoDep :: Text
+treeWithNoDep =
+  [r|
+org:project:1.0.0-snapshot
+|]
+
+treeWithOneDep :: Text
+treeWithOneDep =
+  [r|
+org:project:1.0.0-snapshot
+  +-org:childA:1.0
+|]
+
+treeWithOneDepWithEvication :: Text
+treeWithOneDepWithEvication =
+  [r|
+org:project:1.0.0-snapshot
+  +-org:childA:1.0 (evicted by: 2.0)
+|]
+
+treeWithNestedDep :: Text
+treeWithNestedDep =
+  [r|
+org:project:1.0.0-snapshot
+  +-org:childA:1.0
+    +-org:grandChildA:2.0
+|]
+
+treeWithMultipleNestedDep :: Text
+treeWithMultipleNestedDep =
+  [r|
+org:project:1.0.0-snapshot
+  +-org:childA:1.0
+  +-org:childB:2.0
+  | +-org:grandChildB:3.0
+  | 
+  +-org:childD:4.0
+|]
+
+slightlyComplexTree :: Text
+slightlyComplexTree =
+  [r|
+org:project:1.0.0-snapshot
+  +-org:childA:1
+  +-org:childB:1
+  | +-org:grandChildB:1
+  | | +-org:greatGrandChildB:1
+  | | | +-org:greatGreatGrandChildB:1
+  | | +-org:greatGrandChildC:1
+  | +-org:grandChildD:1
+  +-org:childE:1
+|]
+
+mkArtifact :: Text -> SbtArtifact
+mkArtifact nameAtVersion = do
+  let nameAndVersionSplit = Text.splitOn "@" nameAtVersion
+      artifactId = head nameAndVersionSplit
+      version = last nameAndVersionSplit
+  SbtArtifact "org" artifactId version
+
+parsesTreeSpec :: Spec
+parsesTreeSpec = do
+  describe "sbtTreeParser" $ do
+    let shouldParseInto = parseMatch sbtTreeParser
+
+    it "should parse tree with no dep" $
+      treeWithNoDep
+        `shouldParseInto` [SbtDep (mkArtifact "project@1.0.0-snapshot") mempty]
+
+    it "should parse tree with one dep" $
+      treeWithOneDep
+        `shouldParseInto` [ SbtDep
+                              (mkArtifact "project@1.0.0-snapshot")
+                              [ SbtDep (mkArtifact "childA@1.0") []
+                              ]
+                          ]
+
+    it "should parse tree with one dep" $
+      treeWithOneDepWithEvication
+        `shouldParseInto` [ SbtDep
+                              (mkArtifact "project@1.0.0-snapshot")
+                              [ SbtDep (mkArtifact "childA@2.0") []
+                              ]
+                          ]
+
+    it "should parse tree with nested dep" $
+      treeWithNestedDep
+        `shouldParseInto` [ SbtDep
+                              (mkArtifact "project@1.0.0-snapshot")
+                              [ SbtDep
+                                  (mkArtifact "childA@1.0")
+                                  [ SbtDep (mkArtifact "grandChildA@2.0") mempty
+                                  ]
+                              ]
+                          ]
+
+    it "should parse tree with multiple nested dep" $
+      treeWithMultipleNestedDep
+        `shouldParseInto` [ SbtDep
+                              (mkArtifact "project@1.0.0-snapshot")
+                              [ SbtDep (mkArtifact "childA@1.0") mempty
+                              , SbtDep
+                                  (mkArtifact "childB@2.0")
+                                  [ SbtDep (mkArtifact "grandChildB@3.0") mempty
+                                  ]
+                              , SbtDep (mkArtifact "childD@4.0") mempty
+                              ]
+                          ]
+
+    it "should parse tree with slightly complex nested deps" $
+      slightlyComplexTree
+        `shouldParseInto` [ SbtDep
+                              (mkArtifact "project@1.0.0-snapshot")
+                              [ SbtDep (mkArtifact "childA@1") mempty
+                              , SbtDep
+                                  (mkArtifact "childB@1")
+                                  [ SbtDep
+                                      (mkArtifact "grandChildB@1")
+                                      [ SbtDep
+                                          (mkArtifact "greatGrandChildB@1")
+                                          [ SbtDep (mkArtifact "greatGreatGrandChildB@1") mempty
+                                          ]
+                                      , SbtDep
+                                          (mkArtifact "greatGrandChildC@1")
+                                          mempty
+                                      ]
+                                  , SbtDep (mkArtifact "grandChildD@1") mempty
+                                  ]
+                              , SbtDep (mkArtifact "childE@1") mempty
+                              ]
+                          ]

--- a/test/Scala/SbtDependencyTreeSpec.hs
+++ b/test/Scala/SbtDependencyTreeSpec.hs
@@ -61,15 +61,20 @@ singleProjectGraphSpec graph = do
 
   describe "buildGraph" $ do
     it "should correctly graph dependencies" $ do
-      expectDirect [mkRawDep "default:project_A" "0.0.0"] graph
+      let defaultProject = mkRawDep "default:project_A" "0.0.0"
+      let htmlCleaner = mkRawDep "net.sourceforge.htmlcleaner:htmlcleaner" "2.0"
+      let jdom = mkRawDep "org.jdom:jdom2" "2.0.0"
+      let scalaLib = mkRawDep "org.scala-lang:scala3-library_3" "3.0"
 
-      hasDep $ mkRawDep "net.sourceforge.htmlcleaner:htmlcleaner" "2.0"
-      hasDep $ mkRawDep "org.jdom:jdom2" "2.0.0"
-      hasDep $ mkRawDep "org.scala-lang:scala3-library_3" "3.0"
+      expectDirect [defaultProject] graph
 
-      hasEdge (mkRawDep "default:project_A" "0.0.0") (mkRawDep "net.sourceforge.htmlcleaner:htmlcleaner" "2.0")
-      hasEdge (mkRawDep "default:project_A" "0.0.0") (mkRawDep "org.scala-lang:scala3-library_3" "3.0")
-      hasEdge (mkRawDep "net.sourceforge.htmlcleaner:htmlcleaner" "2.0") (mkRawDep "org.jdom:jdom2" "2.0.0")
+      hasDep htmlCleaner
+      hasDep jdom
+      hasDep scalaLib
+
+      hasEdge defaultProject htmlCleaner
+      hasEdge defaultProject scalaLib
+      hasEdge htmlCleaner jdom
 
 exampleMultiProjectSbtOut :: Text
 exampleMultiProjectSbtOut =
@@ -217,7 +222,7 @@ mkRawDep name version =
   Dependency
     MavenType
     name
-    (CEq <$> Just version)
+    (Just $ CEq version)
     mempty
     (Set.singleton EnvProduction)
     mempty

--- a/test/Scala/SbtDependencyTreeSpec.hs
+++ b/test/Scala/SbtDependencyTreeSpec.hs
@@ -1,0 +1,218 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Scala.SbtDependencyTreeSpec (
+  spec,
+) where
+
+import Data.Foldable (traverse_)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as Text
+import DepTypes (
+  DepEnvironment (EnvProduction),
+  DepType (MavenType),
+  Dependency (Dependency),
+  VerConstraint (CEq),
+ )
+import GraphUtil (expectDep, expectDirect, expectEdge)
+import Graphing (Graphing, directList, edgesList)
+import Strategy.Scala.SbtDependencyTree (buildGraph, removeLogPrefixes, sbtTreeParser)
+import Test.Hspec (
+  Expectation,
+  Spec,
+  describe,
+  expectationFailure,
+  it,
+  runIO,
+ )
+import Text.Megaparsec (errorBundlePretty, runParser)
+import Text.Pretty.Simple (pPrint)
+import Text.RawString.QQ (r)
+
+spec :: Spec
+spec = do
+  checkGraph exampleSingleProjectSbtOut singleProjectGraphSpec
+  checkGraph exampleMultiProjectSbtOut multiProjectGraphSpec
+
+exampleSingleProjectSbtOut :: Text
+exampleSingleProjectSbtOut =
+  [r|[info] welcome to sbt 1.5.5 (Temurin Java 1.8.0_312)
+[info] loading settings for project default:project_A-build from plugin.sbt ...
+[info] loading project definition from /path
+[info] loading settings for project default:project_A from build.sbt ...
+[info] set current project to default:project_A (in build file:/path)
+[info] default:project_A:0.0.0
+[info]   +-net.sourceforge.htmlcleaner:htmlcleaner:2.0
+[info]   | +-org.jdom:jdom2:2.0.0
+[info]   | 
+[info]   +-org.scala-lang:scala3-library_3:3.0 [S]
+[info]   
+[success] Total time: 0 s, completed 19-May-2022 8:17:29 PM
+|]
+
+singleProjectGraphSpec :: Graphing Dependency -> Spec
+singleProjectGraphSpec graph = do
+  let hasEdge :: Dependency -> Dependency -> Expectation
+      hasEdge = expectEdge graph
+
+  let hasDep :: Dependency -> Expectation
+      hasDep dep = expectDep dep graph
+
+  describe "buildGraph" $ do
+    it "should correctly graph dependencies" $ do
+      expectDirect [mkRawDep "default:project_A" "0.0.0"] graph
+
+      hasDep $ mkRawDep "net.sourceforge.htmlcleaner:htmlcleaner" "2.0"
+      hasDep $ mkRawDep "org.jdom:jdom2" "2.0.0"
+      hasDep $ mkRawDep "org.scala-lang:scala3-library_3" "3.0"
+
+      hasEdge (mkRawDep "default:project_A" "0.0.0") (mkRawDep "net.sourceforge.htmlcleaner:htmlcleaner" "2.0")
+      hasEdge (mkRawDep "default:project_A" "0.0.0") (mkRawDep "org.scala-lang:scala3-library_3" "3.0")
+      hasEdge (mkRawDep "net.sourceforge.htmlcleaner:htmlcleaner" "2.0") (mkRawDep "org.jdom:jdom2" "2.0.0")
+
+exampleMultiProjectSbtOut :: Text
+exampleMultiProjectSbtOut =
+  [r|[info] welcome to sbt 1.5.5 (Temurin Java 1.8.0_312)
+[info] Loading settings from plugins.sbt ...
+[info] Loading project definition from /som-path/project
+[info] Loading settings from build.sbt ...
+[info] Set current project to sbt-multi-example (in build file:/some-path/)
+[info] Formatting 1 Scala source in global:sbt ...
+[success] Total time: 1 s, completed 19-May-2022 2:38:08 PM
+[info] Updating {file:/some-path/}common...
+[info] Updating {file:/some-path/}global...
+[info] Done updating.
+[info] org.PARENT:PROJECT:1.0-SNAPSHOT [S]
+[info] Updating {file:/some-path/}some-project2...
+[info] Done updating.
+[info] Updating {file:/some-path/}some-project1...
+[info] org:PROJECTA:1.0-SNAPSHOT [S]
+[info]   +-org:B:1.0
+[info]   | +-org:C:1.0
+[info]   | +-org:D:1.0
+[info]   | 
+[info]   +-org:E:1.0
+[info]   +-org:F:1.0
+[info]     +-org:G:1.0
+[info]       +-org:H:1.0
+[info]       +-org:I:1.0
+[info]       | +-org:J:1.0
+[info]       | | +-org:K:1.0
+[info]       | | 
+[info]       | +-org:L:1.0
+[info]       | | +-org:M:1.0
+[info]       | | | +-org:N:1.0
+[info]       | | | +-org:O:1.0
+[info]       | | | 
+[info]       | | +-org:P:1.0
+[info]       | | +-org:Q:1.0
+[info]       | | 
+[info]       | +-org:R:1.0
+[info]       +-org:S:1.0
+[info]     
+[info] Done updating.
+[info] org:PROJECTB:1.0-SNAPSHOT [S]
+[info]   +-org:T:1.0
+[info]   | +-org:U:1.0
+[info]   | 
+[info]   +-org:W:1.0 (evicted by: 2.0)
+[info]     
+[info] Done updating.
+[info] 
+[success] Total time: 3 s, completed 19-May-2022 2:38:11 PM
+|]
+
+multiProjectGraphSpec :: Graphing Dependency -> Spec
+multiProjectGraphSpec graph = do
+  let hasEdge :: Dependency -> Dependency -> Expectation
+      hasEdge = expectEdge graph
+
+  let hasDep :: Dependency -> Expectation
+      hasDep dep = expectDep dep graph
+
+  describe "buildGraph" $ do
+    it "should correctly graph dependencies" $ do
+      expectDirect [mkRawDep "org.PARENT:PROJECT" "1.0-SNAPSHOT", mkRawDep "org:PROJECTA" "1.0-SNAPSHOT", mkRawDep "org:PROJECTB" "1.0-SNAPSHOT"] graph
+
+      -- For sub project a
+      traverse_
+        hasDep
+        [ mkDep "B@1.0"
+        , mkDep "C@1.0"
+        , mkDep "D@1.0"
+        , mkDep "E@1.0"
+        , mkDep "F@1.0"
+        , mkDep "G@1.0"
+        , mkDep "H@1.0"
+        , mkDep "I@1.0"
+        , mkDep "J@1.0"
+        , mkDep "K@1.0"
+        , mkDep "L@1.0"
+        , mkDep "M@1.0"
+        , mkDep "N@1.0"
+        , mkDep "O@1.0"
+        , mkDep "P@1.0"
+        , mkDep "Q@1.0"
+        , mkDep "R@1.0"
+        , mkDep "S@1.0"
+        ]
+
+      hasEdge (mkDep "PROJECTA@1.0-SNAPSHOT") (mkDep "B@1.0")
+      hasEdge (mkDep "PROJECTA@1.0-SNAPSHOT") (mkDep "E@1.0")
+      hasEdge (mkDep "PROJECTA@1.0-SNAPSHOT") (mkDep "F@1.0")
+
+      hasEdge (mkDep "B@1.0") (mkDep "C@1.0")
+      hasEdge (mkDep "B@1.0") (mkDep "D@1.0")
+      hasEdge (mkDep "F@1.0") (mkDep "G@1.0")
+
+      hasEdge (mkDep "G@1.0") (mkDep "H@1.0")
+      hasEdge (mkDep "G@1.0") (mkDep "I@1.0")
+      hasEdge (mkDep "G@1.0") (mkDep "S@1.0")
+
+      hasEdge (mkDep "I@1.0") (mkDep "J@1.0")
+      hasEdge (mkDep "I@1.0") (mkDep "L@1.0")
+      hasEdge (mkDep "I@1.0") (mkDep "R@1.0")
+
+      hasEdge (mkDep "J@1.0") (mkDep "K@1.0")
+
+      hasEdge (mkDep "L@1.0") (mkDep "M@1.0")
+      hasEdge (mkDep "L@1.0") (mkDep "P@1.0")
+      hasEdge (mkDep "L@1.0") (mkDep "Q@1.0")
+
+      hasEdge (mkDep "M@1.0") (mkDep "N@1.0")
+      hasEdge (mkDep "M@1.0") (mkDep "O@1.0")
+
+      -- For sub project b
+      traverse_
+        hasDep
+        [ mkDep "T@1.0"
+        , mkDep "W@2.0"
+        , mkDep "U@1.0"
+        ]
+
+      hasEdge (mkDep "PROJECTB@1.0-SNAPSHOT") (mkDep "T@1.0")
+      hasEdge (mkDep "PROJECTB@1.0-SNAPSHOT") (mkDep "W@2.0")
+      hasEdge (mkDep "T@1.0") (mkDep "U@1.0")
+
+mkRawDep :: Text -> Text -> Dependency
+mkRawDep name version =
+  Dependency
+    MavenType
+    name
+    (CEq <$> Just version)
+    mempty
+    (Set.singleton EnvProduction)
+    mempty
+
+mkDep :: Text -> Dependency
+mkDep nameAtVersion = do
+  let nameAndVersionSplit = Text.splitOn "@" nameAtVersion
+      name = head nameAndVersionSplit
+      version = last nameAndVersionSplit
+  mkRawDep ("org:" <> name) version
+
+checkGraph :: Text -> (Graphing Dependency -> Spec) -> Spec
+checkGraph rawOutput buildGraphSpec = do
+  case runParser sbtTreeParser "" (removeLogPrefixes rawOutput) of
+    Left err -> describe "sbtDependencyTree" $ it "should parse sbt output" (expectationFailure $ errorBundlePretty err)
+    Right parsedDeps -> buildGraphSpec $ buildGraph parsedDeps

--- a/test/Scala/SbtDependencyTreeSpec.hs
+++ b/test/Scala/SbtDependencyTreeSpec.hs
@@ -15,7 +15,7 @@ import DepTypes (
   VerConstraint (CEq),
  )
 import GraphUtil (expectDep, expectDirect, expectEdge)
-import Graphing (Graphing, directList, edgesList)
+import Graphing (Graphing)
 import Strategy.Scala.SbtDependencyTree (buildGraph, removeLogPrefixes, sbtTreeParser)
 import Test.Hspec (
   Expectation,
@@ -23,10 +23,8 @@ import Test.Hspec (
   describe,
   expectationFailure,
   it,
-  runIO,
  )
 import Text.Megaparsec (errorBundlePretty, runParser)
-import Text.Pretty.Simple (pPrint)
 import Text.RawString.QQ (r)
 
 spec :: Spec


### PR DESCRIPTION
# Overview

This PR adds a strategy for `sbt dependencyTree` for single project builds.

## Acceptance criteria

- As a user, when I analyze sbt project (single project build), `sbt dependencyTree` tactic is attempted

## Testing plan

1. Run `make install-dev`
2. Run `fossa-dev analyze -o | rendergraph` against any of the following candidates:

Candidates:
- https://github.com/fossas/scala3-example-project
- https://github.com/fossas/example-projects
- https://github.com/pauljamescleary/scala-pet-store

* Note that deep dependencies are included
* Note that graph matches that of `sbt depedndencyTree` (note: `rendergraph` and `sbt dependencyTree` may render dependencies in a different order! Also `rendergraph` includes unused (dev/test) dependency in it's output)

## Risks

N/A

## References

https://fossa.atlassian.net/jira/software/c/projects/ANE/boards/39?modal=detail&selectedIssue=ANE-283

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
