### PR TITLE
Container Scanning: Adds ManifestJson

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -78,6 +78,7 @@ common deps
     , containers                   ^>=0.6.0
     , cpio-conduit                 ^>=0.7.0
     , cryptonite                   ^>=0.29
+    , deepseq                      >=1.4.5.0
     , directory                    ^>=1.3.6.1
     , exceptions                   ^>=0.10.4
     , file-embed                   ^>=0.0.11
@@ -224,6 +225,7 @@ library
     App.Version
     App.Version.TH
     Console.Sticky
+    Container.Docker.Manifest
     Control.Carrier.AtomicCounter
     Control.Carrier.AtomicState
     Control.Carrier.Debug
@@ -477,6 +479,7 @@ test-suite unit-tests
     Composer.ComposerLockSpec
     Conda.CondaListSpec
     Conda.EnvironmentYmlSpec
+    Container.Docker.ManifestSpec
     Control.Carrier.DiagnosticsSpec
     Control.Carrier.TelemetrySpec
     Control.TimeoutSpec

--- a/src/Container/Docker/Manifest.hs
+++ b/src/Container/Docker/Manifest.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Container.Docker.Manifest (
+  ManifestJson (..),
+  ManifestJsonImageEntry (..),
+  decodeManifestJson,
+  getLayerPaths,
+  manifestFilename,
+) where
+
+import Control.DeepSeq (NFData)
+import Data.Aeson (
+  FromJSON,
+  ToJSON,
+  defaultOptions,
+  eitherDecode,
+  genericToEncoding,
+  parseJSON,
+  toEncoding,
+  withObject,
+  (.!=),
+  (.:),
+ )
+import Data.ByteString.Lazy qualified as ByteStringLazy
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+manifestFilename :: Text
+manifestFilename = "manifest.json"
+
+-- | The manifest of container image for the top-level image, and optionally for parent images
+-- that this image was derived from. It consists of an array of metadata entries.
+--
+-- Reference:
+-- * https://github.com/moby/moby/blob/master/image/spec/v1.2.md
+-- * https://github.com/moby/moby/blob/master/image/spec/v1.1.md
+newtype ManifestJson = ManifestJson (NonEmpty.NonEmpty ManifestJsonImageEntry)
+  deriving (Show, Eq, Ord, Generic)
+  deriving anyclass (NFData) -- explicitly use DeriveAnyClass strategy to avoid deriving-defaults warning.
+
+instance FromJSON ManifestJson
+instance ToJSON ManifestJson where
+  toEncoding = genericToEncoding defaultOptions
+
+data ManifestJsonImageEntry = ManifestJsonImageEntry
+  { config :: Text -- references another file in the tar which includes the image JSON for this image.
+  , repoTags :: [Text] -- references pointing to this image.
+  , layers :: NonEmpty.NonEmpty FilePath -- points to the filesystem changeset tars
+  }
+  deriving (Show, Eq, Ord, Generic, NFData)
+
+instance ToJSON ManifestJsonImageEntry where
+  toEncoding = genericToEncoding defaultOptions
+
+instance FromJSON ManifestJsonImageEntry where
+  parseJSON = withObject "" $ \o ->
+    ManifestJsonImageEntry
+      <$> o .: "Config"
+      <*> o .: "RepoTags" .!= []
+      <*> o .: "Layers"
+
+getLayerPaths :: ManifestJson -> NonEmpty.NonEmpty FilePath
+getLayerPaths (ManifestJson mjEntries) = layers $ NonEmpty.head mjEntries
+
+decodeManifestJson :: ByteStringLazy.ByteString -> Either String ManifestJson
+decodeManifestJson = eitherDecode

--- a/src/Container/Docker/Manifest.hs
+++ b/src/Container/Docker/Manifest.hs
@@ -21,7 +21,6 @@ import Data.Aeson (
   parseJSON,
   toEncoding,
   withObject,
-  (.!=),
   (.:),
  )
 import Data.ByteString.Lazy qualified as ByteStringLazy
@@ -60,7 +59,7 @@ instance FromJSON ManifestJsonImageEntry where
   parseJSON = withObject "" $ \o ->
     ManifestJsonImageEntry
       <$> o .: "Config"
-      <*> o .: "RepoTags" .!= []
+      <*> o .: "RepoTags"
       <*> o .: "Layers"
 
 getLayerPaths :: ManifestJson -> NonEmpty.NonEmpty FilePath

