### PR TITLE
add FromJSON implementation to SourceUnit types

### DIFF
--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -264,6 +264,17 @@ instance ToJSON SourceUnit where
       , "AdditionalDependencyData" .= additionalData
       ]
 
+instance FromJSON SourceUnit where
+  parseJSON = withObject "SourceUnit" $ \o -> do
+    sourceUnitName <- o .: "Name"
+    sourceUnitType <- o .: "Type"
+    sourceUnitManifest <- o .: "Manifest"
+    sourceUnitBuild <- o .:? "Build"
+    sourceUnitGraphBreadth <- o .: "GraphBreadth"
+    sourceUnitOriginPaths <- o .: "OriginPaths"
+    additionalData <- o .:? "AdditionalDependencyData"
+    pure SourceUnit{sourceUnitName, sourceUnitType, sourceUnitManifest, sourceUnitBuild, sourceUnitGraphBreadth, sourceUnitOriginPaths, additionalData}
+
 instance ToJSON SourceUnitBuild where
   toJSON SourceUnitBuild{..} =
     object
@@ -273,6 +284,14 @@ instance ToJSON SourceUnitBuild where
       , "Dependencies" .= buildDependencies
       ]
 
+instance FromJSON SourceUnitBuild where
+  parseJSON = withObject "SourceUnitBuild" $ \o -> do
+    buildArtifact <- o .: "Artifact"
+    buildSucceeded <- o .: "Succeeded"
+    buildImports <- o .: "Imports"
+    buildDependencies <- o .: "Dependencies"
+    pure SourceUnitBuild{buildArtifact, buildSucceeded, buildImports, buildDependencies}
+
 instance ToJSON SourceUnitDependency where
   toJSON SourceUnitDependency{..} =
     object
@@ -280,12 +299,24 @@ instance ToJSON SourceUnitDependency where
       , "imports" .= sourceDepImports
       ]
 
+instance FromJSON SourceUnitDependency where
+  parseJSON = withObject "SourceUnitDependency" $ \o -> do
+    sourceDepLocator <- o .: "locator"
+    sourceDepImports <- o .: "imports"
+    pure SourceUnitDependency{sourceDepLocator, sourceDepImports}
+
 instance ToJSON AdditionalDepData where
   toJSON AdditionalDepData{..} =
     object
       [ "UserDefinedDependencies" .= userDefinedDeps
       , "RemoteDependencies" .= remoteDeps
       ]
+
+instance FromJSON AdditionalDepData where
+  parseJSON = withObject "AdditionalDepData" $ \o -> do
+    userDefinedDeps <- o .:? "UserDefinedDependencies"
+    remoteDeps <- o .:? "RemoteDependencies"
+    pure AdditionalDepData{userDefinedDeps, remoteDeps}
 
 instance ToJSON SourceUserDefDep where
   toJSON SourceUserDefDep{..} =
@@ -298,6 +329,16 @@ instance ToJSON SourceUserDefDep where
       , "Origin" .= fmap toText srcUserDepOrigin
       ]
 
+instance FromJSON SourceUserDefDep where
+  parseJSON = withObject "SourceUserDefDep" $ \o -> do
+    srcUserDepName <- o .: "Name"
+    srcUserDepVersion <- o .: "Version"
+    srcUserDepLicense <- o .: "License"
+    srcUserDepDescription <- o .:? "Description"
+    srcUserDepHomepage <- o .:? "Homepage"
+    srcUserDepOrigin <- o .:? "Origin"
+    pure SourceUserDefDep{srcUserDepName, srcUserDepVersion, srcUserDepLicense, srcUserDepDescription, srcUserDepHomepage, srcUserDepOrigin}
+
 instance ToJSON SourceRemoteDep where
   toJSON SourceRemoteDep{..} =
     object
@@ -308,6 +349,18 @@ instance ToJSON SourceRemoteDep where
       , "Homepage" .= srcRemoteDepHomepage
       ]
 
