### PR TITLE
Make the CLI `cabal install`-able

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -152,9 +152,10 @@ jobs:
         echo $GITHUB_SHA
         echo ${GITHUB_SHA:0:12}
         echo $(Linux-binaries/fossa --version)
+        echo "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)"
 
         [ "$GITHUB_REF_TYPE" = "tag" ] && echo "Ref type OK"
-        [ "$(Linux-binaries/fossa --version)" = "fossa-cli version $${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
+        [ "$(Linux-binaries/fossa --version)" = "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
 
     # This uses names compatible with our install script.
     - name: Bundle binaries

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -128,10 +128,22 @@ jobs:
       if: ${{ !contains(matrix.os, 'windows')}}
       run: |
         echo $(release/fossa --version)
+
         echo $GITHUB_REF_NAME
+        echo $GITHUB_REF_TYPE
+        if [ "$GITHUB_REF_TYPE" = "branch" ]; then
+          export VERSION_STRING="branch $GITHUB_REF_NAME"
+        elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
+          export VERSION_STRING="version ${GITHUB_REF_NAME:1}"
+        else
+          echo "Unknown ref type: $GITHUB_REF_TYPE"
+          exit 1
+        fi
+
         echo $GITHUB_SHA
         echo ${GITHUB_SHA:0:12}
-        [ "$(release/fossa --version)" = "fossa-cli branch $GITHUB_REF_NAME (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ]
+
+        [ "$(release/fossa --version)" = "fossa-cli $VERSION_STRING (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ]
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -127,6 +127,10 @@ jobs:
     - name: Check that version info was embedded correctly
       if: ${{ !contains(matrix.os, 'windows')}}
       run: |
+        echo $(release/fossa --version)
+        echo $GITHUB_REF_NAME
+        echo $GITHUB_SHA
+        echo ${GITHUB_SHA:0:12}
         [ "$(release/fossa --version)" = "fossa-cli branch $GITHUB_REF_NAME (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ]
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -124,6 +124,11 @@ jobs:
       run: |
         strip release/*
 
+    - name: Check that version info was embedded correctly
+      if: ${{ !contains(matrix.os, 'windows')}}
+      run: |
+        [ "$(release/fossa --version)" = "fossa-cli branch $GITHUB_REF_NAME (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ]
+
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ runner.os }}-binaries

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -145,6 +145,8 @@ jobs:
 
     - name: Check that version info was embedded correctly
       run: |
+        chmod +x Linux-binaries/fossa
+
         echo $GITHUB_REF_NAME
         echo $GITHUB_REF_TYPE
         echo $GITHUB_REF_SHA

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -149,11 +149,12 @@ jobs:
 
         echo $GITHUB_REF_NAME
         echo $GITHUB_REF_TYPE
-        echo $GITHUB_REF_SHA
+        echo $GITHUB_SHA
+        echo ${GITHUB_SHA:0:12}
         echo $(Linux-binaries/fossa --version)
 
-        [ "$GITHUB_REF_TYPE" = "tag" ]
-        [ "$(Linux-binaries/fossa --version)" = "fossa-cli version $${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ]
+        [ "$GITHUB_REF_TYPE" = "tag" ] && echo "Ref type OK"
+        [ "$(Linux-binaries/fossa --version)" = "fossa-cli version $${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
 
     # This uses names compatible with our install script.
     - name: Bundle binaries

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -124,27 +124,6 @@ jobs:
       run: |
         strip release/*
 
-    - name: Check that version info was embedded correctly
-      if: ${{ !contains(matrix.os, 'windows')}}
-      run: |
-        echo $(release/fossa --version)
-
-        echo $GITHUB_REF_NAME
-        echo $GITHUB_REF_TYPE
-        if [ "$GITHUB_REF_TYPE" = "branch" ]; then
-          export VERSION_STRING="branch $GITHUB_REF_NAME"
-        elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
-          export VERSION_STRING="version ${GITHUB_REF_NAME:1}"
-        else
-          echo "Unknown ref type: $GITHUB_REF_TYPE"
-          exit 1
-        fi
-
-        echo $GITHUB_SHA
-        echo ${GITHUB_SHA:0:12}
-
-        [ "$(release/fossa --version)" = "fossa-cli $VERSION_STRING (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ]
-
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ runner.os }}-binaries
@@ -163,6 +142,16 @@ jobs:
       id: get-version
       # This strips the 'v' prefix from the tag.
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+
+    - name: Check that version info was embedded correctly
+      run: |
+        echo $GITHUB_REF_NAME
+        echo $GITHUB_REF_TYPE
+        echo $GITHUB_REF_SHA
+        echo $(Linux-binaries/fossa --version)
+
+        [ "$GITHUB_REF_TYPE" = "tag" ]
+        [ "$(Linux-binaries/fossa --version)" = "fossa-cli version $${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ]
 
     # This uses names compatible with our install script.
     - name: Bundle binaries

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,4 +79,5 @@ jobs:
 
     - name: Run `cabal install`
       run: |
+        cabal update
         cabal install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,3 +57,26 @@ jobs:
     - name: "run cabal-fmt"
       run: |
         cabal-fmt --check spectrometer.cabal
+
+  cabal-install-check:
+    name: cabal-install-check
+    runs-on: ubuntu-latest
+    container: ghcr.io/fossas/haskell-dev-tools:9.0.2
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Run `cabal install`.
+    - uses: actions/cache@v2
+      name: Cache cabal store
+      with:
+        path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.cabal/store' }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-${{ hashFiles('**/*.cabal') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-
+          ${{ runner.os }}-${{ matrix.ghc }}-
+          ${{ runner.os }}-
+
+    - name: Run `cabal install`
+      run: |
+        cabal install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,7 +64,7 @@ jobs:
     container: ghcr.io/fossas/haskell-dev-tools:9.0.2
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Run `cabal install`.
     - uses: actions/cache@v2
@@ -79,5 +79,6 @@ jobs:
 
     - name: Run `cabal install`
       run: |
+        apk add xz-dev bzip2-dev bzip2-static
         cabal update
         cabal install

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -1,13 +1,11 @@
-cabal-version:      2.2
+cabal-version:      3.0
 name:               spectrometer
 version:            0.1.0.0
 license:            MPL-2.0
 build-type:         Simple
 extra-source-files:
-  scripts/depgraph-maven-plugin-3.3.0.jar
-  scripts/jsondeps.gradle
-  vendor-bins/syft
-  vendor-bins/wiggins
+  scripts/*.gradle
+  scripts/*.jar
 
 common lang
   build-depends:      base ^>=4.15

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -38,6 +38,7 @@ data ProjectResult = ProjectResult
   , projectResultGraphBreadth :: GraphBreadth
   , projectResultManifestFiles :: [SomeBase File]
   }
+  deriving (Show)
 
 shouldKeepUnreachableDeps :: DiscoveredProjectType -> Bool
 shouldKeepUnreachableDeps SwiftProjectType = True

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -53,6 +53,7 @@ data DiscoveredProjectScan
   = SkippedDueToProvidedFilter DiscoveredProjectIdentifier
   | SkippedDueToDefaultProductionFilter DiscoveredProjectIdentifier
   | Scanned DiscoveredProjectIdentifier (Result ProjectResult)
+  deriving (Show)
 
 instance Ord DiscoveredProjectScan where
   a `compare` b = orderByScanStatusAndType a b
@@ -79,7 +80,7 @@ data DiscoveredProjectIdentifier = DiscoveredProjectIdentifier
   { dpiProjectPath :: Path Abs Dir
   , dpiProjectType :: DiscoveredProjectType
   }
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
 
 class AnalyzeProject a where
   analyzeProject :: AnalyzeTaskEffs sig m => FoundTargets -> a -> m DependencyResults

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -13,26 +13,29 @@ import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Version (showVersion)
-import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwd)
+import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwdTry)
 import System.Info (compilerName, compilerVersion)
 
 versionNumber :: Maybe Text
 versionNumber = $$(getCurrentTag)
 
-info :: GitInfo
-info = $$(tGitInfoCwd)
+info :: Either String GitInfo
+info = $$(tGitInfoCwdTry)
+
+fromRight' :: v -> (r -> v) -> Either l r -> v
+fromRight' v = either (const v)
 
 currentBranch :: Text
-currentBranch = toText $ giBranch info
+currentBranch = toText $ fromRight' "unknown branch" giBranch info
 
 currentCommit :: Text
-currentCommit = toText $ giHash info
+currentCommit = toText $ fromRight' "unknown commit" giHash info
 
 shortCommit :: Text
 shortCommit = Text.take 12 currentCommit
 
 isDirty :: Bool
-isDirty = giDirty info
+isDirty = fromRight' False giDirty info
 
 compilerId :: Text
 compilerId = name <> "-" <> version

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -26,10 +26,10 @@ fromRight' :: v -> (r -> v) -> Either l r -> v
 fromRight' v = either (const v)
 
 currentBranch :: Text
-currentBranch = toText $ fromRight' "unknown branch" giBranch info
+currentBranch = toText $ fromRight' "unknown" giBranch info
 
 currentCommit :: Text
-currentCommit = toText $ fromRight' "unknown commit" giHash info
+currentCommit = toText $ fromRight' "unknown" giHash info
 
 shortCommit :: Text
 shortCommit = Text.take 12 currentCommit

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -22,20 +22,17 @@ versionNumber = $$(getCurrentTag)
 info :: Either String GitInfo
 info = $$(tGitInfoCwdTry)
 
-fromRight' :: v -> (r -> v) -> Either l r -> v
-fromRight' v = either (const v)
-
 currentBranch :: Text
-currentBranch = toText $ fromRight' "unknown" giBranch info
+currentBranch = toText $ either (const "unknown") giBranch info
 
 currentCommit :: Text
-currentCommit = toText $ fromRight' "unknown" giHash info
+currentCommit = toText $ either (const "unknown") giHash info
 
 shortCommit :: Text
 shortCommit = Text.take 12 currentCommit
 
 isDirty :: Bool
-isDirty = fromRight' False giDirty info
+isDirty = either (const False) giDirty info
 
 compilerId :: Text
 compilerId = name <> "-" <> version

--- a/src/App/Version/TH.hs
+++ b/src/App/Version/TH.hs
@@ -23,7 +23,7 @@ import Effect.Exec (
   runExecIO,
  )
 import Effect.ReadFS (ReadFS, getCurrentDir, runReadFSIO)
-import GitHash (giHash, tGitInfoCwd)
+import GitHash (giHash, tGitInfoCwdTry)
 import Instances.TH.Lift ()
 import Language.Haskell.TH (Code, Q, bindCode_, joinCode)
 import Language.Haskell.TH.Syntax (reportWarning, runIO)
@@ -38,12 +38,14 @@ gitTagPointCommand commit =
 
 getCurrentTag :: Code Q (Maybe Text)
 getCurrentTag = joinCode $ do
-  let commitHash = giHash $$(tGitInfoCwd)
-  result <- runIO . runStack . runDiagnostics . runExecIO . runReadFSIO . getTags $ toText commitHash
-
-  pure $ case result of
-    Success _ tags -> filterTags tags
-    err -> reportWarning (show err) `bindCode_` [||Nothing||]
+  case $$(tGitInfoCwdTry) of
+    Right info -> do
+      let commitHash = giHash info
+      result <- runIO . runStack . runDiagnostics . runExecIO . runReadFSIO . getTags $ toText commitHash
+      pure $ case result of
+        Success _ tags -> filterTags tags
+        err -> reportWarning (show err) `bindCode_` [||Nothing||]
+    Left err -> pure $ reportWarning (show err) `bindCode_` [||Nothing||]
 
 getTags :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => Text -> m [Text]
 getTags hash = do

--- a/src/App/Version/TH.hs
+++ b/src/App/Version/TH.hs
@@ -1,4 +1,10 @@
 {-# LANGUAGE TemplateHaskell #-}
+-- We disable overlapping-patterns in this module to handle the case statement
+-- in `getCurrentTag`. GHC always thinks one of the two cases is redundant
+-- because `tGitInfoCwdTry` is compiled by Template Haskell into a concrete
+-- Right or Left. However, both branches are needed to handle different
+-- compilation environments.
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
 
 module App.Version.TH (
   getCurrentTag,


### PR DESCRIPTION
# Overview

This makes it possible to consume the CLI as a library.

The changes in this PR:

- Update the [`cabal-version`](https://cabal.readthedocs.io/en/latest/file-format-changelog.html). Ideally, we'd update this all the way to the latest version, but [`cabal-fmt` only supports up to Cabal 3.2](https://hackage.haskell.org/package/cabal-fmt-0.1.5.1) and crashes with an error on unrecognized `cabal-version` values.
- Update [`extra-source-files`](https://cabal.readthedocs.io/en/latest/cabal-package.html#pkg-field-extra-source-files) to the correct value. This field specifies extra files bundled when running `cabal sdist`, which determines which files go into the file tree built by `cabal install`. To get a successful build, we need to (1) remove entries which are not present (e.g. `vendor-bins`) and (2) add entries which must be present (e.g. `scripts/`).
- Update the git version embedding logic to not crash when `.git` is unavailable (which occurs during `cabal install`).
- Adds a "lint" check that makes sure `cabal install` still works.

## Acceptance criteria

`cabal install` works.

## Testing plan

Run `cabal install`.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
