### PR TITLE
Adds `fossa test --diff` command

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Changes copyrights field to copyrightsByLicense in the attribution report JSON output. [#966](https://github.com/fossas/fossa-cli/pull/966)
 - Always include the "downloadUrl" field in attribution reports, regardless of the setting in the FOSSA reports UI. ([#979](https://github.com/fossas/fossa-cli/pull/979))
 - Debug: Includes version associated with endpoint in debug bundle, and scan summary. ([#984](https://github.com/fossas/fossa-cli/pull/984))
+- Test: Adds `--diff` option for `fossa test` command. ([#986](https://github.com/fossas/fossa-cli/pull/986))
 
 ## v3.3.6
 - Make CLI-side license scanning the default method of scanning vendored dependencies

--- a/docs/references/subcommands/test.md
+++ b/docs/references/subcommands/test.md
@@ -25,3 +25,33 @@ By default, `fossa test` displays issues in a human-readable format. To instead 
 ```sh
 fossa test --json
 ```
+
+### Test against previous revision
+
+With `--diff <ARG>`, you can check for _only_ new issue comapred to some `<ARG>` revision. 
+
+```sh
+fossa test --diff revisionToCompare
+```
+
+#### Example
+
+```sh
+fossa test --revision 34021e --diff v2.0.0
+```
+
+This will only report issues that are present in `34021e` revision,
+BUT are not present in revision `v2.0.0`.
+
+For instance, 
+
+* If the revision `v2.0.0` has issue: `A`, and the revision `34021e` has issue `A`, 
+  * `fossa-cli` will report no new issues discovered, and will exit with status code of 0.
+  
+
+* If the revision `v2.0.0` has issue: `A`, and the revision `34021e` has 0 issues, 
+  * `fossa-cli` will report no new issues discovered, and will exit with status code of 0.
+
+
+* If the revision `v2.0.0` has issue: `A`, and the revision `34021e` has issues `A`, `B`, 
+  * `fossa-cli` will report issue `B`, and will exit with status code of 1.

--- a/docs/references/subcommands/test.md
+++ b/docs/references/subcommands/test.md
@@ -26,32 +26,32 @@ By default, `fossa test` displays issues in a human-readable format. To instead 
 fossa test --json
 ```
 
-### Test against previous revision
+### Test for new issues compared to another revision
 
-With `--diff <ARG>`, you can check for _only_ new issue comapred to some `<ARG>` revision. 
+`--diff <REVISION>` configures FOSSA to only report new issues observed with the current revision that weren't already reported on the specified `<REVISION>`.
 
-```sh
+\```sh
 fossa test --diff revisionToCompare
-```
+\```
 
 #### Example
 
-```sh
+\```sh
 fossa test --revision 34021e --diff v2.0.0
-```
+\```
 
-This will only report issues that are present in `34021e` revision,
+This only reports issues that are present in `34021e` revision,
 BUT are not present in revision `v2.0.0`.
 
 For instance, 
 
 * If the revision `v2.0.0` has issue: `A`, and the revision `34021e` has issue `A`, 
-  * `fossa-cli` will report no new issues discovered, and will exit with status code of 0.
+  * `fossa-cli` reports no new issues discovered and exits with status code of 0.
   
 
 * If the revision `v2.0.0` has issue: `A`, and the revision `34021e` has 0 issues, 
-  * `fossa-cli` will report no new issues discovered, and will exit with status code of 0.
+  * `fossa-cli` reports no new issues discovered and exits with status code of 0.
 
 
 * If the revision `v2.0.0` has issue: `A`, and the revision `34021e` has issues `A`, `B`, 
-  * `fossa-cli` will report issue `B`, and will exit with status code of 1.
+  * `fossa-cli` reports issue `B` and exits with status code of 1.

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -4,6 +4,7 @@ module App.Fossa.API.BuildWait (
   waitForBuild,
 ) where
 
+import App.Fossa.Config.Test (DiffRevision)
 import App.Types (ProjectRevision (projectName))
 import Control.Effect.Diagnostics (
   Diagnostics,
@@ -84,15 +85,16 @@ waitForIssues ::
   , Has (Lift IO) sig m
   ) =>
   ProjectRevision ->
+  Maybe DiffRevision ->
   Cancel ->
   m Issues
-waitForIssues revision cancelFlag = do
+waitForIssues revision maybeDiffRevision cancelFlag = do
   checkForTimeout cancelFlag
-  issues <- getIssues revision
+  issues <- getIssues revision maybeDiffRevision
   case issuesStatus issues of
     "WAITING" -> do
       pauseForRetry
-      waitForIssues revision cancelFlag
+      waitForIssues revision maybeDiffRevision cancelFlag
     _ -> pure issues
 
 -- | Wait for a "normal" (non-VPS) build completion

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -88,13 +88,13 @@ waitForIssues ::
   Maybe DiffRevision ->
   Cancel ->
   m Issues
-waitForIssues revision maybeDiffRevision cancelFlag = do
+waitForIssues revision diffRevision cancelFlag = do
   checkForTimeout cancelFlag
-  issues <- getIssues revision maybeDiffRevision
+  issues <- getIssues revision diffRevision
   case issuesStatus issues of
     "WAITING" -> do
       pauseForRetry
-      waitForIssues revision maybeDiffRevision cancelFlag
+      waitForIssues revision diffRevision cancelFlag
     _ -> pure issues
 
 -- | Wait for a "normal" (non-VPS) build completion

--- a/src/App/Fossa/Config/Test.hs
+++ b/src/App/Fossa/Config/Test.hs
@@ -86,7 +86,7 @@ data TestConfig = TestConfig
   , timeout :: Duration
   , outputFormat :: OutputFormat
   , projectRevision :: ProjectRevision
-  , maybeDiffRevision :: Maybe DiffRevision
+  , diffRevision :: Maybe DiffRevision
   }
   deriving (Show, Generic)
 
@@ -138,7 +138,7 @@ mergeOpts maybeConfig envvars TestCliOpts{..} = do
       revision =
         collectRevisionData' baseDir maybeConfig ReadOnly $
           OverrideProject (optProjectName commons) (optProjectRevision commons) Nothing
-      maybeDiffRevision = DiffRevision <$> testDiffRevision
+      diffRevision = DiffRevision <$> testDiffRevision
 
   TestConfig
     <$> baseDir
@@ -146,4 +146,4 @@ mergeOpts maybeConfig envvars TestCliOpts{..} = do
     <*> pure timeout
     <*> pure testOutputType
     <*> revision
-    <*> pure maybeDiffRevision
+    <*> pure diffRevision

--- a/src/App/Fossa/Config/Test.hs
+++ b/src/App/Fossa/Config/Test.hs
@@ -106,7 +106,7 @@ parser =
     <*> optional (option auto (long "timeout" <> help "Duration to wait for build completion in seconds (Defaults to 1 hour)"))
     <*> flag TestOutputPretty TestOutputJson (long "json" <> help "Output issues as json")
     <*> baseDirArg
-    <*> optional (strOption (long "diff" <> help "Check for only new issues that do not exist in provided diff revision."))
+    <*> optional (strOption (long "diff" <> help "Checks for new issues of the revision, that does not exist in provided diff revision."))
 
 loadConfig ::
   ( Has (Lift IO) sig m

--- a/src/App/Fossa/Config/Test.hs
+++ b/src/App/Fossa/Config/Test.hs
@@ -4,6 +4,7 @@
 module App.Fossa.Config.Test (
   TestCliOpts,
   TestConfig (..),
+  DiffRevision (..),
   OutputFormat (..),
   mkSubCommand,
   parser,
@@ -32,6 +33,7 @@ import Control.Effect.Lift (Lift)
 import Control.Timeout (Duration (..))
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.String.Conversion (toText)
+import Data.Text (Text)
 import Effect.Exec (Exec)
 import Effect.Logger (Logger, Severity (SevDebug, SevInfo))
 import Effect.ReadFS (ReadFS, getCurrentDir, resolveDir)
@@ -47,6 +49,7 @@ import Options.Applicative (
   option,
   optional,
   progDesc,
+  strOption,
  )
 
 data OutputFormat
@@ -57,11 +60,17 @@ data OutputFormat
 instance ToJSON OutputFormat where
   toEncoding = genericToEncoding defaultOptions
 
+newtype DiffRevision = DiffRevision Text deriving (Show, Eq, Ord, Generic)
+
+instance ToJSON DiffRevision where
+  toEncoding = genericToEncoding defaultOptions
+
 data TestCliOpts = TestCliOpts
   { commons :: CommonOpts
   , testTimeout :: Maybe Int
   , testOutputType :: OutputFormat
   , testBaseDir :: FilePath
+  , testDiffRevision :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 
@@ -77,6 +86,7 @@ data TestConfig = TestConfig
   , timeout :: Duration
   , outputFormat :: OutputFormat
   , projectRevision :: ProjectRevision
+  , maybeDiffRevision :: Maybe DiffRevision
   }
   deriving (Show, Generic)
 
@@ -96,6 +106,7 @@ parser =
     <*> optional (option auto (long "timeout" <> help "Duration to wait for build completion in seconds (Defaults to 1 hour)"))
     <*> flag TestOutputPretty TestOutputJson (long "json" <> help "Output issues as json")
     <*> baseDirArg
+    <*> optional (strOption (long "diff" <> help "Check for only new issues that do not exist in provided diff revision."))
 
 loadConfig ::
   ( Has (Lift IO) sig m
@@ -127,9 +138,12 @@ mergeOpts maybeConfig envvars TestCliOpts{..} = do
       revision =
         collectRevisionData' baseDir maybeConfig ReadOnly $
           OverrideProject (optProjectName commons) (optProjectRevision commons) Nothing
+      maybeDiffRevision = DiffRevision <$> testDiffRevision
+
   TestConfig
     <$> baseDir
     <*> apiOpts
     <*> pure timeout
     <*> pure testOutputType
     <*> revision
+    <*> pure maybeDiffRevision

--- a/src/App/Fossa/Container/Test.hs
+++ b/src/App/Fossa/Container/Test.hs
@@ -63,7 +63,7 @@ test ContainerTestConfig{..} = runStickyLogger SevInfo $
     waitForBuild revision cancelToken
 
     logSticky "[ Waiting for issue scan completion ]"
-    issues <- waitForIssues revision cancelToken
+    issues <- waitForIssues revision Nothing cancelToken
     logSticky ""
 
     case issuesCount issues of

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -79,7 +79,7 @@ fetchReport ReportConfig{..} =
 
       logSticky "[ Waiting for issue scan completion... ]"
 
-      _ <- waitForIssues revision cancelToken
+      _ <- waitForIssues revision Nothing cancelToken
 
       logSticky $ "[ Fetching " <> showT reportType <> " report... ]"
 

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -8,7 +8,12 @@ import App.Fossa.API.BuildWait (
   waitForIssues,
   waitForScanCompletion,
  )
-import App.Fossa.Config.Test (OutputFormat (TestOutputJson, TestOutputPretty), TestCliOpts, TestConfig)
+import App.Fossa.Config.Test (
+  DiffRevision (..),
+  OutputFormat (TestOutputJson, TestOutputPretty),
+  TestCliOpts,
+  TestConfig (maybeDiffRevision),
+ )
 import App.Fossa.Config.Test qualified as Config
 import App.Fossa.Subcommand (SubCommand)
 import App.Types (
@@ -22,6 +27,7 @@ import Control.Effect.Lift (Lift)
 import Control.Timeout (timeout')
 import Data.Aeson qualified as Aeson
 import Data.String.Conversion (decodeUtf8)
+import Data.Text (Text)
 import Data.Text.Extra (showT)
 import Effect.Logger (
   Logger,
@@ -30,6 +36,7 @@ import Effect.Logger (
   logInfo,
   logStdout,
   pretty,
+  vsep,
  )
 import Fossa.API.Types (Issues (..))
 
@@ -49,29 +56,59 @@ testMain config = runStickyLogger SevInfo
   $ \cancelFlag -> do
     let revision = Config.projectRevision config
         outputType = Config.outputFormat config
+        maybeDiffRev = maybeDiffRevision config
+
     logInfo ""
     logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
     logInfo ("Using revision: `" <> pretty (projectRevision revision) <> "`")
 
-    logSticky "[ Waiting for build completion... ]"
+    case maybeDiffRev of
+      Nothing -> logInfo ""
+      Just (DiffRevision rev) -> do
+        logInfo ("diffing against revision: `" <> pretty rev <> "`")
+        logSticky $ "[ Waiting for build completion of " <> rev <> "... ]"
+        waitForScanCompletion revision{projectRevision = rev} cancelFlag
 
+    logSticky "[ Waiting for build completion... ]"
     waitForScanCompletion revision cancelFlag
 
     logSticky "[ Waiting for issue scan completion... ]"
-    issues <- waitForIssues revision cancelFlag
+    issues <- waitForIssues revision maybeDiffRev cancelFlag
     logSticky ""
     logInfo ""
 
     case issuesCount issues of
       0 -> do
-        logInfo "Test passed! 0 issues found"
+        logInfo . pretty $ successMsg maybeDiffRev
         case outputType of
-          TestOutputJson -> logStdout . decodeUtf8 . Aeson.encode $ issues
-          TestOutputPretty -> pure ()
+          TestOutputPretty -> renderJson issues
+          TestOutputJson -> pure ()
       n -> do
         if null (issuesIssues issues)
-          then logError "A push-only API key was used, so issue details cannot be displayed. Check the webapp for issue details, or rerun this command with a full-access API key."
+          then
+            logError $
+              vsep
+                [ "A push-only API key was used, so issue details cannot be displayed."
+                , "Check the webapp for issue details, or rerun this command with a full-access API key."
+                ]
           else case outputType of
             TestOutputPretty -> logError $ pretty issues
-            TestOutputJson -> logStdout . decodeUtf8 . Aeson.encode $ issues
-        fatalText $ "The scan has revealed issues. Number of issues found: " <> showT n
+            TestOutputJson -> renderJson issues
+        fatalText $ issesFoundMsg maybeDiffRev n
+  where
+    successMsg :: Maybe DiffRevision -> Text
+    successMsg maybeDiffRevision = case maybeDiffRevision of
+      Nothing -> "Test passed! 0 issues found"
+      Just (DiffRevision rev) -> "Test passed! No new issues found compared to revision: " <> rev <> "."
+
+    issesFoundMsg :: Maybe DiffRevision -> Int -> Text
+    issesFoundMsg maybeDiffRevision n = case maybeDiffRevision of
+      Nothing -> "The scan has revealed issues. Number of issues found: " <> showT n
+      Just (DiffRevision rev) ->
+        "The scan has revealed new issues compared to revision: "
+          <> rev
+          <> ". Number of new issues found: "
+          <> showT n
+
+    renderJson :: (Has (Lift IO) sig m, Has Logger sig m) => Issues -> m ()
+    renderJson = logStdout . decodeUtf8 . Aeson.encode

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -37,7 +37,7 @@ runFossaApiClient apiOpts =
           FinalizeLicenseScan components -> LicenseScanning.finalizeLicenseScan components
           GetApiOpts -> pure apiOpts
           GetAttribution rev format -> Core.getAttribution rev format
-          GetIssues rev maybeDiffRev -> Core.getIssues rev maybeDiffRev
+          GetIssues rev diffRev -> Core.getIssues rev diffRev
           GetEndpointVersion -> Core.getEndpointVersion
           GetLatestBuild rev -> Core.getLatestBuild rev
           GetLatestScan locator rev -> ScotlandYard.getLatestScan locator rev

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -37,7 +37,7 @@ runFossaApiClient apiOpts =
           FinalizeLicenseScan components -> LicenseScanning.finalizeLicenseScan components
           GetApiOpts -> pure apiOpts
           GetAttribution rev format -> Core.getAttribution rev format
-          GetIssues rev -> Core.getIssues rev
+          GetIssues rev maybeDiffRev -> Core.getIssues rev maybeDiffRev
           GetEndpointVersion -> Core.getEndpointVersion
           GetLatestBuild rev -> Core.getLatestBuild rev
           GetLatestScan locator rev -> ScotlandYard.getLatestScan locator rev

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -17,6 +17,7 @@ module Control.Carrier.FossaApiClient.Internal.Core (
 ) where
 
 import App.Fossa.Config.Report (ReportOutputFormat)
+import App.Fossa.Config.Test (DiffRevision)
 import App.Fossa.Container.Scan (ContainerScan)
 import App.Fossa.VendoredDependency (VendoredDependency (..))
 import App.Types (ProjectMetadata, ProjectRevision (..))
@@ -133,10 +134,11 @@ getIssues ::
   , Has (Reader ApiOpts) sig m
   ) =>
   ProjectRevision ->
+  Maybe DiffRevision ->
   m Issues
-getIssues rev = do
+getIssues rev maybeDiffRevision = do
   apiOpts <- ask
-  API.getIssues apiOpts rev
+  API.getIssues apiOpts rev maybeDiffRevision
 
 getAttribution ::
   ( Has (Lift IO) sig m

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -136,9 +136,9 @@ getIssues ::
   ProjectRevision ->
   Maybe DiffRevision ->
   m Issues
-getIssues rev maybeDiffRevision = do
+getIssues rev diffRevision = do
   apiOpts <- ask
-  API.getIssues apiOpts rev maybeDiffRevision
+  API.getIssues apiOpts rev diffRevision
 
 getAttribution ::
   ( Has (Lift IO) sig m

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -581,11 +581,11 @@ getIssues ::
   ProjectRevision ->
   Maybe DiffRevision ->
   m Issues
-getIssues apiOpts ProjectRevision{..} maybeDiffRevision = fossaReq $ do
+getIssues apiOpts ProjectRevision{..} diffRevision = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
   org <- getOrganization apiOpts
 
-  opts <- case (maybeDiffRevision, orgSupportsIssueDiffs org) of
+  opts <- case (diffRevision, orgSupportsIssueDiffs org) of
     (Just (DiffRevision diffRev), True) -> pure (baseOpts <> "diffRevision" =: diffRev)
     (Just _, False) -> fatal EndpointDoesNotSupportIssueDiffing
     (Nothing, _) -> pure baseOpts

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -606,8 +606,7 @@ instance ToDiagnostic EndpointDoesNotSupportIssueDiffing where
     vsep
       [ "Provided endpoint does not support issue diffing."
       , ""
-      , "If you are an on-prem customer, you will likely need to"
-      , "update your FOSSA server instance."
+      , "If this instance of FOSSA is on-premise, it likely needs to be updated."
       ]
 
 ---------------

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -35,6 +35,7 @@ module Control.Carrier.FossaApiClient.Internal.FossaAPIV1 (
 
 import App.Docs (fossaSslCertDocsUrl)
 import App.Fossa.Config.Report
+import App.Fossa.Config.Test (DiffRevision (DiffRevision))
 import App.Fossa.Container.Scan (ContainerScan (..))
 import App.Fossa.Report.Attribution qualified as Attr
 import App.Fossa.VSI.Fingerprint (Fingerprint, Raw)
@@ -93,7 +94,7 @@ import Fossa.API.Types (
   Contributors,
   Issues,
   OrgId,
-  Organization (organizationId),
+  Organization (orgSupportsIssueDiffs, organizationId),
   Project,
   SignedURL (signedURL),
   UploadResponse,
@@ -578,13 +579,36 @@ getIssues ::
   (Has (Lift IO) sig m, Has Diagnostics sig m) =>
   ApiOpts ->
   ProjectRevision ->
+  Maybe DiffRevision ->
   m Issues
-getIssues apiOpts ProjectRevision{..} = fossaReq $ do
+getIssues apiOpts ProjectRevision{..} maybeDiffRevision = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
+  org <- getOrganization apiOpts
 
-  orgId <- organizationId <$> getOrganization apiOpts
-  response <- req GET (issuesEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision))) NoReqBody jsonResponse baseOpts
+  opts <- case (maybeDiffRevision, orgSupportsIssueDiffs org) of
+    (Just (DiffRevision diffRev), True) -> pure (baseOpts <> "diffRevision" =: diffRev)
+    (Just _, False) -> fatal EndpointDoesNotSupportIssueDiffing
+    (Nothing, _) -> pure baseOpts
+
+  response <-
+    req
+      GET
+      (issuesEndpoint baseUrl (organizationId org) (Locator "custom" projectName (Just projectRevision)))
+      NoReqBody
+      jsonResponse
+      opts
+
   pure (responseBody response)
+
+data EndpointDoesNotSupportIssueDiffing = EndpointDoesNotSupportIssueDiffing
+instance ToDiagnostic EndpointDoesNotSupportIssueDiffing where
+  renderDiagnostic (EndpointDoesNotSupportIssueDiffing) =
+    vsep
+      [ "Provided endpoint does not support issue diffing."
+      , ""
+      , "If you are an on-prem customer, you will likely need to"
+      , "update your FOSSA server instance."
+      ]
 
 ---------------
 

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -35,6 +35,7 @@ module Control.Effect.FossaApiClient (
 ) where
 
 import App.Fossa.Config.Report (ReportOutputFormat)
+import App.Fossa.Config.Test (DiffRevision)
 import App.Fossa.Container.Scan (ContainerScan (..))
 import App.Fossa.VSI.Fingerprint (Fingerprint, Raw)
 import App.Fossa.VSI.Fingerprint qualified as Fingerprint
@@ -84,7 +85,7 @@ data FossaApiClientF a where
   FinalizeLicenseScan :: ArchiveComponents -> FossaApiClientF ()
   GetApiOpts :: FossaApiClientF ApiOpts
   GetAttribution :: ProjectRevision -> ReportOutputFormat -> FossaApiClientF Text
-  GetIssues :: ProjectRevision -> FossaApiClientF Issues
+  GetIssues :: ProjectRevision -> Maybe DiffRevision -> FossaApiClientF Issues
   GetEndpointVersion :: FossaApiClientF (Maybe Text)
   GetLatestBuild :: ProjectRevision -> FossaApiClientF Build
   GetLatestScan :: Locator -> ProjectRevision -> FossaApiClientF ScanResponse
@@ -149,8 +150,8 @@ uploadContributors locator contributors = sendSimple $ UploadContributors locato
 getLatestBuild :: (Has FossaApiClient sig m) => ProjectRevision -> m Build
 getLatestBuild = sendSimple . GetLatestBuild
 
-getIssues :: (Has FossaApiClient sig m) => ProjectRevision -> m Issues
-getIssues = sendSimple . GetIssues
+getIssues :: (Has FossaApiClient sig m) => ProjectRevision -> Maybe DiffRevision -> m Issues
+getIssues projectRevision maybeDiffRevision = sendSimple $ GetIssues projectRevision maybeDiffRevision
 
 getScan :: Has FossaApiClient sig m => Locator -> ScanId -> m ScanResponse
 getScan locator scanId = sendSimple $ GetScan locator scanId

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -151,7 +151,7 @@ getLatestBuild :: (Has FossaApiClient sig m) => ProjectRevision -> m Build
 getLatestBuild = sendSimple . GetLatestBuild
 
 getIssues :: (Has FossaApiClient sig m) => ProjectRevision -> Maybe DiffRevision -> m Issues
-getIssues projectRevision maybeDiffRevision = sendSimple $ GetIssues projectRevision maybeDiffRevision
+getIssues projectRevision diffRevision = sendSimple $ GetIssues projectRevision diffRevision
 
 getScan :: Has FossaApiClient sig m => Locator -> ScanId -> m ScanResponse
 getScan locator scanId = sendSimple $ GetScan locator scanId

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -291,6 +291,7 @@ data Organization = Organization
   , orgCoreSupportsLocalLicenseScan :: Bool
   , orgSupportsAnalyzedRevisionsQuery :: Bool
   , orgDefaultVendoredDependencyScanType :: ArchiveUploadType
+  , orgSupportsIssueDiffs :: Bool
   }
   deriving (Eq, Ord, Show)
 
@@ -301,6 +302,7 @@ instance FromJSON Organization where
       <*> obj .:? "supportsCliLicenseScanning" .!= False
       <*> obj .:? "supportsAnalyzedRevisionsQuery" .!= False
       <*> obj .:? "defaultVendoredDependencyScanType" .!= CLILicenseScan
+      <*> obj .:? "supportsIssueDiffs" .!= False
 
 data Project = Project
   { projectId :: Text

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -41,7 +41,7 @@ spec = do
     describe "SAML URL builder" $ do
       it' "should render simple locators" $ do
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
-            org = Just $ Organization (OrgId 1) True False True CLILicenseScan
+            org = Just $ Organization (OrgId 1) True False True CLILicenseScan True
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -49,7 +49,7 @@ spec = do
 
       it' "should render git@ locators" $ do
         let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
-            org = Just $ Organization (OrgId 103) True False True CLILicenseScan
+            org = Just $ Organization (OrgId 103) True False True CLILicenseScan True
             revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -57,7 +57,7 @@ spec = do
 
       it' "should render full url correctly" $ do
         let locator = Locator "a" "b" $ Just "c"
-            org = Just $ Organization (OrgId 33) True False True CLILicenseScan
+            org = Just $ Organization (OrgId 33) True False True CLILicenseScan True
             revision = ProjectRevision "" "not this revision" $ Just "master"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -74,7 +74,7 @@ spec = do
     describe "Fossa URL Builder" $
       it' "should render from API info" $ do
         GetApiOpts `returnsOnce` Fixtures.apiOpts
-        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan
+        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getFossaBuildUrl revision locator

--- a/test/App/Fossa/API/BuildWaitSpec.hs
+++ b/test/App/Fossa/API/BuildWaitSpec.hs
@@ -91,7 +91,7 @@ spec =
           issues <- waitForIssues Fixtures.projectRevision Nothing cancel
           issues `shouldBe'` Fixtures.issuesAvailable
 
-      it' "should return when the issues diffs are avilable" $ do
+      it' "should return when the issues diffs are available" $ do
         commonExpectations
         expectDiffIssuesAvailable
         runWithTimeout $ \cancel -> do

--- a/test/App/Fossa/API/BuildWaitSpec.hs
+++ b/test/App/Fossa/API/BuildWaitSpec.hs
@@ -88,22 +88,29 @@ spec =
         commonExpectations
         expectIssuesAvailable
         runWithTimeout $ \cancel -> do
-          issues <- waitForIssues Fixtures.projectRevision cancel
+          issues <- waitForIssues Fixtures.projectRevision Nothing cancel
           issues `shouldBe'` Fixtures.issuesAvailable
+
+      it' "should return when the issues diffs are avilable" $ do
+        commonExpectations
+        expectDiffIssuesAvailable
+        runWithTimeout $ \cancel -> do
+          issues <- waitForIssues Fixtures.projectRevision (Just Fixtures.diffRevision) cancel
+          issues `shouldBe'` Fixtures.issuesDiffAvailable
 
       it' "should retry periodically if the issues are not available" $ do
         commonExpectations
         expectIssuesPending
         expectIssuesAvailable
         runWithTimeout $ \cancel -> do
-          issues <- waitForIssues Fixtures.projectRevision cancel
+          issues <- waitForIssues Fixtures.projectRevision Nothing cancel
           issues `shouldBe'` Fixtures.issuesAvailable
 
       it' "should cancel when the timeout expires" $ do
         commonExpectations
         expectIssuesAlwaysWaiting
         expectFatal' . runWithTimeout $
-          waitForIssues Fixtures.projectRevision
+          waitForIssues Fixtures.projectRevision Nothing
     describe "waitForBuild" $ do
       it' "should return when the build is complete" $ do
         expectGetApiOpts
@@ -161,12 +168,17 @@ expectGetScan scanStatus =
 
 expectIssuesAvailable :: Has MockApi sig m => m ()
 expectIssuesAvailable =
-  (GetIssues Fixtures.projectRevision)
+  (GetIssues Fixtures.projectRevision Nothing)
     `returnsOnce` Fixtures.issuesAvailable
+
+expectDiffIssuesAvailable :: Has MockApi sig m => m ()
+expectDiffIssuesAvailable =
+  GetIssues Fixtures.projectRevision (Just Fixtures.diffRevision)
+    `returnsOnce` Fixtures.issuesDiffAvailable
 
 expectIssuesPending :: Has MockApi sig m => m ()
 expectIssuesPending =
-  (GetIssues Fixtures.projectRevision)
+  (GetIssues Fixtures.projectRevision Nothing)
     `returnsOnce` Fixtures.issuesPending
 
 expectScanAlwaysPending :: Has MockApi sig m => m ()
@@ -181,5 +193,5 @@ expectBuildAlwaysRunning =
 
 expectIssuesAlwaysWaiting :: Has MockApi sig m => m ()
 expectIssuesAlwaysWaiting =
-  (GetIssues Fixtures.projectRevision)
+  (GetIssues Fixtures.projectRevision Nothing)
     `alwaysReturns` Fixtures.issuesPending

--- a/test/App/Fossa/ReportSpec.hs
+++ b/test/App/Fossa/ReportSpec.hs
@@ -70,16 +70,16 @@ expectBuildError = do
 
 expectFetchIssuesSuccess :: (Has MockApi sig m) => m ()
 expectFetchIssuesSuccess =
-  (GetIssues Fixtures.projectRevision) `returnsOnce` Fixtures.issuesAvailable
+  (GetIssues Fixtures.projectRevision Nothing) `returnsOnce` Fixtures.issuesAvailable
 
 expectFetchIssuesPending :: (Has MockApi sig m) => m ()
 expectFetchIssuesPending = do
   GetApiOpts `alwaysReturns` Fixtures.apiOpts -- It needs to fetch the poll delay
-  (GetIssues Fixtures.projectRevision) `alwaysReturns` Fixtures.issuesPending
+  (GetIssues Fixtures.projectRevision Nothing) `alwaysReturns` Fixtures.issuesPending
 
 expectFetchIssuesError :: (Has MockApi sig m) => m ()
 expectFetchIssuesError =
-  (GetIssues Fixtures.projectRevision) `fails` "Mock failure: GetIssues"
+  (GetIssues Fixtures.projectRevision Nothing) `fails` "Mock failure: GetIssues"
 
 expectFetchReportSuccess :: (Has MockApi sig m) => m ()
 expectFetchReportSuccess =

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -34,8 +34,11 @@ module Test.Fixtures (
   secondLocator,
   firstLicenseSourceUnit,
   secondLicenseSourceUnit,
+  diffRevision,
+  issuesDiffAvailable,
 ) where
 
+import App.Fossa.Config.Test (DiffRevision (DiffRevision))
 import App.Fossa.VendoredDependency (VendoredDependency (..))
 import App.Types qualified as App
 import Control.Effect.FossaApiClient qualified as App
@@ -68,7 +71,7 @@ apiOpts =
     }
 
 organization :: API.Organization
-organization = API.Organization (API.OrgId 42) True True True CLILicenseScan
+organization = API.Organization (API.OrgId 42) True True True CLILicenseScan True
 
 project :: API.Project
 project =
@@ -112,6 +115,9 @@ projectRevision =
     , App.projectRevision = "testRevision"
     , App.projectBranch = Just "testBranch"
     }
+
+diffRevision :: DiffRevision
+diffRevision = DiffRevision "someDiffRevision"
 
 packageRevision :: App.PackageRevision
 packageRevision =
@@ -213,6 +219,33 @@ issuesAvailable =
       makeIssue issueId issueType =
         API.Issue
           { API.issueId = 200 + issueId
+          , API.issuePriorityString = Nothing
+          , API.issueResolved = False
+          , API.issueRevisionId = "IssueRevisionId" <> showT issueId
+          , API.issueType = issueType
+          , API.issueRule = Nothing
+          }
+      issueList = zipWith makeIssue [1 ..] issueTypes
+   in API.Issues
+        { API.issuesCount = length issueList
+        , API.issuesIssues = issueList
+        , API.issuesStatus = "SCANNED"
+        }
+
+issuesDiffAvailable :: API.Issues
+issuesDiffAvailable =
+  let issueTypes =
+        [ API.IssuePolicyConflict
+        , API.IssuePolicyFlag
+        , API.IssueVulnerability
+        , API.IssueUnlicensedDependency
+        , API.IssueOutdatedDependency
+        , API.IssueOther "TestIssueOther"
+        ]
+      makeIssue :: Int -> API.IssueType -> API.Issue
+      makeIssue issueId issueType =
+        API.Issue
+          { API.issueId = 100 + issueId
           , API.issuePriorityString = Nothing
           , API.issueResolved = False
           , API.issueRevisionId = "IssueRevisionId" <> showT issueId


### PR DESCRIPTION
# Overview

This PR, adds `fossa test --diff <ARG>` command.

## Acceptance criteria

- `fossa test --revision a --diff b`, only reports issues that are in revision `a`, but not in revision `b`.
- `fossa test --revision a --diff b`, provides an actionable error message when `diff` is not supported by FOSSA instance.
- `fossa test --revision a --diff b`, provides an actionable error message when revision `b` is not part of the same project.
- `fossa test --revision a --diff a`, always succeeds.

## Screenshots

### Current `fossa test` Output

<img width="922" alt="CleanShot 2022-06-23 at 20 05 29@2x" src="https://user-images.githubusercontent.com/86321858/175434883-dd46da4b-bb33-4c87-a80e-b7670fcbeaef.png">

### When `fossa test --diff` Passes

<img width="922" alt="CleanShot 2022-06-23 at 20 06 26@2x" src="https://user-images.githubusercontent.com/86321858/175434968-f8654961-5ef2-40b2-aec9-b89818d2e7cf.png">

### When `fossa test --diff` Fails

<img width="922" alt="CleanShot 2022-06-23 at 20 07 15@2x" src="https://user-images.githubusercontent.com/86321858/175435018-47aa2a5b-1fe5-4737-a4c9-75b929d00b04.png">

### When `fossa test --diff` is not supported

<img width="922" alt="CleanShot 2022-06-23 at 20 08 15@2x" src="https://user-images.githubusercontent.com/86321858/175435106-479b2efb-2ffe-49e6-9d95-b8c29d7828d7.png">

## Testing plan
Environment:

```bash
git checkout feat/fossa-test-diff && make install-dev
```

(You will need latest FOSSA/develop)

Setup:

```bash
mkdir sandbox && cd sandbox

# numpy is BSD
echo 'numpy' > reqs.txt
fossa-dev analyze --project ane-388 --revision 1

# FFPopSim is GPL
echo 'numpy\nFFPopSim' > reqs.txt
fossa-dev analyze --project ane-388 --revision 2

# black is MIT
echo 'numpy\nFFPopSim\nblack' > reqs.txt
fossa-dev analyze --project ane-388 --revision 3

```

1) Test without diff (for regression)

```bash
fossa-dev test --project ane-388 --revision 1 # should pass
fossa-dev test --project ane-388 --revision 2 # should fail
fossa-dev test --project ane-388 --revision 3 # should fail
```

2) Test with diff (when no new issues are discovered)

```bash
fossa-dev test --project ane-388 --revision 3 --diff 2 # should pass
```

3) Test with diff (when new issues are discovered)

```bash
fossa-dev test --project ane-388 --revision 3 --diff 1 # should fail
fossa-dev test --project ane-388 --revision 2 --diff 1  # should fail
```

## Risks
N/A

## References
https://fossa.atlassian.net/browse/ANE-388

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
