### PR TITLE
Container Scanning: Adds Os Release Information Parsers

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -226,6 +226,7 @@ library
     App.Version.TH
     Console.Sticky
     Container.Docker.Manifest
+    Container.OsRelease
     Control.Carrier.AtomicCounter
     Control.Carrier.AtomicState
     Control.Carrier.Debug
@@ -480,6 +481,7 @@ test-suite unit-tests
     Conda.CondaListSpec
     Conda.EnvironmentYmlSpec
     Container.Docker.ManifestSpec
+    Container.OsReleaseSpec
     Control.Carrier.DiagnosticsSpec
     Control.Carrier.TelemetrySpec
     Control.TimeoutSpec

--- a/src/Container/OsRelease.hs
+++ b/src/Container/OsRelease.hs
@@ -1,0 +1,205 @@
+-- | Parses system information identifier for linux based operating systems.
+--
+-- Typically such information is stored in following paths:
+--
+--  * /etc/os-release (common)
+--  * /usr/lib/os-release (common)
+--  * /etc/initrd-release
+--  * /usr/lib/extension-release.d/extension-release.IMAGE
+--
+-- The format of os-release is a newline-separated list of environment-like
+-- shell-compatible variable assignments.
+--
+-- ## Example
+-- ----------
+--
+-- NAME="Alpine Linux"
+-- ID=alpine
+-- VERSION_ID=3.15.4
+-- PRETTY_NAME="Alpine Linux v3.15"
+-- HOME_URL="https://alpinelinux.org/"
+-- BUG_REPORT_URL="https://bugs.alpinelinux.org/"
+--
+-- ## Fields of Interest
+-- ---------------------
+--
+-- ID
+--
+--  A lower-case string (no spaces or other characters outside of 0–9, a–z, ".", "_" and "-") identifying the operating system,
+--  excluding any version information and suitable for processing by scripts or usage in generated filenames.
+--  If not set, a default of "ID=linux" may be used. Note that even though this string may not include characters
+--  that require shell quoting, quoting may nevertheless be used.
+--
+--
+-- VERSION_ID
+--
+--  A lower-case string (mostly numeric, no spaces or other characters outside of 0–9, a–z, ".", "_" and "-")
+--  identifying the operating system version, excluding any OS name information or release code name, and
+--  suitable for processing by scripts or usage in generated filenames. This field is optional.
+--
+-- ## Spec
+-- --------
+--
+-- * Variable assignment values are enclosed in double or single quotes if they include spaces, semicolons or
+--   other special characters outside of A–Z, a–z, 0–9.
+--
+-- * Shell special characters ("$", quotes, backslash, backtick) must be escaped with backslashes,
+--   following shell style. All strings should be in UTF-8 encoding, and non-printable characters
+--   should not be used. Concatenation of multiple individually quoted strings is not supported.
+--
+-- * Lines beginning with "#" are treated as comments.
+--
+-- * Blank lines are permitted and ignored.
+module Container.OsRelease (
+  OsInfo (..),
+  getOsInfo,
+
+  -- * for testing
+  osReleaseParser,
+  busyBoxParser,
+  centOsOldFmtParser,
+) where
+
+import Control.Effect.Diagnostics (Diagnostics, (<||>))
+import Control.Monad (void)
+import Data.Foldable (asum)
+import Data.Map qualified as Map
+import Data.SemVer qualified as SemVer
+import Data.String.Conversion (toText)
+import Data.Text (Text)
+import Data.Void (Void)
+import Effect.ReadFS (Has, ReadFS, readContentsParser, resolveFile)
+import Path.Internal.Posix (Path (Path))
+import Text.Megaparsec (
+  MonadParsec (takeWhileP, try),
+  Parsec,
+  anySingle,
+  chunk,
+  empty,
+  many,
+  optional,
+  skipManyTill,
+  some,
+  (<|>),
+ )
+import Text.Megaparsec.Char (alphaNumChar, char)
+import Text.Megaparsec.Char.Lexer qualified as Lexer
+
+type Parser = Parsec Void Text
+
+sc :: Parser ()
+sc =
+  Lexer.space
+    (void $ some $ char ' ' <|> char '\t' <|> char '\n')
+    (Lexer.skipLineComment "#") -- os-release content can have line comments!
+    empty
+
+lexeme :: Parser a -> Parser a
+lexeme = Lexer.lexeme sc
+
+symbol :: Text -> Parser Text
+symbol = Lexer.symbol sc
+
+-- | Os Release Information of a system.
+data OsInfo = OsInfo
+  { nameId :: Text -- name identifier, e.g. alpine
+  , version :: Text -- version identifier e.g. 3.1.4
+  }
+  deriving (Show, Eq)
+
+getOsInfo :: (Has ReadFS sig m, Has Diagnostics sig m) => m OsInfo
+getOsInfo = parseEtcOsRelease <||> parseSystemReleaseCpe <||> parseBinBusyBox
+
+parseEtcOsRelease :: (Has ReadFS sig m, Has Diagnostics sig m) => m OsInfo
+parseEtcOsRelease = readContentsParser osInfoParser (Path "etc/os-release")
+
+parseBinBusyBox :: (Has ReadFS sig m, Has Diagnostics sig m) => m OsInfo
+parseBinBusyBox = readContentsParser busyBoxParser (Path "bin/busybox")
+
+parseSystemReleaseCpe :: (Has ReadFS sig m, Has Diagnostics sig m) => m OsInfo
+parseSystemReleaseCpe = readContentsParser centOsOldFmtParser (Path "etc/system-release-cpe")
+
+-- | Parses Os Release Information.
+osInfoParser :: Parser OsInfo
+osInfoParser =
+  try osReleaseParser
+    <|> try centOsOldFmtParser
+    <|> busyBoxParser
+
+-- | Parses os-release file for OS release information.
+osReleaseParser :: Parser OsInfo
+osReleaseParser = do
+  properties <- propertiesParser
+  let nameId =
+        asum
+          ( map (`Map.lookup` properties) ["ID"]
+              ++ [Just "linux"] -- We should default to linux as last resort per spec!
+          )
+  let versionId = asum $ map (`Map.lookup` properties) ["VERSION_ID"]
+
+  case (nameId, versionId) of
+    (Just name, Just version) -> pure $ OsInfo name version
+    (Just _, Nothing) -> fail "could not identify os's version"
+    (Nothing, Just _) -> fail "could not identify os's name"
+    (Nothing, Nothing) -> fail "could not identify os's name and version"
+  where
+    -- >> parseTest propertiesParser "A=B\nC=D" = fromList [(A, B), (C, D)]
+    -- >> parseTest propertiesParser "A=B\n\nC=D" = fromList [(A, B), (C, D)]
+    propertiesParser :: Parser (Map.Map Text Text)
+    propertiesParser = Map.fromList <$> many (lexeme propertyParser)
+
+    -- >> parseTest propertyParser "A=B" = (A, B)
+    -- >> parseTest propertyParser "A='B'" = (A, B)
+    propertyParser :: Parser (Text, Text)
+    propertyParser = (,) <$> (keyParser <* char '=') <*> valueParser
+
+    keyParser :: Parser Text
+    keyParser = toText <$> (some (alphaNumChar <|> char '_' <|> char '-'))
+
+    -- >> parseTest valueParser "'1.0.2'" = 1.0.2
+    -- >> parseTest valueParser "\"Abc\"" = Abc
+    valueParser :: Parser Text
+    valueParser = do
+      _ <- optional (char '"' <|> char '\'')
+      value <- takeWhileP (Just "entry value") (not . (`elem` ("\r\n\"" :: String)))
+      _ <- optional (char '"' <|> char '\'')
+      pure value
+
+-- | Parses content of /bin/busybox to identify OsInfo.
+--
+-- Busybox distribution does not contain /etc/os-release file,
+-- or equivalent. We identify by parsing /bin/busybox content.
+--
+-- Reference:
+--  https://unix.stackexchange.com/questions/15895/how-do-i-check-busybox-version-from-busybox
+busyBoxParser :: Parser OsInfo
+busyBoxParser = do
+  maybePrefix <- optional (try prefix)
+  case maybePrefix of
+    Nothing -> fail "could not find keyword BusyBox to infer release information"
+    Just _ -> do
+      busyBoxVersion <- SemVer.fromText <$> versionText
+      case busyBoxVersion of
+        Left _ -> fail "could not retrieve release version for busybox"
+        Right ver -> pure $ OsInfo "busybox" (toText $ SemVer.toString ver)
+  where
+    prefix :: Parser Text
+    prefix = skipManyTill anySingle (symbol "BusyBox v")
+
+    versionText :: Parser Text
+    versionText = takeWhileP (Just "busybox version") (not . (`elem` (" " :: String)))
+
+-- | Parses older centos distribution for os information.
+--
+-- Since os-release standard is relatively new (only released in 2012),
+-- some older distros do not adhere to this guideline, and have custom
+-- specification to denote Os release information.
+--
+-- >> cat /etc/system-release-cpe
+-- cpe:/o:centos:linux:6:GA
+centOsOldFmtParser :: Parser OsInfo
+centOsOldFmtParser = OsInfo <$> name <*> version
+  where
+    name = chunk "cpe:/o:" *> tillColon <* chunk ":linux:"
+    version = tillColon
+    tillColon = takeWhileP (Just "entry till :") (not . (`elem` (":\r\n\"" :: String)))

