### PR TITLE
document workaround for version truncating in yaml

### DIFF
--- a/docs/features/manual-dependencies.md
+++ b/docs/features/manual-dependencies.md
@@ -16,10 +16,13 @@ referenced-dependencies:
   name: iron
 - type: pypi
   name: Django
-  version: 2.1.7
+  version: "2.1.7"
 ```
 
 The `name` and `type` fields are required and specify the name of the dependency and where to find it. The `version` field is optional and specifies the preferred version of dependency.
+
+Note that YAML will convert a version like `1.0` or `2.0` into an integer, which is probably not what you want. The workaround is to
+surround the version with quotes.
 
 Supported dependency types:
 
@@ -48,23 +51,26 @@ Supported dependency types:
 FOSSA supports users that have dependencies that can't be automatically discovered or identified, by offering the ability to define new dependencies.
 
 To do this, you must supply the name, version, and license of the dependency.  This creates a stub package which requires no source code or linkage to any other system, but still acts as a normal dependency in other areas of FOSSA, like reports and the dependency views.
+
 You may also supply a description and/or url, but both are optional.  Note that these fields reference the dependency itself, and do not reference the parent project (the one at the current analysis directory), or the individual versions of the dependency.
 
 ```yaml
 custom-dependencies:
 # Custom dependencies need name, version, and license
 - name: foo
-  version: 1.2.3
+  version: "1.2.3"
   license: "MIT or Apache-2.0"
 # You can also provide a description and/or homepage. These values populate metadata fields in reports in the FOSSA web UI.
 - name: foo-wrapper
-  version: 1.2.3
+  version: "1.2.3"
   license: MIT
   metadata:
     homepage: https://www.foowrapper.com/about
     description: Provides foo and a helpful interface around foo-like tasks.
 ```
 
+Note that YAML will convert a version like `1.0` or `2.0` into an integer, which is probably not what you want. The workaround is to
+surround the version with quotes.
 ### Remote dependencies
 
 FOSSA also supports dependencies that can't be automatically discovered or identified, but where the user has a URL where FOSSA can download the source code of the dependency.

--- a/docs/features/manual-dependencies.md
+++ b/docs/features/manual-dependencies.md
@@ -21,8 +21,7 @@ referenced-dependencies:
 
 The `name` and `type` fields are required and specify the name of the dependency and where to find it. The `version` field is optional and specifies the preferred version of dependency.
 
-Note that YAML will convert a version like `1.0` or `2.0` into an integer, which is probably not what you want. The workaround is to
-surround the version with quotes.
+Note: When parsed, YAML considers text that could be a decimal number (such as 1.0 or 2.0) to be a number, not a string. This means that we'd parse the version 1.0 as 1. This probably isn't what you want. To avoid this, surround your version with quotes, as in "1.0".
 
 Supported dependency types:
 
@@ -69,8 +68,8 @@ custom-dependencies:
     description: Provides foo and a helpful interface around foo-like tasks.
 ```
 
-Note that YAML will convert a version like `1.0` or `2.0` into an integer, which is probably not what you want. The workaround is to
-surround the version with quotes.
+Note: When parsed, YAML considers text that could be a decimal number (such as 1.0 or 2.0) to be a number, not a string. This means that we'd parse the version 1.0 as 1. This probably isn't what you want. To avoid this, surround your version with quotes, as in "1.0".
+
 ### Remote dependencies
 
 FOSSA also supports dependencies that can't be automatically discovered or identified, but where the user has a URL where FOSSA can download the source code of the dependency.

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -9,17 +9,19 @@ In order to specify a file path, modify your `fossa-deps.yml` file and add a `ve
 referenced-dependencies:
 - type: gem
   name: rubyXL
-  version: 3.4.16
+  version: "3.4.16"
 
 vendored-dependencies:
 - name: Django
   path: vendor/Django-3.4.16.zip # path can be either a file or a folder.
-  version: 3.4.16 # revision will be set to the MD5 hash of the filepath if left unspecified.
+  version: "3.4.16" # revision will be set to the MD5 hash of the filepath if left unspecified.
 ```
 
 The path to a vendored dependency can either be a path to an archive or a path to a directory.
 
 If it is a path to an archive, then we recursively unarchive and scan the archive. If it is a directory, then we scan the directory and recursively unarchive and scan any archives contained in the directory.
+
+Note: When parsed, YAML considers text that could be a decimal number (such as 1.0 or 2.0) to be a number, not a string. This means that we'd parse the version 1.0 as 1. This probably isn't what you want. To avoid this, surround your version with quotes, as in "1.0".
 
 We also support json-formatted dependencies:
 


### PR DESCRIPTION
# Overview

I just ran into a fun YAML mis-feature when doing something with `fossa-deps.yml`. If you have a `fossa-deps.yml` that has a version like `1.0` or `2.0`, YAML helpfully turns the 1.0 into a 1, and we flag it as an unknown dependency because version 1 of that dependency does not exist (1.0 does, though).

```
referenced-dependencies:
- type: maven
  name: javax.websocket:javax.websocket-client-api
  version: 1.0
```

The workaround is to put quotes around the "1.0". I don't think there's a way to actually fix this: this is just how YAML works, right? 

This PR mentions this behaviour in the documentation and puts quotes around the versions in our sample YAML.

## Acceptance criteria

The docs should help users avoid a footgun

## Testing plan


## Risks


## References



## Checklist

