### PR TITLE
Ane 238 maven depgraph deep deps

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -28,6 +28,7 @@
 - ignore: {name: "Use toString", within: ["Data.String.Conversion"]}
 
 - suggest: {lhs: Data.List.foldl, rhs: Data.List.foldl'}
+- suggest: {lhs: Prelude.foldl, rhs: Data.List.foldl'}
 - suggest: {lhs: "(Data.Set.size x) == 0" , rhs: "Data.Set.null x"}
 - suggest: {lhs: "(Data.Set.size x) /= 0" , rhs: "not $ Data.Set.null x"}
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## v3.3.6
 - Make CLI-side license scanning the default method of scanning vendored dependencies
+- Maven: Report direct dependencies as direct rather than deep. ([#963](https://github.com/fossas/fossa-cli/pull/963))
 
 ## v3.3.5
 - Pnpm: Adds support for dependency analysis using `pnpm-lock.yaml` file. ([#958](https://github.com/fossas/fossa-cli/pull/958))
@@ -11,7 +12,7 @@
 - VSI scans now automatically skip the `.git` directory inside the scan root ([#969](https://github.com/fossas/fossa-cli/pull/969)).
 
 ## v3.3.3
-- Cocoapods: Cocoapods analyzer does not handle subspecs in vendored podspecs. ([#964](https://github.com/fossas/fossa-cli/pull/964/files))
+- Cocoapods: Cocoapods analyzer does not handle subspecs in vendored podspecs. ([#964](https://github.com/fossas/fossa-cli/pull/964/files)) 
 
 ## v3.3.2
 - CLI-side license scans will skip rescanning revisions that are already known to FOSSA. This can be overridden by using the `--force-vendored-dependency-rescans` flag.

--- a/docs/contributing/filtering.md
+++ b/docs/contributing/filtering.md
@@ -5,7 +5,7 @@ do not need to be analyzed at all, and could be safely ignored.  We use the
 `--{only,exclude}-{path,target}` CLI arguments, or the
 `{targets,paths}.{only,exclude}:` config file values to avoid giving users
 information they don't care about, or to avoid doing work that will be thrown
-away.  This document expresses how that filter process works, and clarfies its
+away.  This document expresses how that filter process works, and clarifies its
 semantics and limitations.
 
 ## Shorthand

--- a/docs/references/strategies/languages/maven/mavenplugin.md
+++ b/docs/references/strategies/languages/maven/mavenplugin.md
@@ -18,4 +18,8 @@ Find `pom.xml` files, and treat those as maven projects. Skip all subdirectories
 
 1. unpack the embedded plugin to a temporary directory
 2. install it to the local maven repository `mvn install:install-file -DgroupId=com.github.ferstl -DartifactId=depgraph-maven-plugin -Dversion=4.0.1 -Dpackaging=jar -Dfile=<location>/depgraph-maven-plugin-4.0.1.jar`
-3. invoke the plugin in the top-level project with the command `mvn com.github.ferstl:depgraph-maven-plugin:4.0.1:aggregate -DgraphFormat=dot -DmergeScopes -DreduceEdges=false`
+3. invoke the plugin in the top-level project with the command `mvn com.github.ferstl:depgraph-maven-plugin:4.0.1:aggregate -DgraphFormat=text -DmergeScopes -DreduceEdges=false -DshowVersions=true -DshowGroupIds=true -DshowOptional=true -DrepeatTransitiveDependenciesInTextGraph=true`
+
+For `graphFormat`s other than `text` the data will be output to
+`target/dependency-graph.<format>`. For `text`, it will additionally be output
+to stdout.

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -352,8 +352,8 @@ library
     Strategy.Maven
     Strategy.Maven.DepTree
     Strategy.Maven.Plugin
-    Strategy.Maven.PluginTree
     Strategy.Maven.PluginStrategy
+    Strategy.Maven.PluginTree
     Strategy.Maven.Pom
     Strategy.Maven.Pom.Closure
     Strategy.Maven.Pom.PomFile

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -352,6 +352,7 @@ library
     Strategy.Maven
     Strategy.Maven.DepTree
     Strategy.Maven.Plugin
+    Strategy.Maven.PluginTree
     Strategy.Maven.PluginStrategy
     Strategy.Maven.Pom
     Strategy.Maven.Pom.Closure
@@ -509,6 +510,7 @@ test-suite unit-tests
     Maven.DepTreeSpec
     Maven.PluginSpec
     Maven.PluginStrategySpec
+    Maven.PluginTreeSpec
     Maven.PomStrategySpec
     Nim.NimbleSpec
     Node.NodeSpec

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -507,6 +507,7 @@ test-suite unit-tests
     Haskell.CabalSpec
     Haskell.StackSpec
     Maven.DepTreeSpec
+    Maven.PluginSpec
     Maven.PluginStrategySpec
     Maven.PomStrategySpec
     Nim.NimbleSpec

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -18,7 +18,7 @@ import App.Version (fullVersionDescription)
 import Control.Carrier.Lift
 import Control.Effect.Diagnostics qualified as Diag (Diagnostics)
 import Control.Monad (when)
-import Data.Foldable (traverse_)
+import Data.Foldable (foldl', traverse_)
 import Data.List (sort)
 import Data.Maybe (catMaybes, mapMaybe, maybeToList)
 import Data.Monoid.Extra (isMempty)
@@ -90,7 +90,7 @@ instance Monoid ScanCount where
   mempty = ScanCount 0 0 0 0 0
 
 getScanCount :: [DiscoveredProjectScan] -> ScanCount
-getScanCount = foldl countOf (ScanCount 0 0 0 0 0)
+getScanCount = foldl' countOf (ScanCount 0 0 0 0 0)
   where
     countOf :: ScanCount -> DiscoveredProjectScan -> ScanCount
     countOf tsc (SkippedDueToProvidedFilter _) = tsc{numProjects = numProjects tsc + 1, numSkipped = numSkipped tsc + 1}

--- a/src/Strategy/Erlang/ConfigParser.hs
+++ b/src/Strategy/Erlang/ConfigParser.hs
@@ -23,6 +23,7 @@ module Strategy.Erlang.ConfigParser (
 import Data.Aeson.Types (ToJSON (toJSON))
 import Data.Char qualified as C
 import Data.Functor (($>))
+import Data.List (foldl')
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -93,7 +94,7 @@ stringMatchesRadix rad str = do
 
 -- | Returns the 'raw' string parsed in base 'base'
 intLiteralInBase :: Int -> [Char] -> Int
-intLiteralInBase base = foldl accum 0
+intLiteralInBase base = foldl' accum 0
   where
     accum :: Int -> Char -> Int
     accum value c = value * base + alphaNumToInt c

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -197,6 +197,7 @@ mavenPluginDependenciesCmd plugin =
         , "-DshowVersions=true"
         , "-DshowGroupIds=true"
         , "-DshowOptional=true"
+        , "-DrepeatTransitiveDependenciesInTextGraph=true"
         ]
     , cmdAllowErr = Never
     }

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -4,7 +4,6 @@
 module Strategy.Maven.Plugin (
   withUnpackedPlugin,
   installPlugin,
-  execPlugin,
   parsePluginOutput,
   depGraphPlugin,
   depGraphPluginLegacy,

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -24,7 +24,7 @@ import Control.Effect.Diagnostics (Diagnostics, warn)
 import Control.Effect.Exception (Lift, bracket)
 import Control.Effect.Lift (sendIO)
 import Control.Monad (when)
-import Data.Aeson (FromJSON, parseJSON, withObject, (.:))
+import Data.Aeson (FromJSON, parseJSON, withObject, (.:), (.:?), (.!=))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.FileEmbed (embedFile)
@@ -257,7 +257,7 @@ newtype ReactorOutput = ReactorOutput {reactorArtifacts :: [ReactorArtifact]}
 
 instance FromJSON ReactorOutput where
   parseJSON = withObject "Reactor output" $
-    \o -> ReactorOutput <$> (o .: "artifacts")
+    \o -> ReactorOutput <$> (o .:? "artifacts" .!= [])
 
 data PluginOutput = PluginOutput
   { outArtifacts :: [Artifact]

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -24,7 +24,7 @@ import Control.Effect.Diagnostics (Diagnostics, warn)
 import Control.Effect.Exception (Lift, bracket)
 import Control.Effect.Lift (sendIO)
 import Control.Monad (when)
-import Data.Aeson (FromJSON, parseJSON, withObject, (.:), (.:?), (.!=))
+import Data.Aeson (FromJSON, parseJSON, withObject, (.!=), (.:), (.:?))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.FileEmbed (embedFile)

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -139,8 +139,6 @@ textArtifactToPluginOutput
       lookupArtifactByName :: (Has Diagnostics sig m) => Text -> m (Maybe Int)
       lookupArtifactByName aText = do
         let res = Map.lookup aText namesToIds
-        -- This error should be rare because because we walked the same
-        -- structure aText is a part of to create namesToIds.
         when (isNothing res) $
           warn $ "Could not find artifact with name " <> aText
         pure res
@@ -162,7 +160,9 @@ textArtifactToPluginOutput
             } <-
             fold <$> traverse buildPluginOutput aChildren
           case maybeId of
-            Nothing -> pure childInfo
+            Nothing -> do
+              warn ("Could not find id for artifact " <> aText)
+              pure childInfo
             Just numericId -> do
               let artifact = textArtifactToArtifact numericId t
               newEdges <- buildEdges numericId aChildren

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -11,7 +11,6 @@ module Strategy.Maven.Plugin (
   DepGraphPlugin (..),
   Edge (..),
   PluginOutput (..),
-  parseArtifact,
 ) where
 
 import Control.Algebra
@@ -22,20 +21,14 @@ import Data.Aeson
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.FileEmbed (embedFile)
-import Data.Functor (void, ($>))
-import Data.List (singleton)
+import Data.Functor (void)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Void (Void)
 import Effect.Exec
 import Effect.ReadFS
 import Path
 import Path.IO (createTempDir, getTempDir, removeDirRecur)
 import System.FilePath qualified as FP
-import Text.Megaparsec (Parsec, takeWhile1P, (<|>), manyTill, eof, label, anySingle, some, tokens, chunk)
-import Text.Megaparsec.Char (space1, char)
-import qualified Text.Megaparsec.Char.Lexer as Lexer
-import Data.Char (isSpace)
 
 data DepGraphPlugin = DepGraphPlugin
   { group :: Text
@@ -165,30 +158,3 @@ instance FromJSON Edge where
   parseJSON = withObject "Edge" $ \obj ->
     Edge <$> obj .: "numericFrom"
       <*> obj .: "numericTo"
-
-type Parser = Parsec Void Text
-
-lexeme :: Parser a -> Parser a
-lexeme = Lexer.lexeme space1
-
-parseArtifact :: Int -> Parser Artifact
-parseArtifact artifactId =
-  Artifact artifactId
-    <$> readThruNextColon "groupId"
-    <*> readThruNextColon "artifactId"
-    <*> readThruNextColon "artifactVersion"
-    -- based on  the maven documentation, it  seems there can be  only one scope
-    -- for a given rtifact even though maven-depgraph-plugin returns an array
-    -- of strings in the json output
-    <*> (singleton <$> scopeParse)
-    <*> isOptional
-  where
-    readThruNextColon :: String -> Parser Text
-    readThruNextColon name = takeWhile1P (Just name) (/= ':') <* char ':'
-
-    scopeParse :: Parser Text
-    scopeParse = lexeme (takeWhile1P (Just "scopes") (not . isSpace))
-
-    isOptional :: Parser Bool
-    isOptional = (chunk "(optional)" $> True)
-                 <|> pure False

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -133,6 +133,7 @@ textArtifactToPluginOutput
                 , artifactVersion = version
                 , artifactScopes = scopes
                 , artifactOptional = isOptional
+                , artifactIsDirect = isDirect
                 }
           _ -> Nothing
 
@@ -223,6 +224,7 @@ data Artifact = Artifact
   , artifactVersion :: Text
   , artifactScopes :: [Text]
   , artifactOptional :: Bool
+  , artifactIsDirect :: Bool
   }
   deriving (Eq, Ord, Show)
 

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -129,12 +129,12 @@ buildGraph reactorOutput PluginOutput{..} =
   -- consider those because they're the users' packages, so promote them to
   -- direct when building the graph using `shrinkRoots`.
   shrinkRoots . run . evalGrapher $ do
-      let byNumeric :: Map Int Artifact
-          byNumeric = indexBy artifactNumericId outArtifacts
+    let byNumeric :: Map Int Artifact
+        byNumeric = indexBy artifactNumericId outArtifacts
 
-      depsByNumeric <- traverse toDependency byNumeric
+    depsByNumeric <- traverse toDependency byNumeric
 
-      traverse_ (visitEdge depsByNumeric) outEdges
+    traverse_ (visitEdge depsByNumeric) outEdges
   where
     knownSubmodules :: Set.Set Text
     knownSubmodules = Set.fromList . map reactorArtifactName . reactorArtifacts $ reactorOutput
@@ -171,7 +171,7 @@ buildGraph reactorOutput PluginOutput{..} =
       --
       -- In both cases, we want to mark either the toplevel project name or the
       -- submodule as direct because these are the users' own packages. We will
-      -- prune them from the graph in a later step.
+      -- remove them and promote their postSet to direct in a later step.
       when
         (artifactIsDirect || artifactArtifactId `Set.member` knownSubmodules)
         (Grapher.direct dep)

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -92,12 +92,12 @@ buildGraph PluginOutput{..} =
   -- consider those because they're the users' packages, so promote the root
   -- deps to direct when building the graph using `shrinkRoots`.
   shrinkRoots . run . evalGrapher $ do
-  let byNumeric :: Map Int Artifact
-      byNumeric = indexBy artifactNumericId outArtifacts
+    let byNumeric :: Map Int Artifact
+        byNumeric = indexBy artifactNumericId outArtifacts
 
-  depsByNumeric <- traverse toDependency byNumeric
+    depsByNumeric <- traverse toDependency byNumeric
 
-  traverse_ (visitEdge depsByNumeric) outEdges
+    traverse_ (visitEdge depsByNumeric) outEdges
   where
     toDependency :: Has (Grapher Dependency) sig m => Artifact -> m Dependency
     toDependency Artifact{..} = do

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -86,7 +86,12 @@ instance ToDiagnostic MvnPluginExecFailed where
   renderDiagnostic (MvnPluginExecFailed) = "Failed to execute maven plugin for analysis."
 
 buildGraph :: PluginOutput -> Graphing Dependency
-buildGraph PluginOutput{..} = shrinkRoots . run . evalGrapher $ do
+buildGraph PluginOutput{..} =
+  -- The root deps in the maven depgraph text graph output are either the
+  -- toplevel package or submodules in a multi-module project. We don't want to
+  -- consider those because they're the users' packages, so promote the root
+  -- deps to direct when building the graph using `shrinkRoots`.
+  shrinkRoots . run . evalGrapher $ do
   let byNumeric :: Map Int Artifact
       byNumeric = indexBy artifactNumericId outArtifacts
 

--- a/src/Strategy/Maven/PluginTree.hs
+++ b/src/Strategy/Maven/PluginTree.hs
@@ -3,10 +3,9 @@ module Strategy.Maven.PluginTree (parseArtifact
 
 import Data.Char (isSpace)
 import Data.Functor (($>))
-import Data.List (singleton)
 import Data.Text (Text)
 import Data.Void (Void)
-import Text.Megaparsec (Parsec, chunk, takeWhile1P, (<|>))
+import Text.Megaparsec (Parsec, chunk, takeWhile1P, (<|>), sepBy)
 import Text.Megaparsec.Char (char, space1)
 import Text.Megaparsec.Char.Lexer qualified as Lexer
 
@@ -33,14 +32,14 @@ parseArtifact =
     -- based on  the maven documentation, it  seems there can be  only one scope
     -- for a given rtifact even though maven-depgraph-plugin returns an array
     -- of strings in the json output
-    <*> (singleton <$> scopeParse)
+    <*> scopeParse
     <*> isOptional
   where
     readThruNextColon :: String -> Parser Text
     readThruNextColon name = takeWhile1P (Just name) (/= ':') <* char ':'
 
-    scopeParse :: Parser Text
-    scopeParse = lexeme (takeWhile1P (Just "scopes") (not . isSpace))
+    scopeParse :: Parser [Text]
+    scopeParse = lexeme $ sepBy (takeWhile1P (Just "scopes") (\c -> not (isSpace c || c == '/'))) (char '/')
 
     isOptional :: Parser Bool
     isOptional =

--- a/src/Strategy/Maven/PluginTree.hs
+++ b/src/Strategy/Maven/PluginTree.hs
@@ -9,7 +9,7 @@ import Data.Char (isSpace)
 import Data.Functor (($>))
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Data.Tree
+import Data.Tree (Tree (Node))
 import Data.Void (Void)
 import Text.Megaparsec (
   Parsec,
@@ -95,5 +95,30 @@ parseTextArtifactAndChildren isDirect =
               <|> pure []
           )
 
+-- | Parse output from the maven depgraph plugin.
+--
+-- The output of the depgraph plugin looks like:
+--
+-- @
+-- org.clojure:clojure:1.12.0-master-SNAPSHOT:compile
+-- +- org.clojure:spec.alpha:0.3.218:compile
+-- +- org.clojure:core.specs.alpha:0.2.62:compile
+-- +- org.clojure:test.generative:1.0.0:test
+-- |  +- org.clojure:tools.namespace:1.0.0:test/compile
+-- |  |  +- org.clojure:java.classpath:1.0.0:test
+-- |  |  \- org.clojure:tools.reader:1.3.2:test
+-- |  \- org.clojure:data.generators:1.0.0:test (optional)
+-- +- org.clojure:test.check:1.1.1:test
+-- \- javax.xml.ws:jaxws-api:2.3.0:test
+--    +- javax.xml.bind:jaxb-api:2.3.0:test
+--    \- javax.xml.soap:javax.xml.soap-api:1.4.0:test
+-- @
+--
+-- The strings after the tree structure text (e.g. '+-', '|', '\-') represent
+-- a maven artifact and have the format
+-- @<groupId>:<artifactId>:<version>:<slash delimited scopes> (optional)@
+-- The final '(optional)' string may or may not be present.
+--
+-- The parser should parse the text into a tree of these artifacts.
 parseTextArtifact :: Parser (Tree TextArtifact)
 parseTextArtifact = parseTextArtifactAndChildren True <* eof

--- a/src/Strategy/Maven/PluginTree.hs
+++ b/src/Strategy/Maven/PluginTree.hs
@@ -67,7 +67,8 @@ parseArtifactChild prefixCount =
     void $ takeWhileP Nothing (\c -> c `notElem` ['\\', '+'])
     pos <- currentColumn
     if pos == prefixCount
-      then
+      then -- The parser is where we expect a child of its parent to be positioned
+
         lexeme (string "+-" <|> string "\\-")
           *> parseTextArtifactAndChildren False
       else fail "can't parse child"

--- a/src/Strategy/Maven/PluginTree.hs
+++ b/src/Strategy/Maven/PluginTree.hs
@@ -9,6 +9,7 @@ module Strategy.Maven.PluginTree (
 import Control.Monad (foldM, void)
 import Data.Char (isSpace)
 import Data.Functor (($>))
+import Data.List (foldl')
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Void (Void)
@@ -29,7 +30,6 @@ import Text.Megaparsec (
  )
 import Text.Megaparsec.Char (char, space1, string)
 import Text.Megaparsec.Char.Lexer qualified as Lexer
-import Data.List (foldl')
 
 type Parser = Parsec Void Text
 
@@ -59,7 +59,8 @@ data TextArtifact = TextArtifact
 foldTextArtifactl :: (a -> TextArtifact -> a) -> a -> TextArtifact -> a
 foldTextArtifactl f a t@(TextArtifact{children = children}) =
   inner `seq` foldl' (foldTextArtifactl f) inner children
-  where inner = f a t
+  where
+    inner = f a t
 
 foldTextArtifactM :: Monad m => (a -> TextArtifact -> m a) -> a -> TextArtifact -> m a
 foldTextArtifactM f a t@TextArtifact{children = children} = do

--- a/src/Strategy/Maven/PluginTree.hs
+++ b/src/Strategy/Maven/PluginTree.hs
@@ -6,10 +6,11 @@ import Data.Char (isSpace)
 import Data.Functor (($>))
 import Data.Text (Text)
 import Data.Void (Void)
-import Text.Megaparsec (Parsec, chunk, takeWhile1P, (<|>), sepBy, count, many)
+import Text.Megaparsec (Parsec, chunk, takeWhile1P, (<|>), sepBy, count, many, try)
 import Text.Megaparsec.Char (char, space1)
 import Text.Megaparsec.Char.Lexer qualified as Lexer
 import qualified Data.Text as Text
+import Debug.Trace (traceShow)
 
 type Parser = Parsec Void Text
 
@@ -55,7 +56,7 @@ data TextArtifact = TextArtifact {
 
 parseArtifactChild :: Int -- ^ Number of recursion levels deep we are
                    -> Parser TextArtifact
-parseArtifactChild level =
+parseArtifactChild level = try $
   (count level (lexeme $ char '|'))
   *> lexeme (chunk "+-"
               <|> chunk "\\-") *> (parseLevelNTextArtifact (succ level))

--- a/src/Strategy/Maven/PluginTree.hs
+++ b/src/Strategy/Maven/PluginTree.hs
@@ -1,6 +1,4 @@
 module Strategy.Maven.PluginTree (
-  parseArtifact,
-  Artifact (..),
   parseTextArtifact,
   TextArtifact (..),
   parseArtifactChild,
@@ -12,20 +10,25 @@ import Data.Functor (($>))
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Void (Void)
-import Text.Megaparsec (Parsec, chunk, count, eof, getSourcePos, sepBy, some, sourceColumn, takeWhile1P, takeWhileP, try, unPos, (<|>))
+import Text.Megaparsec (
+  Parsec,
+  chunk,
+  count,
+  eof,
+  getSourcePos,
+  sepBy,
+  some,
+  sourceColumn,
+  takeWhile1P,
+  takeWhileP,
+  try,
+  unPos,
+  (<|>),
+ )
 import Text.Megaparsec.Char (char, space1, string)
 import Text.Megaparsec.Char.Lexer qualified as Lexer
 
 type Parser = Parsec Void Text
-
-data Artifact = Artifact
-  { artifactGroupId :: Text
-  , artifactArtifactId :: Text
-  , artifactVersion :: Text
-  , artifactScopes :: [Text]
-  , artifactOptional :: Bool
-  }
-  deriving (Show, Eq, Ord)
 
 lexeme :: Parser a -> Parser a
 lexeme = Lexer.lexeme (space1 <|> eof <|> fail "Failed to parse lexeme")
@@ -40,16 +43,6 @@ parseIsOptional :: Parser Bool
 parseIsOptional =
   (chunk "(optional)" $> True)
     <|> pure False
-
--- TODO: Do we actually need this?
-parseArtifact :: Parser Artifact
-parseArtifact =
-  Artifact
-    <$> readThruNextColon "groupId"
-    <*> readThruNextColon "artifactId"
-    <*> readThruNextColon "artifactVersion"
-    <*> scopeParse
-    <*> parseIsOptional
 
 data TextArtifact = TextArtifact
   { artifactText :: Text

--- a/src/Strategy/Maven/PluginTree.hs
+++ b/src/Strategy/Maven/PluginTree.hs
@@ -1,0 +1,48 @@
+module Strategy.Maven.PluginTree (parseArtifact
+                                 , Artifact(..)) where
+
+import Data.Char (isSpace)
+import Data.Functor (($>))
+import Data.List (singleton)
+import Data.Text (Text)
+import Data.Void (Void)
+import Text.Megaparsec (Parsec, chunk, takeWhile1P, (<|>))
+import Text.Megaparsec.Char (char, space1)
+import Text.Megaparsec.Char.Lexer qualified as Lexer
+
+type Parser = Parsec Void Text
+
+data Artifact = Artifact
+  { artifactGroupId :: Text
+  , artifactArtifactId :: Text
+  , artifactVersion :: Text
+  , artifactScopes :: [Text]
+  , artifactOptional :: Bool
+  }
+  deriving (Show, Eq, Ord)
+
+lexeme :: Parser a -> Parser a
+lexeme = Lexer.lexeme space1
+
+parseArtifact :: Parser Artifact
+parseArtifact =
+  Artifact
+    <$> readThruNextColon "groupId"
+    <*> readThruNextColon "artifactId"
+    <*> readThruNextColon "artifactVersion"
+    -- based on  the maven documentation, it  seems there can be  only one scope
+    -- for a given rtifact even though maven-depgraph-plugin returns an array
+    -- of strings in the json output
+    <*> (singleton <$> scopeParse)
+    <*> isOptional
+  where
+    readThruNextColon :: String -> Parser Text
+    readThruNextColon name = takeWhile1P (Just name) (/= ':') <* char ':'
+
+    scopeParse :: Parser Text
+    scopeParse = lexeme (takeWhile1P (Just "scopes") (not . isSpace))
+
+    isOptional :: Parser Bool
+    isOptional =
+      (chunk "(optional)" $> True)
+        <|> pure False

--- a/src/Strategy/Maven/PluginTree.hs
+++ b/src/Strategy/Maven/PluginTree.hs
@@ -65,54 +65,6 @@ foldTextArtifactM f a t@TextArtifact{children = children} = do
   res <- f a t
   foldM (foldTextArtifactM f) res children
 
-artifactWithChildren :: TextArtifact
-artifactWithChildren =
-  TextArtifact
-    { artifactText = "org.clojure:test.generative:1.0.0"
-    , scopes = ["test"]
-    , isOptional = False
-    , children =
-        [ TextArtifact
-            { artifactText = "org.clojure:tools.namespace:1.0.0"
-            , scopes = ["test"]
-            , isOptional = False
-            , children =
-                [ TextArtifact
-                    { artifactText = "org.clojure:java.classpath:1.0.0"
-                    , scopes = ["test"]
-                    , children = []
-                    , isOptional = False
-                    }
-                , TextArtifact
-                    { artifactText = "org.fake:fake-pkg:1.0.0"
-                    , scopes = ["compile"]
-                    , children = []
-                    , isOptional = True
-                    }
-                , TextArtifact
-                    { artifactText = "org.clojure:tools.reader:1.3.2"
-                    , scopes = ["test"]
-                    , children = []
-                    , isOptional = False
-                    }
-                ]
-            }
-        , TextArtifact
-            { artifactText = "org.foo:bar:1.0.0"
-            , scopes = ["compile"]
-            , isOptional = False
-            , children =
-                [ TextArtifact
-                    { artifactText = "org.baz:buzz:1.0.0"
-                    , scopes = ["test"]
-                    , children = []
-                    , isOptional = False
-                    }
-                ]
-            }
-        ]
-    }
-
 currentColumn :: Parser Int
 currentColumn = unPos . sourceColumn <$> getSourcePos
 

--- a/test/Maven/PluginSpec.hs
+++ b/test/Maven/PluginSpec.hs
@@ -3,7 +3,7 @@ module Maven.PluginSpec (spec) where
 import Strategy.Maven.Plugin (Artifact (..), Edge (..), PluginOutput (..), textArtifactToPluginOutput)
 import Strategy.Maven.PluginTree (TextArtifact (..))
 import Test.Effect (it', shouldBe')
-import Test.Hspec (Spec, fdescribe, describe)
+import Test.Hspec (Spec, describe)
 
 spec :: Spec
 spec = do
@@ -25,7 +25,7 @@ complexTextArtifact =
   TextArtifact
     { artifactText = "org.clojure:test.generative:1.0.0"
     , scopes = ["test"]
-    , isDirect = False
+    , isDirect = True
     , isOptional = False
     , children =
         [ TextArtifact
@@ -71,7 +71,7 @@ complexPluginOutputArtifacts =
             , artifactVersion = "1.0.0"
             , artifactScopes = ["test"]
             , artifactOptional = False
-            , artifactIsDirect = True
+            , artifactIsDirect = False
             }
         , Artifact
             { artifactNumericId = 1
@@ -107,7 +107,7 @@ complexPluginOutputArtifacts =
             , artifactVersion = "1.0.0"
             , artifactScopes = ["test"]
             , artifactOptional = False
-            , artifactIsDirect = False
+            , artifactIsDirect = True
             }
         ]
     , outEdges =
@@ -117,9 +117,6 @@ complexPluginOutputArtifacts =
         , Edge 4 0
         ]
     }
-
--- TODO: because we use sets, there is no set internal order here so matching the numeric id is difficult without
--- some kind of sort
 
 textArtifactConversionSpec :: Spec
 textArtifactConversionSpec =
@@ -132,7 +129,7 @@ textArtifactConversionSpec =
           , outEdges = []
           }
 
-    it' "Converts a more complext TextArtifact correctly" $ do
+    it' "Converts a more complex TextArtifact correctly" $ do
       pluginOutput <- textArtifactToPluginOutput complexTextArtifact
       pluginOutput `shouldBe'` complexPluginOutputArtifacts
 
@@ -145,5 +142,5 @@ simpleArtifact =
     , artifactVersion = "1.12.0-master-SNAPSHOT"
     , artifactOptional = False
     , artifactScopes = ["test"]
-    , artifactIsDirect = False
+    , artifactIsDirect = True
     }

--- a/test/Maven/PluginSpec.hs
+++ b/test/Maven/PluginSpec.hs
@@ -1,22 +1,22 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module Maven.PluginSpec (spec) where
 
 import Data.Tree (Tree (..))
 import Strategy.Maven.Plugin (Artifact (..), Edge (..), PluginOutput (..), textArtifactToPluginOutput)
 import Strategy.Maven.PluginTree (TextArtifact (..))
 import Test.Effect (it', shouldBe', shouldMatchList')
-import Test.Hspec (Spec, describe, fdescribe)
+import Test.Hspec (Spec, describe)
 
 spec :: Spec
 spec = do
-  -- TODO: Consider moving this to PluginStrategySpec.hs
   textArtifactConversionSpec
 
 singleTextArtifact :: TextArtifact
 singleTextArtifact =
   TextArtifact
     { artifactText = "org.clojure:clojure:1.12.0-master-SNAPSHOT"
+    , groupId = "org.clojure"
+    , artifactId = "clojure"
+    , textArtifactVersion = "1.12.0-master-SNAPSHOT"
     , scopes = ["test"]
     , isDirect = True
     , isOptional = False
@@ -27,6 +27,9 @@ complexTextArtifact =
   Node
     TextArtifact
       { artifactText = "org.clojure:test.generative:1.0.0"
+      , groupId = "org.clojure"
+      , artifactId = "test.generative"
+      , textArtifactVersion = "1.0.0"
       , scopes = ["test"]
       , isDirect = True
       , isOptional = False
@@ -34,6 +37,9 @@ complexTextArtifact =
     [ Node
         TextArtifact
           { artifactText = "org.fake:fake-pkg:1.0.0"
+          , groupId = "org.fake"
+          , artifactId = "fake-pkg"
+          , textArtifactVersion = "1.0.0"
           , scopes = ["compile"]
           , isDirect = False
           , isOptional = True
@@ -42,6 +48,9 @@ complexTextArtifact =
     , Node
         TextArtifact
           { artifactText = "org.foo:bar:1.0.0"
+          , groupId = "org.foo"
+          , artifactId = "bar"
+          , textArtifactVersion = "1.0.0"
           , isDirect = False
           , scopes = ["compile"]
           , isOptional = False
@@ -49,6 +58,9 @@ complexTextArtifact =
         [ Node
             TextArtifact
               { artifactText = "org.baz:buzz:1.0.0"
+              , groupId = "org.baz"
+              , artifactId = "buzz"
+              , textArtifactVersion = "1.0.0"
               , isDirect = False
               , scopes = ["test"]
               , isOptional = False
@@ -58,6 +70,9 @@ complexTextArtifact =
     , Node
         TextArtifact
           { artifactText = "org.clojure:data.generators:1.0.0"
+          , groupId = "org.clojure"
+          , artifactId = "data.generators"
+          , textArtifactVersion = "1.0.0"
           , isDirect = False
           , scopes = ["test"]
           , isOptional = False

--- a/test/Maven/PluginSpec.hs
+++ b/test/Maven/PluginSpec.hs
@@ -1,15 +1,9 @@
 module Maven.PluginSpec (spec) where
 
-import Data.Aeson (decode)
-import Data.Either (fromRight)
-import Data.Set qualified as Set
-import Data.String.Conversion (encodeUtf8)
-import Data.Text (Text)
-import Strategy.Maven.Plugin (Artifact (..), PluginOutput (..), textArtifactToPluginOutput)
+import Strategy.Maven.Plugin (Artifact (..), Edge (..), PluginOutput (..), textArtifactToPluginOutput)
 import Strategy.Maven.PluginTree (TextArtifact (..))
 import Test.Effect (it', shouldBe')
-import Test.Hspec (Spec, describe, fdescribe, it, shouldBe, shouldMatchList, shouldSatisfy)
-import Text.RawString.QQ (r)
+import Test.Hspec (Spec, fdescribe)
 
 spec :: Spec
 spec = do
@@ -50,6 +44,12 @@ complexTextArtifact =
                     }
                 ]
             }
+        , TextArtifact
+            { artifactText = "org.clojure:data.generators:1.0.0"
+            , scopes = ["test"]
+            , isOptional = False
+            , children = []
+            }
         ]
     }
 
@@ -59,6 +59,14 @@ complexPluginOutputArtifacts =
     { outArtifacts =
         [ Artifact
             { artifactNumericId = 0
+            , artifactGroupId = "org.clojure"
+            , artifactArtifactId = "data.generators"
+            , artifactVersion = "1.0.0"
+            , artifactScopes = ["test"]
+            , artifactOptional = False
+            }
+        , Artifact
+            { artifactNumericId = 1
             , artifactGroupId = "org.baz"
             , artifactArtifactId = "buzz"
             , artifactVersion = "1.0.0"
@@ -66,7 +74,7 @@ complexPluginOutputArtifacts =
             , artifactOptional = False
             }
         , Artifact
-            { artifactNumericId = 1
+            { artifactNumericId = 2
             , artifactGroupId = "org.foo"
             , artifactArtifactId = "bar"
             , artifactVersion = "1.0.0"
@@ -74,7 +82,7 @@ complexPluginOutputArtifacts =
             , artifactOptional = False
             }
         , Artifact
-            { artifactNumericId = 2
+            { artifactNumericId = 3
             , artifactGroupId = "org.fake"
             , artifactArtifactId = "fake-pkg"
             , artifactVersion = "1.0.0"
@@ -82,7 +90,7 @@ complexPluginOutputArtifacts =
             , artifactOptional = True
             }
         , Artifact
-            { artifactNumericId = 3
+            { artifactNumericId = 4
             , artifactGroupId = "org.clojure"
             , artifactArtifactId = "test.generative"
             , artifactVersion = "1.0.0"
@@ -90,7 +98,12 @@ complexPluginOutputArtifacts =
             , artifactOptional = False
             }
         ]
-    , outEdges = []
+    , outEdges =
+        [ Edge 2 1
+        , Edge 4 3
+        , Edge 4 2
+        , Edge 4 0
+        ]
     }
 
 -- TODO: because we use sets, there is no set internal order here so matching the numeric id is difficult without

--- a/test/Maven/PluginSpec.hs
+++ b/test/Maven/PluginSpec.hs
@@ -3,10 +3,11 @@ module Maven.PluginSpec (spec) where
 import Strategy.Maven.Plugin (Artifact (..), Edge (..), PluginOutput (..), textArtifactToPluginOutput)
 import Strategy.Maven.PluginTree (TextArtifact (..))
 import Test.Effect (it', shouldBe')
-import Test.Hspec (Spec, fdescribe)
+import Test.Hspec (Spec, fdescribe, describe)
 
 spec :: Spec
 spec = do
+  -- TODO: Consider moving this to PluginStrategySpec.hs
   textArtifactConversionSpec
 
 singleTextArtifact :: TextArtifact
@@ -14,6 +15,7 @@ singleTextArtifact =
   TextArtifact
     { artifactText = "org.clojure:clojure:1.12.0-master-SNAPSHOT"
     , scopes = ["test"]
+    , isDirect = True
     , isOptional = False
     , children = []
     }
@@ -23,21 +25,25 @@ complexTextArtifact =
   TextArtifact
     { artifactText = "org.clojure:test.generative:1.0.0"
     , scopes = ["test"]
+    , isDirect = False
     , isOptional = False
     , children =
         [ TextArtifact
             { artifactText = "org.fake:fake-pkg:1.0.0"
             , scopes = ["compile"]
+            , isDirect = False
             , children = []
             , isOptional = True
             }
         , TextArtifact
             { artifactText = "org.foo:bar:1.0.0"
+            , isDirect = False
             , scopes = ["compile"]
             , isOptional = False
             , children =
                 [ TextArtifact
                     { artifactText = "org.baz:buzz:1.0.0"
+                    , isDirect = False
                     , scopes = ["test"]
                     , children = []
                     , isOptional = False
@@ -46,6 +52,7 @@ complexTextArtifact =
             }
         , TextArtifact
             { artifactText = "org.clojure:data.generators:1.0.0"
+            , isDirect = False
             , scopes = ["test"]
             , isOptional = False
             , children = []
@@ -64,6 +71,7 @@ complexPluginOutputArtifacts =
             , artifactVersion = "1.0.0"
             , artifactScopes = ["test"]
             , artifactOptional = False
+            , artifactIsDirect = True
             }
         , Artifact
             { artifactNumericId = 1
@@ -72,6 +80,7 @@ complexPluginOutputArtifacts =
             , artifactVersion = "1.0.0"
             , artifactScopes = ["test"]
             , artifactOptional = False
+            , artifactIsDirect = False
             }
         , Artifact
             { artifactNumericId = 2
@@ -80,6 +89,7 @@ complexPluginOutputArtifacts =
             , artifactVersion = "1.0.0"
             , artifactScopes = ["compile"]
             , artifactOptional = False
+            , artifactIsDirect = False
             }
         , Artifact
             { artifactNumericId = 3
@@ -88,6 +98,7 @@ complexPluginOutputArtifacts =
             , artifactVersion = "1.0.0"
             , artifactScopes = ["compile"]
             , artifactOptional = True
+            , artifactIsDirect = False
             }
         , Artifact
             { artifactNumericId = 4
@@ -96,6 +107,7 @@ complexPluginOutputArtifacts =
             , artifactVersion = "1.0.0"
             , artifactScopes = ["test"]
             , artifactOptional = False
+            , artifactIsDirect = False
             }
         ]
     , outEdges =
@@ -111,7 +123,7 @@ complexPluginOutputArtifacts =
 
 textArtifactConversionSpec :: Spec
 textArtifactConversionSpec =
-  fdescribe "Maven text artifact tree conversion" $ do
+  describe "Maven text artifact -> PluginOutput conversion" $ do
     it' "Converts a single TextArtifact correctly" $ do
       pluginOutput <- textArtifactToPluginOutput singleTextArtifact
       pluginOutput
@@ -133,4 +145,5 @@ simpleArtifact =
     , artifactVersion = "1.12.0-master-SNAPSHOT"
     , artifactOptional = False
     , artifactScopes = ["test"]
+    , artifactIsDirect = False
     }

--- a/test/Maven/PluginSpec.hs
+++ b/test/Maven/PluginSpec.hs
@@ -6,8 +6,7 @@ import Data.Aeson (decode)
 import Data.String.Conversion (encodeUtf8)
 import Data.Text (Text)
 import Strategy.Maven.Plugin (Artifact (..))
-import Test.Hspec (Spec, describe, fcontext, it, shouldBe)
-import Text.Megaparsec (ParseErrorBundle, Parsec, runParser)
+import Test.Hspec (Spec, describe, it, shouldBe)
 import Text.RawString.QQ (r)
 
 jsonArtifact :: Text

--- a/test/Maven/PluginSpec.hs
+++ b/test/Maven/PluginSpec.hs
@@ -5,16 +5,10 @@ module Maven.PluginSpec (spec) where
 import Data.Aeson (decode)
 import Data.String.Conversion (encodeUtf8)
 import Data.Text (Text)
-import Strategy.Maven.Plugin (Artifact (..), parseArtifact)
+import Strategy.Maven.Plugin (Artifact (..))
 import Test.Hspec (Spec, describe, fcontext, it, shouldBe)
 import Text.Megaparsec (ParseErrorBundle, Parsec, runParser)
 import Text.RawString.QQ (r)
-
-shouldParse :: Parsec e s a -> s -> Either (ParseErrorBundle s e) a
-shouldParse parser = runParser parser ""
-
-to :: (Show a1, Show a2, Eq a2) => Either a1 a2 -> a2 -> IO ()
-to parsed expected = either (fail . show) (`shouldBe` expected) parsed
 
 jsonArtifact :: Text
 jsonArtifact =
@@ -32,19 +26,12 @@ jsonArtifact =
 spec :: Spec
 spec = do
   parseJsonArtifactSpec
-  parseTextArtifactSpec
 
 parseJsonArtifactSpec :: Spec
 parseJsonArtifactSpec = do
   describe "json Artifact parsing" $ do
     it "Parses an artifact from JSON" $
       (decode . encodeUtf8 $ jsonArtifact) `shouldBe` Just simpleArtifact
-
-simpleArtifactString :: Text
-simpleArtifactString = "org.clojure:clojure:1.12.0-master-SNAPSHOT:compile "
-
-optionalArtifactString :: Text
-optionalArtifactString = "jakarta.mail:jakarta.mail-api:2.0.1:compile (optional)"
 
 simpleArtifact :: Artifact
 simpleArtifact =
@@ -56,21 +43,3 @@ simpleArtifact =
     , artifactOptional = False
     , artifactScopes = ["compile"]
     }
-
-optionalArtifact :: Artifact
-optionalArtifact =
-  Artifact
-    { artifactNumericId = 0
-    , artifactGroupId = "jakarta.mail"
-    , artifactArtifactId = "jakarta.mail-api"
-    , artifactVersion = "2.0.1"
-    , artifactScopes = ["compile"]
-    , artifactOptional = True
-    }
-
-parseTextArtifactSpec :: Spec
-parseTextArtifactSpec = do
-  it "Parses an artifact from a string" $
-    parseArtifact 0 `shouldParse` simpleArtifactString `to` simpleArtifact
-  it "Parses an optional artifact from a string" $
-    parseArtifact 0 `shouldParse` optionalArtifactString `to` optionalArtifact

--- a/test/Maven/PluginSpec.hs
+++ b/test/Maven/PluginSpec.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Maven.PluginSpec (spec) where
+
+import Data.Aeson (decode)
+import Data.String.Conversion (encodeUtf8)
+import Data.Text (Text)
+import Strategy.Maven.Plugin (Artifact (..), parseArtifact)
+import Test.Hspec (Spec, describe, fcontext, it, shouldBe)
+import Text.Megaparsec (ParseErrorBundle, Parsec, runParser)
+import Text.RawString.QQ (r)
+
+shouldParse :: Parsec e s a -> s -> Either (ParseErrorBundle s e) a
+shouldParse parser = runParser parser ""
+
+to :: (Show a1, Show a2, Eq a2) => Either a1 a2 -> a2 -> IO ()
+to parsed expected = either (fail . show) (`shouldBe` expected) parsed
+
+jsonArtifact :: Text
+jsonArtifact =
+  [r|{
+    "id" : "org.clojure:clojure:jar",
+    "numericId" : 1,
+    "groupId" : "org.clojure",
+    "artifactId" : "clojure",
+    "version" : "1.12.0-master-SNAPSHOT",
+    "optional" : false,
+    "scopes" : [ "compile" ],
+    "types" : [ "jar" ]
+  }|]
+
+spec :: Spec
+spec = do
+  parseJsonArtifactSpec
+  parseTextArtifactSpec
+
+parseJsonArtifactSpec :: Spec
+parseJsonArtifactSpec = do
+  describe "json Artifact parsing" $ do
+    it "Parses an artifact from JSON" $
+      (decode . encodeUtf8 $ jsonArtifact) `shouldBe` Just simpleArtifact
+
+simpleArtifactString :: Text
+simpleArtifactString = "org.clojure:clojure:1.12.0-master-SNAPSHOT:compile "
+
+optionalArtifactString :: Text
+optionalArtifactString = "jakarta.mail:jakarta.mail-api:2.0.1:compile (optional)"
+
+simpleArtifact :: Artifact
+simpleArtifact =
+  Artifact
+    { artifactNumericId = 0
+    , artifactGroupId = "org.clojure"
+    , artifactArtifactId = "clojure"
+    , artifactVersion = "1.12.0-master-SNAPSHOT"
+    , artifactOptional = False
+    , artifactScopes = ["compile"]
+    }
+
+optionalArtifact :: Artifact
+optionalArtifact =
+  Artifact
+    { artifactNumericId = 0
+    , artifactGroupId = "jakarta.mail"
+    , artifactArtifactId = "jakarta.mail-api"
+    , artifactVersion = "2.0.1"
+    , artifactScopes = ["compile"]
+    , artifactOptional = True
+    }
+
+parseTextArtifactSpec :: Spec
+parseTextArtifactSpec = do
+  it "Parses an artifact from a string" $
+    parseArtifact 0 `shouldParse` simpleArtifactString `to` simpleArtifact
+  it "Parses an optional artifact from a string" $
+    parseArtifact 0 `shouldParse` optionalArtifactString `to` optionalArtifact

--- a/test/Maven/PluginSpec.hs
+++ b/test/Maven/PluginSpec.hs
@@ -7,6 +7,7 @@ import Data.String.Conversion (encodeUtf8)
 import Data.Text (Text)
 import Strategy.Maven.Plugin (Artifact (..), PluginOutput (..), textArtifactToPluginOutput)
 import Strategy.Maven.PluginTree (TextArtifact (..))
+import Test.Effect (it', shouldBe')
 import Test.Hspec (Spec, describe, fdescribe, it, shouldBe, shouldMatchList, shouldSatisfy)
 import Text.RawString.QQ (r)
 
@@ -52,41 +53,45 @@ complexTextArtifact =
         ]
     }
 
-complexPluginOutputArtifacts :: [Artifact]
+complexPluginOutputArtifacts :: PluginOutput
 complexPluginOutputArtifacts =
-  [ Artifact
-      { artifactNumericId = 0
-      , artifactGroupId = "org.baz"
-      , artifactArtifactId = "buzz"
-      , artifactVersion = "1.0.0"
-      , artifactScopes = ["test"]
-      , artifactOptional = False
-      }
-  , Artifact
-      { artifactNumericId = 1
-      , artifactGroupId = "org.foo"
-      , artifactArtifactId = "bar"
-      , artifactVersion = "1.0.0"
-      , artifactScopes = ["compile"]
-      , artifactOptional = False
-      }
-  , Artifact
-      { artifactNumericId = 2
-      , artifactGroupId = "org.fake"
-      , artifactArtifactId = "fake-pkg"
-      , artifactVersion = "1.0.0"
-      , artifactScopes = ["compile"]
-      , artifactOptional = True
-      }
-  , Artifact
-      { artifactNumericId = 3
-      , artifactGroupId = "org.clojure"
-      , artifactArtifactId = "test.generative"
-      , artifactVersion = "1.0.0"
-      , artifactScopes = ["test"]
-      , artifactOptional = False
-      }
-  ]
+  PluginOutput
+    { outArtifacts =
+        [ Artifact
+            { artifactNumericId = 0
+            , artifactGroupId = "org.baz"
+            , artifactArtifactId = "buzz"
+            , artifactVersion = "1.0.0"
+            , artifactScopes = ["test"]
+            , artifactOptional = False
+            }
+        , Artifact
+            { artifactNumericId = 1
+            , artifactGroupId = "org.foo"
+            , artifactArtifactId = "bar"
+            , artifactVersion = "1.0.0"
+            , artifactScopes = ["compile"]
+            , artifactOptional = False
+            }
+        , Artifact
+            { artifactNumericId = 2
+            , artifactGroupId = "org.fake"
+            , artifactArtifactId = "fake-pkg"
+            , artifactVersion = "1.0.0"
+            , artifactScopes = ["compile"]
+            , artifactOptional = True
+            }
+        , Artifact
+            { artifactNumericId = 3
+            , artifactGroupId = "org.clojure"
+            , artifactArtifactId = "test.generative"
+            , artifactVersion = "1.0.0"
+            , artifactScopes = ["test"]
+            , artifactOptional = False
+            }
+        ]
+    , outEdges = []
+    }
 
 -- TODO: because we use sets, there is no set internal order here so matching the numeric id is difficult without
 -- some kind of sort
@@ -94,20 +99,17 @@ complexPluginOutputArtifacts =
 textArtifactConversionSpec :: Spec
 textArtifactConversionSpec =
   fdescribe "Maven text artifact tree conversion" $ do
-    it "Converts a single TextArtifact correctly" $
-      textArtifactToPluginOutput singleTextArtifact
-        `shouldBe` Right
-          PluginOutput
-            { outArtifacts = [simpleArtifact]
-            , outEdges = []
-            }
+    it' "Converts a single TextArtifact correctly" $ do
+      pluginOutput <- textArtifactToPluginOutput singleTextArtifact
+      pluginOutput
+        `shouldBe'` PluginOutput
+          { outArtifacts = [simpleArtifact]
+          , outEdges = []
+          }
 
-    it "Converts a more complext TextArtifact correctly" $ do
-      let PluginOutput{outArtifacts = artifacts} =
-            fromRight
-              (error "This test should not have failed")
-              (textArtifactToPluginOutput complexTextArtifact)
-      artifacts `shouldBe` complexPluginOutputArtifacts
+    it' "Converts a more complext TextArtifact correctly" $ do
+      pluginOutput <- textArtifactToPluginOutput complexTextArtifact
+      pluginOutput `shouldBe'` complexPluginOutputArtifacts
 
 simpleArtifact :: Artifact
 simpleArtifact =

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -63,6 +63,37 @@ mavenOutput =
         ]
     }
 
+mavenOutputWithDirects :: PluginOutput
+mavenOutputWithDirects =
+  PluginOutput
+    { outArtifacts =
+        [ Artifact
+            { artifactNumericId = 0
+            , artifactGroupId = "mygroup"
+            , artifactArtifactId = "packageOne"
+            , artifactVersion = "1.0.0"
+            , artifactOptional = False
+            , artifactScopes = ["compile", "test"]
+            , artifactIsDirect = True
+            }
+        , Artifact
+            { artifactNumericId = 1
+            , artifactGroupId = "mygroup"
+            , artifactArtifactId = "packageTwo"
+            , artifactVersion = "2.0.0"
+            , artifactOptional = True
+            , artifactScopes = ["compile"]
+            , artifactIsDirect = False
+            }
+        ]
+    , outEdges =
+        [ Edge
+            { edgeFrom = 0
+            , edgeTo = 1
+            }
+        ]
+    }
+
 spec :: Spec
 spec = do
   describe "buildGraph" $ do
@@ -72,3 +103,10 @@ spec = do
       expectDeps [packageOne, packageTwo] graph
       expectDirect [] graph
       expectEdges [(packageOne, packageTwo)] graph
+
+    it "Should promote children of root dep(s) to direct" $ do
+      let graph = buildGraph mavenOutputWithDirects
+      expectDeps [packageTwo] graph
+      expectDirect [packageTwo] graph
+      expectEdges [] graph
+      

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -43,6 +43,7 @@ mavenOutput =
             , artifactVersion = "1.0.0"
             , artifactOptional = False
             , artifactScopes = ["compile", "test"]
+            , artifactIsDirect = False
             }
         , Artifact
             { artifactNumericId = 1
@@ -51,6 +52,7 @@ mavenOutput =
             , artifactVersion = "2.0.0"
             , artifactOptional = True
             , artifactScopes = ["compile"]
+            , artifactIsDirect = False
             }
         ]
     , outEdges =

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -40,8 +40,7 @@ packageFour =
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = mempty
-    , dependencyTags = Map.fromList [("scopes", ["compile"])]
-    }
+    , dependencyTags = Map.fromList [("scopes", ["compile"])]}
 
 mavenOutput :: PluginOutput
 mavenOutput =
@@ -106,8 +105,7 @@ mavenOutputWithDirects =
     }
 
 mavenMultimoduleOutputWithDirects :: PluginOutput
-mavenMultimoduleOutputWithDirects =
-  PluginOutput
+mavenMultimoduleOutputWithDirects = PluginOutput
     { outArtifacts =
         [ Artifact
             { artifactNumericId = 0
@@ -152,6 +150,55 @@ mavenMultimoduleOutputWithDirects =
         ]
     }
 
+    
+mavenCrossDependentSubModules :: PluginOutput
+mavenCrossDependentSubModules =
+  PluginOutput
+    { outArtifacts =
+        [ Artifact
+            { artifactNumericId = 0
+            , artifactGroupId = "mygroup"
+            , artifactArtifactId = "packageOne"
+            , artifactVersion = "1.0.0"
+            , artifactOptional = False
+            , artifactScopes = ["compile", "test"]
+            , artifactIsDirect = True
+            }
+        , Artifact
+            { artifactNumericId = 1
+            , artifactGroupId = "mygroup"
+            , artifactArtifactId = "packageTwo"
+            , artifactVersion = "2.0.0"
+            , artifactOptional = True
+            , artifactScopes = ["compile"]
+            , artifactIsDirect = False
+            }
+        , Artifact
+            { artifactNumericId = 2
+            , artifactGroupId = "mygroup"
+            , artifactArtifactId = "packageThree"
+            , artifactVersion = "3.0.0"
+            , artifactOptional = False
+            , artifactScopes = ["compile"]
+            , artifactIsDirect = True
+            }
+        , Artifact
+            { artifactNumericId = 3
+            , artifactGroupId = "mygroup2"
+            , artifactArtifactId = "packageFour"
+            , artifactVersion = "4.0.0"
+            , artifactOptional = False
+            , artifactScopes = ["compile"]
+            , artifactIsDirect = False
+            }
+        ]
+    , outEdges =
+        [ Edge 0 1
+        , Edge 2 3
+        , Edge 3 0
+        ]
+    }
+
 spec :: Spec
 spec = do
   fdescribe "buildGraph" $ do
@@ -173,3 +220,9 @@ spec = do
       expectDeps [packageTwo, packageFour] graph
       expectDirect [packageTwo, packageFour] graph
       expectEdges [] graph
+
+    it "Should remove cross dependent submodules in multimodule projects" $ do
+      let graph = buildGraph mavenCrossDependentSubModules
+      expectDeps [packageTwo, packageFour] graph
+      expectDirect [packageTwo, packageFour] graph
+      expectEdges [(packageFour, packageTwo)] graph

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -4,11 +4,31 @@ module Maven.PluginStrategySpec (
 
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
-import DepTypes
-import GraphUtil
-import Strategy.Maven.Plugin
-import Strategy.Maven.PluginStrategy
-import Test.Hspec
+import DepTypes (
+  DepEnvironment (EnvTesting),
+  DepType (MavenType),
+  Dependency (..),
+  VerConstraint (CEq),
+ )
+import GraphUtil (expectDeps, expectDirect, expectEdges)
+import Strategy.Maven.Plugin (
+  Artifact (
+    Artifact,
+    artifactArtifactId,
+    artifactGroupId,
+    artifactIsDirect,
+    artifactNumericId,
+    artifactOptional,
+    artifactScopes,
+    artifactVersion
+  ),
+  Edge (Edge, edgeFrom, edgeTo),
+  PluginOutput (..),
+  ReactorArtifact (..),
+  ReactorOutput (..),
+ )
+import Strategy.Maven.PluginStrategy (buildGraph)
+import Test.Hspec (Spec, describe, it)
 
 packageOne :: Dependency
 packageOne =
@@ -40,7 +60,8 @@ packageFour =
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
     , dependencyEnvironments = mempty
-    , dependencyTags = Map.fromList [("scopes", ["compile"])]}
+    , dependencyTags = Map.fromList [("scopes", ["compile"])]
+    }
 
 mavenOutput :: PluginOutput
 mavenOutput =
@@ -105,54 +126,7 @@ mavenOutputWithDirects =
     }
 
 mavenMultimoduleOutputWithDirects :: PluginOutput
-mavenMultimoduleOutputWithDirects = PluginOutput
-    { outArtifacts =
-        [ Artifact
-            { artifactNumericId = 0
-            , artifactGroupId = "mygroup"
-            , artifactArtifactId = "packageOne"
-            , artifactVersion = "1.0.0"
-            , artifactOptional = False
-            , artifactScopes = ["compile", "test"]
-            , artifactIsDirect = True
-            }
-        , Artifact
-            { artifactNumericId = 1
-            , artifactGroupId = "mygroup"
-            , artifactArtifactId = "packageTwo"
-            , artifactVersion = "2.0.0"
-            , artifactOptional = True
-            , artifactScopes = ["compile"]
-            , artifactIsDirect = False
-            }
-        , Artifact
-            { artifactNumericId = 2
-            , artifactGroupId = "mygroup"
-            , artifactArtifactId = "packageThree"
-            , artifactVersion = "3.0.0"
-            , artifactOptional = False
-            , artifactScopes = ["compile"]
-            , artifactIsDirect = True
-            }
-        , Artifact
-            { artifactNumericId = 3
-            , artifactGroupId = "mygroup2"
-            , artifactArtifactId = "packageFour"
-            , artifactVersion = "4.0.0"
-            , artifactOptional = False
-            , artifactScopes = ["compile"]
-            , artifactIsDirect = False
-            }
-        ]
-    , outEdges =
-        [ Edge 0 1
-        , Edge 2 3
-        ]
-    }
-
-    
-mavenCrossDependentSubModules :: PluginOutput
-mavenCrossDependentSubModules =
+mavenMultimoduleOutputWithDirects =
   PluginOutput
     { outArtifacts =
         [ Artifact
@@ -195,34 +169,83 @@ mavenCrossDependentSubModules =
     , outEdges =
         [ Edge 0 1
         , Edge 2 3
+        ]
+    }
+
+mavenCrossDependentSubModules :: PluginOutput
+mavenCrossDependentSubModules =
+  PluginOutput
+    { outArtifacts =
+        [ Artifact
+            { artifactNumericId = 0
+            , artifactGroupId = "mygroup"
+            , artifactArtifactId = "packageOne"
+            , artifactVersion = "1.0.0"
+            , artifactOptional = False
+            , artifactScopes = ["compile", "test"]
+            , artifactIsDirect = True
+            }
+        , Artifact
+            { artifactNumericId = 1
+            , artifactGroupId = "mygroup"
+            , artifactArtifactId = "packageTwo"
+            , artifactVersion = "2.0.0"
+            , artifactOptional = True
+            , artifactScopes = ["compile"]
+            , artifactIsDirect = False
+            }
+        , Artifact
+            { artifactNumericId = 2
+            , artifactGroupId = "mygroup"
+            , artifactArtifactId = "packageThree"
+            , artifactVersion = "3.0.0"
+            , artifactOptional = False
+            , artifactScopes = ["compile"]
+            , artifactIsDirect = False
+            }
+        , Artifact
+            { artifactNumericId = 3
+            , artifactGroupId = "mygroup2"
+            , artifactArtifactId = "packageFour"
+            , artifactVersion = "4.0.0"
+            , artifactOptional = False
+            , artifactScopes = ["compile"]
+            , artifactIsDirect = False
+            }
+        ]
+    , outEdges =
+        [ Edge 0 1
+        , Edge 2 3
         , Edge 3 0
         ]
     }
 
 spec :: Spec
 spec = do
-  fdescribe "buildGraph" $ do
+  describe "buildGraph" $ do
     it "should produce expected output" $ do
-      let graph = buildGraph mavenOutput
+      let graph = buildGraph (ReactorOutput []) mavenOutput
 
       expectDeps [packageOne, packageTwo] graph
       expectDirect [] graph
       expectEdges [(packageOne, packageTwo)] graph
 
     it "Should promote children of root dep(s) to direct" $ do
-      let graph = buildGraph mavenOutputWithDirects
+      let graph = buildGraph (ReactorOutput []) mavenOutputWithDirects
       expectDeps [packageTwo] graph
       expectDirect [packageTwo] graph
       expectEdges [] graph
 
     it "Should promote children of root dep(s) to direct in multimodule projects" $ do
-      let graph = buildGraph mavenMultimoduleOutputWithDirects
+      let graph = buildGraph (ReactorOutput []) mavenMultimoduleOutputWithDirects
       expectDeps [packageTwo, packageFour] graph
       expectDirect [packageTwo, packageFour] graph
       expectEdges [] graph
 
-    it "Should remove cross dependent submodules in multimodule projects" $ do
-      let graph = buildGraph mavenCrossDependentSubModules
-      expectDeps [packageTwo, packageFour] graph
+    let graph = buildGraph (ReactorOutput [ReactorArtifact "packageThree"]) mavenCrossDependentSubModules
+    it "Should mark top-level graph artifacts and known submodules as direct, then shrinkRoots" $ do
       expectDirect [packageTwo, packageFour] graph
+
+    it "Should remove submodules in projects where submodules depend on eachother" $ do
+      expectDeps [packageTwo, packageFour] graph
       expectEdges [(packageFour, packageTwo)] graph

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -72,7 +72,7 @@ mavenOutputWithDirects =
             , artifactGroupId = "mygroup"
             , artifactArtifactId = "packageOne"
             , artifactVersion = "1.0.0"
-            , artifactOptional = False
+            , artifactOptional = True
             , artifactScopes = ["compile", "test"]
             , artifactIsDirect = True
             }
@@ -109,4 +109,3 @@ spec = do
       expectDeps [packageTwo] graph
       expectDirect [packageTwo] graph
       expectEdges [] graph
-      

--- a/test/Maven/PluginTreeSpec.hs
+++ b/test/Maven/PluginTreeSpec.hs
@@ -84,21 +84,34 @@ parseTextArtifactSpec = fcontext "" $ do
 artifactWithChildren :: TextArtifact
 artifactWithChildren =
   TextArtifact {
-  artifactText = "org.clojure:tools.namespace:1.0.0"
+  artifactText = "org.clojure:test.generative:1.0.0"
   , scopes = ["test"]
-  , children = [ TextArtifact {
-                   artifactText = "org.clojure:java.classpath:1.0.0"
-                   , scopes = ["test"]
-                   , children = []}
-               , TextArtifact {
-                   artifactText = "org.clojure:tools.reader:1.3.2"
-                   , scopes = ["test"]
-                   , children = []
-                   }]
-               }
+  , children = [
+      TextArtifact {
+          artifactText = "org.clojure:tools.namespace:1.0.0"
+          , scopes = ["test"]
+          , children = [ TextArtifact {
+                           artifactText = "org.clojure:java.classpath:1.0.0"
+                           , scopes = ["test"]
+                           , children = []}
+                       , 
+                         TextArtifact {
+                           artifactText = "org.clojure:tools.reader:1.3.2"
+                           , scopes = ["test"]
+                           , children = []
+                           }]
+          }
+      , TextArtifact {
+          artifactText = "org.foo:bar:1.0.0"
+          , scopes = ["compile"]
+          , children = []
+          }]
+  }
 
 artifactTextWithChildren :: Text
 artifactTextWithChildren =
-  [r|org.clojure:tools.namespace:1.0.0:test
-+- org.clojure:java.classpath:1.0.0:test
-\- org.clojure:tools.reader:1.3.2:test |]
+  [r|org.clojure:test.generative:1.0.0:test
++- org.clojure:tools.namespace:1.0.0:test
+|  +- org.clojure:java.classpath:1.0.0:test
+|  \- org.clojure:tools.reader:1.3.2:test
+\- org.foo:bar:1.0.0:compile |]

--- a/test/Maven/PluginTreeSpec.hs
+++ b/test/Maven/PluginTreeSpec.hs
@@ -1,0 +1,48 @@
+module Maven.PluginTreeSpec (spec) where
+
+import Data.Text (Text)
+import Strategy.Maven.PluginTree (Artifact (..), parseArtifact)
+import Test.Hspec (Spec, shouldBe, it)
+import Text.Megaparsec (ParseErrorBundle, Parsec, runParser)
+
+shouldParse :: Parsec e s a -> s -> Either (ParseErrorBundle s e) a
+shouldParse parser = runParser parser ""
+
+to :: (Show a1, Show a2, Eq a2) => Either a1 a2 -> a2 -> IO ()
+to parsed expected = either (fail . show) (`shouldBe` expected) parsed
+
+spec :: Spec
+spec = parseTextArtifactSpec
+
+simpleArtifactString :: Text
+simpleArtifactString = "org.clojure:clojure:1.12.0-master-SNAPSHOT:compile "
+
+optionalArtifactString :: Text
+optionalArtifactString = "jakarta.mail:jakarta.mail-api:2.0.1:compile (optional)"
+
+simpleArtifact :: Artifact
+simpleArtifact =
+  Artifact
+    { artifactGroupId = "org.clojure"
+    , artifactArtifactId = "clojure"
+    , artifactVersion = "1.12.0-master-SNAPSHOT"
+    , artifactOptional = False
+    , artifactScopes = ["compile"]
+    }
+
+optionalArtifact :: Artifact
+optionalArtifact =
+  Artifact
+    { artifactGroupId = "jakarta.mail"
+    , artifactArtifactId = "jakarta.mail-api"
+    , artifactVersion = "2.0.1"
+    , artifactScopes = ["compile"]
+    , artifactOptional = True
+    }
+
+parseTextArtifactSpec :: Spec
+parseTextArtifactSpec = do
+  it "Parses an artifact from a string" $
+    parseArtifact `shouldParse` simpleArtifactString `to` simpleArtifact
+  it "Parses an optional artifact from a string" $
+    parseArtifact `shouldParse` optionalArtifactString `to` optionalArtifact

--- a/test/Maven/PluginTreeSpec.hs
+++ b/test/Maven/PluginTreeSpec.hs
@@ -35,6 +35,9 @@ mockArtifact =
   Node
     TextArtifact
       { artifactText = "org.clojure:clojure:1.12.0-master-SNAPSHOT"
+      , groupId = "org.clojure"
+      , artifactId = "clojure"
+      , textArtifactVersion = "1.12.0-master-SNAPSHOT"
       , scopes = ["test"]
       , isDirect = True
       , isOptional = False
@@ -46,6 +49,9 @@ multiScopeTextArtifact =
   Node
     TextArtifact
       { artifactText = "org.clojure:clojure:1.12.0-master-SNAPSHOT"
+      , groupId = "org.clojure"
+      , artifactId = "clojure"
+      , textArtifactVersion = "1.12.0-master-SNAPSHOT"
       , scopes = ["compile", "test"]
       , isDirect = True
       , isOptional = False
@@ -57,6 +63,9 @@ optionalTextArtifact =
   Node
     TextArtifact
       { artifactText = "jakarta.mail:jakarta.mail-api:2.0.1"
+      , groupId = "jakarta.mail"
+      , artifactId = "jakarta.mail-api"
+      , textArtifactVersion = "2.0.1"
       , scopes = ["compile"]
       , isDirect = True
       , isOptional = True
@@ -79,6 +88,9 @@ artifactWithChildren =
   Node
     TextArtifact
       { artifactText = "org.clojure:test.generative:1.0.0"
+      , groupId = "org.clojure"
+      , artifactId = "test.generative"
+      , textArtifactVersion = "1.0.0"
       , scopes = ["test"]
       , isDirect = True
       , isOptional = False
@@ -86,6 +98,9 @@ artifactWithChildren =
     [ Node
         TextArtifact
           { artifactText = "org.clojure:tools.namespace:1.0.0"
+          , groupId = "org.clojure"
+          , artifactId = "tools.namespace"
+          , textArtifactVersion = "1.0.0"
           , scopes = ["test"]
           , isOptional = False
           , isDirect = False
@@ -93,6 +108,9 @@ artifactWithChildren =
         [ Node
             TextArtifact
               { artifactText = "org.clojure:java.classpath:1.0.0"
+              , groupId = "org.clojure"
+              , artifactId = "java.classpath"
+              , textArtifactVersion = "1.0.0"
               , scopes = ["test"]
               , isDirect = False
               , isOptional = False
@@ -101,6 +119,9 @@ artifactWithChildren =
         , Node
             TextArtifact
               { artifactText = "org.fake:fake-pkg:1.0.0"
+              , groupId = "org.fake"
+              , artifactId = "fake-pkg"
+              , textArtifactVersion = "1.0.0"
               , isDirect = False
               , scopes = ["compile"]
               , isOptional = True
@@ -109,6 +130,9 @@ artifactWithChildren =
         , Node
             TextArtifact
               { artifactText = "org.clojure:tools.reader:1.3.2"
+              , groupId = "org.clojure"
+              , artifactId = "tools.reader"
+              , textArtifactVersion = "1.3.2"
               , isDirect = False
               , scopes = ["test"]
               , isOptional = False
@@ -118,6 +142,9 @@ artifactWithChildren =
     , Node
         TextArtifact
           { artifactText = "org.foo:bar:1.0.0"
+          , groupId = "org.foo"
+          , artifactId = "bar"
+          , textArtifactVersion = "1.0.0"
           , isDirect = False
           , scopes = ["compile"]
           , isOptional = False
@@ -125,6 +152,9 @@ artifactWithChildren =
         [ Node
             TextArtifact
               { artifactText = "org.baz:buzz:1.0.0"
+              , groupId = "org.baz"
+              , artifactId = "buzz"
+              , textArtifactVersion = "1.0.0"
               , isDirect = False
               , scopes = ["test"]
               , isOptional = False

--- a/test/Maven/PluginTreeSpec.hs
+++ b/test/Maven/PluginTreeSpec.hs
@@ -9,9 +9,6 @@ import Test.Hspec (Spec, describe, it, shouldBe)
 import Text.Megaparsec (ParseErrorBundle, Parsec, runParser)
 import Text.RawString.QQ (r)
 
--- TODO: test edgecase where a dep is optional in one part of the
--- maven-depgraph-plugin output but required in another
-
 shouldParse :: Parsec e s a -> s -> Either (ParseErrorBundle s e) a
 shouldParse parser = runParser parser ""
 

--- a/test/Maven/PluginTreeSpec.hs
+++ b/test/Maven/PluginTreeSpec.hs
@@ -24,7 +24,7 @@ simpleArtifactString :: Text
 simpleArtifactString = "org.clojure:clojure:1.12.0-master-SNAPSHOT:compile "
 
 multiScopeArtifactString :: Text
-multiScopeArtifactString = "org.clojure:clojure:1.12.0-master-SNAPSHOT:compile/test "
+multiScopeArtifactString = "org.clojure:clojure:1.12.0-master-SNAPSHOT:compile/test"
 
 optionalArtifactString :: Text
 optionalArtifactString = "jakarta.mail:jakarta.mail-api:2.0.1:compile (optional)"
@@ -45,7 +45,7 @@ multiScopeTextArtifact =
     { artifactText = "org.clojure:clojure:1.12.0-master-SNAPSHOT"
     , scopes = ["compile", "test"]
     , children = []
-    -- , isOptional = False
+    , isOptional = False
     }
 
 multiScopeArtifact :: Artifact
@@ -83,30 +83,45 @@ parseTextArtifactSpec = fcontext "" $ do
 
 artifactWithChildren :: TextArtifact
 artifactWithChildren =
-  TextArtifact {
-  artifactText = "org.clojure:test.generative:1.0.0"
-  , scopes = ["test"]
-  , children = [
-      TextArtifact {
-          artifactText = "org.clojure:tools.namespace:1.0.0"
-          , scopes = ["test"]
-          , children = [ TextArtifact {
-                           artifactText = "org.clojure:java.classpath:1.0.0"
-                           , scopes = ["test"]
-                           , children = []}
-                       , 
-                         TextArtifact {
-                           artifactText = "org.clojure:tools.reader:1.3.2"
-                           , scopes = ["test"]
-                           , children = []
-                           }]
-          }
-      , TextArtifact {
-          artifactText = "org.foo:bar:1.0.0"
-          , scopes = ["compile"]
-          , children = []
-          }]
-  }
+  TextArtifact
+    { artifactText = "org.clojure:test.generative:1.0.0"
+    , scopes = ["test"]
+    , isOptional = False
+    , children =
+        [ TextArtifact
+            { artifactText = "org.clojure:tools.namespace:1.0.0"
+            , scopes = ["test"]
+            , isOptional = False
+            , children =
+                [ TextArtifact
+                    { artifactText = "org.clojure:java.classpath:1.0.0"
+                    , scopes = ["test"]
+                    , children = []
+                    , isOptional = False
+                    }
+                , TextArtifact
+                    { artifactText = "org.clojure:tools.reader:1.3.2"
+                    , scopes = ["test"]
+                    , children = []
+                    , isOptional = False
+                    }
+                ]
+            }
+        , TextArtifact
+            { artifactText = "org.foo:bar:1.0.0"
+            , scopes = ["compile"]
+            , isOptional = False
+            , children =
+                [ TextArtifact
+                    { artifactText = "org.baz:buzz:1.0.0"
+                    , scopes = ["test"]
+                    , children = []
+                    , isOptional = False
+                    }
+                ]
+            }
+        ]
+    }
 
 artifactTextWithChildren :: Text
 artifactTextWithChildren =
@@ -114,4 +129,10 @@ artifactTextWithChildren =
 +- org.clojure:tools.namespace:1.0.0:test
 |  +- org.clojure:java.classpath:1.0.0:test
 |  \- org.clojure:tools.reader:1.3.2:test
-\- org.foo:bar:1.0.0:compile |]
+\- org.foo:bar:1.0.0:compile
+   \- org.baz:buzz:1.0.0:test|]
+
+--   [r|org.clojure:test.generative:1.0.0:test
+-- \- org.foo:bar:1.0.0:compile
+--    \- org.baz:buzz:1.0.0:test |]
+

--- a/test/Maven/PluginTreeSpec.hs
+++ b/test/Maven/PluginTreeSpec.hs
@@ -4,7 +4,7 @@ module Maven.PluginTreeSpec (spec) where
 
 import Data.Text (Text)
 import Strategy.Maven.PluginTree (TextArtifact (..), parseTextArtifact)
-import Test.Hspec (Spec, it, shouldBe, fdescribe, describe)
+import Test.Hspec (Spec, describe, it, shouldBe)
 import Text.Megaparsec (ParseErrorBundle, Parsec, runParser)
 import Text.RawString.QQ (r)
 
@@ -18,8 +18,7 @@ to :: (Show a1, Show a2, Eq a2) => Either a1 a2 -> a2 -> IO ()
 to parsed expected = either (fail . show) (`shouldBe` expected) parsed
 
 spec :: Spec
-spec = fdescribe "Maven dep-tree plugin parsing" $
-  do parseTextArtifactSpec
+spec = do parseTextArtifactSpec
 
 mockArtifactString :: Text
 mockArtifactString = "org.clojure:clojure:1.12.0-master-SNAPSHOT:test"

--- a/test/Maven/PluginTreeSpec.hs
+++ b/test/Maven/PluginTreeSpec.hs
@@ -5,6 +5,9 @@ import Strategy.Maven.PluginTree (Artifact (..), parseArtifact)
 import Test.Hspec (Spec, shouldBe, it)
 import Text.Megaparsec (ParseErrorBundle, Parsec, runParser)
 
+-- TODO: test edgecase where a dep is optional in one part of the
+-- maven-depgraph-plugin output but required in another
+
 shouldParse :: Parsec e s a -> s -> Either (ParseErrorBundle s e) a
 shouldParse parser = runParser parser ""
 
@@ -17,6 +20,9 @@ spec = parseTextArtifactSpec
 simpleArtifactString :: Text
 simpleArtifactString = "org.clojure:clojure:1.12.0-master-SNAPSHOT:compile "
 
+multiScopeArtifactString :: Text
+multiScopeArtifactString = "org.clojure:clojure:1.12.0-master-SNAPSHOT:compile/test "
+
 optionalArtifactString :: Text
 optionalArtifactString = "jakarta.mail:jakarta.mail-api:2.0.1:compile (optional)"
 
@@ -28,6 +34,16 @@ simpleArtifact =
     , artifactVersion = "1.12.0-master-SNAPSHOT"
     , artifactOptional = False
     , artifactScopes = ["compile"]
+    }
+
+multiScopeArtifact :: Artifact
+multiScopeArtifact =
+  Artifact
+    { artifactGroupId = "org.clojure"
+    , artifactArtifactId = "clojure"
+    , artifactVersion = "1.12.0-master-SNAPSHOT"
+    , artifactOptional = False
+    , artifactScopes = ["compile", "test"]
     }
 
 optionalArtifact :: Artifact
@@ -44,5 +60,7 @@ parseTextArtifactSpec :: Spec
 parseTextArtifactSpec = do
   it "Parses an artifact from a string" $
     parseArtifact `shouldParse` simpleArtifactString `to` simpleArtifact
+  it "Parses an artifact with multiple scopes a string" $
+    parseArtifact `shouldParse` multiScopeArtifactString `to` multiScopeArtifact
   it "Parses an optional artifact from a string" $
     parseArtifact `shouldParse` optionalArtifactString `to` optionalArtifact

--- a/test/Maven/PluginTreeSpec.hs
+++ b/test/Maven/PluginTreeSpec.hs
@@ -3,6 +3,7 @@
 module Maven.PluginTreeSpec (spec) where
 
 import Data.Text (Text)
+import Data.Tree (Tree (..))
 import Strategy.Maven.PluginTree (TextArtifact (..), parseTextArtifact)
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Text.Megaparsec (ParseErrorBundle, Parsec, runParser)
@@ -29,35 +30,38 @@ multiScopeArtifactString = "org.clojure:clojure:1.12.0-master-SNAPSHOT:compile/t
 optionalArtifactString :: Text
 optionalArtifactString = "jakarta.mail:jakarta.mail-api:2.0.1:compile (optional)"
 
-mockArtifact :: TextArtifact
+mockArtifact :: Tree TextArtifact
 mockArtifact =
-  TextArtifact
-    { artifactText = "org.clojure:clojure:1.12.0-master-SNAPSHOT"
-    , scopes = ["test"]
-    , isDirect = True
-    , isOptional = False
-    , children = []
-    }
+  Node
+    TextArtifact
+      { artifactText = "org.clojure:clojure:1.12.0-master-SNAPSHOT"
+      , scopes = ["test"]
+      , isDirect = True
+      , isOptional = False
+      }
+    []
 
-multiScopeTextArtifact :: TextArtifact
+multiScopeTextArtifact :: Tree TextArtifact
 multiScopeTextArtifact =
-  TextArtifact
-    { artifactText = "org.clojure:clojure:1.12.0-master-SNAPSHOT"
-    , scopes = ["compile", "test"]
-    , isDirect = True
-    , children = []
-    , isOptional = False
-    }
+  Node
+    TextArtifact
+      { artifactText = "org.clojure:clojure:1.12.0-master-SNAPSHOT"
+      , scopes = ["compile", "test"]
+      , isDirect = True
+      , isOptional = False
+      }
+    []
 
-optionalTextArtifact :: TextArtifact
+optionalTextArtifact :: Tree TextArtifact
 optionalTextArtifact =
-  TextArtifact
-    { artifactText = "jakarta.mail:jakarta.mail-api:2.0.1"
-    , scopes = ["compile"]
-    , isDirect = True
-    , isOptional = True
-    , children = []
-    }
+  Node
+    TextArtifact
+      { artifactText = "jakarta.mail:jakarta.mail-api:2.0.1"
+      , scopes = ["compile"]
+      , isDirect = True
+      , isOptional = True
+      }
+    []
 
 parseTextArtifactSpec :: Spec
 parseTextArtifactSpec = describe "Parsing maven artifact text" $ do
@@ -70,60 +74,64 @@ parseTextArtifactSpec = describe "Parsing maven artifact text" $ do
   it "Parses a TextArtifact with nested children" $
     parseTextArtifact `shouldParse` artifactTextWithChildren `to` artifactWithChildren
 
-artifactWithChildren :: TextArtifact
+artifactWithChildren :: Tree TextArtifact
 artifactWithChildren =
-  TextArtifact
-    { artifactText = "org.clojure:test.generative:1.0.0"
-    , scopes = ["test"]
-    , isDirect = True
-    , isOptional = False
-    , children =
-        [ TextArtifact
-            { artifactText = "org.clojure:tools.namespace:1.0.0"
-            , scopes = ["test"]
-            , isOptional = False
-            , isDirect = False
-            , children =
-                [ TextArtifact
-                    { artifactText = "org.clojure:java.classpath:1.0.0"
-                    , scopes = ["test"]
-                    , isDirect = False
-                    , children = []
-                    , isOptional = False
-                    }
-                , TextArtifact
-                    { artifactText = "org.fake:fake-pkg:1.0.0"
-                    , isDirect = False
-                    , scopes = ["compile"]
-                    , children = []
-                    , isOptional = True
-                    }
-                , TextArtifact
-                    { artifactText = "org.clojure:tools.reader:1.3.2"
-                    , isDirect = False
-                    , scopes = ["test"]
-                    , children = []
-                    , isOptional = False
-                    }
-                ]
-            }
-        , TextArtifact
-            { artifactText = "org.foo:bar:1.0.0"
-            , isDirect = False
-            , scopes = ["compile"]
-            , isOptional = False
-            , children =
-                [ TextArtifact
-                    { artifactText = "org.baz:buzz:1.0.0"
-                    , isDirect = False
-                    , scopes = ["test"]
-                    , children = []
-                    , isOptional = False
-                    }
-                ]
-            }
+  Node
+    TextArtifact
+      { artifactText = "org.clojure:test.generative:1.0.0"
+      , scopes = ["test"]
+      , isDirect = True
+      , isOptional = False
+      }
+    [ Node
+        TextArtifact
+          { artifactText = "org.clojure:tools.namespace:1.0.0"
+          , scopes = ["test"]
+          , isOptional = False
+          , isDirect = False
+          }
+        [ Node
+            TextArtifact
+              { artifactText = "org.clojure:java.classpath:1.0.0"
+              , scopes = ["test"]
+              , isDirect = False
+              , isOptional = False
+              }
+            []
+        , Node
+            TextArtifact
+              { artifactText = "org.fake:fake-pkg:1.0.0"
+              , isDirect = False
+              , scopes = ["compile"]
+              , isOptional = True
+              }
+            []
+        , Node
+            TextArtifact
+              { artifactText = "org.clojure:tools.reader:1.3.2"
+              , isDirect = False
+              , scopes = ["test"]
+              , isOptional = False
+              }
+            []
         ]
-    }
+    , Node
+        TextArtifact
+          { artifactText = "org.foo:bar:1.0.0"
+          , isDirect = False
+          , scopes = ["compile"]
+          , isOptional = False
+          }
+        [ Node
+            TextArtifact
+              { artifactText = "org.baz:buzz:1.0.0"
+              , isDirect = False
+              , scopes = ["test"]
+              , isOptional = False
+              }
+            []
+        ]
+    ]
 
 artifactTextWithChildren :: Text
 artifactTextWithChildren =

--- a/test/Ruby/ParseSpec.hs
+++ b/test/Ruby/ParseSpec.hs
@@ -11,7 +11,6 @@ import Test.Hspec (Spec, context, describe, it, shouldBe)
 import Text.Megaparsec (MonadParsec (eof), ParseErrorBundle, Parsec, runParser, takeWhile1P)
 import Text.RawString.QQ (r)
 
--- I'm not sure about these helpers. Get guidance on whether they help readability.
 shouldParse :: Parsec e s a -> s -> Either (ParseErrorBundle s e) a
 shouldParse parser = runParser parser ""
 


### PR DESCRIPTION
# Overview

Maven projects weren't having top-level dependencies marked as a direct, instead they were all deep. The depgraph plugin, however, doesn't give any indication that a dep is deep except using the text formatted graph. This change switches the maven plugin strategy to use the text graph output.

## Acceptance criteria

1. `sourceUnits` should have direct dependencies in the top-level `Imports` field.
2. Project submodules should not be included and their immediate dependencies should be promoted to being direct.

## Testing plan

I used several projects to verify that this was working. The simplest was [clojure](https://github.com/clojure/clojure/archive/refs/tags/clojure-1.11.1.tar.gz) which has a tree of dependencies with no submodules. In addition, I used [zookeeper](https://www.apache.org/dyn/closer.lua/zookeeper/zookeeper-3.8.0/apache-zookeeper-3.8.0.tar.gz) and [log4j](https://www.apache.org/dyn/closer.lua/logging/log4j/2.17.2/apache-log4j-2.17.2-src.tar.gz).

To test:

1. Run fossa against one of those projects
2. Open `target/dependency-graph.txt` next to the output of fossa.
3. Check that the top-level `Imports` in `sourceUnits` are either at the top of the tree printed by the plugin or the direct dependencies of a submodule as show in the dependency graph. Submodules may not appear as a top-level item, in the case of submodules depending on eachother, they may be children of each other.
4. The list of submodules can be viewed by opening `pom.xml` and looking for the `<modules>` tag. These submodules should not appear in the output graph.

## Risks

This change will likely change the output for many existing customers because in the past we weren't marking any deps as direct. Is there anything else we can do to get assurance of its correctness?

## References

[ANE-238](https://fossa.atlassian.net/browse/ANE-238)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