--- a/src/Container/OsRelease.hs
+++ b/src/Container/OsRelease.hs
@@ -161,9 +161,9 @@ osReleaseParser = do
 
   case (nameId, versionId) of
     (Just name, Just version) -> pure $ OsInfo name version
-    (Just _, Nothing) -> fail "could not identify os's version"
-    (Nothing, Just _) -> fail "could not identify os's name"
-    (Nothing, Nothing) -> fail "could not identify os's name and version"
+    (Just _, Nothing) -> fail "could not identify os version"
+    (Nothing, Just _) -> fail "could not identify os name"
+    (Nothing, Nothing) -> fail "could not identify os name or version"
   where
     -- >> parseTest propertiesParser "A=B\nC=D" = fromList [(A, B), (C, D)]
     -- >> parseTest propertiesParser "A=B\n\nC=D" = fromList [(A, B), (C, D)]

--- a/src/Container/OsRelease.hs
+++ b/src/Container/OsRelease.hs
@@ -157,7 +157,7 @@ osReleaseParser = do
           ( map (`Map.lookup` properties) ["ID"]
               ++ [Just "linux"] -- We should default to linux as last resort per spec!
           )
-  let versionId = asum $ map (`Map.lookup` properties) ["VERSION_ID"]
+  let versionId = Map.lookup "VERSION_ID" properties
 
   case (nameId, versionId) of
     (Just name, Just version) -> pure $ OsInfo name version

