### PR TITLE
VSI: Skip `{scandir}/.git` by default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,9 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## v3.3.4
 
 - Removes copyright information from attribution reports in the JSON output ([#945](https://github.com/fossas/fossa-cli/pull/945)) as it was never available from the server.
+- VSI scans now automatically skip the `.git` directory inside the scan root ([#969](https://github.com/fossas/fossa-cli/pull/969)).
 
 ## v3.3.3
 - Cocoapods: Cocoapods analyzer does not handle subspecs in vendored podspecs. ([#964](https://github.com/fossas/fossa-cli/pull/964/files)) 

--- a/docs/references/experimental/vsi/README.md
+++ b/docs/references/experimental/vsi/README.md
@@ -18,6 +18,12 @@ fossa analyze --experimental-enable-vsi
 
 VSI support requires a feature flag enabled in your FOSSA organization. If you're interested in using this feature please contact us!
 
+### Default Filters
+
+By default, VSI ignores the following directory:
+
+- `{scandir}/.git`
+
 ### FAQ
 
 #### Why not always enable VSI?

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -101,7 +101,7 @@ runFingerprintDiscovery ::
   m ()
 runFingerprintDiscovery capabilities files dir filters = do
   runStickyLogger SevInfo . withTaskPool capabilities (updateProgress " > Fingerprint files") . runAtomicCounter $ do
-    let pathFilters = (withDefaultFilters dir $ toPathFilters dir filters)
+    let pathFilters = withDefaultFilters dir $ toPathFilters dir filters
     res <- runDiagnosticsIO $ discover files pathFilters dir ancestryDirect
     withResult SevError SevWarn res (const (pure ()))
 


### PR DESCRIPTION
# Overview

Skips the `.git` directory in VSI scans by default.

## Acceptance criteria

When scanning a project, the `.git` dir is not considered for VSI matches.

## Testing plan

Using the VSI demo project ([go/cpp-vsi-demo](https://go/cpp-vsi-demo)), I scanned using the current release of `fossa`:
```
; fossa analyze --experimental-enable-vsi
[ INFO] Running VSI analysis
[ INFO] Created Scan ID: bd3a9e8b-16a3-4958-8996-1e73ca652f92
[ INFO] Finalizing scan
[ INFO] Waiting for cloud analysis
[ INFO]
[ INFO] Scan Summary
[ INFO] ------------
[ INFO] fossa-cli version 3.2.14 (revision 693e703343c3 compiled with ghc-9.0)
[ INFO]
[ INFO] 1 projects scanned;  0 skipped,  1 succeeded,  0 failed,  0 analysis warnings
[ INFO]
[ INFO] -
[ INFO] * vsi analysis: succeeded
[ INFO]
[ INFO]   Some projects may not appear in the summary if they were filtered during discovery.
[ INFO]   You can run `fossa list-targets` to see all discoverable projects.
[ INFO]
[ INFO] You can pass `--debug` option to eagerly show all warning and failure messages.
[ INFO] You can also view analysis summary with warning and error messages at: "/private/var/folders/q7/3nvvpy0d6js28m8lypw3tcx80000gn/T/fossa-analyze-scan-summary.txt"
[ INFO] ------------
[ INFO]
[ INFO] Using project name: `git@github.com:fossas/cpp-vsi-demo.git`
[ INFO] Using revision: `76987d9d364bc2c73897549a71d13371a32cd3e7`
[ INFO] Using branch: `main`
[ INFO] ============================================================
[ INFO]
[ INFO]     View FOSSA Report:
[ INFO]     https://app.fossa.com/projects/custom%2b24357%2fgit%40github.com%3afossas%2fcpp-vsi-demo.git/refs/branch/main/76987d9d364bc2c73897549a71d13371a32cd3e7
[ INFO]
[ INFO] ============================================================
```

This resulted in an incorrect `GitForWindows` result:
<img width="1277" alt="Screen Shot 2022-06-08 at 12 24 41 PM" src="https://user-images.githubusercontent.com/55713231/172700587-149d96e8-25e2-41bc-95c4-9cdabf3797a2.png">

I then performed the same scan again on this branch:
```
; cabal run fossa -- analyze ~/projects/cpp-vsi-demo --experimental-enable-vsi
Up to date
[ INFO] Running VSI analysis
[ INFO] Created Scan ID: 559f2ea7-4167-4fd9-a5f8-7ec0f6a08896
[ INFO] Finalizing scan
[ INFO] Waiting for cloud analysis
[ INFO]
[ INFO] Scan Summary
[ INFO] ------------
[ INFO] fossa-cli branch vsi-ignore-git-default (revision 3d90e1746261 compiled with ghc-9.0)
[ INFO]
[ INFO] 1 projects scanned;  0 skipped,  1 succeeded,  0 failed,  0 analysis warnings
[ INFO]
[ INFO] -
[ INFO] * vsi analysis: succeeded
[ INFO]
[ INFO]   Some projects may not appear in the summary if they were filtered during discovery.
[ INFO]   You can run `fossa list-targets` to see all discoverable projects.
[ INFO]
[ INFO] You can pass `--debug` option to eagerly show all warning and failure messages.
[ INFO] You can also view analysis summary with warning and error messages at: "/private/var/folders/q7/3nvvpy0d6js28m8lypw3tcx80000gn/T/fossa-analyze-scan-summary.txt"
[ INFO] ------------
[ INFO]
[ INFO] Using project name: `git@github.com:fossas/cpp-vsi-demo.git`
[ INFO] Using revision: `76987d9d364bc2c73897549a71d13371a32cd3e7`
[ INFO] Using branch: `main`
[ INFO] ============================================================
[ INFO]
[ INFO]     View FOSSA Report:
[ INFO]     https://app.fossa.com/projects/custom%2b24357%2fgit%40github.com%3afossas%2fcpp-vsi-demo.git/refs/branch/main/76987d9d364bc2c73897549a71d13371a32cd3e7
[ INFO]
[ INFO] ============================================================
```

Which provides the correct results:
<img width="1277" alt="Screen Shot 2022-06-08 at 12 28 32 PM" src="https://user-images.githubusercontent.com/55713231/172700794-5df549d2-fe8e-4321-829a-a81c03bfca79.png">

## Risks

Not risky.

## References

[ANE-182](https://fossa.atlassian.net/browse/ANE-182), which was reported a bit ago but Ericsson complained about it today and I'm on duty so I figured I'd just do it real quick.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