--- a/test/Container/Docker/ManifestSpec.hs
+++ b/test/Container/Docker/ManifestSpec.hs
@@ -1,0 +1,31 @@
+module Container.Docker.ManifestSpec (spec) where
+
+import Container.Docker.Manifest (ManifestJson (..), ManifestJsonImageEntry (..))
+import Data.Aeson (decodeFileStrict')
+import Data.List.NonEmpty qualified as NonEmpty
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+expectedManifestJson :: ManifestJson
+expectedManifestJson =
+  ManifestJson $
+    NonEmpty.fromList
+      [ ManifestJsonImageEntry
+          "0ac33e5f5afa79e084075e8698a22d574816eea8d7b7d480586835657c3e1c8b.json"
+          ["alpine:latest"]
+          $ NonEmpty.fromList ["0e29dcfcf3a535424b4d3e373a006d31521eb2630d340f842d530b0b28582bb0/layer.tar"]
+      , ManifestJsonImageEntry 
+          "e04c818066afe78a0c9379f62ec65aece28566024fd348242de92760293454b8.json" 
+          ["alpine:3.14"] 
+          $ NonEmpty.fromList ["8bda15652bf72885f009c3cc3d623a11a25bec6a362905b23576bad0e8b74f33/layer.tar"]
+      , ManifestJsonImageEntry 
+          "43773d1dba76c4d537b494a8454558a41729b92aa2ad0feb23521c3e58cd0440.json" 
+          ["alpine:3.6"] 
+          $ NonEmpty.fromList ["eea126ee9bd5ff1ae7944088f4d6b32abb9874a6b00935646b5526e1b57ceb86/layer.tar"]
+      ]
+
+spec :: Spec
+spec = do
+  describe "Docker Manifest" $
+    it "should parse manifest file with multiple entries" $ do
+      manifest <- decodeFileStrict' "test/Container/Docker/testdata/manifest.json"
+      manifest `shouldBe` Just expectedManifestJson

--- a/test/Container/Docker/ManifestSpec.hs
+++ b/test/Container/Docker/ManifestSpec.hs
@@ -13,13 +13,13 @@ expectedManifestJson =
           "0ac33e5f5afa79e084075e8698a22d574816eea8d7b7d480586835657c3e1c8b.json"
           ["alpine:latest"]
           $ NonEmpty.fromList ["0e29dcfcf3a535424b4d3e373a006d31521eb2630d340f842d530b0b28582bb0/layer.tar"]
-      , ManifestJsonImageEntry 
-          "e04c818066afe78a0c9379f62ec65aece28566024fd348242de92760293454b8.json" 
-          ["alpine:3.14"] 
+      , ManifestJsonImageEntry
+          "e04c818066afe78a0c9379f62ec65aece28566024fd348242de92760293454b8.json"
+          ["alpine:3.14"]
           $ NonEmpty.fromList ["8bda15652bf72885f009c3cc3d623a11a25bec6a362905b23576bad0e8b74f33/layer.tar"]
-      , ManifestJsonImageEntry 
-          "43773d1dba76c4d537b494a8454558a41729b92aa2ad0feb23521c3e58cd0440.json" 
-          ["alpine:3.6"] 
+      , ManifestJsonImageEntry
+          "43773d1dba76c4d537b494a8454558a41729b92aa2ad0feb23521c3e58cd0440.json"
+          ["alpine:3.6"]
           $ NonEmpty.fromList ["eea126ee9bd5ff1ae7944088f4d6b32abb9874a6b00935646b5526e1b57ceb86/layer.tar"]
       ]
 

--- a/test/Container/Docker/testdata/manifest.json
+++ b/test/Container/Docker/testdata/manifest.json
@@ -1,0 +1,23 @@
+[
+  {
+    "Config": "0ac33e5f5afa79e084075e8698a22d574816eea8d7b7d480586835657c3e1c8b.json",
+    "RepoTags": ["alpine:latest"],
+    "Layers": [
+      "0e29dcfcf3a535424b4d3e373a006d31521eb2630d340f842d530b0b28582bb0/layer.tar"
+    ]
+  },
+  {
+    "Config": "e04c818066afe78a0c9379f62ec65aece28566024fd348242de92760293454b8.json",
+    "RepoTags": ["alpine:3.14"],
+    "Layers": [
+      "8bda15652bf72885f009c3cc3d623a11a25bec6a362905b23576bad0e8b74f33/layer.tar"
+    ]
+  },
+  {
+    "Config": "43773d1dba76c4d537b494a8454558a41729b92aa2ad0feb23521c3e58cd0440.json",
+    "RepoTags": ["alpine:3.6"],
+    "Layers": [
+      "eea126ee9bd5ff1ae7944088f4d6b32abb9874a6b00935646b5526e1b57ceb86/layer.tar"
+    ]
+  }
+]


### PR DESCRIPTION
# Overview

This PR adds Os Release parser as part of container scanning scaffolding works.

## Acceptance criteria

- Can parse manifest.json from exported container image tarball

## Testing plan

I have added unit tests. As native container scanning is not configured E/E it cannot be tested manually yet.

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-284

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
