### PR TITLE
[ANE-419] Adds more logging, considers nested subspec, fixes a bug for podspec path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,9 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## v3.3.9
 
 - Maven: Always use Maven Install Plugin 3.0.0-M1 to install depgraph. This avoids a Maven bug with older versions failing to install the plugin correctly from a vendored JAR. ([#988](https://github.com/fossas/fossa-cli/pull/988/files))
+- Cocoapods: Fixes podpsec bug in which nested subspecs (of external sources), were not aptly handled, and better logging. ([#994](https://github.com/fossas/fossa-cli/pull/994))
 
 ## v3.3.8
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## v3.3.9
 
 - Maven: Always use Maven Install Plugin 3.0.0-M1 to install depgraph. This avoids a Maven bug with older versions failing to install the plugin correctly from a vendored JAR. ([#988](https://github.com/fossas/fossa-cli/pull/988/files))
-- Cocoapods: Fixes podpsec bug in which nested subspecs (of external sources), were not aptly handled, and better logging. ([#994](https://github.com/fossas/fossa-cli/pull/994))
+- Cocoapods: Fixes podpsec bug in which nested subspecs (of external sources), were not appropriately handled. Improves logging. ([#994](https://github.com/fossas/fossa-cli/pull/994))
 
 ## v3.3.8
 


### PR DESCRIPTION
# Overview

This PR,
- Adds more debug logging for the Podlock file strategy. 
- Updates Podlock strategy to use file suffix to infer external source type instead of attribute
- Considers nested subspecs when using sources of vendored subspecs
- Fixes a bug where exception in `ipc spec` was leading to non-complete results

## Acceptance criteria

- Podlock strategy replaces dependency (of nested subspec) with vendored subspec's git source (if source present)
- Podlock strategy uses alternatives for exception handling
- Podlock strategy has better debug messages, indicating which subspec is in consideration for replacement and which are getting replaced

## Testing plan

```bash
git clone https://github.com/react-native-maps/react-native-maps/ && cd react-native-maps && git checkout 71727a5f && cd example && yarn && cd ios
fossa analyze --project ane419 --revision pr994a
```

You should not see any unknown dependency in FOSSA Web UI.

Note:
- `turbomodule/core` is a nested subspec of ReactCommon

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-419

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
