### PR TITLE
Fix perl parser

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - CLI-side license scans will skip rescanning revisions that are already known to FOSSA. This can be overridden by using the `--force-vendored-dependency-rescans` flag.
 - Swift: Added support for `Package.resolved` v2 files ([#957](https://github.com/fossas/fossa-cli/pull/957)).
+- Perl: Updated version number parser to be more lenient on non-textual version numbers ([#960](https://github.com/fossas/fossa-cli/pull/960)) 
 
 ## v3.3.1
 - Vendor Dependencies: Considers `licence` and `license` equivalent when performing native license scan ([#939](https://github.com/fossas/fossa-cli/pull/939)).

--- a/test/Perl/testdata/MetaV1_4.json
+++ b/test/Perl/testdata/MetaV1_4.json
@@ -4,7 +4,7 @@
       "Some Author"
     ],
     "build_requires": {
-      "Compress::Zlib": "0"
+      "Compress::Zlib": 0
     },
     "configure_requires": {
       "ExtUtils::MakeMaker": "0"

--- a/test/Perl/testdata/MetaV1_4.yml
+++ b/test/Perl/testdata/MetaV1_4.yml
@@ -12,6 +12,6 @@ meta-spec:
   version: '1.4'
 name: Some-App
 requires:
-  Archive::Zip: '0'
+  Archive::Zip: 0
   perl: '5.006'
 version: 1.16

--- a/test/Perl/testdata/MetaV2.json
+++ b/test/Perl/testdata/MetaV2.json
@@ -10,7 +10,7 @@
     "prereqs": {
         "configure": {
             "requires": {
-                "ExtUtils::MakeMaker": "0",
+                "ExtUtils::MakeMaker": 0,
                 "perl": "5.006"
             }
         },

--- a/test/Perl/testdata/MetaV2.yml
+++ b/test/Perl/testdata/MetaV2.yml
@@ -9,7 +9,7 @@ prereqs:
       perl: '5.006'
   develop:
     requires:
-      Dist::Zilla: '5'
+      Dist::Zilla: 5
       perl: '5.006'
   runtime:
     requires:


### PR DESCRIPTION
# Overview

Given the following perl manifest `META.yml` file, we report an error when parsing the `requires` field:

```yaml
name: Parse-Pidl
abstract: Generate parsers / DCE/RPC-clients from IDL
author:
    - Andrew Tridgell <tridge@samba.org>
    - Jelmer Vernooij <jelmer@samba.org>
    - Stefan Metzmacher <metze@samba.org>
    - Tim Potter <tpot@samba.org>
license: gplv3
installdirs:  site
homepage: http://www.samba.org/
bugtracker: http://bugzilla.samba.org/
requires:
    Parse::Yapp: 0    
recommends:
    Data::Dumper: 0
meta-spec:
    version: 1.3
    url: http://module-build.sourceforge.net/META-spec-v1.3.html
```

We expect the `Parse::Yapp` key (or any package name key) to have a textual version number, but here, it's an integer.
We have run into this before, and we use the `TextLike` data type for accepting any of `text`, `integer`, or `double` datatypes in JSON and YAML parsers, and forcing them to become text.

This PR uses the `TextLike` datatype for package version numbers in the perl analyzer.

## Acceptance criteria

- Test changes reflect the issue correctly
- Tests continue to pass

## Testing plan

Unit tests should be sufficient here.

## Risks

None, the type system confirms that we have handled the text correctly until the transition point of `TextLike -> Text`, and the tests confirm the behavior is correct.

Reviewer, please validate the changes to the test files, and ensure that without these changes, the tests would fail.

## References

[ZD 4387](https://fossa.zendesk.com/agent/tickets/4387)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
