### PR TITLE
Fix version of maven-install-plugin used to install depgraph

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Maven: Fixes a bug where running depgraph would sometimes fail dependending on the local Maven repository's state
+
 ## v3.3.7
 
 - Report: Changes copyrights field to copyrightsByLicense in the attribution report JSON output. [#966](https://github.com/fossas/fossa-cli/pull/966)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Maven: Fixes a bug where running depgraph would sometimes fail dependending on the local Maven repository's state
+- Maven: Always use Maven Install Plugin 3.0.0-M1 to install depgraph. This avoids a Maven bug with older versions failing to install the plugin correctly from a vendored JAR. ([#988](https://github.com/fossas/fossa-cli/pull/988/files))
 
 ## v3.3.7
 

--- a/docs/references/strategies/languages/maven/mavenplugin.md
+++ b/docs/references/strategies/languages/maven/mavenplugin.md
@@ -21,7 +21,7 @@ Find `pom.xml` files, and treat those as maven projects. Skip all subdirectories
 ## Analysis
 
 1. unpack the embedded plugin to a temporary directory
-2. install it to the local maven repository `mvn install:install-file -DgroupId=com.github.ferstl -DartifactId=depgraph-maven-plugin -Dversion=4.0.1 -Dpackaging=jar -Dfile=<location>/depgraph-maven-plugin-4.0.1.jar`
+2. install it to the local maven repository `mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file -DgroupId=com.github.ferstl -DartifactId=depgraph-maven-plugin -Dversion=4.0.1 -Dpackaging=jar -Dfile=<location>/depgraph-maven-plugin-4.0.1.jar` (uses a specific version of [Maven Install Plugin](https://maven.apache.org/plugins/maven-install-plugin/) to avoid a [bug in earlier versions](https://issues.apache.org/jira/browse/MINSTALL-110))
 3. invoke the plugin in the top-level project with the command `mvn com.github.ferstl:depgraph-maven-plugin:4.0.1:aggregate -DgraphFormat=text -DmergeScopes -DreduceEdges=false -DshowVersions=true -DshowGroupIds=true -DshowOptional=true -DrepeatTransitiveDependenciesInTextGraph=true`
 
 For `graphFormat`s other than `text` the data will be output to

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -195,7 +195,7 @@ mavenInstallPluginCmd pluginFilePath plugin =
   Command
     { cmdName = "mvn"
     , cmdArgs =
-        [ "install:install-file"
+        [ "org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file"
         , "-DgroupId=" <> group plugin
         , "-DartifactId=" <> artifact plugin
         , "-Dversion=" <> version plugin


### PR DESCRIPTION

# Overview

Fixes depgraph installation by avoiding this Maven bug: https://issues.apache.org/jira/browse/MINSTALL-110

When using the Maven strategy (specifically the depgraph tactic), fossa-cli will try to install the vendored depgraph JAR file by calling `mvn install:install-file`: https://github.com/fossas/fossa-cli/blob/655f6d273d66854a2dded389e2108c4f51db46ea/src/Strategy/Maven/Plugin.hs#L198

This is the same as running this command: `mvn org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file`

However, this command has a bug which causes only a stub POM to be generated, which is missing all of this project’s dependencies. For example:

```
# ignore anything existing in the local Maven repository
rm -rf ~/.m2/repository/com/github/ferstl/depgraph-maven-plugin/4.0.1

# manually install depgraph (using the same jar vendored by fossa-cli)
mvn org.apache.maven.plugins:maven-install-plugin:2.5.1:install-file -DgroupId=com.github.ferstl -DartifactId=depgraph-maven-plugin -Dversion=4.0.1 -Dpackaging=jar -Dfile=depgraph-maven-plugin-4.0.1.jar
```

The saved POM file is only a stub and has no dependency declarations:

```
$ cat ~/.m2/repository/com/github/ferstl/depgraph-maven-plugin/4.0.1/depgraph-maven-plugin-4.0.1.pom
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.github.ferstl</groupId>
  <artifactId>depgraph-maven-plugin</artifactId>
  <version>4.0.1</version>
  <description>POM was created from install:install-file</description>
</project>
```

Trying to use depgraph with an `~/.m2` repository in this state will always fail:

```
$ mvn com.github.ferstl:depgraph-maven-plugin:4.0.1:reactor -DgraphFormat=json -DoutputFileName=fossa-reactor-graph.json
[INFO] Scanning for projects...
[INFO]
[INFO] -------------< com.ericsson.oss.apps:eric-oss-cnr5gassist >-------------
[INFO] Building eric-oss-cnr5gassist 1.1.5-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- depgraph-maven-plugin:4.0.1:reactor (default-cli) @ eric-oss-cnr5gassist ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.188 s
[INFO] Finished at: 2022-06-27T15:30:14-03:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.ferstl:depgraph-maven-plugin:4.0.1:reactor (default-cli) on project eric-oss-cnr5gassist: Execution default-cli of goal com.github.ferstl:depgraph-maven-plugin:4.0.1:reactor failed: A required class was missing while executing com.github.ferstl:depgraph-maven-plugin:4.0.1:reactor: com/google/common/base/Joiner
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>com.github.ferstl:depgraph-maven-plugin:4.0.1
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/rolodato/.m2/repository/com/github/ferstl/depgraph-maven-plugin/4.0.1/depgraph-maven-plugin-4.0.1.jar
[ERROR] urls[1] = file:/home/rolodato/.m2/repository/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR]
[ERROR] -----------------------------------------------------
[ERROR] : com.google.common.base.Joiner
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException
```

However, if we install the same jar using the newest version of the install plugin, this works:

```
# manually install depgraph using the newer install plugin
# if a stub POM already exists in ~/.m2, it will be overwritten
mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file -DgroupId=com.github.ferstl -DartifactId=depgraph-maven-plugin -Dversion=4.0.1 -Dpackaging=jar -Dfile=depgraph-maven-plugin-4.0.1.jar

# this file is now a full POM and not a stub
# cat ~/.m2/repository/com/github/ferstl/depgraph-maven-plugin/4.0.1/depgraph-maven-plugin-4.0.1.pom

# run the same depgraph command, works fine
mvn com.github.ferstl:depgraph-maven-plugin:4.0.1:reactor -DgraphFormat=json -DoutputFileName=fossa-reactor-graph.json
[INFO] Scanning for projects...
[INFO]
[INFO] -------------< com.ericsson.oss.apps:eric-oss-cnr5gassist >-------------
[INFO] Building eric-oss-cnr5gassist 1.1.5-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- depgraph-maven-plugin:4.0.1:reactor (default-cli) @ eric-oss-cnr5gassist ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.368 s
[INFO] Finished at: 2022-06-27T15:33:39-03:00
[INFO] ------------------------------------------------------------------------
```

## Acceptance criteria

Depgraph installation should always succeed, no matter the current state of the local Maven repository.

## Testing plan

Manually ran different `mvn` commands to isolate this from `fossa-cli`, see description above. Not actually tested with the CLI yet.

## Risks

One concern that was raised is that using a newer version of `maven-install-plugin` introduces a dependency on Maven Central. This is not the case as we already have this dependency implicitly. You can test this by getting rid of your local Maven repository and trying to run a command like:

```
mvn --offline org.apache.maven.plugins:maven-install-plugin:install-file -DgroupId=com.github.ferstl -DartifactId=depgraph-maven-plugin -Dversion=4.0.1 -Dpackaging=jar -Dfile=depgraph-maven-plugin-4.0.1.jar
```

## References

- https://fossa.atlassian.net/browse/ANE-398
- https://teamfossa.slack.com/archives/C0155DTGWB1/p1656346983015349

## Checklist

- [ ] ~I added tests for this PR's change (or explained in the PR description why tests don't make sense).~
- [ ] ~If this PR introduced a user-visible change, I added documentation into `docs/`.~
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] ~If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).~