+instance FromJSON SourceRemoteDep where
+  parseJSON = withObject "SourceRemoteDep" $ \o -> do
+    srcRemoteDepName <- o .: "Name"
+    srcRemoteDepVersion <- o .: "Version"
+    srcRemoteDepUrl <- o .: "Url"
+    srcRemoteDepDescription <- o .:? "Description"
+    srcRemoteDepHomepage <- o .:? "Homepage"
+    pure SourceRemoteDep{srcRemoteDepName, srcRemoteDepVersion, srcRemoteDepUrl, srcRemoteDepDescription, srcRemoteDepHomepage}
+
 instance ToJSON Locator where
   -- render as text
   toJSON = toJSON . renderLocator
+
+instance FromJSON Locator where
+  parseJSON = withText "Locator" (pure . parseLocator)

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -265,15 +265,14 @@ instance ToJSON SourceUnit where
       ]
 
 instance FromJSON SourceUnit where
-  parseJSON = withObject "SourceUnit" $ \o -> do
-    sourceUnitName <- o .: "Name"
-    sourceUnitType <- o .: "Type"
-    sourceUnitManifest <- o .: "Manifest"
-    sourceUnitBuild <- o .:? "Build"
-    sourceUnitGraphBreadth <- o .: "GraphBreadth"
-    sourceUnitOriginPaths <- o .: "OriginPaths"
-    additionalData <- o .:? "AdditionalDependencyData"
-    pure SourceUnit{sourceUnitName, sourceUnitType, sourceUnitManifest, sourceUnitBuild, sourceUnitGraphBreadth, sourceUnitOriginPaths, additionalData}
+  parseJSON = withObject "SourceUnit" $ \obj ->
+    SourceUnit <$> obj .: "Name"
+    <*> obj .: "Type"
+    <*> obj .: "Manifest"
+    <*> obj .:? "Build"
+    <*> obj .: "GraphBreadth"
+    <*> obj .: "OriginPaths"
+    <*> obj .:? "AdditionalDependencyData"
 
 instance ToJSON SourceUnitBuild where
   toJSON SourceUnitBuild{..} =
@@ -285,12 +284,11 @@ instance ToJSON SourceUnitBuild where
       ]
 
 instance FromJSON SourceUnitBuild where
-  parseJSON = withObject "SourceUnitBuild" $ \o -> do
-    buildArtifact <- o .: "Artifact"
-    buildSucceeded <- o .: "Succeeded"
-    buildImports <- o .: "Imports"
-    buildDependencies <- o .: "Dependencies"
-    pure SourceUnitBuild{buildArtifact, buildSucceeded, buildImports, buildDependencies}
+  parseJSON = withObject "SourceUnitBuild" $ \obj ->
+    SourceUnitBuild <$> obj .: "Artifact"
+    <*> obj .: "Succeeded"
+    <*> obj .: "Imports"
+    <*> obj .: "Dependencies"
 
 instance ToJSON SourceUnitDependency where
   toJSON SourceUnitDependency{..} =
@@ -300,10 +298,9 @@ instance ToJSON SourceUnitDependency where
       ]
 
 instance FromJSON SourceUnitDependency where
-  parseJSON = withObject "SourceUnitDependency" $ \o -> do
-    sourceDepLocator <- o .: "locator"
-    sourceDepImports <- o .: "imports"
-    pure SourceUnitDependency{sourceDepLocator, sourceDepImports}
+  parseJSON = withObject "SourceUnitDependency" $ \obj ->
+    SourceUnitDependency <$> obj .: "locator"
+    <*> obj .: "imports"
 
 instance ToJSON AdditionalDepData where
   toJSON AdditionalDepData{..} =
@@ -313,10 +310,9 @@ instance ToJSON AdditionalDepData where
       ]
 
 instance FromJSON AdditionalDepData where
