### PR TITLE
Add debug logging to `embedFile`

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -10,7 +10,7 @@
   - {name: Data.Map.Strict, as: Map, message: "Use complete name for qualified import of Strict Map"}
   - {name: Data.Text, as: Text, message: "Use complete name for qualified import of Text"}
   # Don't allow unsafe IO
-  - {name: System.IO.Unsafe, within: [Data.FileEmbed.Extra]}
+  - {name: System.IO.Unsafe, within: []}
   # Arrows are more complicated than the problem they solve
   - {name: Control.Arrow, within: []}
 

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -10,7 +10,7 @@
   - {name: Data.Map.Strict, as: Map, message: "Use complete name for qualified import of Strict Map"}
   - {name: Data.Text, as: Text, message: "Use complete name for qualified import of Text"}
   # Don't allow unsafe IO
-  - {name: System.IO.Unsafe, within: []}
+  - {name: System.IO.Unsafe, within: [Data.FileEmbed.Extra]}
   # Arrows are more complicated than the problem they solve
   - {name: Control.Arrow, within: []}
 
@@ -36,7 +36,7 @@
   - {name: error, within: [Data.String.Conversion, Control.Effect.Replay]}
   - {name: undefined, within: []}
   - {name: Prelude.head, within: [Control.Effect.*.TH, "**.*Spec"], message: "Use Data.List.Extra.head' instead."}
-  - {name: Prelude.tail, within: []}
+  - {name: Prelude.tail, within: [Data.FileEmbed.Extra]}
   - {name: Prelude.init, within: []}
   - {name: Prelude.last, within: ["**.*Spec"]}
   - {name: Data.ByteString.head, within: []}

