### PR TITLE
[ANE-350] Replaces externally vendored subspec dependency with it's source

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## v3.3.3
-- Cocoapods: Cocoapods analyzer does not handle subspecs in vendored podspecs. 
+- Cocoapods: Cocoapods analyzer does not handle subspecs in vendored podspecs. ([#964](https://github.com/fossas/fossa-cli/pull/964/files)) 
 
 ## v3.3.2
 - CLI-side license scans will skip rescanning revisions that are already known to FOSSA. This can be overridden by using the `--force-vendored-dependency-rescans` flag.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.3.3
+- Cocoapods: Cocoapods analyzer does not handle subspecs in vendored podspecs. 
+
 ## v3.3.2
 - CLI-side license scans will skip rescanning revisions that are already known to FOSSA. This can be overridden by using the `--force-vendored-dependency-rescans` flag.
 - Swift: Added support for `Package.resolved` v2 files ([#957](https://github.com/fossas/fossa-cli/pull/957)).

--- a/docs/references/strategies/platforms/ios/cocoapods.md
+++ b/docs/references/strategies/platforms/ios/cocoapods.md
@@ -41,7 +41,7 @@ DEPENDENCIES:
   - "five/+zlib (7.0.0)"
 ```
 
-We also look at the `EXTERNAL SOURCES` section to try and resolve locally vendored Cocoapods. If we see a locally vendored Cocoapod using either `:podspec` or `:path` to a local directory, we'll read the Podspec at that directory and also upload that dependency if it has a supported `source`. We currently only support the `git` source.
+We also look at the `EXTERNAL SOURCES` section to try and resolve locally vendored Cocoapods. If we see a locally vendored Cocoapod using either `:podspec` or `:path` to a local directory, we'll read the Podspec at that directory and also upload that dependency if it has a supported `source`. We will also replace any dependencies originating via subspec of locally vendored dependency, with it's vendored dependency's `source`. We currently only support the `git` source. 
 
 ## Limitations
 

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -27,6 +27,7 @@ import Discovery.Walk (
   walkWithFilters',
  )
 import Effect.Exec (Exec)
+import Effect.Logger (Logger)
 import Effect.ReadFS (Has, ReadFS, readContentsParser)
 import GHC.Generics (Generic)
 import Path (Abs, Dir, File, Path, toFilePath)
@@ -107,7 +108,7 @@ mkProject project =
     , projectData = project
     }
 
-getDeps :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec sig m) => CocoapodsProject -> m DependencyResults
+getDeps :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec sig m, Has Logger sig m) => CocoapodsProject -> m DependencyResults
 getDeps project =
   context "Cocoapods" $
     context
@@ -130,7 +131,7 @@ analyzePodfile project = do
       , dependencyManifestFiles = [podFile]
       }
 
-analyzePodfileLock :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec sig m) => CocoapodsProject -> m DependencyResults
+analyzePodfileLock :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec sig m, Has Logger sig m) => CocoapodsProject -> m DependencyResults
 analyzePodfileLock project = do
   lockFile <- Diag.fromMaybeText "No Podfile.lock present in the project" (cocoapodsPodfileLock project)
   graph <- PodfileLock.analyze' lockFile

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -404,9 +404,10 @@ instance FromJSON PodSpecJSON where
   parseJSON = JSON.withObject "PodSpecJSON" $ \o -> do
     source <- o .: "source"
     subSpecs <- (o .:? "subspecs" .!= mempty)
-    externalGitSource <- ExternalGitSource 
-      <$> source .: "git" 
-      <*> source .:? "tag" 
-      <*> source .:? "commit" 
-      <*> source .:? "branch"
+    externalGitSource <-
+      ExternalGitSource
+        <$> source .: "git"
+        <*> source .:? "tag"
+        <*> source .:? "commit"
+        <*> source .:? "branch"
     pure $ PodSpecJSON externalGitSource subSpecs

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -36,7 +36,7 @@ import Data.SemVer qualified as SemVer
 import Data.SemVer.Internal (Version (..))
 import Data.Set (Set)
 import Data.String.Conversion (decodeUtf8, toString, toText)
-import Data.Text (Text, strip)
+import Data.Text (Text, null, strip)
 import Data.Text.Extra (showT, splitOnceOn)
 import Data.Void (Void)
 import Data.Yaml ((.:), (.:?))
@@ -211,7 +211,7 @@ buildGraph lockFilePath lockFile@PodLock{lockExternalSources} = do
           -- We replace this dependency with parent's git sourced dependency.
           let (parentSpec, candidateSubSpec) = splitOnceOn "/" dependencyName
 
-          if candidateSubSpec == mempty
+          if Data.Text.null candidateSubSpec
             then pure d
             else do
               revisedDep <- case Map.lookup parentSpec lockExternalSources of

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -44,7 +44,7 @@ import Data.Yaml qualified as Yaml
 import DepTypes (DepType (GitType, PodType), Dependency (..), VerConstraint (CEq))
 import Effect.Exec (AllowErr (..), Command (..), Exec, exec, execJson)
 import Effect.Grapher (LabeledGrapher, direct, edge, label, withLabeling)
-import Effect.Logger (Logger, Pretty (pretty), logDebug, logInfo, vsep)
+import Effect.Logger (Logger, Pretty (pretty), logDebug)
 import Effect.ReadFS (ReadFS, readContentsYaml)
 import Graphing (Graphing, gtraverse)
 import Options.Applicative (Alternative ((<|>)))

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -21,28 +21,30 @@ import Control.Effect.Diagnostics (
  )
 import Control.Effect.State (State, get, put)
 import Control.Monad (when)
-import Data.Aeson (FromJSON (parseJSON))
+import Data.Aeson (FromJSON (parseJSON), (.!=))
 import Data.Aeson qualified as JSON
 import Data.Aeson.Types (FromJSONKey)
 import Data.Bifunctor (first)
 import Data.Char qualified as C
-import Data.Foldable (asum, traverse_)
+import Data.Foldable (asum, find, traverse_)
 import Data.Functor (void)
 import Data.HashMap.Lazy qualified as HashMap (toList)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.SemVer qualified as SemVer
 import Data.SemVer.Internal (Version (..))
 import Data.Set (Set)
 import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text, strip)
-import Data.Text.Extra (showT)
+import Data.Text.Extra (showT, splitOnceOn)
 import Data.Void (Void)
 import Data.Yaml ((.:), (.:?))
 import Data.Yaml qualified as Yaml
 import DepTypes (DepType (GitType, PodType), Dependency (..), VerConstraint (CEq))
 import Effect.Exec (AllowErr (..), Command (..), Exec, exec, execJson)
 import Effect.Grapher (LabeledGrapher, direct, edge, label, withLabeling)
+import Effect.Logger (Logger, Pretty (pretty), logDebug, logInfo, vsep)
 import Effect.ReadFS (ReadFS, readContentsYaml)
 import Graphing (Graphing, gtraverse)
 import Options.Applicative (Alternative ((<|>)))
@@ -52,7 +54,7 @@ import Text.Megaparsec (Parsec, between, empty, errorBundlePretty, parse, some, 
 import Text.Megaparsec.Char (char)
 import Text.Megaparsec.Char.Lexer qualified as L
 
-analyze' :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec sig m) => Path Abs File -> m (Graphing Dependency)
+analyze' :: (Has ReadFS sig m, Has Diagnostics sig m, Has Exec sig m, Has Logger sig m) => Path Abs File -> m (Graphing Dependency)
 analyze' podfileLockFilepath = do
   podfileLock <- readContentsYaml podfileLockFilepath
   context "Building dependency graph" $
@@ -144,7 +146,7 @@ podVersionCmd :: Command
 podVersionCmd = Command{cmdName = "pod", cmdArgs = ["--version"], cmdAllowErr = Never}
 
 buildGraph ::
-  (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m) =>
+  (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m, Has Logger sig m) =>
   Path Abs File ->
   PodLock ->
   m (Graphing Dependency)
@@ -178,24 +180,87 @@ buildGraph lockFilePath lockFile@PodLock{lockExternalSources} = do
     lockFileDir :: Path Abs Dir
     lockFileDir = parent lockFilePath
 
+    toPodSpecPath :: Text -> Text -> Text
+    toPodSpecPath podPath dependencyName = toText $ toString podPath </> (toString dependencyName <.> "podspec")
+
     replaceVendoredPods ::
       ( Has Exec sig m
       , Has Diagnostics sig m
       , Has (State PodSpecCache) sig m
+      , Has Logger sig m
       ) =>
       Dependency ->
       m Dependency
     replaceVendoredPods d@Dependency{dependencyType, dependencyName} = case dependencyType of
       PodType -> case Map.lookup dependencyName lockExternalSources of
         Just es -> case es of
-          ExternalPodSpec podSpecPath ->
-            readPodSpecAt podSpecPath <||> pure d
-          ExternalPath podPath ->
-            readPodSpecAt (toText $ toString podPath </> (toString dependencyName <.> "podspec")) <||> pure d
+          ExternalPodSpec podSpecPath -> readPodSpecAt podSpecPath <||> pure d
+          ExternalPath podPath -> readPodSpecAt (toPodSpecPath podPath dependencyName) <||> pure d
           ExternalGitType _ -> pure d
           ExternalOtherType -> pure d
-        Nothing -> pure d
+        Nothing -> do
+          -- Pod dependency can be included as part of externally sourced dependency's sub spec.
+          -- Refer to: https://guides.cocoapods.org/syntax/podspec.html#subspec
+          --
+          -- To aptly resolve such dependencies, we infer candidate parent,
+          -- and candidate sub spec from dependency's name. If and only if:
+          --  * Candidate parent spec exists within external sources
+          --  * Parent's pod spec has sub spec listed
+          --  * Parent has git source
+          --
+          -- We replace this dependency with parent's git sourced dependency.
+          let (parentSpec, candidateSubSpec) = splitOnceOn "/" dependencyName
+
+          if candidateSubSpec == mempty
+            then pure d
+            else do
+              revisedDep <- case Map.lookup parentSpec lockExternalSources of
+                Just (ExternalPodSpec podSpecPath) -> fromMaybe d <$> (readPodSubSpecSourceAt podSpecPath parentSpec)
+                Just (ExternalPath podPath) -> fromMaybe d <$> (readPodSubSpecSourceAt (toPodSpecPath podPath parentSpec) candidateSubSpec)
+                _ -> pure d
+
+              when (revisedDep /= d) $
+                logDebug . pretty $
+                  "Replaced " <> dependencyName <> " with " <> parentSpec
+                    <> ", since "
+                    <> dependencyName
+                    <> " is subspec of "
+                    <> parentSpec
+
+              pure revisedDep
       _ -> pure d
+
+    readPodSubSpecSourceAt ::
+      ( Has Exec sig m
+      , Has Diagnostics sig m
+      , Has (State PodSpecCache) sig m
+      ) =>
+      Text ->
+      Text ->
+      m (Maybe Dependency)
+    readPodSubSpecSourceAt podSpecPath candidateSubSpec = context ("Resolving vendored subspec of podspec at " <> showT podSpecPath) $ do
+      podSpecCache :: PodSpecCache <- get
+      (PodSpecJSON ExternalGitSource{urlOf, tagOf, commitOf, branchOf} subSpecs) <-
+        case Map.lookup podSpecPath podSpecCache of
+          Just cached -> pure cached
+          Nothing -> do
+            podSpec <- execJson lockFileDir $ podIpcSpecCmd podSpecPath
+            put $ Map.insert podSpecPath podSpec podSpecCache
+            pure podSpec
+
+      case find (== (PodsSpecJSONSubSpec candidateSubSpec)) subSpecs of
+        Nothing -> pure Nothing
+        Just _ -> do
+          pure $
+            Just $
+              Dependency
+                { dependencyType = GitType
+                , dependencyName = urlOf
+                , dependencyVersion = CEq <$> asum [tagOf, commitOf, branchOf]
+                , dependencyLocations = []
+                , dependencyEnvironments = mempty
+                , dependencyTags = Map.empty
+                }
 
     readPodSpecAt ::
       ( Has Exec sig m
@@ -206,7 +271,7 @@ buildGraph lockFilePath lockFile@PodLock{lockExternalSources} = do
       m Dependency
     readPodSpecAt podSpecPath = context ("Resolving vendored podspec at " <> showT podSpecPath) $ do
       podSpecCache :: PodSpecCache <- get
-      (PodSpecJSON ExternalGitSource{urlOf, tagOf, commitOf, branchOf}) <-
+      (PodSpecJSON ExternalGitSource{urlOf, tagOf, commitOf, branchOf} _) <-
         case Map.lookup podSpecPath podSpecCache of
           Just cached -> pure cached
           Nothing -> do
@@ -322,14 +387,26 @@ lexeme = L.lexeme sc
 sc :: Parser ()
 sc = L.space (void $ some (char ' ')) empty empty
 
-newtype PodSpecJSON = PodSpecJSON ExternalGitSource
+data PodSpecJSON = PodSpecJSON
+  { podSpecSources :: ExternalGitSource
+  , podSpecSubSpecs :: [PodsSpecJSONSubSpec]
+  }
+  deriving (Show, Eq, Ord)
+
+newtype PodsSpecJSONSubSpec = PodsSpecJSONSubSpec {subSpecName :: Text}
+  deriving (Show, Eq, Ord)
+
+instance FromJSON PodsSpecJSONSubSpec where
+  parseJSON = JSON.withObject "PodSpecJSON" $ \o ->
+    PodsSpecJSONSubSpec <$> o .: "name"
 
 instance FromJSON PodSpecJSON where
-  parseJSON = JSON.withObject "PodSpecJSON" $ \o ->
-    PodSpecJSON <$> do
-      source <- o .: "source"
-      ExternalGitSource
-        <$> source .: "git"
-        <*> source .:? "tag"
-        <*> source .:? "commit"
-        <*> source .:? "branch"
+  parseJSON = JSON.withObject "PodSpecJSON" $ \o -> do
+    source <- o .: "source"
+    subSpecs <- (o .:? "subspecs" .!= mempty)
+    externalGitSource <- ExternalGitSource 
+      <$> source .: "git" 
+      <*> source .:? "tag" 
+      <*> source .:? "commit" 
+      <*> source .:? "branch"
+    pure $ PodSpecJSON externalGitSource subSpecs


### PR DESCRIPTION
# Overview

This PR updates cocoapods analyzer such that, 
- any dependency originating via sub-spec of external dependency is replaced with its parent spec (i.e. `React-Core/RCTSettingHeader` is sub-spec of  `React-Core` then `React-Core/RCTSettingHeader` is replaced with a source of `React-Core`) 


## Acceptance criteria

- Any `pod` dependency that originates from subspec of externally sourced dependency is replaced with the git source of externally sourced dependency

## Testing plan

```
# Build
git pull origin && git checkout feat/podspec-ane-350 && make install-dev

# Get Test project
cd .. && git clone https://github.com/react-native-maps/react-native-maps/ && cd react-native-maps && git checkout 71727a5f && cd example && yarn && cd ios

# Run fossa analyzer
fossa-dev analyze -o | rendergraph
```

Assert that,
- `pod+React-Core/RCTSettingsHeaders$0.65.1` is replaced by git source of `react-native`
- Run `fossa-dev analyze -o --debug` (to listing of all subspec pods replaced by their parents)

```bash 
# cat debug.out.txt | grep "Replaced"
[DEBUG] Replaced React-Core/DevSupport with React-Core, since React-Core/DevSupport is subspec of React-Core
[DEBUG] Replaced React-Core/RCTWebSocket with React-Core, since React-Core/RCTWebSocket is subspec of React-Core
[DEBUG] Replaced React-Core/DevSupport with React-Core, since React-Core/DevSupport is subspec of React-Core
[DEBUG] Replaced React-Core/RCTWebSocket with React-Core, since React-Core/RCTWebSocket is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/CoreModulesHeaders with React-Core, since React-Core/CoreModulesHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/DevSupport with React-Core, since React-Core/DevSupport is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/RCTWebSocket with React-Core, since React-Core/RCTWebSocket is subspec of React-Core
[DEBUG] Replaced React-Core/RCTActionSheetHeaders with React-Core, since React-Core/RCTActionSheetHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/RCTAnimationHeaders with React-Core, since React-Core/RCTAnimationHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/RCTBlobHeaders with React-Core, since React-Core/RCTBlobHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/RCTImageHeaders with React-Core, since React-Core/RCTImageHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/RCTLinkingHeaders with React-Core, since React-Core/RCTLinkingHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/RCTNetworkHeaders with React-Core, since React-Core/RCTNetworkHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/RCTSettingsHeaders with React-Core, since React-Core/RCTSettingsHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/RCTTextHeaders with React-Core, since React-Core/RCTTextHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/RCTVibrationHeaders with React-Core, since React-Core/RCTVibrationHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/RCTWebSocket with React-Core, since React-Core/RCTWebSocket is subspec of React-Core
[DEBUG] Replaced React-Core/Default with React-Core, since React-Core/Default is subspec of React-Core
[DEBUG] Replaced React-Core/CoreModulesHeaders with React-Core, since React-Core/CoreModulesHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/RCTActionSheetHeaders with React-Core, since React-Core/RCTActionSheetHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/RCTAnimationHeaders with React-Core, since React-Core/RCTAnimationHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/RCTBlobHeaders with React-Core, since React-Core/RCTBlobHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/RCTWebSocket with React-Core, since React-Core/RCTWebSocket is subspec of React-Core
[DEBUG] Replaced React-Core/RCTImageHeaders with React-Core, since React-Core/RCTImageHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/RCTLinkingHeaders with React-Core, since React-Core/RCTLinkingHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/RCTNetworkHeaders with React-Core, since React-Core/RCTNetworkHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/RCTSettingsHeaders with React-Core, since React-Core/RCTSettingsHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/RCTTextHeaders with React-Core, since React-Core/RCTTextHeaders is subspec of React-Core
[DEBUG] Replaced React-Core/RCTVibrationHeaders with React-Core, since React-Core/RCTVibrationHeaders is subspec of React-Core
[DEBUG] Replaced React-jsi/Default with React-jsi, since React-jsi/Default is subspec of React-jsi
[DEBUG] Replaced React-jsi/Default with React-jsi, since React-jsi/Default is subspec of React-jsi
```

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-350

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