--- a/src/Container/OsRelease.hs
+++ b/src/Container/OsRelease.hs
@@ -78,7 +78,7 @@ import Effect.ReadFS (
   readContentsParser,
  )
 import Path (Abs, File)
-import Path.Internal.Posix (Path (Path))
+import Path.Internal (Path (Path))
 import Text.Megaparsec (
   MonadParsec (takeWhileP, try),
   Parsec,

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -32,7 +32,7 @@ import Data.Aeson (
   (.:),
   (.:?),
  )
-import Data.Foldable (forM_, for_, traverse_)
+import Data.Foldable (for_, traverse_)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -32,7 +32,7 @@ import Data.Aeson (
   (.:),
   (.:?),
  )
-import Data.Foldable (for_, traverse_)
+import Data.Foldable (forM_, for_, traverse_)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)

--- a/test/Container/OsReleaseSpec.hs
+++ b/test/Container/OsReleaseSpec.hs
@@ -2,19 +2,23 @@
 
 module Container.OsReleaseSpec (spec) where
 
-import Container.OsRelease (OsInfo (OsInfo), busyBoxParser, centOsOldFmtParser, osReleaseParser)
+import Container.OsRelease (
+  OsInfo (OsInfo),
+  busyBoxParser,
+  centOsOldFmtParser,
+  osReleaseParser,
+ )
+import Data.ByteString qualified as BS
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8With)
+import Data.Text.Encoding.Error (OnDecodeError)
+import Data.Void (Void)
 import Test.Hspec (Expectation, Spec, describe, it, runIO)
 import Test.Hspec.Megaparsec (shouldParse)
 import Text.Megaparsec (
   Parsec,
   parse,
  )