--- a/src/Data/FileEmbed/Extra.hs
+++ b/src/Data/FileEmbed/Extra.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskellQuotes #-}
-
 module Data.FileEmbed.Extra (
   embedFileL,
   embedFileIfExists,
@@ -7,26 +5,16 @@ module Data.FileEmbed.Extra (
 
 import Control.Exception (try)
 import Control.Monad (when)
-import Data.ByteString qualified as B
-import Data.ByteString.Char8 qualified as B8
-import Data.ByteString.Internal qualified as B
-import Data.ByteString.Unsafe (unsafePackAddressLen)
 import Data.FileEmbed (embedFile)
 import Data.Foldable (traverse_)
 import Data.Maybe (isJust)
-import Language.Haskell.TH (bytesPrimL, mkBytes, reportWarning, runIO)
-import Language.Haskell.TH.Syntax (
-  Exp (AppE, LitE, VarE),
-  Lit (..),
-  Q,
-  qAddDependentFile,
- )
+import Language.Haskell.TH (reportWarning, runIO)
+import Language.Haskell.TH.Syntax (Exp (LitE), Lit (..), Q)
 import Path (parseRelFile)
 import Path.IO (doesFileExist)
 import System.Directory (getCurrentDirectory, listDirectory)
 import System.Environment (lookupEnv)
 import System.FilePath (isRelative, splitPath, takeDirectory)
-import System.IO.Unsafe (unsafePerformIO)
 
 embedFileIfExists :: FilePath -> Q Exp
 embedFileIfExists inputPath = do
@@ -46,11 +34,14 @@ embedFileIfExists inputPath = do
 -- | Like `embedFile`, but prints out debug logging when
 -- @FOSSA_DEBUG_EMBED_FILE@ is set.
 embedFileL :: FilePath -> Q Exp
-embedFileL fp = qAddDependentFile fp >> runIO embedWithLogging >>= bsToExp
+embedFileL fp = do
+  _ <- runIO logEmbedFile
+  embedFile fp
   where
-    embedWithLogging = do
+    logEmbedFile :: IO (Either IOError ())
+    logEmbedFile = do
       embedLogEnvVar <- lookupEnv "FOSSA_DEBUG_EMBED_FILE"
-      _ :: Either IOError () <- try $
+      try $
         when (isJust embedLogEnvVar) $ do
           cwd <- getCurrentDirectory
           putStrLn $ "CWD: " <> cwd
@@ -61,24 +52,8 @@ embedFileL fp = qAddDependentFile fp >> runIO embedWithLogging >>= bsToExp
 
           let dirs = take (length (splitPath fp) - if isRel then 0 else 1) $ tail $ iterate takeDirectory fp
           traverse_ ls dirs
-      B.readFile fp
 
     ls :: FilePath -> IO ()
     ls dir = do
       files <- listDirectory dir
       putStrLn $ "ls " <> show dir <> ": " <> show files
-
--- See https://github.com/snoyberg/file-embed/blob/548430d2a79bb6f4cb4256768761071f59909aa5/Data/FileEmbed.hs#L184-L204
-bsToExp :: B.ByteString -> Q Exp
-bsToExp bs =
-  pure $
-    VarE 'unsafePerformIO
-      `AppE` ( VarE 'unsafePackAddressLen
-                `AppE` LitE (IntegerL $ fromIntegral $ B8.length bs)
-                `AppE` LitE
-                  ( bytesPrimL
-                      ( let B.PS ptr off sz = bs
-                         in mkBytes ptr (fromIntegral off) (fromIntegral sz)
-                      )
-                  )
-             )

--- a/src/Data/FileEmbed/Extra.hs
+++ b/src/Data/FileEmbed/Extra.hs
@@ -1,5 +1,5 @@
 module Data.FileEmbed.Extra (
-  embedFileL,
+  embedFile',
   embedFileIfExists,
 ) where
 
@@ -25,7 +25,7 @@ embedFileIfExists inputPath = do
     (_, Just path) -> do
       exists <- doesFileExist path
       if exists
-        then embedFile inputPath
+        then embedFile' inputPath
         else do
           reportWarning $ "File " <> inputPath <> " not found"
           pure (LitE $ StringL "")
@@ -33,8 +33,8 @@ embedFileIfExists inputPath = do
 
 -- | Like `embedFile`, but prints out debug logging when
 -- @FOSSA_DEBUG_EMBED_FILE@ is set.
-embedFileL :: FilePath -> Q Exp
-embedFileL fp = do
+embedFile' :: FilePath -> Q Exp
+embedFile' fp = do
   _ <- runIO logEmbedFile
   embedFile fp
   where

--- a/src/Data/FileEmbed/Extra.hs
+++ b/src/Data/FileEmbed/Extra.hs
@@ -1,12 +1,32 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
 module Data.FileEmbed.Extra (
+  embedFileL,
   embedFileIfExists,
 ) where
 
+import Control.Exception (try)
+import Control.Monad (when)
+import Data.ByteString qualified as B
+import Data.ByteString.Char8 qualified as B8
+import Data.ByteString.Internal qualified as B
+import Data.ByteString.Unsafe (unsafePackAddressLen)
 import Data.FileEmbed (embedFile)
-import Language.Haskell.TH (Exp (LitE), Lit (StringL), Q, reportWarning, runIO)
+import Data.Foldable (traverse_)
+import Data.Maybe (isJust)
+import Language.Haskell.TH (bytesPrimL, mkBytes, reportWarning, runIO)
+import Language.Haskell.TH.Syntax (
+  Exp (AppE, LitE, VarE),
+  Lit (..),
+  Q,
+  qAddDependentFile,
+ )
 import Path (parseRelFile)
 import Path.IO (doesFileExist)
+import System.Directory (getCurrentDirectory, listDirectory)
 import System.Environment (lookupEnv)
+import System.FilePath (isRelative, splitPath, takeDirectory)
+import System.IO.Unsafe (unsafePerformIO)
 
 embedFileIfExists :: FilePath -> Q Exp
 embedFileIfExists inputPath = do
@@ -22,3 +42,43 @@ embedFileIfExists inputPath = do
           reportWarning $ "File " <> inputPath <> " not found"
           pure (LitE $ StringL "")
     (_, Nothing) -> fail "No filepath provided"
+
+-- | Like `embedFile`, but prints out debug logging when
+-- @FOSSA_DEBUG_EMBED_FILE@ is set.
+embedFileL :: FilePath -> Q Exp
+embedFileL fp = qAddDependentFile fp >> runIO embedWithLogging >>= bsToExp
+  where
+    embedWithLogging = do
+      embedLogEnvVar <- lookupEnv "FOSSA_DEBUG_EMBED_FILE"
+      _ :: Either IOError () <- try $
+        when (isJust embedLogEnvVar) $ do
+          cwd <- getCurrentDirectory
+          putStrLn $ "CWD: " <> cwd
+
+          putStrLn $ "Embedding file: " <> fp
+          let isRel = isRelative fp
+          putStrLn $ "Relative?: " <> show isRel
+
+          let dirs = take (length (splitPath fp) - if isRel then 0 else 1) $ tail $ iterate takeDirectory fp
+          traverse_ ls dirs
+      B.readFile fp
+
+    ls :: FilePath -> IO ()
+    ls dir = do
+      files <- listDirectory dir
+      putStrLn $ "ls " <> show dir <> ": " <> show files
+
+-- See https://github.com/snoyberg/file-embed/blob/548430d2a79bb6f4cb4256768761071f59909aa5/Data/FileEmbed.hs#L184-L204
+bsToExp :: B.ByteString -> Q Exp
+bsToExp bs =
+  pure $
+    VarE 'unsafePerformIO
+      `AppE` ( VarE 'unsafePackAddressLen
+                `AppE` LitE (IntegerL $ fromIntegral $ B8.length bs)
+                `AppE` LitE
+                  ( bytesPrimL
+                      ( let B.PS ptr off sz = bs
+                         in mkBytes ptr (fromIntegral off) (fromIntegral sz)
+                      )
+                  )
+             )

--- a/src/Data/FileEmbed/Extra.hs
+++ b/src/Data/FileEmbed/Extra.hs
@@ -34,9 +34,7 @@ embedFileIfExists inputPath = do
 -- | Like `embedFile`, but prints out debug logging when
 -- @FOSSA_DEBUG_EMBED_FILE@ is set.
 embedFile' :: FilePath -> Q Exp
-embedFile' fp = do
-  _ <- runIO logEmbedFile
-  embedFile fp
+embedFile' fp = runIO logEmbedFile *> embedFile fp
   where
     logEmbedFile :: IO (Either IOError ())
     logEmbedFile = do
@@ -50,6 +48,8 @@ embedFile' fp = do
           let isRel = isRelative fp
           putStrLn $ "Relative?: " <> show isRel
 
+          -- `tail` is safe here because `iterate` returns an infinite list and
+          -- therefore must always have at least 1 element.
           let dirs = take (length (splitPath fp) - if isRel then 0 else 1) $ tail $ iterate takeDirectory fp
           traverse_ ls dirs
 

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -37,7 +37,7 @@ import Data.Aeson (ToJSON)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
-import Data.FileEmbed (embedFile)
+import Data.FileEmbed.Extra (embedFileL)
 import Data.Foldable (find, traverse_)
 import Data.List (isPrefixOf)
 import Data.Maybe (mapMaybe)
@@ -261,7 +261,7 @@ getDeps targets project = context "Gradle" $ do
 
 -- See the release process to see how this script gets vendored.
 initScript :: ByteString
-initScript = $(embedFile "scripts/jsondeps.gradle")
+initScript = $(embedFileL "scripts/jsondeps.gradle")
 
 -- During analysis, we unpack the Gradle init script, run it, and parse the
 -- output.

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -37,7 +37,7 @@ import Data.Aeson (ToJSON)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
-import Data.FileEmbed.Extra (embedFileL)
+import Data.FileEmbed.Extra (embedFile')
 import Data.Foldable (find, traverse_)
 import Data.List (isPrefixOf)
 import Data.Maybe (mapMaybe)
@@ -261,7 +261,7 @@ getDeps targets project = context "Gradle" $ do
 
 -- See the release process to see how this script gets vendored.
 initScript :: ByteString
-initScript = $(embedFileL "scripts/jsondeps.gradle")
+initScript = $(embedFile' "scripts/jsondeps.gradle")
 
 -- During analysis, we unpack the Gradle init script, run it, and parse the
 -- output.

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -20,7 +20,7 @@ import Control.Effect.Lift (sendIO)
 import Data.Aeson
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
-import Data.FileEmbed.Extra (embedFileL)
+import Data.FileEmbed.Extra (embedFile')
 import Data.Functor (void)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
@@ -44,7 +44,7 @@ depGraphPlugin =
     { group = "com.github.ferstl"
     , artifact = "depgraph-maven-plugin"
     , version = "4.0.1"
-    , jar = $(embedFileL "scripts/depgraph-maven-plugin-4.0.1.jar")
+    , jar = $(embedFile' "scripts/depgraph-maven-plugin-4.0.1.jar")
     }
 
 depGraphPluginLegacy :: DepGraphPlugin
@@ -53,7 +53,7 @@ depGraphPluginLegacy =
     { group = "com.github.ferstl"
     , artifact = "depgraph-maven-plugin"
     , version = "3.3.0"
-    , jar = $(embedFileL "scripts/depgraph-maven-plugin-3.3.0.jar")
+    , jar = $(embedFile' "scripts/depgraph-maven-plugin-3.3.0.jar")
     }
 
 withUnpackedPlugin ::

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -20,7 +20,7 @@ import Control.Effect.Lift (sendIO)
 import Data.Aeson
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
-import Data.FileEmbed (embedFile)
+import Data.FileEmbed.Extra (embedFileL)
 import Data.Functor (void)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
@@ -44,7 +44,7 @@ depGraphPlugin =
     { group = "com.github.ferstl"
     , artifact = "depgraph-maven-plugin"
     , version = "4.0.1"
-    , jar = $(embedFile "scripts/depgraph-maven-plugin-4.0.1.jar")
+    , jar = $(embedFileL "scripts/depgraph-maven-plugin-4.0.1.jar")
     }
 
 depGraphPluginLegacy :: DepGraphPlugin
@@ -53,7 +53,7 @@ depGraphPluginLegacy =
     { group = "com.github.ferstl"
     , artifact = "depgraph-maven-plugin"
     , version = "3.3.0"
-    , jar = $(embedFile "scripts/depgraph-maven-plugin-3.3.0.jar")
+    , jar = $(embedFileL "scripts/depgraph-maven-plugin-3.3.0.jar")
     }
 
 withUnpackedPlugin ::


### PR DESCRIPTION
# Overview

This PR adds a new function `embedFileL` to `Data.FileEmbed.Extra`, which adds optional debug logging that can be turned on using environment variable `FOSSA_DEBUG_EMBED_FILE`.

This is useful for debugging file embedding issues and seeing what files are actually being embedded.

## Acceptance criteria

When `FOSSA_DEBUG_EMBED_FILE` is set, `cabal build` will now print debug logs when embedding files. See my example incremental build output:

```
$ FOSSA_DEBUG_EMBED_FILE=1 cabal build
Build profile: -w ghc-9.0.2 -O0
In order, the following will be built (use -v for more details):
 - spectrometer-0.1.0.0 (lib) (file src/Data/FileEmbed/Extra.hs changed)
 - spectrometer-0.1.0.0 (test:unit-tests) (dependency rebuilt)
 - spectrometer-0.1.0.0 (exe:pathfinder) (dependency rebuilt)
 - spectrometer-0.1.0.0 (test:integration-tests) (dependency rebuilt)
 - spectrometer-0.1.0.0 (exe:fossa) (dependency rebuilt)
Preprocessing library for spectrometer-0.1.0.0..
Building library for spectrometer-0.1.0.0..
[225 of 266] Compiling Data.FileEmbed.Extra ( src/Data/FileEmbed/Extra.hs, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/Data/FileEmbed/Extra.o, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/Data/FileEmbed/Extra.dyn_o )
[226 of 266] Compiling App.Fossa.EmbeddedBinary ( src/App/Fossa/EmbeddedBinary.hs, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/App/Fossa/EmbeddedBinary.o, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/App/Fossa/EmbeddedBinary.dyn_o ) [TH]

src/App/Fossa/EmbeddedBinary.hs:189:26: warning:
    File vendor-bins/wiggins not found
    |
189 | embeddedBinaryWiggins = $(embedFileIfExists "vendor-bins/wiggins")
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/App/Fossa/EmbeddedBinary.hs:192:23: warning:
    File vendor-bins/syft not found
    |
192 | embeddedBinarySyft = $(embedFileIfExists "vendor-bins/syft")
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/App/Fossa/EmbeddedBinary.hs:195:25: warning:
    File vendor-bins/themis-cli not found
    |
195 | embeddedBinaryThemis = $(embedFileIfExists "vendor-bins/themis-cli")
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/App/Fossa/EmbeddedBinary.hs:198:30: warning:
    File vendor-bins/index.gob.xz not found
    |
198 | embeddedBinaryThemisIndex = $(embedFileIfExists "vendor-bins/index.gob.xz")
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[228 of 266] Compiling Strategy.Maven.Plugin ( src/Strategy/Maven/Plugin.hs, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/Strategy/Maven/Plugin.o, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/Strategy/Maven/Plugin.dyn_o ) [TH]
CWD: /home/leo/src/fossa/fossa-cli
Embedding file: scripts/depgraph-maven-plugin-4.0.1.jar
Relative?: True
ls "scripts": ["depgraph-maven-plugin-4.0.1.jar","jsondeps.gradle","depgraph-maven-plugin-3.3.0.jar"]
ls ".": [".markdown-link-check.json","test","spectrometer.cabal","cabal.project","install-v1.ps1",".editorconfig","cabal.project.ci.windows","Makefile","hie.yaml","shell.nix","scripts","Changelog.md","dist-newstyle","fossa.debug.json.gz",".scratch","install-latest.sh","integration-test","cabal.project.ci.linux",".gitignore","fossa.debug.json","install.sh","app","experimental-scripts","install.ps1","cabal.project.ci.macos","src","install-v1.sh","README.md","LICENSE",".circleci","vendor_download.sh","install-latest.ps1",".github","fourmolu.yaml",".hlint.yaml",".git","docs"]
CWD: /home/leo/src/fossa/fossa-cli
Embedding file: scripts/depgraph-maven-plugin-3.3.0.jar
Relative?: True
ls "scripts": ["depgraph-maven-plugin-4.0.1.jar","jsondeps.gradle","depgraph-maven-plugin-3.3.0.jar"]
ls ".": [".markdown-link-check.json","test","spectrometer.cabal","cabal.project","install-v1.ps1",".editorconfig","cabal.project.ci.windows","Makefile","hie.yaml","shell.nix","scripts","Changelog.md","dist-newstyle","fossa.debug.json.gz",".scratch","install-latest.sh","integration-test","cabal.project.ci.linux",".gitignore","fossa.debug.json","install.sh","app","experimental-scripts","install.ps1","cabal.project.ci.macos","src","install-v1.sh","README.md","LICENSE",".circleci","vendor_download.sh","install-latest.ps1",".github","fourmolu.yaml",".hlint.yaml",".git","docs"]
[237 of 266] Compiling App.Fossa.API.BuildLink ( src/App/Fossa/API/BuildLink.hs, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/App/Fossa/API/BuildLink.o, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/App/Fossa/API/BuildLink.dyn_o ) [TH]
[252 of 266] Compiling App.Fossa.VSI.Analyze ( src/App/Fossa/VSI/Analyze.hs, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/App/Fossa/VSI/Analyze.o, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/App/Fossa/VSI/Analyze.dyn_o ) [TH]
[255 of 266] Compiling App.Fossa.ManualDeps ( src/App/Fossa/ManualDeps.hs, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/App/Fossa/ManualDeps.o, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/App/Fossa/ManualDeps.dyn_o ) [TH]
[259 of 266] Compiling Strategy.Gradle  ( src/Strategy/Gradle.hs, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/Strategy/Gradle.o, /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/noopt/build/Strategy/Gradle.dyn_o ) [TH]
CWD: /home/leo/src/fossa/fossa-cli
Embedding file: scripts/jsondeps.gradle
Relative?: True
ls "scripts": ["depgraph-maven-plugin-4.0.1.jar","jsondeps.gradle","depgraph-maven-plugin-3.3.0.jar"]
ls ".": [".markdown-link-check.json","test","spectrometer.cabal","cabal.project","install-v1.ps1",".editorconfig","cabal.project.ci.windows","Makefile","hie.yaml","shell.nix","scripts","Changelog.md","dist-newstyle","fossa.debug.json.gz",".scratch","install-latest.sh","integration-test","cabal.project.ci.linux",".gitignore","fossa.debug.json","install.sh","app","experimental-scripts","install.ps1","cabal.project.ci.macos","src","install-v1.sh","README.md","LICENSE",".circleci","vendor_download.sh","install-latest.ps1",".github","fourmolu.yaml",".hlint.yaml",".git","docs"]
Preprocessing executable 'pathfinder' for spectrometer-0.1.0.0..
Building executable 'pathfinder' for spectrometer-0.1.0.0..
Preprocessing test suite 'unit-tests' for spectrometer-0.1.0.0..
Building test suite 'unit-tests' for spectrometer-0.1.0.0..
Preprocessing executable 'fossa' for spectrometer-0.1.0.0..
Building executable 'fossa' for spectrometer-0.1.0.0..
Preprocessing test suite 'integration-tests' for spectrometer-0.1.0.0..
Building test suite 'integration-tests' for spectrometer-0.1.0.0..
Linking /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/x/fossa/noopt/build/fossa/fossa ...
Linking /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/x/pathfinder/noopt/build/pathfinder/pathfinder ...
Linking /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/t/integration-tests/noopt/build/integration-tests/integration-tests ...
Linking /home/leo/src/fossa/fossa-cli/dist-newstyle/build/x86_64-linux/ghc-9.0.2/spectrometer-0.1.0.0/t/unit-tests/noopt/build/unit-tests/unit-tests ...
```

## Testing plan

1. Check out this PR.
2. Run `cabal build` and verify that the build behaves as before.
3. Run `cabal clean`. Alternatively, add a new empty line to `Data.FileEmbed.Extra` (we just need to invalidate Cabal's cache for this module and its dependents).
4. Run `FOSSA_DEBUG_EMBED_FILE=1 cabal build` and verify that debug logging occurs.

## Risks

I've added some `hlint` exceptions to get the status check passing. IMO, these are safe because this module only contains compile-time code. Is this the preferred way to do exceptions? Or would you prefer that I use pragmas in files?

Personally, I think pragmas are more maintainable because it's easier to write comments next to them justifying each exception, but the rest of the codebase seems to use `.hlint.yaml` exceptions.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
