### PR TITLE
refactor: Add concurrent in-memory logger

### DIFF
--- a/src/Effect/Logger.hs
+++ b/src/Effect/Logger.hs
@@ -12,7 +12,7 @@ module Effect.Logger (
   withLogger,
   withDefaultLogger,
   withWriterLogger,
-  withConcurrentLogger,
+  withTVarLogger,
   runLogger,
   ignoreLogger,
   log,
@@ -141,7 +141,9 @@ withWriterLogger sev = runLogger ctx
         , logCtxWrite = tell . pure @f
         }
 
-withConcurrentLogger ::
+-- | Like `withWriterLogger`, except it works even when the logged action forks
+-- threads.
+withTVarLogger ::
   forall f sig m a.
   ( Applicative f
   , Monoid (f (Doc AnsiStyle))
@@ -151,7 +153,7 @@ withConcurrentLogger ::
   Severity ->
   LoggerC m a ->
   m a
-withConcurrentLogger sev = runLogger ctx
+withTVarLogger sev = runLogger ctx
   where
     ctx :: LogCtx (Doc AnsiStyle) m
     ctx =

--- a/test/Effect/LoggerSpec.hs
+++ b/test/Effect/LoggerSpec.hs
@@ -1,45 +1,55 @@
 module Effect.LoggerSpec (spec) where
 
 import Control.Algebra (run)
-import Control.Carrier.State.Strict (execState)
+import Control.Carrier.Reader (runReader)
 import Control.Carrier.Writer.Strict (execWriter)
 import Control.Concurrent (getNumCapabilities)
-import Data.Sequence (Seq)
+import Control.Concurrent.STM (newTVarIO, readTVarIO)
+import Control.Monad (forM_)
+import Data.Foldable (traverse_)
+import Data.Sequence (Seq, sort)
 import Data.Sequence qualified as Seq
 import Test.Hspec (Spec, describe, it, shouldBe)
 
 import Control.Carrier.TaskPool (forkTask, withTaskPool)
-import Control.Monad (forM_)
-import Effect.Logger (Severity (..), logInfo, pretty, renderIt, withStateLogger, withWriterLogger)
+import Data.Functor.Extra ((<$$>))
+import Data.Text.Extra (showT)
+import Effect.Logger (Severity (..), logInfo, pretty, renderIt, withConcurrentLogger, withWriterLogger)
 
 spec :: Spec
 spec = do
   describe "withWriterLogger" $ do
     it "records logged messages" $ do
       let messages =
-            run . execWriter . withWriterLogger @Seq SevInfo $ do
-              logInfo "this is a test message"
-              logInfo "this is another test message"
-      renderIt <$> messages `shouldBe` Seq.fromList ["this is a test message", "this is another test message"]
+            fmap renderIt
+              . run
+              . execWriter
+              . withWriterLogger @Seq SevInfo
+              $ do
+                logInfo "this is a test message"
+                logInfo "this is another test message"
+      messages `shouldBe` Seq.fromList ["this is a test message", "this is another test message"]
 
-  describe "withStateLogger" $ do
-    it "records logged messages" $ do
-      let messages =
-            run . execState Seq.empty . withStateLogger @Seq SevInfo $ do
-              logInfo "this is a test message"
-              logInfo "this is another test message"
-      renderIt <$> messages `shouldBe` Seq.fromList ["this is a test message", "this is another test message"]
+  describe "withConcurrentLogger" $ do
+    it "records logged messages from a single thread" $ do
+      logs <- newTVarIO Seq.empty
+      runReader logs . withConcurrentLogger @Seq SevInfo $ do
+        logInfo "this is a test message"
+        logInfo "this is another test message"
+      messages <- renderIt <$$> readTVarIO logs
+      messages `shouldBe` Seq.fromList ["this is a test message", "this is another test message"]
 
     it "records logged messages from forked threads" $ do
       capabilities <- getNumCapabilities
+      let threads = [0 .. capabilities]
+          msgIds :: [Int] = [0 .. 5]
 
-      messages <-
-        execState Seq.empty
-          . withStateLogger @Seq SevInfo
-          . withTaskPool capabilities (logInfo . pretty . show)
-          $ forM_ [0 .. capabilities] $
-            \i -> forkTask $ do
-              logInfo $ pretty $ show @(Int, Int) (i, 1)
-              logInfo $ pretty $ show @(Int, Int) (i, 2)
+      logs <- newTVarIO Seq.empty
+      runReader logs
+        . withConcurrentLogger @Seq SevInfo
+        . withTaskPool capabilities (const $ pure ())
+        $ forM_ threads $ \t -> forkTask $ traverse_ (logInfo . pretty . show . (t,)) msgIds
+      messages <- renderIt <$$> readTVarIO logs
 
-      renderIt <$> messages `shouldBe` Seq.fromList ["this is a test message", "this is another test message"]
+      let expected = Seq.fromList $ showT @(Int, Int) <$> [(t, m) | t <- threads, m <- msgIds]
+      sort messages `shouldBe` sort expected

--- a/test/Effect/LoggerSpec.hs
+++ b/test/Effect/LoggerSpec.hs
@@ -14,7 +14,7 @@ import Test.Hspec (Spec, describe, it, shouldBe)
 import Control.Carrier.TaskPool (forkTask, withTaskPool)
 import Data.Functor.Extra ((<$$>))
 import Data.Text.Extra (showT)
-import Effect.Logger (Severity (..), logInfo, pretty, renderIt, withConcurrentLogger, withWriterLogger)
+import Effect.Logger (Severity (..), logInfo, pretty, renderIt, withTVarLogger, withWriterLogger)
 
 spec :: Spec
 spec = do
@@ -30,10 +30,10 @@ spec = do
                 logInfo "this is another test message"
       messages `shouldBe` Seq.fromList ["this is a test message", "this is another test message"]
 
-  describe "withConcurrentLogger" $ do
+  describe "withTVarLogger" $ do
     it "records logged messages from a single thread" $ do
       logs <- newTVarIO Seq.empty
-      runReader logs . withConcurrentLogger @Seq SevInfo $ do
+      runReader logs . withTVarLogger @Seq SevInfo $ do
         logInfo "this is a test message"
         logInfo "this is another test message"
       messages <- renderIt <$$> readTVarIO logs
@@ -46,7 +46,7 @@ spec = do
 
       logs <- newTVarIO Seq.empty
       runReader logs
-        . withConcurrentLogger @Seq SevInfo
+        . withTVarLogger @Seq SevInfo
         . withTaskPool capabilities (const $ pure ())
         $ forM_ threads $ \t -> forkTask $ traverse_ (logInfo . pretty . show . (t,)) msgIds
       messages <- renderIt <$$> readTVarIO logs

--- a/test/Effect/LoggerSpec.hs
+++ b/test/Effect/LoggerSpec.hs
@@ -1,19 +1,45 @@
 module Effect.LoggerSpec (spec) where
 
 import Control.Algebra (run)
+import Control.Carrier.State.Strict (execState)
 import Control.Carrier.Writer.Strict (execWriter)
+import Control.Concurrent (getNumCapabilities)
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import Test.Hspec (Spec, describe, it, shouldBe)
 
-import Effect.Logger (Severity (..), logInfo, renderIt, withWriterLogger)
+import Control.Carrier.TaskPool (forkTask, withTaskPool)
+import Control.Monad (forM_)
+import Effect.Logger (Severity (..), logInfo, pretty, renderIt, withStateLogger, withWriterLogger)
 
 spec :: Spec
 spec = do
-  describe "Writer-based Logger" $ do
-    it "should record logged messages" $ do
+  describe "withWriterLogger" $ do
+    it "records logged messages" $ do
       let messages =
             run . execWriter . withWriterLogger @Seq SevInfo $ do
               logInfo "this is a test message"
               logInfo "this is another test message"
+      renderIt <$> messages `shouldBe` Seq.fromList ["this is a test message", "this is another test message"]
+
+  describe "withStateLogger" $ do
+    it "records logged messages" $ do
+      let messages =
+            run . execState Seq.empty . withStateLogger @Seq SevInfo $ do
+              logInfo "this is a test message"
+              logInfo "this is another test message"
+      renderIt <$> messages `shouldBe` Seq.fromList ["this is a test message", "this is another test message"]
+
+    it "records logged messages from forked threads" $ do
+      capabilities <- getNumCapabilities
+
+      messages <-
+        execState Seq.empty
+          . withStateLogger @Seq SevInfo
+          . withTaskPool capabilities (logInfo . pretty . show)
+          $ forM_ [0 .. capabilities] $
+            \i -> forkTask $ do
+              logInfo $ pretty $ show @(Int, Int) (i, 1)
+              logInfo $ pretty $ show @(Int, Int) (i, 2)
+
       renderIt <$> messages `shouldBe` Seq.fromList ["this is a test message", "this is another test message"]


### PR DESCRIPTION
# Overview

This PR adds `withTVarLogger`, which runs a `Logger` into a `Reader TVar`. This is a lot like `withWriterLogger` (#977) except that it also collects logged messages across all threads in the presence of `withTaskPool`.

## Acceptance criteria

`withTVarLogger` allows consumers to run a `Logger` into a `Reader TVar`, and collects all logged messages even when the logged action forks threads.

## Testing plan

See the accompanying unit tests. Run with `make test ARGS="Effect.Logger"`.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
