### PR TITLE
fix rust integration spec

### DIFF
--- a/integration-test/Analysis/RustSpec.hs
+++ b/integration-test/Analysis/RustSpec.hs
@@ -37,7 +37,9 @@ fd =
       [reldir|rust/fd/|]
       [reldir|fd-8.3.0/|]
 
+-- These numbers can change as the dependency tree for sharkdp changes.
+-- The fix for now is to just update the numbers when the spec breaks
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary bat CargoProjectType (DependencyResultsSummary 146 29 270 1 Complete)
+  testSuiteDepResultSummary bat CargoProjectType (DependencyResultsSummary 146 29 268 1 Complete)
   testSuiteDepResultSummary fd CargoProjectType (DependencyResultsSummary 74 25 145 1 Complete)


### PR DESCRIPTION
# Overview

Fixes the failing Rust integration test by just updating the expected dependency count.

This isn't a perfect fix, but it gets us green until it breaks again or we make the test resilient to changes in the dependency we're testing against.

## Acceptance criteria

The Rust integration tests should pass

