### PR TITLE
`DiscoveredProjectScans` should be `Show`-able

### DIFF
--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -38,6 +38,7 @@ data ProjectResult = ProjectResult
   , projectResultGraphBreadth :: GraphBreadth
   , projectResultManifestFiles :: [SomeBase File]
   }
+  deriving (Show)
 
 shouldKeepUnreachableDeps :: DiscoveredProjectType -> Bool
 shouldKeepUnreachableDeps SwiftProjectType = True

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -53,6 +53,7 @@ data DiscoveredProjectScan
   = SkippedDueToProvidedFilter DiscoveredProjectIdentifier
   | SkippedDueToDefaultProductionFilter DiscoveredProjectIdentifier
   | Scanned DiscoveredProjectIdentifier (Result ProjectResult)
+  deriving (Show)
 
 instance Ord DiscoveredProjectScan where
   a `compare` b = orderByScanStatusAndType a b
@@ -79,7 +80,7 @@ data DiscoveredProjectIdentifier = DiscoveredProjectIdentifier
   { dpiProjectPath :: Path Abs Dir
   , dpiProjectType :: DiscoveredProjectType
   }
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
 
 class AnalyzeProject a where
   analyzeProject :: AnalyzeTaskEffs sig m => FoundTargets -> a -> m DependencyResults


### PR DESCRIPTION
# Overview

This PR adds derived `Show` instances for various types so that `DiscoveredProjectScans` can be `Show`.

This PR is stacked on #973. Use https://github.com/fossas/fossa-cli/compare/leo/refactor/cabal-installable...leo/refactor/showable-scans for a clean diff.

## Acceptance criteria

`DiscoveredProjectScans` are `Show`.

## Testing plan

Run `cabal build`, and see that this builds.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
