### PR TITLE
Fixes fossa test --json for 0 issues case

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## v3.3.11
 
-- `fossa test` - `fossa test --json` produces json output when there are 0 issues found. ([]())
+- `fossa test` - `fossa test --json` produces json output when there are 0 issues found. ([#999](https://github.com/fossas/fossa-cli/pull/999))
 
 ## v3.3.10
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.3.11
+
+- `fossa test` - `fossa test --json` produces json output when there are 0 issues found. ([]())
+
 ## v3.3.10
 
 - Svn: Fixes project inference bug, where revision values included `\r`. ([#997](https://github.com/fossas/fossa-cli/pull/997))

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -81,8 +81,8 @@ testMain config = runStickyLogger SevInfo
       0 -> do
         logInfo . pretty $ successMsg diffRev
         case outputType of
-          TestOutputPretty -> renderJson issues
-          TestOutputJson -> pure ()
+          TestOutputPretty -> pure ()
+          TestOutputJson -> renderJson issues
       n -> do
         if null (issuesIssues issues)
           then


### PR DESCRIPTION
# Overview

This PR fixes `fossa test --json`, such that

- `--json` flag produces json stdout
- without `--json` flag we do not produce json stdout

## Acceptance criteria

When there are 0 issues;
- `--json` flag produces json stdout
- without `--json` flag we do not produce json stdout

## Testing plan

```bash
mkdir sandbox
touch 'numpy' > sandbox/reqs.txt
fossa analyze sandbox
fossa test sandbox --json # confirm json output
fossa test sandbox # confirm no json output
```

```bash
➜  fossa-cli git:(fix/fossa-test-output) ✗ fossa-dev test sandbox
[ INFO] 
[ INFO] Using project name: `git@github.com:fossas/fossa-cli.git`
[ INFO] Using revision: `05ba936f8cea4bb3affe550b3b57cd969cb6bb2f`
[ INFO] 
[ INFO] 
[ INFO] Test passed! 0 issues found
➜  fossa-cli git:(fix/fossa-test-output) ✗ fossa-dev test sandbox --json
[ INFO] 
[ INFO] Using project name: `git@github.com:fossas/fossa-cli.git`
[ INFO] Using revision: `05ba936f8cea4bb3affe550b3b57cd969cb6bb2f`
[ INFO] 
[ INFO] 
[ INFO] Test passed! 0 issues found
{"status":"SCANNED","count":0,"issues":[]}%
```

## Risks

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
