### PR TITLE
[ANE-325] Adds initial pnpm support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,9 @@
 # FOSSA CLI Changelog
 
-## v3.3.4
+## v3.3.5
+- Pnpm: Adds support for dependency analysis using `pnpm-lock.yaml` file. ([#958](https://github.com/fossas/fossa-cli/pull/958))
 
+## v3.3.4
 - Removes copyright information from attribution reports in the JSON output ([#945](https://github.com/fossas/fossa-cli/pull/945)) as it was never available from the server.
 - VSI scans now automatically skip the `.git` directory inside the scan root ([#969](https://github.com/fossas/fossa-cli/pull/969)).
 

--- a/docs/differences-from-v1.md
+++ b/docs/differences-from-v1.md
@@ -58,6 +58,7 @@ FOSSA 3.x supports following new build managers and languages:
 - [Mix (for Elixir)](references/strategies/languages/elixir/elixir.md)
 - [Fortran Package Manager (for Fortran)](references/strategies/languages/fortran/fortran.md)
 - [Nim (Nimble)](references/strategies/languages/nim/nimble.md)
+- [Pnpm (for javascript)](references/strategies/languages/nodejs/pnpm.md)
 
 ### Automatic analysis target discovery
 

--- a/docs/references/files/fossa-yml.v3.schema.json
+++ b/docs/references/files/fossa-yml.v3.schema.json
@@ -234,6 +234,10 @@
                         {
                             "const": "perl",
                             "description": "For perl targets (using *META.{json,yml})"
+                        },
+                        {
+                            "const": "pnpm",
+                            "description": "For pnpm targets (javascript)"
                         }
                     ],
                     "description": "Target (package manager)"

--- a/docs/references/strategies/README.md
+++ b/docs/references/strategies/README.md
@@ -57,7 +57,7 @@
 
 - [yarn](languages/nodejs/yarn.md)
 - [npm](languages/nodejs/npm.md)
-
+- [pnpm](languages/nodejs/pnpm.md)
 ### nim
 
 - [Nimble](languages/nim/nimble.md)

--- a/docs/references/strategies/languages/nodejs/nodejs.md
+++ b/docs/references/strategies/languages/nodejs/nodejs.md
@@ -1,9 +1,10 @@
 # NodeJS Analysis
 
-The nodejs buildtool ecosystem consists of two major toolchains: the `npm` cli and `yarn`
+The nodejs buildtool ecosystem consists of three major toolchains: the `npm` cli, `pnpm` and `yarn`.
 
 | Strategy                      | Direct Deps | Deep Deps | Edges |
 | ----------------------------- | ----------- | --------- | ----- |
 | [yarnlock](yarn.md)           | ✅           | ✅         | ✅     |
 | [npmlock](npm-lockfile.md)    | ✅           | ✅         | ✅     |
+| [pnpmlock](pnpm.md)           | ✅           | ✅         | ✅     |
 | [packagejson](packagejson.md) | ✅           | ❌         | ❌     |

--- a/docs/references/strategies/languages/nodejs/pnpm.md
+++ b/docs/references/strategies/languages/nodejs/pnpm.md
@@ -150,12 +150,13 @@ CLI will infer the package name and version using `/${dependencyName}/${dependen
 * Peer dependencies will be included in the analysis (they are treated like any other dependency).
 * Pnpm workspaces are supported.
 * Development dependencies (`dev: true`) are ignored by default from analysis. To include them in the analysis, execute CLI with `--include-unused` flag e.g. `fossa analyze --include-unused`.
+* Optional dependencies are included in the analysis by default. They can be ignored in FOSSA UI.
 
 # F.A.Q
 
-### How do I *only perform analysis* for the pmpm?
+### How do I perform analysis only for pnpm projects?
 
-You can explicitly specify an analysis target in `.fossa.yml` file. The example below will exclude all analysis targets except for the pnpm.
+You can explicitly specify an analysis target in `.fossa.yml` file. The example below will exclude all analysis targets except for pnpm.
 
 ```yaml
 # .fossa.yml 

--- a/docs/references/strategies/languages/nodejs/pnpm.md
+++ b/docs/references/strategies/languages/nodejs/pnpm.md
@@ -1,0 +1,168 @@
+# Pnpm
+
+[Pnpm](https://pnpm.io/) is a fast, disk space-efficient package manager. 
+Unlike npm and yarn, pnpm uses symbolic links to create a nested structure
+of dependencies.
+
+## Project Discovery
+
+Find files named `pnpm-lock.yaml` with a corresponding `package.json` file.
+
+## Analysis
+
+Only `pnpm-lock.yaml` is used for analysis. CLI will parse and use the following fields.
+in `pnpm-lock.yaml` to analyze the dependency graph.
+
+- `importers`
+  - `[importersKey]`
+    - `dependencies`: list of direct dependencies
+    - `devDependencies`: list of development dependencies
+
+- `packages`
+  - `[packagesKey]`
+    - `resolution`: infer git URL, git commit, or package source URL.  
+    - `dependencies`: list of deep dependencies 
+    - `peerDependencies`: list of peer dependencies (will be treated like any other dependency)
+    - `dev`: to infer if this is used dependency or not. If the value is `true,` by default CLI will not include this in the final analysis.
+    - `optional`: to infer if this is used dependency or not. If the value is `true`, by default CLI will not include this in the final analysis.
+
+An example is provided below:
+
+```yml
+lockfileVersion: 5.4
+
+importers:
+  .:
+    specifiers:
+      some-pkg: https://some-url/pkg.tar.gz
+      react: '*'
+      my-local-pkg: file:../libs/my-local-pkg 
+    dependencies:
+      some-pkg: '@some-url/pkg.tar.gz'
+      my-local-pkg: file:../libs/my-local-pkg
+    devDependencies:
+      react: 18.1.0
+
+  # workspace project in packages/some-ws-pkg directory from root.
+  packages/some-ws-pkg: 
+    specifiers:
+      commander: 9.2.0
+    dependencies:
+      commander: 9.2.0
+
+packages:
+    '@some-url/pkg.tar.gz':
+        resolution: {tarball: https://some-url/pkg.tar.gz}
+        name: some-pkg
+        version: 1.0.0
+        engines: {node: '>=4.0.0'}
+        dev: false
+
+    file:../libs/my-local-pkg:
+        resolution: {directory: "../libs/my-local-pkg", type: directory}
+        name: unifier
+        version: 1.0.0
+        dependencies:
+            loose-envify: 1.4.0
+        engines: {node: '>=4.0.0'}
+        dev: false
+
+    /commander/9.2.0:
+        resolution: {integrity: sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==}
+        engines: {node: ^12.20.0 || >=14}
+        dev: false
+
+    /react/18.1.0:
+        resolution: {integrity: sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==}
+        engines: {node: '>=0.10.0'}
+        dependencies:
+            loose-envify: 1.4.0
+        dev: true
+
+    /loose-envify/1.4.0:
+        resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+        hasBin: true
+        dependencies:
+            js-tokens: 4.0.0
+        dev: false
+
+    /js-tokens/4.0.0:
+        resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+        dev: true
+
+```
+
+* If the dependency was resolved using git (`resolution` will have `type: git` attribute),
+Fossa will use provided `repo` and `commit` attribute to analyze this dependency.
+
+```yaml
+    # FOSSA will use `commit` and `repo` to analyze the this dependency.
+    github.com/Marak/colors.js/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26:
+      resolution: {commit: 6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26, repo: git+ssh://git@github.com/Marak/colors.js, type: git}
+      name: colors
+      version: 1.4.44-liberty-2
+      engines: {node: '>=0.1.90'}
+      dev: false
+```
+
+* If the dependency was resolved using tarball (`resolution` will have `tarball` attribute) 
+Fossa will use provided URL address to download and analyze this dependency.
+
+```yaml
+    # FOSSA will analyze lodash from the tarball URL.
+    '@some-url/pkg.tar.gz':
+        resolution: {tarball: https://some-url/pkg.tar.gz}
+        name: some-pkg
+        version: 1.0.0
+        engines: {node: '>=4.0.0'}
+        dev: false
+```
+
+* If the dependency was resolved using the local directory (`resolution` will have the `type: directory` attribute),
+Fossa will not analyze this dependency. Local dependency's deep dependencies will be analyzed, 
+and they will be promoted in place of local dependency. 
+
+```yaml
+    # FOSSA will not analyze this dependency, 
+    # But FOSSA will analyze its transitive dependency (if they are not sourced from the local directory)
+    #
+    # FOSSA will promote loose-envify of 1.4.0 in place of unifier.
+    file:../libs/my-local-pkg:
+        resolution: {directory: "../libs/my-local-pkg", type: directory}
+        name: unifier
+        version: 1.0.0
+        dependencies:
+            loose-envify: 1.4.0
+        engines: {node: '>=4.0.0'}
+        dev: false
+```
+
+* If the dependency was resolved using registry resolver, Fossa will use the registry to analyze the dependency. 
+CLI will infer the package name and version using `/${dependencyName}/${dependencyVersion}` scheme from the package's key.
+
+```yaml
+    # Resolves to npm dependency: commander with 9.2.0 version
+    /commander/9.2.0:
+        resolution: {integrity: sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==}
+        engines: {node: ^12.20.0 || >=14}
+        dev: false
+```
+
+* Peer dependencies will be included in the analysis (they are treated like any other dependency).
+* Pnpm workspaces are supported.
+* Development dependencies (`dev: true`) or optional dependencies `optional: true` are ignored by default from analysis. To include them in the analysis, execute CLI with `--include-unused` flag e.g. `fossa analyze --include-unused`.
+
+# F.A.Q
+
+### How do I *only perform analysis* for the pmpm?
+
+You can explicitly specify an analysis target in `.fossa.yml` file. The example below will exclude all analysis targets except for the pnpm.
+
+```yaml
+# .fossa.yml 
+
+version: 3
+targets:
+  only:
+    - type: pnpm
+```

--- a/docs/references/strategies/languages/nodejs/pnpm.md
+++ b/docs/references/strategies/languages/nodejs/pnpm.md
@@ -23,7 +23,7 @@ in `pnpm-lock.yaml` to analyze the dependency graph.
     - `resolution`: infer git URL, git commit, or package source URL.  
     - `dependencies`: list of deep dependencies 
     - `peerDependencies`: list of peer dependencies (will be treated like any other dependency)
-    - `dev`: to infer if this is used dependency or not. If the value is `true,` by default CLI will not include this in the final analysis.
+    - `dev`: to infer if this is used dependency or not. If the value is `true` by default CLI will not include this in the final analysis.
 
 An example is provided below:
 

--- a/docs/references/strategies/languages/nodejs/pnpm.md
+++ b/docs/references/strategies/languages/nodejs/pnpm.md
@@ -24,7 +24,6 @@ in `pnpm-lock.yaml` to analyze the dependency graph.
     - `dependencies`: list of deep dependencies 
     - `peerDependencies`: list of peer dependencies (will be treated like any other dependency)
     - `dev`: to infer if this is used dependency or not. If the value is `true,` by default CLI will not include this in the final analysis.
-    - `optional`: to infer if this is used dependency or not. If the value is `true`, by default CLI will not include this in the final analysis.
 
 An example is provided below:
 
@@ -150,7 +149,7 @@ CLI will infer the package name and version using `/${dependencyName}/${dependen
 
 * Peer dependencies will be included in the analysis (they are treated like any other dependency).
 * Pnpm workspaces are supported.
-* Development dependencies (`dev: true`) or optional dependencies `optional: true` are ignored by default from analysis. To include them in the analysis, execute CLI with `--include-unused` flag e.g. `fossa analyze --include-unused`.
+* Development dependencies (`dev: true`) are ignored by default from analysis. To include them in the analysis, execute CLI with `--include-unused` flag e.g. `fossa analyze --include-unused`.
 
 # F.A.Q
 

--- a/integration-test/Analysis/FixtureExpectationUtils.hs
+++ b/integration-test/Analysis/FixtureExpectationUtils.hs
@@ -6,7 +6,7 @@ module Analysis.FixtureExpectationUtils (
 
   -- * spec helpers
   testSuiteDepResultSummary,
-  testSuitHasSomeDepResults,
+  testSuiteHasSomeDepResults,
 
   -- * expectation helpers
   getDepResultsOf,
@@ -90,8 +90,8 @@ withProjectOfType ::
 withProjectOfType result (projType, projPath) =
   find (\(dr, _) -> projectType dr == projType && projectPath dr == projPath) result
 
-testSuitHasSomeDepResults :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> DiscoveredProjectType -> Spec
-testSuitHasSomeDepResults fixture projType = aroundAll (withAnalysisOf fixture) $
+testSuiteHasSomeDepResults :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> DiscoveredProjectType -> Spec
+testSuiteHasSomeDepResults fixture projType = aroundAll (withAnalysisOf fixture) $
   describe (toString $ testName fixture) $ do
     it "should find targets" $ \(result, extractedDir) ->
       expectProject (projType, extractedDir) result

--- a/integration-test/Analysis/PnpmSpec.hs
+++ b/integration-test/Analysis/PnpmSpec.hs
@@ -1,13 +1,18 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE QuasiQuotes #-}
 
 module Analysis.PnpmSpec (spec) where
 
-import Analysis.FixtureExpectationUtils
-import Analysis.FixtureUtils
-import Path
+import Analysis.FixtureExpectationUtils (
+  testSuiteHasSomeDepResults,
+ )
+import Analysis.FixtureUtils (
+  AnalysisTestFixture (AnalysisTestFixture),
+  FixtureArtifact (FixtureArtifact),
+  FixtureEnvironment (LocalEnvironment),
+ )
+import Path (reldir)
 import Strategy.Node qualified as Node
-import Test.Hspec
+import Test.Hspec (Spec)
 import Types (DiscoveredProjectType (..))
 
 elementPlus :: AnalysisTestFixture (Node.NodeProject)
@@ -24,4 +29,4 @@ elementPlus =
 
 spec :: Spec
 spec = do
-  testSuitHasSomeDepResults elementPlus PnpmProjectType
+  testSuiteHasSomeDepResults elementPlus PnpmProjectType

--- a/integration-test/Analysis/PnpmSpec.hs
+++ b/integration-test/Analysis/PnpmSpec.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.PnpmSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.Node qualified as Node
+import Test.Hspec
+import Types (DiscoveredProjectType (..))
+
+elementPlus :: AnalysisTestFixture (Node.NodeProject)
+elementPlus =
+  AnalysisTestFixture
+    "element-plus"
+    Node.discover
+    LocalEnvironment
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/element-plus/element-plus/archive/refs/tags/2.0.0.tar.gz"
+      [reldir|pnpm/element-plus/|]
+      [reldir|element-plus-2.0.0/|]
+
+spec :: Spec
+spec = do
+  testSuitHasSomeDepResults elementPlus PnpmProjectType

--- a/integration-test/Analysis/RustSpec.hs
+++ b/integration-test/Analysis/RustSpec.hs
@@ -8,7 +8,7 @@ import Analysis.FixtureUtils
 import Path
 import Strategy.Cargo qualified as Cargo
 import Test.Hspec
-import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
+import Types (DiscoveredProjectType (..))
 
 rustEnv :: FixtureEnvironment
 rustEnv = NixEnv ["rustc", "cargo"]

--- a/integration-test/Analysis/RustSpec.hs
+++ b/integration-test/Analysis/RustSpec.hs
@@ -37,9 +37,13 @@ fd =
       [reldir|rust/fd/|]
       [reldir|fd-8.3.0/|]
 
--- These numbers can change as the dependency tree for sharkdp changes.
--- The fix for now is to just update the numbers when the spec breaks
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary bat CargoProjectType (DependencyResultsSummary 146 29 268 1 Complete)
-  testSuiteDepResultSummary fd CargoProjectType (DependencyResultsSummary 74 25 145 1 Complete)
+  testSuitHasSomeDepResults bat CargoProjectType
+  testSuitHasSomeDepResults fd CargoProjectType
+
+-- The dependency number can change as the dependency tree for following changes,
+-- This is ramification of how `rust` builds are analyzed.
+--
+-- testSuiteDepResultSummary bat CargoProjectType (DependencyResultsSummary 146 29 268 1 Complete)
+-- testSuiteDepResultSummary fd CargoProjectType (DependencyResultsSummary 74 25 145 1 Complete)

--- a/integration-test/Analysis/RustSpec.hs
+++ b/integration-test/Analysis/RustSpec.hs
@@ -3,11 +3,17 @@
 
 module Analysis.RustSpec (spec) where
 
-import Analysis.FixtureExpectationUtils
-import Analysis.FixtureUtils
-import Path
+import Analysis.FixtureExpectationUtils (
+  testSuiteHasSomeDepResults,
+ )
+import Analysis.FixtureUtils (
+  AnalysisTestFixture (AnalysisTestFixture),
+  FixtureArtifact (FixtureArtifact),
+  FixtureEnvironment (NixEnv),
+ )
+import Path (reldir)
 import Strategy.Cargo qualified as Cargo
-import Test.Hspec
+import Test.Hspec (Spec)
 import Types (DiscoveredProjectType (..))
 
 rustEnv :: FixtureEnvironment
@@ -39,8 +45,8 @@ fd =
 
 spec :: Spec
 spec = do
-  testSuitHasSomeDepResults bat CargoProjectType
-  testSuitHasSomeDepResults fd CargoProjectType
+  testSuiteHasSomeDepResults bat CargoProjectType
+  testSuiteHasSomeDepResults fd CargoProjectType
 
 -- The dependency number can change as the dependency tree for following changes,
 -- This is ramification of how `rust` builds are analyzed.

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -365,6 +365,7 @@ library
     Strategy.Node.Npm.PackageLock
     Strategy.Node.Npm.PackageLockV3
     Strategy.Node.PackageJson
+    Strategy.Node.Pnpm.PnpmLock
     Strategy.Node.YarnV1.YarnLock
     Strategy.Node.YarnV2.Lockfile
     Strategy.Node.YarnV2.Resolvers
@@ -520,6 +521,7 @@ test-suite unit-tests
     NuGet.ProjectAssetsJsonSpec
     NuGet.ProjectJsonSpec
     Perl.PerlSpec
+    Pnpm.PnpmLockSpec
     Python.PipenvSpec
     Python.Poetry.CommonSpec
     Python.Poetry.PoetryLockSpec
@@ -579,6 +581,7 @@ test-suite integration-tests
     Analysis.LicenseScannerSpec
     Analysis.MavenSpec
     Analysis.NugetSpec
+    Analysis.PnpmSpec
     Analysis.Python.PipenvSpec
     Analysis.Python.PoetrySpec
     Analysis.Python.SetuptoolsSpec

--- a/src/Strategy/Node/Pnpm/PnpmLock.hs
+++ b/src/Strategy/Node/Pnpm/PnpmLock.hs
@@ -1,0 +1,300 @@
+module Strategy.Node.Pnpm.PnpmLock (
+  analyze,
+
+  -- * for testing
+  buildGraph,
+) where
+
+import Control.Applicative ((<|>))
+import Control.Effect.Diagnostics (Diagnostics, Has, context)
+import Data.Foldable (for_)
+import Data.Map (Map, toList)
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Yaml (FromJSON, (.!=), (.:), (.:?))
+import Data.Yaml qualified as Yaml
+import DepTypes (
+  DepEnvironment (EnvDevelopment, EnvProduction),
+  DepType (GitType, NodeJSType, URLType, UserType),
+  Dependency (Dependency, dependencyType),
+  VerConstraint (CEq),
+ )
+import Effect.Grapher (deep, direct, edge, evalGrapher, run)
+import Effect.ReadFS (ReadFS, readContentsYaml)
+import Graphing (Graphing, shrink)
+import Path (Abs, File, Path)
+
+-- | Pnpm Lockfile
+--
+-- Pnpm lockfile (in yaml) has the following shape (irrelevant fields omitted):
+--
+-- @
+-- > lockFileVersion: 5.4
+-- > importers:
+-- >   .:
+-- >     specifiers:
+-- >       aws-sdk: ^2.0.0
+-- >     dependencies:
+-- >       aws-sdk: 2.1148.0
+-- >     devDependencies:
+-- >       react: 18.1.0
+-- >
+-- >   packages/a:
+-- >     specifiers:
+-- >       commander: 9.2.0
+-- >     dependencies:
+-- >       commander: 9.2.0
+-- >
+-- > packages:
+-- >  /aws-sdk/2.1148.0:
+-- >    dev: false
+-- >    peerDependencies:
+-- >      ...
+-- >    dependencies:
+-- >      buffer: 4.9.2
+-- >
+-- >  /react/18.1.0:
+-- >    dev: true
+-- >
+-- >  /buffer/4.9.2:
+-- >    dev: false
+-- @
+--
+--  In this file,
+--    * `importers`: refers to configurations imported/specified via package.json.
+--      * Key of `importers` (e.g. ".") refers to package.json filepath.
+--        * `specifier`: refers to version constraint specified in package.json.
+--        * `dependencies`: refer to direct and resolved production dependencies.
+--        * `devDependencies`: refer to direct and resolved development dependencies,
+--
+--    * `packages`: lists all resolved dependencies (it does not include root level workspace package, or root package itself)
+--      * Key of `packages` refer (e.g. "/buffer/4.9.2:") denotes name of dependency and resolved version.
+--          - For dependency resolved via registry resolver, format is: "/${dependencyName}/${resolvedVersion}".
+--          - For dependency resolved via tarball resolver, format is: "${Url}".
+--          - For dependency resolved via git resolver, format is: "${Url}".
+--          - For dependency resolved via directory resolver, format is: "file:${relativePath}".
+--
+--  References:
+--    - [pnpm](https://pnpm.io/)
+--    - [pnpm-lockfile](https://github.com/pnpm/pnpm/blob/5cfd6d01946edcce86f62580bddc788d02f93ed6/packages/lockfile-types/src/index.ts)
+data PnpmLockfile = PnpmLockfile
+  { lockFileVersion :: Float
+  , importers :: Map Text PnpmProjectSnapshot
+  , packages :: Map Text PnpmPackageSnapshot
+  }
+  deriving (Show, Eq, Ord)
+
+instance FromJSON PnpmLockfile where
+  parseJSON = Yaml.withObject "pnpm-lock content" $ \obj -> do
+    lockFileVersion <- obj .: "lockfileVersion"
+    importers <- obj .:? "importers" .!= mempty
+    packages <- obj .:? "packages" .!= mempty
+
+    -- Map pnpm non-workspace lockfile format to pnpm workspace lockfile format.
+    --
+    -- For lockfile without workspaces, the 'importers' field is not included in
+    -- the lockfile. And 'dependencies' and 'devDependencies' are instead shown
+    -- at the root level.
+    --
+    -- A project without a workspace is the same as having a single workspace at
+    -- the path of ".".
+
+    dependencies <- obj .:? "dependencies" .!= mempty
+    devDependencies <- obj .:? "devDependencies" .!= mempty
+    let virtualRootWs = PnpmProjectSnapshot dependencies devDependencies
+    let refinedImporters =
+          if Map.null importers
+            then Map.insert "." virtualRootWs importers
+            else importers
+
+    pure $ PnpmLockfile lockFileVersion refinedImporters packages
+
+data PnpmProjectSnapshot = PnpmProjectSnapshot
+  { directDependencies :: Map Text Text
+  , directDevDependencies :: Map Text Text
+  }
+  deriving (Show, Eq, Ord)
+
+instance FromJSON PnpmProjectSnapshot where
+  parseJSON = Yaml.withObject "PnpmProjectSnapshot" $ \obj ->
+    PnpmProjectSnapshot <$> obj .:? "dependencies" .!= mempty
+      <*> obj .:? "devDependencies" .!= mempty
+
+data PnpmPackageSnapshot = PnpmPackageSnapshot
+  { isDev :: Bool
+  , isOptional :: Bool
+  , name :: Maybe Text -- only provided when non-registry resolver is used
+  , resolution :: Resolution
+  , dependencies :: Map Text Text
+  , peerDependencies :: Map Text Text
+  }
+  deriving (Show, Eq, Ord)
+
+instance FromJSON PnpmPackageSnapshot where
+  parseJSON = Yaml.withObject "PnpmPackageSnapshot" $ \obj ->
+    PnpmPackageSnapshot <$> (obj .:? "dev" .!= False)
+      <*> (obj .:? "optional" .!= False)
+      <*> obj .:? "name"
+      <*> obj .: "resolution"
+      <*> (obj .:? "dependencies" .!= mempty)
+      <*> (obj .:? "peerDependencies" .!= mempty)
+
+data Resolution
+  = GitResolution GitPnpmResolution
+  | RegistryResolution RegistryPnpmResolution
+  | TarballResolution TarballPnpmResolution
+  | DirectoryResolution DirectoryPnpmResolution
+  deriving (Show, Eq, Ord)
+
+data GitPnpmResolution = GitPnpmResolution
+  { gitUrl :: Text
+  , revision :: Text
+  }
+  deriving (Show, Eq, Ord)
+
+newtype TarballPnpmResolution = TarballPnpmResolution {tarballUrl :: Text} deriving (Show, Eq, Ord)
+newtype RegistryPnpmResolution = RegistryPnpmResolution {integrity :: Text} deriving (Show, Eq, Ord)
+newtype DirectoryPnpmResolution = DirectoryPnpmResolution {directory :: Text} deriving (Show, Eq, Ord)
+
+instance FromJSON Resolution where
+  parseJSON = Yaml.withObject "Resolution" $ \obj ->
+    GitResolution <$> (GitPnpmResolution <$> obj .: "repo" <*> obj .: "commit")
+      <|> (TarballResolution <$> (TarballPnpmResolution <$> obj .: "tarball"))
+      <|> (DirectoryResolution <$> (DirectoryPnpmResolution <$> obj .: "directory"))
+      <|> (RegistryResolution <$> (RegistryPnpmResolution <$> obj .: "integrity"))
+
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
+analyze file = context "Analyzing Npm Lockfile (v3)" $ do
+  pnpmLockFile <- context "Parsing pnpm-lock file" $ readContentsYaml file
+  context "Building dependency graph" $ pure $ buildGraph pnpmLockFile
+
+buildGraph :: PnpmLockfile -> Graphing Dependency
+buildGraph lockFile = withoutLocalPackages $
+  run . evalGrapher $ do
+    for_ (toList $ importers lockFile) $ \(_, projectSnapshot) -> do
+      let allDirectDependencies =
+            toList (directDependencies projectSnapshot)
+              <> toList (directDevDependencies projectSnapshot)
+
+      for_ allDirectDependencies $ \(depName, depVersion) -> do
+        case (toResolvedDependency depName depVersion) of
+          Just dep -> direct dep
+          Nothing -> pure ()
+
+    -- Add edges and deep dependencies by iterating over all packages.
+    --
+    -- Use `dev` to infer if this is production or non-production dependency.
+    -- Use `dependencies` to infer the edge from this dependency (aws-sdk@2.1148.0)
+    --   to its children. If the child entry cannot be found in `packages`,
+    --   do not provision an edge.
+    --
+    -- @
+    -- > packages:
+    -- >
+    -- >  /aws-sdk/2.1148.0:
+    -- >    resolution: {integrity: sha512-FUYAyveKmS5eq..==}
+    -- >    engines: {node: '>= 10.0.0'}
+    -- >    dependencies:
+    -- >      buffer: 4.9.2
+    -- >      events: 1.1.1
+    -- >    dev: false
+    -- @
+    for_ (toList $ packages lockFile) $ \(pkgKey, pkgMeta) -> do
+      let deepDependencies =
+            toList (dependencies pkgMeta)
+              <> toList (peerDependencies pkgMeta)
+
+      let (depName, depVersion) = case getPkgNameVersion pkgKey of
+            Nothing -> (pkgKey, Nothing)
+            Just (name, version) -> (name, Just version)
+      let parentDep = toDependency depName depVersion pkgMeta
+
+      -- It is ok, if this dependency was already graphed as direct
+      -- @direct 1 <> deep 1 = direct 1@
+      deep parentDep
+
+      for_ deepDependencies $ \(deepName, deepVersion) -> do
+        case (toResolvedDependency deepName deepVersion) of
+          Just childDep -> edge parentDep childDep
+          Nothing -> pure ()
+  where
+    -- Gets package name and version from package's key.
+    --
+    -- >> getPkgNameVersion "" = Nothing
+    -- >> getPkgNameVersion "github.com/something" = Nothing
+    -- >> getPkgNameVersion "/pkg-a/1.0.0" = Just ("pkg-a", "1.0.0")
+    getPkgNameVersion :: Text -> Maybe (Text, Text)
+    getPkgNameVersion pkgKey = case (Text.stripPrefix "/" pkgKey) of
+      Nothing -> Nothing
+      Just txt -> do
+        let (nameWithSlash, version) = Text.breakOnEnd "/" txt
+        case (Text.stripSuffix "/" nameWithSlash, version) of
+          (Just name, v) -> Just (name, v)
+          _ -> Nothing
+
+    -- Non-registry resolvers (tarball, git, directory) use non-version identifier
+    -- as version value in dependencies map, as well as for it's `packages` key.
+    --
+    -- @
+    -- >  dependencies:
+    -- >    chokidar: 1.0.0 # resolved with registry
+    -- >    some-other-project: file:../local-package # resolved with non-registry resolver
+    -- @
+    -- -
+    -- For any dependency resolved via registry resolver, it will use
+    -- the following format for its `packages` key:
+    --
+    --   /${depName}/${depVersion}
+    --
+    -- For dependency resolved via non-registry resolvers,
+    -- it will use the dependency's version value for its `packages` key:
+    --
+    --    e.g.
+    --      file:../local-package
+    --
+    toResolvedDependency :: Text -> Text -> Maybe Dependency
+    toResolvedDependency depName depVersion = do
+      let maybeNonRegistrySrcPackage = Map.lookup depVersion (packages lockFile)
+      let maybeRegistrySrcPackage = Map.lookup (mkPkgKey depName depVersion) (packages lockFile)
+      case (maybeNonRegistrySrcPackage, maybeRegistrySrcPackage) of
+        (Nothing, Nothing) -> Nothing
+        (Just nonRegistryPkg, _) -> Just $ toDependency depName Nothing nonRegistryPkg
+        (Nothing, Just registryPkg) -> Just $ toDependency depName (Just depVersion) registryPkg
+
+    -- Makes representative key if the package was
+    -- resolved via registry resolver.
+    --
+    -- >> mkPkgKey "pkg-a" "1.0.0" = "/pkg-a/1.0.0"
+    mkPkgKey :: Text -> Text -> Text
+    mkPkgKey name version = "/" <> name <> "/" <> version
+
+    toDependency :: Text -> Maybe Text -> PnpmPackageSnapshot -> Dependency
+    toDependency name maybeVersion (PnpmPackageSnapshot isDev isOptional _ (RegistryResolution _) _ _) =
+      toDep NodeJSType name (withoutSymConstraint <$> maybeVersion) (isDev || isOptional)
+    toDependency _ _ (PnpmPackageSnapshot isDev isOptional _ (GitResolution (GitPnpmResolution url rev)) _ _) =
+      toDep GitType url (Just rev) (isDev || isOptional)
+    toDependency _ _ (PnpmPackageSnapshot isDev isOptional _ (TarballResolution (TarballPnpmResolution url)) _ _) =
+      toDep URLType url Nothing (isDev || isOptional)
+    toDependency _ _ (PnpmPackageSnapshot isDev isOptional (Just name) (DirectoryResolution _) _ _) =
+      toDep UserType name Nothing (isDev || isOptional)
+    toDependency name _ (PnpmPackageSnapshot isDev isOptional Nothing (DirectoryResolution _) _ _) =
+      toDep UserType name Nothing (isDev || isOptional)
+
+    -- Sometimes package versions include symlinked paths
+    -- of sibling dependencies used for resolution.
+    --
+    -- >> withoutSymLinks "1.2.0" = "1.2.0"
+    -- >> withoutSymLinks "1.2.0_vue@3.0" = "1.2.0"
+    withoutSymConstraint :: Text -> Text
+    withoutSymConstraint version = fst $ Text.breakOn "_" version
+
+    toDep :: DepType -> Text -> Maybe Text -> Bool -> Dependency
+    toDep depType name version isDev = Dependency depType name (CEq <$> version) mempty (toEnv isDev) mempty
+
+    toEnv :: Bool -> Set.Set DepEnvironment
+    toEnv isNotRequired = Set.singleton $ if isNotRequired then EnvDevelopment else EnvProduction
+
+    withoutLocalPackages :: Graphing Dependency -> Graphing Dependency
+    withoutLocalPackages = Graphing.shrink (\dep -> dependencyType dep /= UserType)

--- a/src/Strategy/Node/Pnpm/PnpmLock.hs
+++ b/src/Strategy/Node/Pnpm/PnpmLock.hs
@@ -228,6 +228,7 @@ buildGraph lockFile = withoutLocalPackages $
     -- >> getPkgNameVersion "" = Nothing
     -- >> getPkgNameVersion "github.com/something" = Nothing
     -- >> getPkgNameVersion "/pkg-a/1.0.0" = Just ("pkg-a", "1.0.0")
+    -- >> getPkgNameVersion "/@angular/core/1.0.0" = Just ("@angular/core", "1.0.0")
     getPkgNameVersion :: Text -> Maybe (Text, Text)
     getPkgNameVersion pkgKey = case (Text.stripPrefix "/" pkgKey) of
       Nothing -> Nothing

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -83,6 +83,7 @@ data DiscoveredProjectType
   | PaketProjectType
   | PerlProjectType
   | PipenvProjectType
+  | PnpmProjectType
   | PoetryProjectType
   | ProjectAssetsJsonProjectType
   | ProjectJsonProjectType
@@ -124,6 +125,7 @@ projectTypeToText = \case
   PaketProjectType -> "packet"
   PerlProjectType -> "perl"
   PipenvProjectType -> "pipenv"
+  PnpmProjectType -> "pnpm"
   PoetryProjectType -> "poetry"
   ProjectAssetsJsonProjectType -> "projectassetsjson"
   ProjectJsonProjectType -> "projectjson"

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -182,7 +182,7 @@ shrinkingSpec = context "Shrinking" $ do
       expectEdges [(1, 4), (4, 5)] graph'
 
       expectDirect [2] graph''
-      expectDeps [2, 3, 4] graph'
+      expectDeps [2, 3, 4] graph''
       expectEdges [(2, 3), (3, 4)] graph''
 
   describe "shrinkWithoutPromotionToDirect" $ do

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -173,9 +173,17 @@ shrinkingSpec = context "Shrinking" $ do
           graph' :: Graphing Int
           graph' = Graphing.shrink (\x -> x /= 2 && x /= 3) graph
 
+          -- 1 -> 2 -> 3 -> 4
+          graph'' :: Graphing Int
+          graph'' = Graphing.shrink (/= 1) (Graphing.direct 1 <> Graphing.edges [(1, 2), (2, 3), (3, 4)])
+
       expectDirect [] graph'
       expectDeps [1, 4, 5] graph'
       expectEdges [(1, 4), (4, 5)] graph'
+
+      expectDirect [2] graph''
+      expectDeps [2, 3, 4] graph'
+      expectEdges [(2, 3), (3, 4)] graph''
 
   describe "shrinkWithoutPromotionToDirect" $ do
     it "should preserve set of direct nodes" $ do

--- a/test/Pnpm/PnpmLockSpec.hs
+++ b/test/Pnpm/PnpmLockSpec.hs
@@ -1,0 +1,256 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Pnpm.PnpmLockSpec (
+  spec,
+) where
+
+import Data.Set qualified as Set
+import Data.String.Conversion (toString)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Yaml (decodeFileEither, prettyPrintParseException)
+import DepTypes (
+  DepEnvironment (EnvDevelopment, EnvProduction),
+  DepType (GitType, NodeJSType, URLType),
+  Dependency (..),
+  VerConstraint (CEq),
+ )
+import GraphUtil (
+  expectDirect,
+  expectEdge,
+ )
+import Graphing (Graphing)
+import Path (Abs, File, Path, mkRelFile, (</>))
+import Path.IO (getCurrentDir)
+import Strategy.Node.Pnpm.PnpmLock (buildGraph)
+import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, runIO)
+
+mkProdDep :: Text -> Dependency
+mkProdDep nameAtVersion = mkDep nameAtVersion (Just EnvProduction)
+
+mkDevDep :: Text -> Dependency
+mkDevDep nameAtVersion = mkDep nameAtVersion (Just EnvDevelopment)
+
+mkDep :: Text -> Maybe DepEnvironment -> Dependency
+mkDep nameAtVersion env = do
+  let nameAndVersionSplit = Text.splitOn "@" nameAtVersion
+      name = head nameAndVersionSplit
+      version = last nameAndVersionSplit
+  Dependency
+    NodeJSType
+    name
+    (CEq <$> (Just version))
+    mempty
+    (maybe mempty Set.singleton env)
+    mempty
+
+checkGraph :: Path Abs File -> (Graphing Dependency -> Spec) -> Spec
+checkGraph pathToFixture buildGraphSpec = do
+  eitherDecodedLockFile <- runIO $ decodeFileEither (toString pathToFixture)
+  case eitherDecodedLockFile of
+    Right pnpmLock -> buildGraphSpec (buildGraph pnpmLock)
+    Left err ->
+      describe "pnpm-lock" $
+        it "should parse lockfile" (expectationFailure $ prettyPrintParseException err)
+
+spec :: Spec
+spec = do
+  currentDir <- runIO getCurrentDir
+  let pnpmLockPath = currentDir </> $(mkRelFile "test/Pnpm/testdata/pnpm-lock.yaml")
+  let pnpmLockWithoutWorkspacePath = currentDir </> $(mkRelFile "test/Pnpm/testdata/pnpm-lock-without-workspace.yaml")
+
+  checkGraph pnpmLockPath pnpmLockGraphSpec
+  checkGraph pnpmLockWithoutWorkspacePath pnpmLockGraphWithoutWorkspaceSpec
+
+pnpmLockGraphSpec :: Graphing Dependency -> Spec
+pnpmLockGraphSpec graph = do
+  let hasEdge :: Dependency -> Dependency -> Expectation
+      hasEdge = expectEdge graph
+
+  let colors =
+        Dependency
+          GitType
+          "git+ssh://git@github.com/Marak/colors.js"
+          (Just $ CEq "6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26")
+          mempty
+          (Set.singleton EnvProduction)
+          mempty
+
+  let lodash =
+        Dependency
+          URLType
+          "https://github.com/lodash/lodash/archive/refs/heads/master.tar.gz"
+          Nothing
+          mempty
+          (Set.singleton EnvProduction)
+          mempty
+
+  describe "buildGraph with workspaces" $ do
+    it "should include dependencies of root and workspace package as direct" $ do
+      expectDirect
+        [ mkProdDep "aws-sdk@2.1148.0"
+        , colors
+        , lodash
+        , mkDevDep "react@18.1.0"
+        , mkProdDep "glob@8.0.3" -- promoted from local package
+        , mkProdDep "chokidar@1.0.0" -- promoted from nested local package
+        , -- from workspace-a-name@2.0.0
+          mkProdDep "aws-sdk@1.0.0"
+        , mkProdDep "commander@9.2.0"
+        ]
+        graph
+
+    it "should include all relevant edges and deps for example@1.0.0" $ do
+      -- aws-sdk 2.1148.0
+      -- ├─┬ buffer 4.9.2
+      -- │ ├── base64-js 1.5.1
+      -- │ ├── ieee754 1.1.13
+      -- │ └── isarray 1.0.0
+      -- ├── events 1.1.1
+      -- ├── ieee754 1.1.13
+      -- ├── jmespath 0.16.0
+      -- ├── querystring 0.2.0
+      -- ├── sax 1.2.1
+      -- ├─┬ url 0.10.3
+      -- │ ├── punycode 1.3.2
+      -- │ └── querystring 0.2.0
+      -- ├── uuid 8.0.0
+      -- └─┬ xml2js 0.4.19
+      --   ├── sax 1.2.1
+      --   └── xmlbuilder 9.0.7
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "buffer@4.9.2")
+      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "base64-js@1.5.1")
+      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "ieee754@1.1.13")
+      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "isarray@1.0.0")
+
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "events@1.1.1")
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "ieee754@1.1.13")
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "jmespath@0.16.0")
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "sax@1.2.1")
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "url@0.10.3")
+
+      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "punycode@1.3.2")
+      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "querystring@0.2.0")
+      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "punycode@1.3.2")
+      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "querystring@0.2.0")
+
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "uuid@8.0.0")
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "xml2js@0.4.19")
+
+      hasEdge (mkProdDep "xml2js@0.4.19") (mkProdDep "sax@1.2.1")
+      hasEdge (mkProdDep "xml2js@0.4.19") (mkProdDep "xmlbuilder@9.0.7")
+      -- example-local-pkg 1.0.0
+      -- └─┬ glob 8.0.3
+      --   ├── fs.realpath 1.0.0
+      --   ├─┬ inflight 1.0.6
+      --   │ ├─┬ once 1.4.0
+      --   │ │ └── wrappy 1.0.2
+      --   │ └── wrappy 1.0.2
+      --   ├── inherits 2.0.4
+      --   ├─┬ minimatch 5.1.0
+      --   │ └─┬ brace-expansion 2.0.1
+      --   │   └── balanced-match 1.0.2
+      --   └─┬ once 1.4.0
+      --     └── wrappy 1.0.2
+      hasEdge (mkProdDep "glob@8.0.3") (mkProdDep "fs.realpath@1.0.0")
+      hasEdge (mkProdDep "glob@8.0.3") (mkProdDep "inflight@1.0.6")
+
+      hasEdge (mkProdDep "inflight@1.0.6") (mkProdDep "once@1.4.0")
+      hasEdge (mkProdDep "inflight@1.0.6") (mkProdDep "wrappy@1.0.2")
+
+      hasEdge (mkProdDep "once@1.4.0") (mkProdDep "wrappy@1.0.2")
+
+      hasEdge (mkProdDep "glob@8.0.3") (mkProdDep "inherits@2.0.4")
+      hasEdge (mkProdDep "glob@8.0.3") (mkProdDep "minimatch@5.1.0")
+
+      hasEdge (mkProdDep "minimatch@5.1.0") (mkProdDep "brace-expansion@2.0.1")
+      hasEdge (mkProdDep "brace-expansion@2.0.1") (mkProdDep "balanced-match@1.0.2")
+
+      hasEdge (mkProdDep "glob@8.0.3") (mkProdDep "once@1.4.0")
+      hasEdge (mkProdDep "once@1.4.0") (mkProdDep "wrappy@1.0.2")
+      -- react 18.1.0
+      -- └─┬ loose-envify 1.4.0
+      --   └── js-tokens 4.0.0
+      hasEdge (mkDevDep "react@18.1.0") (mkDevDep "loose-envify@1.4.0")
+      hasEdge (mkDevDep "loose-envify@1.4.0") (mkDevDep "js-tokens@4.0.0")
+
+    it "should include all relevant edges and deps for workspace-a-name@2.0.0" $ do
+      -- workspace-a-name@2.0.0 /Users/user/Work/upstream/example-projects/javascript/pnpm/packages/a
+      -- dependencies:
+      -- aws-sdk 1.0.0
+      -- ├─┬ xml2js 0.2.4
+      -- │ └── sax 1.2.1
+      -- └── xmlbuilder 15.1.1
+      -- commander 9.2.0
+      hasEdge (mkProdDep "aws-sdk@1.0.0") (mkProdDep "xml2js@0.2.4")
+      hasEdge (mkProdDep "aws-sdk@1.0.0") (mkProdDep "xmlbuilder@15.1.1")
+      hasEdge (mkProdDep "xml2js@0.2.4") (mkProdDep "sax@1.2.1")
+
+pnpmLockGraphWithoutWorkspaceSpec :: Graphing Dependency -> Spec
+pnpmLockGraphWithoutWorkspaceSpec graph = do
+  let hasEdge :: Dependency -> Dependency -> Expectation
+      hasEdge = expectEdge graph
+
+  let colors =
+        Dependency
+          URLType
+          "https://codeload.github.com/Marak/colors.js/tar.gz/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26"
+          Nothing
+          mempty
+          (Set.singleton EnvProduction)
+          mempty
+
+  describe "buildGraph without workspaces" $ do
+    it "should include dependencies of root and workspace package as direct" $ do
+      expectDirect
+        [ mkProdDep "aws-sdk@2.1148.0"
+        , colors
+        , mkDevDep "react@18.1.0"
+        ]
+        graph
+
+    it "should include all relevant edges and deps for example@1.0.0" $ do
+      -- aws-sdk 2.1148.0
+      -- ├─┬ buffer 4.9.2
+      -- │ ├── base64-js 1.5.1
+      -- │ ├── ieee754 1.1.13
+      -- │ └── isarray 1.0.0
+      -- ├── events 1.1.1
+      -- ├── ieee754 1.1.13
+      -- ├── jmespath 0.16.0
+      -- ├── querystring 0.2.0
+      -- ├── sax 1.2.1
+      -- ├─┬ url 0.10.3
+      -- │ ├── punycode 1.3.2
+      -- │ └── querystring 0.2.0
+      -- ├── uuid 8.0.0
+      -- └─┬ xml2js 0.4.19
+      --   ├── sax 1.2.1
+      --   └── xmlbuilder 9.0.7
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "buffer@4.9.2")
+      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "base64-js@1.5.1")
+      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "ieee754@1.1.13")
+      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "isarray@1.0.0")
+
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "events@1.1.1")
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "ieee754@1.1.13")
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "jmespath@0.16.0")
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "sax@1.2.1")
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "url@0.10.3")
+
+      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "punycode@1.3.2")
+      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "querystring@0.2.0")
+      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "punycode@1.3.2")
+      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "querystring@0.2.0")
+
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "uuid@8.0.0")
+      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "xml2js@0.4.19")
+
+      hasEdge (mkProdDep "xml2js@0.4.19") (mkProdDep "sax@1.2.1")
+      hasEdge (mkProdDep "xml2js@0.4.19") (mkProdDep "xmlbuilder@9.0.7")
+
+      -- react 18.1.0
+      -- └─┬ loose-envify 1.4.0
+      --   └── js-tokens 4.0.0
+      hasEdge (mkDevDep "react@18.1.0") (mkDevDep "loose-envify@1.4.0")
+      hasEdge (mkDevDep "loose-envify@1.4.0") (mkDevDep "js-tokens@4.0.0")

--- a/test/Pnpm/PnpmLockSpec.hs
+++ b/test/Pnpm/PnpmLockSpec.hs
@@ -191,66 +191,13 @@ pnpmLockGraphWithoutWorkspaceSpec graph = do
   let hasEdge :: Dependency -> Dependency -> Expectation
       hasEdge = expectEdge graph
 
-  let colors =
-        Dependency
-          URLType
-          "https://codeload.github.com/Marak/colors.js/tar.gz/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26"
-          Nothing
-          mempty
-          (Set.singleton EnvProduction)
-          mempty
-
   describe "buildGraph without workspaces" $ do
     it "should include dependencies of root and workspace package as direct" $ do
-      expectDirect
-        [ mkProdDep "aws-sdk@2.1148.0"
-        , colors
-        , mkDevDep "react@18.1.0"
-        ]
-        graph
+      expectDirect [mkProdDep "react@18.1.0"] graph
 
-    it "should include all relevant edges and deps for example@1.0.0" $ do
-      -- aws-sdk 2.1148.0
-      -- ├─┬ buffer 4.9.2
-      -- │ ├── base64-js 1.5.1
-      -- │ ├── ieee754 1.1.13
-      -- │ └── isarray 1.0.0
-      -- ├── events 1.1.1
-      -- ├── ieee754 1.1.13
-      -- ├── jmespath 0.16.0
-      -- ├── querystring 0.2.0
-      -- ├── sax 1.2.1
-      -- ├─┬ url 0.10.3
-      -- │ ├── punycode 1.3.2
-      -- │ └── querystring 0.2.0
-      -- ├── uuid 8.0.0
-      -- └─┬ xml2js 0.4.19
-      --   ├── sax 1.2.1
-      --   └── xmlbuilder 9.0.7
-      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "buffer@4.9.2")
-      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "base64-js@1.5.1")
-      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "ieee754@1.1.13")
-      hasEdge (mkProdDep "buffer@4.9.2") (mkProdDep "isarray@1.0.0")
-
-      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "events@1.1.1")
-      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "ieee754@1.1.13")
-      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "jmespath@0.16.0")
-      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "sax@1.2.1")
-      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "url@0.10.3")
-
-      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "punycode@1.3.2")
-      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "querystring@0.2.0")
-      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "punycode@1.3.2")
-      hasEdge (mkProdDep "url@0.10.3") (mkProdDep "querystring@0.2.0")
-
-      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "uuid@8.0.0")
-      hasEdge (mkProdDep "aws-sdk@2.1148.0") (mkProdDep "xml2js@0.4.19")
-
-      hasEdge (mkProdDep "xml2js@0.4.19") (mkProdDep "sax@1.2.1")
-      hasEdge (mkProdDep "xml2js@0.4.19") (mkProdDep "xmlbuilder@9.0.7")
-
+    it "should include all relevant edges and deps" $ do
       -- react 18.1.0
       -- └─┬ loose-envify 1.4.0
       --   └── js-tokens 4.0.0
-      hasEdge (mkDevDep "react@18.1.0") (mkDevDep "loose-envify@1.4.0")
-      hasEdge (mkDevDep "loose-envify@1.4.0") (mkDevDep "js-tokens@4.0.0")
+      hasEdge (mkProdDep "react@18.1.0") (mkProdDep "loose-envify@1.4.0")
+      hasEdge (mkProdDep "loose-envify@1.4.0") (mkProdDep "js-tokens@4.0.0")

--- a/test/Pnpm/testdata/pnpm-lock-without-workspace.yaml
+++ b/test/Pnpm/testdata/pnpm-lock-without-workspace.yaml
@@ -1,0 +1,123 @@
+lockfileVersion: 5.3
+
+specifiers:
+  aws-sdk: ^2.0.0
+  colors: git+https://github.com/Marak/colors.js.git
+  react: '*'
+
+dependencies:
+  aws-sdk: 2.1148.0
+  colors: github.com/Marak/colors.js/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26
+
+devDependencies:
+  react: 18.1.0
+
+packages:
+
+  /aws-sdk/2.1148.0:
+    resolution: {integrity: sha512-FUYAyveKmS5eqIiGQgrGVsLZwwtI+K6S6Gz8oJf56pgypZCo9dV+cXO4aaS+vN0+LSmGh6dSKc6G8h8FYASIJg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      buffer: 4.9.2
+      events: 1.1.1
+      ieee754: 1.1.13
+      jmespath: 0.16.0
+      querystring: 0.2.0
+      sax: 1.2.1
+      url: 0.10.3
+      uuid: 8.0.0
+      xml2js: 0.4.19
+    dev: false
+
+  /base64-js/1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
+  /buffer/4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.1.13
+      isarray: 1.0.0
+    dev: false
+
+  /events/1.1.1:
+    resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
+    engines: {node: '>=0.4.x'}
+    dev: false
+
+  /ieee754/1.1.13:
+    resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
+    dev: false
+
+  /isarray/1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    dev: false
+
+  /jmespath/0.16.0:
+    resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
+    engines: {node: '>= 0.6.0'}
+    dev: false
+
+  /js-tokens/4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
+  /loose-envify/1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: true
+
+  /punycode/1.3.2:
+    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
+    dev: false
+
+  /querystring/0.2.0:
+    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+    dev: false
+
+  /react/18.1.0:
+    resolution: {integrity: sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: true
+
+  /sax/1.2.1:
+    resolution: {integrity: sha1-e45lYZCyKOgaZq6nSEgNgozS03o=}
+    dev: false
+
+  /url/0.10.3:
+    resolution: {integrity: sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=}
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+    dev: false
+
+  /uuid/8.0.0:
+    resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    hasBin: true
+    dev: false
+
+  /xml2js/0.4.19:
+    resolution: {integrity: sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==}
+    dependencies:
+      sax: 1.2.1
+      xmlbuilder: 9.0.7
+    dev: false
+
+  /xmlbuilder/9.0.7:
+    resolution: {integrity: sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=}
+    engines: {node: '>=4.0'}
+    dev: false
+
+  github.com/Marak/colors.js/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26:
+    resolution: {tarball: https://codeload.github.com/Marak/colors.js/tar.gz/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26}
+    name: colors
+    version: 1.4.44-liberty-2
+    engines: {node: '>=0.1.90'}
+    dev: false

--- a/test/Pnpm/testdata/pnpm-lock-without-workspace.yaml
+++ b/test/Pnpm/testdata/pnpm-lock-without-workspace.yaml
@@ -1,83 +1,22 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
-  aws-sdk: ^2.0.0
-  colors: git+https://github.com/Marak/colors.js.git
   react: '*'
 
 dependencies:
-  aws-sdk: 2.1148.0
-  colors: github.com/Marak/colors.js/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26
-
-devDependencies:
   react: 18.1.0
 
 packages:
 
-  /aws-sdk/2.1148.0:
-    resolution: {integrity: sha512-FUYAyveKmS5eqIiGQgrGVsLZwwtI+K6S6Gz8oJf56pgypZCo9dV+cXO4aaS+vN0+LSmGh6dSKc6G8h8FYASIJg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      buffer: 4.9.2
-      events: 1.1.1
-      ieee754: 1.1.13
-      jmespath: 0.16.0
-      querystring: 0.2.0
-      sax: 1.2.1
-      url: 0.10.3
-      uuid: 8.0.0
-      xml2js: 0.4.19
-    dev: false
-
-  /base64-js/1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-    dev: false
-
-  /buffer/4.9.2:
-    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.1.13
-      isarray: 1.0.0
-    dev: false
-
-  /events/1.1.1:
-    resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
-    engines: {node: '>=0.4.x'}
-    dev: false
-
-  /ieee754/1.1.13:
-    resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
-    dev: false
-
-  /isarray/1.0.0:
-    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-    dev: false
-
-  /jmespath/0.16.0:
-    resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
-    engines: {node: '>= 0.6.0'}
-    dev: false
-
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: true
+    dev: false
 
   /loose-envify/1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: true
-
-  /punycode/1.3.2:
-    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
-    dev: false
-
-  /querystring/0.2.0:
-    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
-    engines: {node: '>=0.4.x'}
-    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
     dev: false
 
   /react/18.1.0:
@@ -85,39 +24,4 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: true
-
-  /sax/1.2.1:
-    resolution: {integrity: sha1-e45lYZCyKOgaZq6nSEgNgozS03o=}
-    dev: false
-
-  /url/0.10.3:
-    resolution: {integrity: sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=}
-    dependencies:
-      punycode: 1.3.2
-      querystring: 0.2.0
-    dev: false
-
-  /uuid/8.0.0:
-    resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
-    hasBin: true
-    dev: false
-
-  /xml2js/0.4.19:
-    resolution: {integrity: sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==}
-    dependencies:
-      sax: 1.2.1
-      xmlbuilder: 9.0.7
-    dev: false
-
-  /xmlbuilder/9.0.7:
-    resolution: {integrity: sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=}
-    engines: {node: '>=4.0'}
-    dev: false
-
-  github.com/Marak/colors.js/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26:
-    resolution: {tarball: https://codeload.github.com/Marak/colors.js/tar.gz/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26}
-    name: colors
-    version: 1.4.44-liberty-2
-    engines: {node: '>=0.1.90'}
     dev: false

--- a/test/Pnpm/testdata/pnpm-lock.yaml
+++ b/test/Pnpm/testdata/pnpm-lock.yaml
@@ -1,0 +1,249 @@
+lockfileVersion: 5.4
+
+importers:
+
+  .:
+    specifiers:
+      aws-sdk: ^2.0.0
+      colors: Marak/colors.js
+      example-local-pkg: file:../local-package/
+      lodash: https://github.com/lodash/lodash/archive/refs/heads/master.tar.gz
+      react: '*'
+    dependencies:
+      aws-sdk: 2.1148.0
+      colors: github.com/Marak/colors.js/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26
+      example-local-pkg: file:../local-package
+      lodash: '@github.com/lodash/lodash/archive/refs/heads/master.tar.gz'
+    devDependencies:
+      react: 18.1.0
+
+  packages/a:
+    specifiers:
+      aws-sdk: 1.0.0
+      commander: 9.2.0
+    dependencies:
+      aws-sdk: 1.0.0
+      commander: 9.2.0
+
+packages:
+
+  /aws-sdk/1.0.0:
+    resolution: {integrity: sha512-MhxZ5bSkbnFEp9CnQ1dPeMVbrCVCv+VCx7fttdS0vB8anbFN3yzCxB1q76buci5ugxAKDqrySLssUI/OexoVXg==}
+    engines: {node: '>= 0.6.0'}
+    dependencies:
+      xml2js: 0.2.4
+      xmlbuilder: 15.1.1
+    dev: false
+
+  /aws-sdk/2.1148.0:
+    resolution: {integrity: sha512-FUYAyveKmS5eqIiGQgrGVsLZwwtI+K6S6Gz8oJf56pgypZCo9dV+cXO4aaS+vN0+LSmGh6dSKc6G8h8FYASIJg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      buffer: 4.9.2
+      events: 1.1.1
+      ieee754: 1.1.13
+      jmespath: 0.16.0
+      querystring: 0.2.0
+      sax: 1.2.1
+      url: 0.10.3
+      uuid: 8.0.0
+      xml2js: 0.4.19
+    dev: false
+
+  /balanced-match/1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: false
+
+  /base64-js/1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
+  /brace-expansion/2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: false
+
+  /buffer/4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.1.13
+      isarray: 1.0.0
+    dev: false
+
+  /commander/9.2.0:
+    resolution: {integrity: sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==}
+    engines: {node: ^12.20.0 || >=14}
+    dev: false
+
+  /events/1.1.1:
+    resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
+    engines: {node: '>=0.4.x'}
+    dev: false
+
+  /fs.realpath/1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: false
+
+  /glob/8.0.3:
+    resolution: {integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.0
+      once: 1.4.0
+    dev: false
+
+  /ieee754/1.1.13:
+    resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
+    dev: false
+
+  /inflight/1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: false
+
+  /inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /isarray/1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    dev: false
+
+  /jmespath/0.16.0:
+    resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
+    engines: {node: '>= 0.6.0'}
+    dev: false
+
+  /js-tokens/4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
+  /loose-envify/1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: true
+
+  /minimatch/5.1.0:
+    resolution: {integrity: sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
+  /once/1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    dependencies:
+      wrappy: 1.0.2
+    dev: false
+
+  /punycode/1.3.2:
+    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
+    dev: false
+
+  /querystring/0.2.0:
+    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+    dev: false
+
+  /react/18.1.0:
+    resolution: {integrity: sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: true
+
+  /sax/1.2.1:
+    resolution: {integrity: sha1-e45lYZCyKOgaZq6nSEgNgozS03o=}
+    dev: false
+
+  /url/0.10.3:
+    resolution: {integrity: sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=}
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+    dev: false
+
+  /uuid/8.0.0:
+    resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    hasBin: true
+    dev: false
+
+  /wrappy/1.0.2:
+    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    dev: false
+
+  /xml2js/0.2.4:
+    resolution: {integrity: sha1-mltXf6HmzfiSPV4TcvejGIQ25E0=}
+    dependencies:
+      sax: 1.2.1
+    dev: false
+
+  /xml2js/0.4.19:
+    resolution: {integrity: sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==}
+    dependencies:
+      sax: 1.2.1
+      xmlbuilder: 9.0.7
+    dev: false
+
+  /xmlbuilder/15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
+    dev: false
+
+  /xmlbuilder/9.0.7:
+    resolution: {integrity: sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=}
+    engines: {node: '>=4.0'}
+    dev: false
+
+  '@github.com/lodash/lodash/archive/refs/heads/master.tar.gz':
+    resolution: {tarball: https://github.com/lodash/lodash/archive/refs/heads/master.tar.gz}
+    name: lodash
+    version: 5.0.0
+    engines: {node: '>=4.0.0'}
+    dev: false
+
+  file:../local-package:
+    resolution: {directory: ../local-package, type: directory}
+    name: example-local-pkg
+    version: 1.0.0
+    dependencies:
+      glob: 8.0.3
+      some-other-local-pkg: file:../some-other-local-package
+      more-other-local-pkg: file:../more-other-local-package
+    dev: false
+  
+  file:../some-other-local-package:
+    resolution: {directory: ../local-package, type: directory}
+    name: some-other-local-package
+    version: 1.0.0
+    dependencies:
+      chokidar: 1.0.0
+    dev: false
+
+  /chokidar/1.0.0:
+    resolution: {integrity: sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=}
+    engines: {node: '>=4.0'}
+    dev: false
+
+  file:../more-other-local-package:
+    resolution: {directory: ../local-package, type: directory}
+    name: more-other-local-package
+    version: 1.0.0
+    dev: false
+
+  github.com/Marak/colors.js/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26:
+    resolution: {commit: 6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26, repo: git+ssh://git@github.com/Marak/colors.js, type: git}
+    name: colors
+    version: 1.4.44-liberty-2
+    engines: {node: '>=0.1.90'}
+    dev: false


### PR DESCRIPTION
# Overview

This PR adds pnpm support. 

## Acceptance criteria

- `pnpm-lock.yaml` file can be analyzed with pnpm analyzer.
- pnpm analyzer reports direct, deep dependencies, and edges amongst them.
- pnpm analyzer by default exclude dev dependencies.
- pnpm analyzer reports git dependencies.
- pnpm analyzer reports URL dependencies.
- pnpm analyzer reports npm registry dependencies.
- pnpm analyzer does not report directory sourced dependencies.
- pnpm analyzer promotes deep dependencies of directory sourced dependencies.
- pnpm analyzer works for lockfile which has no workspaces.
- pnpm analyzer works for lockfile which has workspaces.

## Testing plan

1) Get an example pnpm project from: https://github.com/fossas/example-projects (javascript/pnpm directory) or from open source community
2) Analyze project with:
```
make install-dev
fossa-dev analyze -o | jq
```

Compare the graph to confirm fossa-cli is reporting the correct result. You can also refer to included unit tests.

## Risks
None - It has no impact on existing analyzers, or functionalities.

## References
https://fossa.atlassian.net/browse/ANE-325

## Post Approval Checklist
- [x] Update Changelog
- [ ] Update Product Documentation (in docs.fossa.com)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
