### PR TITLE
add cc-by-4.0 notification for licensing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ If you're interested in contributing, check out our [contributor documentation](
 
 ## Licensing Data
 
-Some of the data used for CLI-side license scanning is provided by nexB under a [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/legalcode) license. This data can be found here: https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data
+Some of the data used for CLI-side license scanning is provided by nexB under a [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/legalcode) license. This data can be found here: https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data.
 
-Copyright (c) nexB Inc. and others. All rights reserved.
+The licensing data is Copyright (c) nexB Inc. and others. All rights reserved.
     ScanCode is a trademark of nexB Inc.
     SPDX-License-Identifier: CC-BY-4.0
     See https://creativecommons.org/licenses/by/4.0/legalcode for the license text.


### PR DESCRIPTION
# Overview

Some of the data we use when doing CLI-side license scans is provided under a CC-by-4.0 license by nexB.

This PR adds the attribution notice for that data to our README.

The data we are using can be found here: https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data

There is some text for a "preferred attribution notice" in [scancode-data.ABOUT](https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/scancode-data.ABOUT) in that directory, so I added that text to the README with a bit more verbiage.

## Acceptance criteria

We should have an appropriate attribution notice for our use of the licensing data from scancode toolkit

## Testing plan

This is a README only change

## Risks

None

## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
