### PR TITLE
[untested]: Make walker resilient to dir access errors

### DIFF
--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -34,6 +34,8 @@ module Control.Effect.Diagnostics (
   fromMaybeText,
   tagError,
   combineSuccessful,
+  recoverWith,
+  recoverWithDefault,
 
   -- * Algebra re-exports
   module X,
@@ -51,6 +53,7 @@ import Control.Exception (Exception, IOException, SomeException (..))
 import Control.Exception.Extra (safeCatch)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes)
+import Data.Maybe qualified as Maybe
 import Data.Semigroup (sconcat)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
@@ -214,3 +217,11 @@ combineSuccessful err war actions = do
   case successful of
     Nothing -> fatal err
     Just xs -> pure (sconcat xs)
+
+-- | Recover from an error and apply a function
+recoverWith :: Has Diagnostics sig m => (Maybe a -> b) -> m a -> m b
+recoverWith f act = f <$> recover act
+
+-- | Recover from an error and provide a fallback value
+recoverWithDefault :: Has Diagnostics sig m => a -> m a -> m a
+recoverWithDefault x = recoverWith (Maybe.fromMaybe x)

--- a/src/Discovery/Walk.hs
+++ b/src/Discovery/Walk.hs
@@ -21,7 +21,7 @@ import Control.Carrier.Writer.Church (
 import Control.Effect.Diagnostics (
   Diagnostics,
   context,
-  recover,
+  recoverWithDefault,
  )
 import Control.Effect.Reader (Reader, ask)
 import Control.Monad.Trans (MonadTrans (lift))
@@ -30,7 +30,7 @@ import Data.Foldable (find)
 import Data.Functor (void)
 import Data.Glob qualified as Glob
 import Data.List ((\\))
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (mapMaybe)
 import Data.Set qualified as Set
 import Data.String.Conversion (toString)
 import Data.Text (Text)
@@ -178,7 +178,7 @@ walkDir handler topdir =
       -- and claim that it has no children.  We don't log it because it would
       -- happen for every discovery process and would be very noisy.
       -- TODO: use a (State (Set SkippedDirs)) effect to track and report this
-      (subdirs, files) <- fmap (fromMaybe ([], [])) $ recover $ listDir curdir
+      (subdirs, files) <- recoverWithDefault ([], []) $ listDir curdir
       action <- handler curdir subdirs files
       case action of
         WalkFinish -> pure Nothing


### PR DESCRIPTION
# Overview

When the discovery traverses the file tree, it crashes if there are any errors reading the directory, or executing the directory handler.

This PR only addresses the read errors, since handler errors could be valid.

## Acceptance criteria

Walker is resilient to errors during the `listdir` operation.

## Testing plan

TBD

## Risks

We lose information here, since we can't log the directories that failed (too noisy to do it for every discovery).

## References

Internal slack thread: https://teamfossa.slack.com/archives/C0155DTGWB1/p1655439461261949

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
