### PR TITLE
Container Scanning: Adds entry point scaffolding

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -178,6 +178,7 @@ library
     App.Fossa.Config.Test
     App.Fossa.Container
     App.Fossa.Container.Analyze
+    App.Fossa.Container.AnalyzeNative
     App.Fossa.Container.Scan
     App.Fossa.Container.Test
     App.Fossa.DumpBinaries

--- a/src/App/Fossa/Config/Container/Analyze.hs
+++ b/src/App/Fossa/Config/Container/Analyze.hs
@@ -46,6 +46,7 @@ import Options.Applicative (
   progDesc,
   short,
   strOption,
+  switch,
  )
 
 data NoUpload = NoUpload
@@ -54,6 +55,7 @@ data ContainerAnalyzeConfig = ContainerAnalyzeConfig
   { scanDestination :: ScanDestination
   , revisionOverride :: OverrideProject
   , imageLocator :: ImageText
+  , usesExperimentalScanner :: Bool
   }
   deriving (Eq, Ord, Show, Generic)
 
@@ -66,6 +68,7 @@ data ContainerAnalyzeOptions = ContainerAnalyzeOptions
   , containerBranch :: Maybe Text
   , containerMetadata :: ProjectMetadata
   , containerAnalyzeImage :: ImageText
+  , containerExperimentalScanner :: Bool
   }
 
 subcommand :: (ContainerAnalyzeOptions -> a) -> Mod CommandFields a
@@ -95,6 +98,7 @@ cliParser =
       )
     <*> metadataOpts
     <*> imageTextArg
+    <*> switch (long "experimental-scanner" <> short 'x' <> help "Uses experimental fossa native container scanner")
 
 mergeOpts ::
   Has Diagnostics sig m =>
@@ -115,6 +119,7 @@ mergeOpts cfgfile envvars cliOpts@ContainerAnalyzeOptions{..} = do
     <$> scanDest
     <*> pure revOverride
     <*> pure imageLoc
+    <*> pure containerExperimentalScanner
 
 collectScanDestination ::
   Has Diagnostics sig m =>

--- a/src/App/Fossa/Config/Container/Analyze.hs
+++ b/src/App/Fossa/Config/Container/Analyze.hs
@@ -98,7 +98,7 @@ cliParser =
       )
     <*> metadataOpts
     <*> imageTextArg
-    <*> switch (long "experimental-scanner" <> short 'x' <> help "Uses experimental fossa native container scanner")
+    <*> switch (long "experimental-scanner" <> help "Uses experimental fossa native container scanner")
 
 mergeOpts ::
   Has Diagnostics sig m =>

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -5,6 +5,7 @@ module App.Fossa.Container (
 ) where
 
 import App.Fossa.Config.Container (
+  ContainerAnalyzeConfig (usesExperimentalScanner),
   ContainerCommand,
   ContainerDumpScanConfig (ContainerDumpScanConfig),
   ContainerParseFileConfig (ContainerParseFileConfig),
@@ -12,6 +13,7 @@ import App.Fossa.Config.Container (
  )
 import App.Fossa.Config.Container qualified as Config
 import App.Fossa.Container.Analyze qualified as Analyze
+import App.Fossa.Container.AnalyzeNative qualified as AnalyzeNative
 import App.Fossa.Container.Scan (SyftResponse, syftCommand, toContainerScan)
 import App.Fossa.Container.Test qualified as Test
 import App.Fossa.EmbeddedBinary (withSyftBinary)
@@ -48,7 +50,10 @@ dispatch ::
   ContainerScanConfig ->
   m ()
 dispatch = \case
-  AnalyzeCfg cfg -> Analyze.analyze cfg
+  AnalyzeCfg cfg ->
+    if usesExperimentalScanner cfg
+      then AnalyzeNative.analyzeExperimental cfg
+      else Analyze.analyze cfg
   TestCfg cfg -> Test.test cfg
   DumpCfg cfg -> dumpSyftScan cfg
   ParseCfg cfg -> parseSyftOutput cfg

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.Container.AnalyzeNative (
+  analyzeExperimental,
+) where
+
+import App.Fossa.Config.Container.Analyze (
+  ContainerAnalyzeConfig (
+    ContainerAnalyzeConfig,
+    imageLocator,
+    revisionOverride,
+    scanDestination
+  ),
+ )
+import App.Fossa.Config.Container.Common (ImageText (unImageText))
+import Control.Effect.Diagnostics (Diagnostics, fatalText)
+import Control.Effect.Lift (Lift)
+import Data.Text (Text)
+import Effect.Logger (
+  Has,
+  Logger,
+  logInfo,
+ )
+import Path (Abs, File, Path)
+
+data ContainerImageSource
+  = ContainerExportedTarball (Path Abs File)
+  | ContainerDockerImage Text
+  | ContainerOCIRegistry Text Text
+  deriving (Show, Eq)
+
+analyzeExperimental ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  ) =>
+  ContainerAnalyzeConfig ->
+  m ()
+analyzeExperimental ContainerAnalyzeConfig{..} = do
+  logInfo "Running container scanning with fossa experimental-scanner!"
+  parsedSource <- parseContainerImageSource (unImageText imageLocator)
+  case parsedSource of
+    ContainerDockerImage _ -> fatalText "container images from daemon are not yet supported!"
+    ContainerOCIRegistry _ _ -> fatalText "container images from oci registry are not yet supported!"
+    ContainerExportedTarball _ -> fatalText "exported container images are not yet supported!"
+
+parseContainerImageSource :: (Has (Lift IO) sig m) => Text -> m (ContainerImageSource)
+parseContainerImageSource tag = pure $ ContainerDockerImage tag


### PR DESCRIPTION
# Overview

This PR adds entry point scaffolding for experimental container scanning.

## Acceptance criteria

- When `-x` or `--experimental-scanner` switch is used, a native container scanning path is used.

## Testing plan

- Compile, and `fossa-dev container analyze '' -x`


## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-284

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