-
-import Data.ByteString qualified as BS
-import Data.Text (Text)
-import Data.Text.Encoding (decodeUtf8With)
-import Data.Text.Encoding.Error (OnDecodeError)
-import Data.Void (Void)
 import Text.RawString.QQ (r)
 
 -- | Replace an invalid input byte with the Unicode replacement (U+FFFD).

--- a/test/Container/OsReleaseSpec.hs
+++ b/test/Container/OsReleaseSpec.hs
@@ -1,0 +1,224 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Container.OsReleaseSpec (spec) where
+
+import Container.OsRelease (OsInfo (OsInfo), busyBoxParser, centOsOldFmtParser, osReleaseParser)
+import Test.Hspec (Expectation, Spec, describe, it, runIO)
+import Test.Hspec.Megaparsec (shouldParse)
+import Text.Megaparsec (
+  Parsec,
+  parse,
+ )
+
+import Data.ByteString qualified as BS
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8With)
+import Data.Text.Encoding.Error (OnDecodeError)
+import Data.Void (Void)
+import Text.RawString.QQ (r)
+
+-- | Replace an invalid input byte with the Unicode replacement (U+FFFD).
+lenientDecode :: OnDecodeError
+lenientDecode _ _ = Just '\xfffd'
+
+parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
+parseMatch parser input expected = parse parser "" input `shouldParse` expected
+
+spec :: Spec
+spec = do
+  -- binary content of /bin/busybox has to be lenientDecoded to not throw exception!
+  -- as content is not fully UTF8/locale compliant
+  busyBoxContent <- runIO (decodeUtf8With lenientDecode <$> BS.readFile "test/Container/Os/testdata/busybox")
+
+  describe "example release info files" $ do
+    let shouldOsReleaseParseInto = parseMatch osReleaseParser
+    let shouldBusyBoxParser = parseMatch busyBoxParser
+    let shouldCentOsOldFmtParser = parseMatch centOsOldFmtParser
+
+    it "should parse release info" $ do
+      alpine `shouldOsReleaseParseInto` OsInfo "alpine" "3.15.4"
+      ubuntu `shouldOsReleaseParseInto` OsInfo "ubuntu" "20.04"
+      fedora `shouldOsReleaseParseInto` OsInfo "fedora" "31"
+      centOs `shouldOsReleaseParseInto` OsInfo "centos" "8"
+      centOs7 `shouldOsReleaseParseInto` OsInfo "centos" "7"
+      oracleLinux `shouldOsReleaseParseInto` OsInfo "ol" "8.5"
+      amazon2Linux `shouldOsReleaseParseInto` OsInfo "amzn" "2"
+      openSuseLeap `shouldOsReleaseParseInto` OsInfo "opensuse-leap" "15.4"
+
+    it "should parse release info from cents os 6 cpe format" $ do
+      centOs6SystemReleaseCpe `shouldCentOsOldFmtParser` OsInfo "centos" "6"
+
+    it "should parse release info even with line break" $ do
+      alpineWithLineBreak `shouldOsReleaseParseInto` OsInfo "alpine" "3.15.4"
+
+    it "should not parse comments in release info " $ do
+      alpineWithComment `shouldOsReleaseParseInto` OsInfo "alpine" "3.15.4"
+
+    it "should parse busybox release info" $ do
+      busyBoxContent `shouldBusyBoxParser` OsInfo "busybox" "1.34.1"
+
+alpine :: Text
+alpine =
+  [r|NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.15.4
+PRETTY_NAME="Alpine Linux v3.15"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://bugs.alpinelinux.org/"
+|]
+
+alpineWithComment :: Text
+alpineWithComment =
+  [r|NAME="Alpine Linux"
+ID=alpine
+# some comment
+# VERSION_ID=0
+VERSION_ID=3.15.4
+PRETTY_NAME="Alpine Linux v3.15"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://bugs.alpinelinux.org/"
+|]
+
+alpineWithLineBreak :: Text
+alpineWithLineBreak =
+  [r|NAME="Alpine Linux"
+ID=alpine
+
+VERSION_ID=3.15.4
+PRETTY_NAME="Alpine Linux v3.15"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://bugs.alpinelinux.org/"
+|]
+
+ubuntu :: Text
+ubuntu =
+  [r|NAME="Ubuntu"
+VERSION="20.04 LTS (Focal Fossa)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 20.04 LTS"
+VERSION_ID="20.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=focal
+UBUNTU_CODENAME=focal
+|]
+
+fedora :: Text
+fedora =
+  [r|NAME=Fedora
+VERSION="31 (Container Image)"
+ID=fedora
+VERSION_ID=31
+VERSION_CODENAME=""
+PLATFORM_ID="platform:f31"
+PRETTY_NAME="Fedora 31 (Container Image)"
+ANSI_COLOR="0;34"
+LOGO=fedora-logo-icon
+CPE_NAME="cpe:/o:fedoraproject:fedora:31"
+HOME_URL="https://fedoraproject.org/"
+DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f31/system-administrators-guide/"
+SUPPORT_URL="https://fedoraproject.org/wiki/Communicating_and_getting_help"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+REDHAT_BUGZILLA_PRODUCT="Fedora"
+REDHAT_BUGZILLA_PRODUCT_VERSION=31
+REDHAT_SUPPORT_PRODUCT="Fedora"
+REDHAT_SUPPORT_PRODUCT_VERSION=31
+PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
+VARIANT="Container Image"
+VARIANT_ID=container
+|]
+
+centOs :: Text
+centOs =
+  [r|NAME="CentOS Linux"
+VERSION="8 (Core)"
+ID="centos"
+ID_LIKE="rhel fedora"
+VERSION_ID="8"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="CentOS Linux 8 (Core)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:centos:centos:8"
+HOME_URL="https://www.centos.org/"
+BUG_REPORT_URL="https://bugs.centos.org/"
+
+CENTOS_MANTISBT_PROJECT="CentOS-8"
+CENTOS_MANTISBT_PROJECT_VERSION="8"
+REDHAT_SUPPORT_PRODUCT="centos"
+REDHAT_SUPPORT_PRODUCT_VERSION="8"
+|]
+
+centOs7 :: Text
+centOs7 =
+  [r|NAME="CentOS Linux"
+VERSION="7 (Core)"
+ID="centos"
+ID_LIKE="rhel fedora"
+VERSION_ID="7"
+PRETTY_NAME="CentOS Linux 7 (Core)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:centos:centos:7"
+HOME_URL="https://www.centos.org/"
+BUG_REPORT_URL="https://bugs.centos.org/"
+
+CENTOS_MANTISBT_PROJECT="CentOS-7"
+CENTOS_MANTISBT_PROJECT_VERSION="7"
+REDHAT_SUPPORT_PRODUCT="centos"
+REDHAT_SUPPORT_PRODUCT_VERSION="7
+|]
+
+centOs6SystemReleaseCpe :: Text
+centOs6SystemReleaseCpe = [r|cpe:/o:centos:linux:6:GA|]
+
+oracleLinux :: Text
+oracleLinux =
+  [r|NAME="Oracle Linux Server"
+VERSION="8.5"
+ID="ol"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="8.5"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="Oracle Linux Server 8.5"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:8:5:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 8"
+ORACLE_BUGZILLA_PRODUCT_VERSION=8.5
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=8.5
+|]
+
+amazon2Linux :: Text
+amazon2Linux =
+  [r|NAME="Amazon Linux"
+VERSION="2"
+ID="amzn"
+ID_LIKE="centos rhel fedora"
+VERSION_ID="2"
+PRETTY_NAME="Amazon Linux 2"
+ANSI_COLOR="0;33"
+CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
+HOME_URL="https://amazonlinux.com/"
+|]
+
+openSuseLeap :: Text
+openSuseLeap =
+  [r|NAME="openSUSE Leap"
+VERSION="15.4"
+ID="opensuse-leap"
+ID_LIKE="suse opensuse"
+VERSION_ID="15.4"
+PRETTY_NAME="openSUSE Leap 15.4"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:leap:15.4"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
+DOCUMENTATION_URL="https://en.opensuse.org/Portal:Leap"
+LOGO="distributor-logo-Leap|]

--- a/test/Container/OsReleaseSpec.hs
+++ b/test/Container/OsReleaseSpec.hs
@@ -8,12 +8,9 @@ import Container.OsRelease (
   centOsOldFmtParser,
   osReleaseParser,
  )
-import Data.ByteString qualified as BS
 import Data.Text (Text)
-import Data.Text.Encoding (decodeUtf8With)
-import Data.Text.Encoding.Error (OnDecodeError)
 import Data.Void (Void)
-import Test.Hspec (Expectation, Spec, describe, it, runIO)
+import Test.Hspec (Expectation, Spec, describe, it)
 import Test.Hspec.Megaparsec (shouldParse)
 import Text.Megaparsec (
   Parsec,
@@ -21,19 +18,11 @@ import Text.Megaparsec (
  )
 import Text.RawString.QQ (r)
 
--- | Replace an invalid input byte with the Unicode replacement (U+FFFD).
-lenientDecode :: OnDecodeError
-lenientDecode _ _ = Just '\xfffd'
-
 parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
 parseMatch parser input expected = parse parser "" input `shouldParse` expected
 
 spec :: Spec
 spec = do
-  -- binary content of /bin/busybox has to be lenientDecoded to not throw exception!
-  -- as content is not fully UTF8/locale compliant
-  busyBoxContent <- runIO (decodeUtf8With lenientDecode <$> BS.readFile "test/Container/Os/testdata/busybox")
-
   describe "example release info files" $ do
     let shouldOsReleaseParseInto = parseMatch osReleaseParser
     let shouldBusyBoxParser = parseMatch busyBoxParser
@@ -226,3 +215,12 @@ BUG_REPORT_URL="https://bugs.opensuse.org"
 HOME_URL="https://www.opensuse.org/"
 DOCUMENTATION_URL="https://en.opensuse.org/Portal:Leap"
 LOGO="distributor-logo-Leap|]
+
+busyBoxContent :: Text
+busyBoxContent =
+  [r|BusyBox is copyrighted by many authors between 1998-2015.
+        BusyBox is a multi-call binary that combines many common Unix
+        link to busybox for each function they wish to use and BusyBox
+BusyBox v1.34.1 (2022-06-06 22:12:17 UTC)
+syslogd started: BusyBox v1.34.1
+|]


### PR DESCRIPTION
# Overview

This PR adds Os Release parser as part of container scanning scaffolding works.

## Acceptance criteria

- Can parse os info from container/linux image 

## Testing plan

I have added unit tests. As native container scanning is not configured E/E it cannot be tested manually yet.

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-284

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