-  parseJSON = withObject "AdditionalDepData" $ \o -> do
-    userDefinedDeps <- o .:? "UserDefinedDependencies"
-    remoteDeps <- o .:? "RemoteDependencies"
-    pure AdditionalDepData{userDefinedDeps, remoteDeps}
+  parseJSON = withObject "AdditionalDepData" $ \obj ->
+    AdditionalDepData <$> obj .:? "UserDefinedDependencies"
+    <*> obj .:? "RemoteDependencies"
 
 instance ToJSON SourceUserDefDep where
   toJSON SourceUserDefDep{..} =
@@ -330,14 +326,13 @@ instance ToJSON SourceUserDefDep where
       ]
 
 instance FromJSON SourceUserDefDep where
-  parseJSON = withObject "SourceUserDefDep" $ \o -> do
-    srcUserDepName <- o .: "Name"
-    srcUserDepVersion <- o .: "Version"
-    srcUserDepLicense <- o .: "License"
-    srcUserDepDescription <- o .:? "Description"
-    srcUserDepHomepage <- o .:? "Homepage"
-    srcUserDepOrigin <- o .:? "Origin"
-    pure SourceUserDefDep{srcUserDepName, srcUserDepVersion, srcUserDepLicense, srcUserDepDescription, srcUserDepHomepage, srcUserDepOrigin}
+  parseJSON = withObject "SourceUserDefDep" $ \obj ->
+    SourceUserDefDep <$> obj .: "Name"
+    <*> obj .: "Version"
+    <*> obj .: "License"
+    <*> obj .:? "Description"
+    <*> obj .:? "Homepage"
+    <*> obj .:? "Origin"
 
 instance ToJSON SourceRemoteDep where
   toJSON SourceRemoteDep{..} =
@@ -350,13 +345,12 @@ instance ToJSON SourceRemoteDep where
       ]
 
 instance FromJSON SourceRemoteDep where
-  parseJSON = withObject "SourceRemoteDep" $ \o -> do
-    srcRemoteDepName <- o .: "Name"
-    srcRemoteDepVersion <- o .: "Version"
-    srcRemoteDepUrl <- o .: "Url"
-    srcRemoteDepDescription <- o .:? "Description"
-    srcRemoteDepHomepage <- o .:? "Homepage"
-    pure SourceRemoteDep{srcRemoteDepName, srcRemoteDepVersion, srcRemoteDepUrl, srcRemoteDepDescription, srcRemoteDepHomepage}
+  parseJSON = withObject "SourceRemoteDep" $ \obj ->
+    SourceRemoteDep <$> obj .: "Name"
+    <*> obj .: "Version"
+    <*> obj .: "Url"
+    <*> obj .:? "Description"
+    <*> obj .:? "Homepage"
 
 instance ToJSON Locator where
   -- render as text

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -267,12 +267,12 @@ instance ToJSON SourceUnit where
 instance FromJSON SourceUnit where
   parseJSON = withObject "SourceUnit" $ \obj ->
     SourceUnit <$> obj .: "Name"
-    <*> obj .: "Type"
-    <*> obj .: "Manifest"
-    <*> obj .:? "Build"
-    <*> obj .: "GraphBreadth"
-    <*> obj .: "OriginPaths"
-    <*> obj .:? "AdditionalDependencyData"
+      <*> obj .: "Type"
+      <*> obj .: "Manifest"
+      <*> obj .:? "Build"
+      <*> obj .: "GraphBreadth"
+      <*> obj .: "OriginPaths"
+      <*> obj .:? "AdditionalDependencyData"
 
 instance ToJSON SourceUnitBuild where
   toJSON SourceUnitBuild{..} =
@@ -286,9 +286,9 @@ instance ToJSON SourceUnitBuild where
 instance FromJSON SourceUnitBuild where
   parseJSON = withObject "SourceUnitBuild" $ \obj ->
     SourceUnitBuild <$> obj .: "Artifact"
-    <*> obj .: "Succeeded"
-    <*> obj .: "Imports"
-    <*> obj .: "Dependencies"
+      <*> obj .: "Succeeded"
+      <*> obj .: "Imports"
+      <*> obj .: "Dependencies"
 
 instance ToJSON SourceUnitDependency where
   toJSON SourceUnitDependency{..} =
