### PR TITLE
refactor: Remove uncommitted files from extra-source-files

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -6,8 +6,6 @@ build-type:         Simple
 extra-source-files:
   scripts/depgraph-maven-plugin-3.3.0.jar
   scripts/jsondeps.gradle
-  vendor-bins/syft
-  vendor-bins/wiggins
 
 common lang
   build-depends:      base ^>=4.15

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -3,9 +3,6 @@ name:               spectrometer
 version:            0.1.0.0
 license:            MPL-2.0
 build-type:         Simple
-extra-source-files:
-  scripts/depgraph-maven-plugin-3.3.0.jar
-  scripts/jsondeps.gradle
 
 common lang
   build-depends:      base ^>=4.15


### PR DESCRIPTION
# Overview

[`extra-source-files`](https://cabal.readthedocs.io/en/latest/cabal-package.html#pkg-field-extra-source-files) is a field in Cabal files that specifies extra files bundled when running `cabal sdist`. This causes these files to be included with publishing to Hackage, and to be included in the isolated file tree that `cabal install` uses to build packages.

Since we no longer use `cabal install`, and we internally only use the CLI as library by downloading it from GitHub, keeping this field around mostly just causes build breakages:

```
➜ cabal build
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Total 3 (delta 2), reused 3 (delta 2), pack-reused 0
Unpacking objects: 100% (3/3), 955 bytes | 238.00 KiB/s, done.
From https://github.com/fossas/fossa-cli
 * [new branch]        leo/refactor/no-uncommitted-source-files -> origin/leo/refactor/no-uncommitted-source-files
HEAD is now at e9702ec4 wip: Hackily expose top-level parsers
cabal: sdist of spectrometer-0.1.0.0: filepath wildcard 'vendor-bins/syft'
does not match any files.
```

This PR removes this field to fix these build breakages.

## Acceptance criteria

When using the CLI as a library, build breakages due to "filepath wildcard does not match any files" are fixed.

## Testing plan

Check that the CI run for this PR succeeds.

Construct a new no-op project that relies on `spectrometer` with `cabal.project`:

```
source-repository-package
  type: git
  location: https://github.com/fossas/fossa-cli
  tag: leo/refactor/no-uncommitted-source-files
```

See that the "filepath wildcard does not match any files" breakage no longer occurs.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
