### PR TITLE
[No Ticket] Includes fossa endpoint version in the scan summary and debug bundle

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 - Changes copyrights field to copyrightsByLicense in the attribution report JSON output. [#966](https://github.com/fossas/fossa-cli/pull/966)
 - Always include the "downloadUrl" field in attribution reports, regardless of the setting in the FOSSA reports UI. ([#979](https://github.com/fossas/fossa-cli/pull/979))
-- Debug: Includes version associated with endpoint in debug bundle, and scan summary. ([]())
+- Debug: Includes version associated with endpoint in debug bundle, and scan summary. ([#984](https://github.com/fossas/fossa-cli/pull/984))
 
 ## v3.3.6
 - Make CLI-side license scanning the default method of scanning vendored dependencies

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Changes copyrights field to copyrightsByLicense in the attribution report JSON output. [#966](https://github.com/fossas/fossa-cli/pull/966)
 - Always include the "downloadUrl" field in attribution reports, regardless of the setting in the FOSSA reports UI. ([#979](https://github.com/fossas/fossa-cli/pull/979))
+- Debug: Includes version associated with endpoint in debug bundle, and scan summary. ([]())
 
 ## v3.3.6
 - Make CLI-side license scanning the default method of scanning vendored dependencies

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -77,7 +77,6 @@ import Control.Carrier.TaskPool (
   withTaskPool,
  )
 import Control.Concurrent (getNumCapabilities)
-import Control.Effect.Debug (debugMetadata)
 import Control.Effect.Exception (Lift)
 import Control.Effect.FossaApiClient (FossaApiClient, getEndpointVersion)
 import Control.Effect.Git (Git)

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -77,8 +77,9 @@ import Control.Carrier.TaskPool (
   withTaskPool,
  )
 import Control.Concurrent (getNumCapabilities)
+import Control.Effect.Debug (debugMetadata)
 import Control.Effect.Exception (Lift)
-import Control.Effect.FossaApiClient (FossaApiClient)
+import Control.Effect.FossaApiClient (FossaApiClient, getEndpointVersion)
 import Control.Effect.Git (Git)
 import Control.Effect.Lift (sendIO)
 import Control.Effect.Stack (Stack, withEmptyStack)
@@ -308,7 +309,14 @@ analyze cfg = Diag.context "fossa-analyze" $ do
 
   let analysisResult = AnalysisScanResult projectScansWithSkippedProdPath vsiResults binarySearchResults manualSrcUnits dynamicLinkedResults
 
-  renderScanSummary (severity cfg) analysisResult $ Config.filterSet cfg
+  maybeEndpointAppVersion <- case destination of
+    UploadScan apiOpts _ -> runFossaApiClient apiOpts $ do
+      version <- getEndpointVersion
+      debugMetadata "FossaEndpointCoreVersion" version
+      pure version
+    _ -> pure Nothing
+
+  renderScanSummary (severity cfg) maybeEndpointAppVersion analysisResult $ Config.filterSet cfg
 
   -- Need to check if vendored is empty as well, even if its a boolean that vendoredDeps exist
   case checkForEmptyUpload includeAll projectResults filteredProjects additionalSourceUnits of
@@ -320,6 +328,8 @@ analyze cfg = Diag.context "fossa-analyze" $ do
         Diag.context "upload-results"
           . runFossaApiClient apiOpts
           $ do
+            --
+
             locator <- uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision sourceUnits
             doAssertRevisionBinaries iatAssertion locator
 

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -38,6 +38,7 @@ runFossaApiClient apiOpts =
           GetApiOpts -> pure apiOpts
           GetAttribution rev format -> Core.getAttribution rev format
           GetIssues rev -> Core.getIssues rev
+          GetEndpointVersion -> Core.getEndpointVersion
           GetLatestBuild rev -> Core.getLatestBuild rev
           GetLatestScan locator rev -> ScotlandYard.getLatestScan locator rev
           GetOrganization -> Core.getOrganization

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -13,6 +13,7 @@ module Control.Carrier.FossaApiClient.Internal.Core (
   uploadArchive,
   uploadContainerScan,
   uploadContributors,
+  getEndpointVersion,
 ) where
 
 import App.Fossa.Config.Report (ReportOutputFormat)
@@ -180,3 +181,13 @@ uploadArchive ::
   m ByteString
 uploadArchive =
   API.archiveUpload
+
+getEndpointVersion ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has (Reader ApiOpts) sig m
+  ) =>
+  m (Maybe Text)
+getEndpointVersion = do
+  apiOpts <- ask
+  API.getEndpointVersion apiOpts

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -52,7 +52,7 @@ import App.Version (versionNumber)
 import Codec.Compression.GZip qualified as GZIP
 import Control.Algebra (Algebra, Has, type (:+:))
 import Control.Carrier.Empty.Maybe (Empty, EmptyC, runEmpty)
-import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (..), context, fatal, fromEither, fromMaybeText, warn)
+import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (..), context, fatal, fromMaybeText, warn)
 import Control.Effect.Empty (empty)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Exception (Exception (displayException), SomeException)

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -15,6 +15,7 @@ module Control.Effect.FossaApiClient (
   getIssues,
   getLatestBuild,
   getLatestScan,
+  getEndpointVersion,
   getOrganization,
   getProject,
   getAnalyzedRevisions,
@@ -84,6 +85,7 @@ data FossaApiClientF a where
   GetApiOpts :: FossaApiClientF ApiOpts
   GetAttribution :: ProjectRevision -> ReportOutputFormat -> FossaApiClientF Text
   GetIssues :: ProjectRevision -> FossaApiClientF Issues
+  GetEndpointVersion :: FossaApiClientF (Maybe Text)
   GetLatestBuild :: ProjectRevision -> FossaApiClientF Build
   GetLatestScan :: Locator -> ProjectRevision -> FossaApiClientF ScanResponse
   GetOrganization :: FossaApiClientF Organization
@@ -206,3 +208,6 @@ getVsiScanAnalysisStatus = sendSimple . GetVsiScanAnalysisStatus
 
 getVsiInferences :: Has FossaApiClient sig m => VSI.ScanID -> m [Locator]
 getVsiInferences = sendSimple . GetVsiInferences
+
+getEndpointVersion :: Has FossaApiClient sig m => m (Maybe Text)
+getEndpointVersion = sendSimple GetEndpointVersion

--- a/test/Test/MockApi.hs
+++ b/test/Test/MockApi.hs
@@ -212,6 +212,7 @@ matchExpectation a@(GetIssues{}) (ApiExpectation _ requestExpectation b@(GetIssu
 matchExpectation a@(GetLatestBuild{}) (ApiExpectation _ requestExpectation b@(GetLatestBuild{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetLatestScan{}) (ApiExpectation _ requestExpectation b@(GetLatestScan{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetOrganization{}) (ApiExpectation _ requestExpectation b@(GetOrganization{}) resp) = checkResult requestExpectation a b resp
+matchExpectation a@(GetEndpointVersion{}) (ApiExpectation _ requestExpectation b@(GetEndpointVersion{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetProject{}) (ApiExpectation _ requestExpectation b@(GetProject{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetScan{}) (ApiExpectation _ requestExpectation b@(GetScan{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetSignedLicenseScanUrl{}) (ApiExpectation _ requestExpectation b@(GetSignedLicenseScanUrl{}) resp) = checkResult requestExpectation a b resp


### PR DESCRIPTION
# Overview

This PR includes the endpoint version in the debug bundle, and in the scan summary. I know this format is changing eventually, but wanted to get this in to help triage some issues as they come up.

## Acceptance criteria

- endpoint version is included in scan summary
- endpoint version is included in debug bundle, when `--debug` is passed
- endpoint version is 'n/a' when --output flag is passed

## Testing plan

```
mkdir sandbox && echo 'numpy' > sandbox/reqs.txt
fossa analyze sandbox
```

You should see endpoint's version in the scan summary, likewise if you pass `--debug`, you should see the version in the debug bundle.

## Risks

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
