### PR TITLE
[No-Ticket] Checks for incorrect spelling of Fossa at CI time

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,3 +57,12 @@ jobs:
     - name: "run cabal-fmt"
       run: |
         cabal-fmt --check spectrometer.cabal
+
+  common-verbiage-check:
+    name: "Check for correct spelling of FOSSA"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Check for incorrect FOSSA wording"
+        run: |
+          ! grep 'Fossa ' **/*.md

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -1,6 +1,6 @@
 ### License scanning local dependencies
 
-Fossa offers the ability to license scan your code directly. This is used primarily if a package manager is not yet supported or if you are vendoring dependencies. Using the license scanning feature will allow you to capture the licenses for dependencies that may otherwise be missed from normal fossa analysis that relies on package manager information.
+FOSSA offers the ability to license scan your code directly. This is used primarily if a package manager is not yet supported or if you are vendoring dependencies. Using the license scanning feature will allow you to capture the licenses for dependencies that may otherwise be missed from normal fossa analysis that relies on package manager information.
 
 In order to specify a file path, modify your `fossa-deps.yml` file and add a `vendored-dependencies` section like the following:
 


### PR DESCRIPTION
# Overview

This PR adds a CI check that checks for incorrect spelling of Fossa per the new style guide. The check is not a required step.

I'm adding this as I will indefinitely forget to check for this in code review, or during development. Adding this is so it's not in my blindspots.

## Acceptance criteria

- `Check for incorrect FOSSA wording` step fails if `Fossa` word is used in documentation.

## Testing plan

N/A

## Risks

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