@@ -300,7 +300,7 @@ instance ToJSON SourceUnitDependency where
 instance FromJSON SourceUnitDependency where
   parseJSON = withObject "SourceUnitDependency" $ \obj ->
     SourceUnitDependency <$> obj .: "locator"
-    <*> obj .: "imports"
+      <*> obj .: "imports"
 
 instance ToJSON AdditionalDepData where
   toJSON AdditionalDepData{..} =
@@ -312,7 +312,7 @@ instance ToJSON AdditionalDepData where
 instance FromJSON AdditionalDepData where
   parseJSON = withObject "AdditionalDepData" $ \obj ->
     AdditionalDepData <$> obj .:? "UserDefinedDependencies"
-    <*> obj .:? "RemoteDependencies"
+      <*> obj .:? "RemoteDependencies"
 
 instance ToJSON SourceUserDefDep where
   toJSON SourceUserDefDep{..} =
@@ -328,11 +328,11 @@ instance ToJSON SourceUserDefDep where
 instance FromJSON SourceUserDefDep where
   parseJSON = withObject "SourceUserDefDep" $ \obj ->
     SourceUserDefDep <$> obj .: "Name"
-    <*> obj .: "Version"
-    <*> obj .: "License"
-    <*> obj .:? "Description"
-    <*> obj .:? "Homepage"
-    <*> obj .:? "Origin"
+      <*> obj .: "Version"
+      <*> obj .: "License"
+      <*> obj .:? "Description"
+      <*> obj .:? "Homepage"
+      <*> obj .:? "Origin"
 
 instance ToJSON SourceRemoteDep where
   toJSON SourceRemoteDep{..} =
@@ -347,10 +347,10 @@ instance ToJSON SourceRemoteDep where
 instance FromJSON SourceRemoteDep where
   parseJSON = withObject "SourceRemoteDep" $ \obj ->
     SourceRemoteDep <$> obj .: "Name"
-    <*> obj .: "Version"
-    <*> obj .: "Url"
-    <*> obj .:? "Description"
-    <*> obj .:? "Homepage"
+      <*> obj .: "Version"
+      <*> obj .: "Url"
+      <*> obj .:? "Description"
+      <*> obj .:? "Homepage"
 
 instance ToJSON Locator where
   -- render as text

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -183,6 +183,12 @@ data DependencyResults = DependencyResults
 data GraphBreadth = Complete | Partial
   deriving (Eq, Ord, Show)
 
+instance FromJSON GraphBreadth where
+  parseJSON = withText "GraphBreadth" $ \case
+    "complete" -> pure Complete
+    "partial" -> pure Partial
+    _ -> fail "invalid graphBreadth value"
+
 instance ToJSON GraphBreadth where
   -- render as text
   toJSON = toJSON . renderGraphType

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -187,7 +187,7 @@ instance FromJSON GraphBreadth where
   parseJSON = withText "GraphBreadth" $ \case
     "complete" -> pure Complete
     "partial" -> pure Partial
-    _ -> fail "invalid graphBreadth value"
+    _ -> fail "invalid GraphBreadth value"
 
 instance ToJSON GraphBreadth where
   -- render as text


### PR DESCRIPTION
# Overview

This PR adds a `FromJSON` implementation to the `SourceUnit` type and any type referenced by `SourceUnit`

## Acceptance criteria

- a `SourceUnit` can be decoded

## Testing plan

- run this command on a project `fossa analyze -o --json | jq -cr ".sourceUnits" | sed -E 's/([^\]|^)"/\1\\"/g'`
- copy the output
- run `cabal repl` and test you can decode the output:
```
import Srclib.Converter (toSourceUnit)
import Srclib.Types (SourceUnit)
import Data.Aeson (decode)
let t = "output"
decode t :: Maybe [SourceUnit]
```
- there are no errors decoding to `SourceUnit`

## Risks

n/a

## References


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
