### PR TITLE
Container Scanning: Indexed FileTree Scaffolding

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,4 @@
 name: Benchmarks
-
-# Only run workflow manually
-# Refer to https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_dispatch
 on: [push]
 
 jobs:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,62 @@
+name: Benchmarks
+
+# Only run workflow manually
+# Refer to https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_dispatch
+on: [push]
+
+jobs:
+  benchmarks:
+    name: benchmarks
+    runs-on: ubuntu-latest
+    container: fossa/haskell-static-alpine:ghc-9.0.2
+
+    steps:
+    - name: Install alpine binary dependencies
+      shell: sh
+      run: |
+        apk add bash xz-dev bzip2-dev bzip2-static upx curl jq
+
+    - uses: actions/checkout@v3
+      with:
+        lfs: true
+
+    - name: Ensures git ownership check does not lead to compile error (we run git during compile for version tagging, etc.)
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    - uses: cachix/install-nix-action@v17
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - name: Debugging information
+      run: |
+        ghc --version || echo "no ghc"
+        cabal --version || echo "no cabal"
+        ghcup --version || echo "no ghcup"
+
+    - uses: actions/cache@v2
+      name: Cache cabal store
+      with:
+        path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.cabal/store' }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-${{ hashFiles('**/*.cabal') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-
+          ${{ runner.os }}-${{ matrix.ghc }}-
+          ${{ runner.os }}-
+
+    - name: Update vendored binaries
+      run: |
+        mkdir vendor-bins
+        ./vendor_download.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.BASIS_ACCESS_TOKEN }}
+
+    - name: Build
+      env:
+        RUN_CMD: cabal build --project-file=cabal.project.ci.linux all
+      run: |
+        cabal update
+        $RUN_CMD || $RUN_CMD
+
+    - name: Bench
+      run: |
+        cabal bench --benchmark-options '+RTS -T'

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ clean-test-data:
 # `@command` does not echo the command before running
 fmt:
 	@echo "Running fourmolu"
-	./fourmolu --version
-	./fourmolu --mode inplace ${FMT_OPTS} $(shell find ${FIND_OPTS})
+	@fourmolu --version
+	@fourmolu --mode inplace ${FMT_OPTS} $(shell find ${FIND_OPTS})
 	@echo "Running cabal-fmt"
 	@cabal-fmt spectrometer.cabal --inplace
 
@@ -83,8 +83,8 @@ check-fmt:
 # Lint everything (If this fails, update .hlint.yaml or report the failure)
 lint:
 	@echo "Running hlint"
-	./hlint --version
-	./hlint src test integration-test --cross --timing -vj
+	@hlint --version
+	@hlint src test integration-test --cross --timing -vj
 	@echo "No linter errors found"
 
 # Runs linter on only modified files

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ clean-test-data:
 # `@command` does not echo the command before running
 fmt:
 	@echo "Running fourmolu"
-	@fourmolu --version
-	@fourmolu --mode inplace ${FMT_OPTS} $(shell find ${FIND_OPTS})
+	./fourmolu --version
+	./fourmolu --mode inplace ${FMT_OPTS} $(shell find ${FIND_OPTS})
 	@echo "Running cabal-fmt"
 	@cabal-fmt spectrometer.cabal --inplace
 
@@ -83,8 +83,8 @@ check-fmt:
 # Lint everything (If this fails, update .hlint.yaml or report the failure)
 lint:
 	@echo "Running hlint"
-	@hlint --version
-	@hlint src test integration-test --cross --timing -vj
+	./hlint --version
+	./hlint src test integration-test --cross --timing -vj
 	@echo "No linter errors found"
 
 # Runs linter on only modified files

--- a/Makefile
+++ b/Makefile
@@ -142,4 +142,8 @@ ci-shell:
 	docker pull ${DEV_TOOLS}
 	docker run -it ${MOUNTED_DEV_TOOLS} bash
 
-.PHONY: build test integration-test analyze install-local fmt check check-fmt lint check-ci fmt-ci build-test-data clean-test-data install-dev test-all
+# Runs benchmarks
+bench:
+	cabal bench --benchmark-options '+RTS -T'
+
+.PHONY: build test integration-test analyze install-local fmt check check-fmt lint check-ci fmt-ci build-test-data clean-test-data install-dev test-all bench

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,3 +1,5 @@
+import Control.DeepSeq (force)
+import Control.Exception (evaluate)
 import Data.FileTree.IndexFileTree (
   SomeFileTree (..),
   allLeadingPaths,
@@ -11,7 +13,8 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.IO qualified as TextIO
-import Test.Tasty.Bench (bench, bgroup, defaultMain, nf, whnfAppIO)
+import System.IO.Unsafe
+import Test.Tasty.Bench (bench, bgroup, defaultMain, env, nf, whnfAppIO)
 
 hundredKFilePaths :: FilePath
 hundredKFilePaths = "bench/benchdata/filepaths.txt"
@@ -20,22 +23,43 @@ main :: IO ()
 main = do
   -- Tar entries do not have `/` prefix in their absolute paths, but bench data does.
   -- Remove them to mimic TarEntries fmt.
-  benchPaths <- map rmLeadingSlash <$> fmap Text.lines (TextIO.readFile hundredKFilePaths)
+
+  -- paths <- (map rmLeadingSlash <$> fmap Text.lines (TextIO.readFile hundredKFilePaths))
+  -- benchPaths <- map rmLeadingSlash <$> fmap Text.lines (TextIO.readFile hundredKFilePaths)
 
   defaultMain
-    [ bgroup
-        "indexed file tree"
-        [ bench "splitting 100k filepaths components" $ nf (map (zippedPath . allLeadingPaths)) benchPaths
-        , bench "inserting 1k filepaths" $ whnfAppIO mkTree (take 1000 benchPaths)
-        , bench "inserting 10k filepaths" $ whnfAppIO mkTree (take 10000 benchPaths)
-        , bench "inserting 100k filepaths" $ whnfAppIO mkTree (take 100000 benchPaths)
-        ]
+    [ env
+        ( evaluate
+            ( force
+                ( take 27000 $
+                    unsafePerformIO $
+                      map rmLeadingSlash <$> fmap Text.lines (TextIO.readFile hundredKFilePaths)
+                )
+            )
+        )
+        $ \centOsFileChangeSet ->
+          bench "centOsFileChangeSet" $ whnfAppIO mkTree centOsFileChangeSet
     ]
+
+-- defaultMain
+--   [ bgroup
+--       "indexed file tree" [
+--       -- [ bench "splitting 100k filepaths components" $ nf (map (zippedPath . allLeadingPaths)) benchPaths
+--       -- , bench "inserting 1k filepaths" $ whnfAppIO mkTree (take 1000 benchPaths)
+--       -- , bench "inserting 10k filepaths" $ whnfAppIO mkTree (take 10000 benchPaths)
+--         bench "inserting 100k filepaths" $ whnfAppIO $ do
+
+--           pure (mkTree paths)
+--       ]
+--   ]
 
 -- * Helpers
 
 rmLeadingSlash :: Text -> Text
 rmLeadingSlash t = fromMaybe t $ Text.stripPrefix "/" t
+
+mkTreeIO :: IO [Text] -> IO (SomeFileTree Int)
+mkTreeIO entries = mkTree =<< entries
 
 mkTree :: [Text] -> IO (SomeFileTree Int)
 mkTree = foldrM (\p tree -> insert (toSomePath p) Nothing tree) empty

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -11,7 +11,6 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.IO qualified as TextIO
-import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty.Bench (bench, defaultMain, env, nf)
 
 hundredKFilePaths :: FilePath
@@ -19,16 +18,13 @@ hundredKFilePaths = "bench/benchdata/filepaths.txt"
 
 main :: IO ()
 main = do
+  -- Tar entries do not have `/` prefix in their absolute paths, but bench data does.
+  -- Remove them to mimic TarEntries fmt.
+  txt <- map rmLeadingSlash <$> fmap Text.lines (TextIO.readFile hundredKFilePaths)
   defaultMain
     [ env
         ( evaluate
-            ( force
-                ( unsafePerformIO $
-                    -- Tar entries do not have `/` prefix in their absolute paths, but bench data does.
-                    -- Remove them to mimic TarEntries fmt.
-                    map rmLeadingSlash <$> fmap Text.lines (TextIO.readFile hundredKFilePaths)
-                )
-            )
+            (force txt)
         )
         $ \largeSetsOfFiles ->
           bench "100k path insertions" $ nf mkTree largeSetsOfFiles

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,0 +1,16 @@
+import Test.Tasty.Bench
+import qualified Data.Text.IO as TextIO
+import qualified Data.Text as Text
+
+filepaths :: FilePath
+filepaths = "bench/benchdata/filepaths.txt"
+
+main :: IO ()
+main = do
+    benchPaths <- TextIO.readFile filepaths
+    defaultMain
+        [ bgroup
+            "indexed file tree"
+            [   bench "splits by line-break" $ nf Text.lines benchPaths
+            ]
+        ]

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -6,7 +6,7 @@ import Data.FileTree.IndexFileTree (
   insert,
   toSomePath,
  )
-import Data.Foldable (Foldable (foldr'))
+import Data.Foldable (Foldable (foldl'))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -36,4 +36,4 @@ rmLeadingSlash :: Text -> Text
 rmLeadingSlash t = fromMaybe t $ Text.stripPrefix "/" t
 
 mkTree :: [Text] -> (SomeFileTree Int)
-mkTree = foldr' (\p tree -> insert (toSomePath p) Nothing tree) empty
+mkTree items = foldl' (\tree p -> insert (toSomePath p) Nothing tree) empty items

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,16 +1,32 @@
 import Test.Tasty.Bench
 import qualified Data.Text.IO as TextIO
-import qualified Data.Text as Text
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.FileTree.IndexFileTree (allLeadingPaths, zippedPath, make, SomeFileTree(..))
+import Text.Pretty.Simple (pPrint)
+import qualified Data.HashTable.IO as H
 
 filepaths :: FilePath
-filepaths = "bench/benchdata/filepaths.txt"
+filepaths = "bench/benchdata/filepaths_cents.txt"
+
+filesWithoutLeadingSlash :: Text -> Text
+filesWithoutLeadingSlash t = fromMaybe t $ Text.stripPrefix "/" t
+
+mk :: [Text] -> IO SomeFileTree
+mk = make
 
 main :: IO ()
 main = do
-    benchPaths <- TextIO.readFile filepaths
+    -- Tar entries do not have `/` prefix in their absolute paths.
+    -- Remove them to mimic TarEntries fmt. 
+    benchPaths <- map filesWithoutLeadingSlash <$> fmap Text.lines (TextIO.readFile filepaths)
+
+    let splitPaths = map (zippedPath . allLeadingPaths)
+
     defaultMain
         [ bgroup
             "indexed file tree"
-            [   bench "splits by line-break" $ nf Text.lines benchPaths
+            [   bench "splits by line-break" $ whnfAppIO mk benchPaths
             ]
         ]

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -2,68 +2,42 @@ import Control.DeepSeq (force)
 import Control.Exception (evaluate)
 import Data.FileTree.IndexFileTree (
   SomeFileTree (..),
-  allLeadingPaths,
   empty,
   insert,
   toSomePath,
-  zippedPath,
  )
-import Data.HashTable.IO qualified as H
+import Data.Foldable (Foldable (foldr'))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.IO qualified as TextIO
-import System.IO.Unsafe
-import Test.Tasty.Bench (bench, bgroup, defaultMain, env, nf, whnfAppIO)
+import System.IO.Unsafe (unsafePerformIO)
+import Test.Tasty.Bench (bench, defaultMain, env, nf)
 
 hundredKFilePaths :: FilePath
 hundredKFilePaths = "bench/benchdata/filepaths.txt"
 
 main :: IO ()
 main = do
-  -- Tar entries do not have `/` prefix in their absolute paths, but bench data does.
-  -- Remove them to mimic TarEntries fmt.
-
-  -- paths <- (map rmLeadingSlash <$> fmap Text.lines (TextIO.readFile hundredKFilePaths))
-  -- benchPaths <- map rmLeadingSlash <$> fmap Text.lines (TextIO.readFile hundredKFilePaths)
-
   defaultMain
     [ env
         ( evaluate
             ( force
-                ( take 27000 $
-                    unsafePerformIO $
-                      map rmLeadingSlash <$> fmap Text.lines (TextIO.readFile hundredKFilePaths)
+                ( unsafePerformIO $
+                    -- Tar entries do not have `/` prefix in their absolute paths, but bench data does.
+                    -- Remove them to mimic TarEntries fmt.
+                    map rmLeadingSlash <$> fmap Text.lines (TextIO.readFile hundredKFilePaths)
                 )
             )
         )
-        $ \centOsFileChangeSet ->
-          bench "centOsFileChangeSet" $ whnfAppIO mkTree centOsFileChangeSet
+        $ \largeSetsOfFiles ->
+          bench "100k path insertions" $ nf mkTree largeSetsOfFiles
     ]
-
--- defaultMain
---   [ bgroup
---       "indexed file tree" [
---       -- [ bench "splitting 100k filepaths components" $ nf (map (zippedPath . allLeadingPaths)) benchPaths
---       -- , bench "inserting 1k filepaths" $ whnfAppIO mkTree (take 1000 benchPaths)
---       -- , bench "inserting 10k filepaths" $ whnfAppIO mkTree (take 10000 benchPaths)
---         bench "inserting 100k filepaths" $ whnfAppIO $ do
-
---           pure (mkTree paths)
---       ]
---   ]
 
 -- * Helpers
 
 rmLeadingSlash :: Text -> Text
 rmLeadingSlash t = fromMaybe t $ Text.stripPrefix "/" t
 
-mkTreeIO :: IO [Text] -> IO (SomeFileTree Int)
-mkTreeIO entries = mkTree =<< entries
-
-mkTree :: [Text] -> IO (SomeFileTree Int)
-mkTree = foldrM (\p tree -> insert (toSomePath p) Nothing tree) empty
-  where
-    -- monadic foldr
-    foldrM :: Monad m => (a -> b -> m b) -> m b -> [a] -> m b
-    foldrM f = foldr ((=<<) . f)
+mkTree :: [Text] -> (SomeFileTree Int)
+mkTree = foldr' (\p tree -> insert (toSomePath p) Nothing tree) empty

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,32 +1,45 @@
-import Test.Tasty.Bench
-import qualified Data.Text.IO as TextIO
+import Data.FileTree.IndexFileTree (
+  SomeFileTree (..),
+  allLeadingPaths,
+  empty,
+  insert,
+  toSomePath,
+  zippedPath,
+ )
+import Data.HashTable.IO qualified as H
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Data.FileTree.IndexFileTree (allLeadingPaths, zippedPath, make, SomeFileTree(..))
-import Text.Pretty.Simple (pPrint)
-import qualified Data.HashTable.IO as H
+import Data.Text.IO qualified as TextIO
+import Test.Tasty.Bench (bench, bgroup, defaultMain, nf, whnfAppIO)
 
-filepaths :: FilePath
-filepaths = "bench/benchdata/filepaths_cents.txt"
-
-filesWithoutLeadingSlash :: Text -> Text
-filesWithoutLeadingSlash t = fromMaybe t $ Text.stripPrefix "/" t
-
-mk :: [Text] -> IO SomeFileTree
-mk = make
+hundredKFilePaths :: FilePath
+hundredKFilePaths = "bench/benchdata/filepaths.txt"
 
 main :: IO ()
 main = do
-    -- Tar entries do not have `/` prefix in their absolute paths.
-    -- Remove them to mimic TarEntries fmt. 
-    benchPaths <- map filesWithoutLeadingSlash <$> fmap Text.lines (TextIO.readFile filepaths)
+  -- Tar entries do not have `/` prefix in their absolute paths, but bench data does.
+  -- Remove them to mimic TarEntries fmt.
+  benchPaths <- map rmLeadingSlash <$> fmap Text.lines (TextIO.readFile hundredKFilePaths)
 
-    let splitPaths = map (zippedPath . allLeadingPaths)
-
-    defaultMain
-        [ bgroup
-            "indexed file tree"
-            [   bench "splits by line-break" $ whnfAppIO mk benchPaths
-            ]
+  defaultMain
+    [ bgroup
+        "indexed file tree"
+        [ bench "splitting 100k filepaths components" $ nf (map (zippedPath . allLeadingPaths)) benchPaths
+        , bench "inserting 1k filepaths" $ whnfAppIO mkTree (take 1000 benchPaths)
+        , bench "inserting 10k filepaths" $ whnfAppIO mkTree (take 10000 benchPaths)
+        , bench "inserting 100k filepaths" $ whnfAppIO mkTree (take 100000 benchPaths)
         ]
+    ]
+
+-- * Helpers
+
+rmLeadingSlash :: Text -> Text
+rmLeadingSlash t = fromMaybe t $ Text.stripPrefix "/" t
+
+mkTree :: [Text] -> IO (SomeFileTree Int)
+mkTree = foldrM (\p tree -> insert (toSomePath p) Nothing tree) empty
+  where
+    -- monadic foldr
+    foldrM :: Monad m => (a -> b -> m b) -> m b -> [a] -> m b
+    foldrM f = foldr ((=<<) . f)

--- a/hie.yaml
+++ b/hie.yaml
@@ -8,3 +8,5 @@ cradle:
       component: "test:unit-tests"
     - path: "./integration-test"
       component: "test:integration-tests"
+    - path: "./bench"
+      component: "bench"

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -88,6 +88,8 @@ common deps
     , fused-effects-exceptions     ^>=1.1.0.0
     , git-config                   ^>=0.1.2
     , githash                      ^>=0.1.4.0
+    , hashable                     >= 1.0.0.1
+    , hashtables                   >=1.2
     , hedn                         ^>=0.3.0.1
     , http-client                  ^>=0.7.1
     , http-types                   ^>=0.12.3
@@ -279,6 +281,7 @@ library
     Data.Aeson.Extra
     Data.Conduit.Extra
     Data.FileEmbed.Extra
+    Data.FileTree.IndexFileTree
     Data.Flag
     Data.Functor.Extra
     Data.Glob

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -633,4 +633,8 @@ benchmark bench
     , spectrometer
     , tasty-bench
 
+  -- Although this is not 1:1 representative of build profile
+  -- It provides comparable benchamark for evalauting different
+  -- implementation. Refer to tasty-bench documentation, for
+  -- use of rtsopts=-A32m, and --nonmoving-gc.
   ghc-options:    "-with-rtsopts=-A32m --nonmoving-gc"

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -88,7 +88,7 @@ common deps
     , fused-effects-exceptions     ^>=1.1.0.0
     , git-config                   ^>=0.1.2
     , githash                      ^>=0.1.4.0
-    , hashable                     >= 1.0.0.1
+    , hashable                     >=1.0.0.1
     , hashtables                   >=1.2
     , hedn                         ^>=0.3.0.1
     , http-client                  ^>=0.7.1
@@ -231,6 +231,7 @@ library
     Container.Errors
     Container.OsRelease
     Container.Tarball
+    Container.TarballReadFs
     Container.Types
     Control.Carrier.AtomicCounter
     Control.Carrier.AtomicState
@@ -497,6 +498,7 @@ test-suite unit-tests
     Dart.PubDepsSpec
     Dart.PubSpecLockSpec
     Dart.PubSpecSpec
+    Data.IndexFileTreeSpec
     Discovery.ArchiveSpec
     Discovery.FiltersSpec
     Discovery.WalkSpec
@@ -631,4 +633,4 @@ benchmark bench
     , spectrometer
     , tasty-bench
 
-  ghc-options:    -with-rtsopts=-A32m
+  ghc-options:    "-with-rtsopts=-A32m --nonmoving-gc"

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -617,3 +617,15 @@ test-suite integration-tests
     , hspec-megaparsec                ^>=2.2
     , req-conduit                     ^>=1.0.1
     , spectrometer
+
+benchmark bench
+  import:         lang
+  import:         deps
+  hs-source-dirs: bench/
+  main-is:        Main.hs
+  type:           exitcode-stdio-1.0
+  build-depends:
+    , spectrometer
+    , tasty-bench
+
+  ghc-options:    -with-rtsopts=-A32m

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -89,7 +89,6 @@ common deps
     , git-config                   ^>=0.1.2
     , githash                      ^>=0.1.4.0
     , hashable                     >=1.0.0.1
-    , hashtables                   >=1.2
     , hedn                         ^>=0.3.0.1
     , http-client                  ^>=0.7.1
     , http-types                   ^>=0.12.3

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -491,6 +491,7 @@ test-suite unit-tests
     Conda.EnvironmentYmlSpec
     Container.Docker.ManifestSpec
     Container.OsReleaseSpec
+    Container.TarballReadFSSpec
     Container.TarballSpec
     Control.Carrier.DiagnosticsSpec
     Control.Carrier.TelemetrySpec

--- a/src/Container/Tarball.hs
+++ b/src/Container/Tarball.hs
@@ -4,6 +4,9 @@ module Container.Tarball (
   removeWhiteOut,
   mkEntries,
   mkImage,
+
+  -- * utilities
+  filePathOf,
 ) where
 
 import Codec.Archive.Tar (

--- a/src/Container/TarballReadFs.hs
+++ b/src/Container/TarballReadFs.hs
@@ -71,6 +71,10 @@ import Effect.ReadFS (
   catchingIO,
  )
 import Path (Abs, Dir, File, SomeBase (..))
+
+-- We use internal module, as we cannot use parse_B_T (e.g. parseAbsFile), etc. to craft
+-- Path b t, since tarball paths are not representative of POSIX, or windows
+-- and such, parse__B_T is not useful.
 import Path.Internal (Path (Path))
 import System.IO (IOMode (ReadMode), withFile)
 

--- a/src/Container/TarballReadFs.hs
+++ b/src/Container/TarballReadFs.hs
@@ -1,0 +1,164 @@
+{-# LANGUAGE GADTs #-}
+
+module Container.TarballReadFs (
+  runTarballReadFSIO,
+) where
+
+import Codec.Archive.Tar (
+  Entry (entryContent),
+  EntryContent (
+    BlockDevice,
+    CharacterDevice,
+    Directory,
+    HardLink,
+    NamedPipe,
+    NormalFile,
+    OtherEntryType,
+    SymbolicLink
+  ),
+ )
+import Codec.Archive.Tar.Index (TarEntryOffset, hReadEntry)
+import Control.Carrier.Simple (interpret)
+import Control.Effect.Exception (throw)
+import Control.Effect.Lift (Has, Lift, sendIO)
+import Control.Monad (filterM)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as ByteString
+import Data.FileTree.IndexFileTree (
+  SomeFileTree,
+  doesDirExist,
+  doesFileExist,
+  lookupDir,
+  lookupFileRef,
+ )
+import Data.Set qualified as Set
+import Data.String.Conversion (
+  ConvertUtf8 (decodeUtf8),
+  LazyStrict (toStrict),
+  ToText (toText),
+  toString,
+ )
+import Data.Text (Text)
+import Effect.ReadFS (
+  DirID (..),
+  ReadFSErr (CurrentDirError, FileReadError, ListDirError, ResolveError),
+  ReadFSF (
+    DoesDirExist,
+    DoesFileExist,
+    GetCurrentDir,
+    GetIdentifier,
+    ListDir,
+    ReadContentsBS',
+    ReadContentsBSLimit',
+    ReadContentsText',
+    ResolveDir',
+    ResolveFile',
+    ResolvePath
+  ),
+  ReadFSIOC,
+  SomePath (SomeDir, SomeFile),
+  catchingIO,
+ )
+import Path (Abs, Dir, File, Path, SomeBase (..))
+import Path.Internal.Posix (Path (Path))
+import System.IO (IOMode (ReadMode), withFile)
+import System.Random
+
+readContentBS :: SomeFileTree TarEntryOffset -> Path Abs File -> SomeBase File -> IO ByteString
+readContentBS fs tarball target = do
+  fileRef <- lookupFileRef (toText target) fs
+  case fileRef of
+    Nothing -> throw $ userError $ "ReadContentBS: Could not find " <> (toString target) <> " in " <> (toString tarball)
+    Just tarOffset ->
+      withFile (toString tarball) ReadMode $ \handle ->
+        (getContent fs tarball) =<< hReadEntry handle tarOffset
+
+getContent :: SomeFileTree TarEntryOffset -> Path Abs File -> Entry -> IO ByteString
+getContent _ _ entry =
+  case entryContent entry of
+    NormalFile content _ -> pure $ toStrict content
+    Directory -> throw $ userError "directory found, cannot get file content of a directory."
+    NamedPipe -> throw $ userError "named pipe found, cannot get file content of a named pipe."
+    BlockDevice _ _ -> throw $ userError "block device found, cannot get file content of block device."
+    CharacterDevice _ _ -> throw $ userError "character device found, cannot get file content of character device."
+    OtherEntryType{} -> throw $ userError "other entry type found, cannot get file content of other entry type."
+    -- TODO: Add Symbolic link support.
+    SymbolicLink _ -> throw $ userError "symbolic link found, cannot get file content of symbolic link."
+    HardLink _ -> throw $ userError "hard link found, cannot get file content of hard link."
+
+readContentsBSLimit :: SomeFileTree TarEntryOffset -> Path Abs File -> SomeBase File -> Int -> IO ByteString
+readContentsBSLimit fs tarball target limit = ByteString.take limit <$> (readContentBS fs tarball target)
+
+readContentText :: SomeFileTree TarEntryOffset -> Path Abs File -> SomeBase File -> IO Text
+readContentText fs tarball target = decodeUtf8 <$> (readContentBS fs tarball target)
+
+resolveFile :: SomeFileTree TarEntryOffset -> Path Abs File -> Path Abs Dir -> Text -> IO (Path Abs File)
+resolveFile fs tarball dir target = do
+  fileExist <- doesFileExist candidatePath fs
+  if fileExist
+    then throw $ userError $ "ResolveFile: Could not find " <> (toString target) <> " in " <> (toString tarball)
+    else pure $ Path (toString candidatePath)
+  where
+    candidatePath :: Text
+    candidatePath = (toText dir) <> "/" <> target
+
+resolveDir :: SomeFileTree TarEntryOffset -> Path Abs File -> Path Abs Dir -> Text -> IO (Path Abs Dir)
+resolveDir fs tarball dir target = do
+  dirExist <- doesDirExist candidatePath fs
+  if dirExist
+    then throw $ userError $ "ResolveDir: Could not find " <> (toString target) <> " in " <> (toString tarball)
+    else pure $ Path (toString candidatePath)
+  where
+    candidatePath :: Text
+    candidatePath = (toText dir) <> "/" <> target <> "/"
+
+listDir :: SomeFileTree TarEntryOffset -> Path Abs File -> Path Abs Dir -> IO ([Path Abs Dir], [Path Abs File])
+listDir fs tarball target = do
+  dirListing <- lookupDir (toText target) fs
+  case dirListing of
+    Nothing -> throw $ userError $ "ListDir: Could not find " <> (toString target) <> " in " <> (toString tarball)
+    Just paths -> do
+      dirs <- filterM (`doesDirExist` fs) $ Set.toList paths
+      files <- filterM (`doesDirExist` fs) $ Set.toList paths
+      pure (map (Path . toString) dirs, map (Path . toString) files)
+
+getIdentifier :: SomeFileTree TarEntryOffset -> Path Abs File -> Path Abs Dir -> IO DirID
+getIdentifier fs tarball target = do
+  fileRef <- lookupFileRef (toText target) fs
+  case fileRef of
+    Nothing -> do
+      -- TODO: Fix when adding symbolic link support.
+      -- Tarball changeset do not have inode IDs!
+      rand1 <- randomIO :: IO Int -- EVIL
+      rand2 <- randomIO :: IO Int -- EVIL
+      dirExist <- doesDirExist (toText target) fs
+      if dirExist
+        then pure $ DirID (toInteger rand1) (toInteger rand2)
+        else throw $ userError $ "GetIdentifier: Could not find directory " <> toString target <> " in " <> toString tarball
+    Just tarOffset -> pure $ DirID (toInteger tarOffset) (toInteger tarOffset)
+
+resolvePath :: SomeFileTree TarEntryOffset -> Path Abs File -> Path Abs Dir -> FilePath -> IO Effect.ReadFS.SomePath
+resolvePath fs tarball dir target = do
+  dirExist <- doesDirExist candidatePath fs
+  fileExist <- doesFileExist candidatePath fs
+  case (dirExist, fileExist) of
+    (True, _) -> pure $ Effect.ReadFS.SomeDir (Abs (Path $ toString candidatePath))
+    (_, True) -> pure $ Effect.ReadFS.SomeFile (Abs (Path $ toString candidatePath))
+    (_, _) -> throw $ userError $ "ResolvePath: Could not find " <> target <> " in " <> (toString tarball)
+  where
+    candidatePath :: Text
+    candidatePath = (toText dir) <> "/" <> (toText target) <> "/"
+
+runTarballReadFSIO :: Has (Lift IO) sig m => (SomeFileTree TarEntryOffset) -> (Path Abs File) -> Effect.ReadFS.ReadFSIOC m a -> m a
+runTarballReadFSIO fs tarball = interpret $ \case
+  Effect.ReadFS.ReadContentsBS' file -> readContentBS fs tarball file `Effect.ReadFS.catchingIO` Effect.ReadFS.FileReadError (toString file)
+  Effect.ReadFS.ReadContentsBSLimit' file limit -> readContentsBSLimit fs tarball file limit `Effect.ReadFS.catchingIO` Effect.ReadFS.FileReadError (toString file)
+  Effect.ReadFS.ReadContentsText' file -> readContentText fs tarball file `Effect.ReadFS.catchingIO` Effect.ReadFS.FileReadError (toString file)
+  Effect.ReadFS.ResolveFile' dir path -> resolveFile fs tarball dir path `Effect.ReadFS.catchingIO` Effect.ReadFS.ResolveError (toString dir) (toString path)
+  Effect.ReadFS.ResolveDir' dir path -> resolveDir fs tarball dir path `Effect.ReadFS.catchingIO` Effect.ReadFS.ResolveError (toString dir) (toString path)
+  Effect.ReadFS.ListDir dir -> listDir fs tarball dir `Effect.ReadFS.catchingIO` Effect.ReadFS.ListDirError (toString dir)
+  Effect.ReadFS.GetIdentifier dir -> getIdentifier fs tarball dir `Effect.ReadFS.catchingIO` Effect.ReadFS.FileReadError (toString dir)
+  Effect.ReadFS.ResolvePath root path -> resolvePath fs tarball root path `Effect.ReadFS.catchingIO` Effect.ReadFS.ResolveError (toString root) path
+  Effect.ReadFS.GetCurrentDir -> pure (Left $ Effect.ReadFS.CurrentDirError "there is no current directory within tar!")
+  Effect.ReadFS.DoesFileExist file -> sendIO $ doesFileExist (toText file) fs
+  Effect.ReadFS.DoesDirExist dir -> sendIO $ doesDirExist (toText dir) fs

--- a/src/Container/TarballReadFs.hs
+++ b/src/Container/TarballReadFs.hs
@@ -20,8 +20,7 @@ import Codec.Archive.Tar (
 import Codec.Archive.Tar.Index (TarEntryOffset, hReadEntry)
 import Control.Carrier.Simple (interpret)
 import Control.Effect.Exception (throw)
-import Control.Effect.Lift (Has, Lift, sendIO)
-import Control.Monad (filterM)
+import Control.Effect.Lift (Has, Lift)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as ByteString
 import Data.FileTree.IndexFileTree (
@@ -31,6 +30,7 @@ import Data.FileTree.IndexFileTree (
   lookupDir,
   lookupFileRef,
  )
+import Data.Hashable (hash)
 import Data.Set qualified as Set
 import Data.String.Conversion (
   ConvertUtf8 (decodeUtf8),
@@ -62,18 +62,29 @@ import Effect.ReadFS (
 import Path (Abs, Dir, File, SomeBase (..))
 import Path.Internal (Path (Path))
 import System.IO (IOMode (ReadMode), withFile)
-import System.Random (randomIO)
 
-readContentBS :: SomeFileTree TarEntryOffset -> Path Abs File -> SomeBase File -> IO ByteString
-readContentBS fs tarball target = do
-  fileRef <- lookupFileRef (toText target) fs
-  case fileRef of
-    Nothing -> throw $ userError $ "ReadContentBS: Could not find " <> (toString target) <> " in " <> (toString tarball)
+readContentBS ::
+  SomeFileTree TarEntryOffset ->
+  Path Abs File ->
+  SomeBase File ->
+  IO ByteString
+readContentBS fs tarball target =
+  case lookupFileRef (toText target) fs of
+    Nothing ->
+      throw . userError $
+        "ReadContentBS: Could not find "
+          <> (toString target)
+          <> " in "
+          <> (toString tarball)
     Just tarOffset ->
-      withFile (toString tarball) ReadMode $ \handle ->
+      withFile (toString tarball) ReadMode $ \handle -> do
         (getContent fs tarball) =<< hReadEntry handle tarOffset
 
-getContent :: SomeFileTree TarEntryOffset -> Path Abs File -> Entry -> IO ByteString
+getContent ::
+  SomeFileTree TarEntryOffset ->
+  Path Abs File ->
+  Entry ->
+  IO ByteString
 getContent _ _ entry =
   case entryContent entry of
     NormalFile content _ -> pure $ toStrict content
@@ -82,74 +93,130 @@ getContent _ _ entry =
     BlockDevice _ _ -> throw $ userError "block device found, cannot get file content of block device."
     CharacterDevice _ _ -> throw $ userError "character device found, cannot get file content of character device."
     OtherEntryType{} -> throw $ userError "other entry type found, cannot get file content of other entry type."
-    -- TODO: Add Symbolic link support.
     SymbolicLink _ -> throw $ userError "symbolic link found, cannot get file content of symbolic link."
     HardLink _ -> throw $ userError "hard link found, cannot get file content of hard link."
 
-readContentsBSLimit :: SomeFileTree TarEntryOffset -> Path Abs File -> SomeBase File -> Int -> IO ByteString
-readContentsBSLimit fs tarball target limit = ByteString.take limit <$> (readContentBS fs tarball target)
+readContentsBSLimit ::
+  SomeFileTree TarEntryOffset ->
+  Path Abs File ->
+  SomeBase File ->
+  Int ->
+  IO ByteString
+readContentsBSLimit fs tarball target limit =
+  ByteString.take limit <$> (readContentBS fs tarball target)
 
-readContentText :: SomeFileTree TarEntryOffset -> Path Abs File -> SomeBase File -> IO Text
-readContentText fs tarball target = decodeUtf8 <$> (readContentBS fs tarball target)
+readContentText ::
+  SomeFileTree TarEntryOffset ->
+  Path Abs File ->
+  SomeBase File ->
+  IO Text
+readContentText fs tarball target =
+  decodeUtf8 <$> (readContentBS fs tarball target)
 
-resolveFile :: SomeFileTree TarEntryOffset -> Path Abs File -> Path Abs Dir -> Text -> IO (Path Abs File)
-resolveFile fs tarball dir target = do
-  fileExist <- doesFileExist candidatePath fs
-  if fileExist
-    then throw $ userError $ "ResolveFile: Could not find " <> (toString target) <> " in " <> (toString tarball)
+resolveFile ::
+  SomeFileTree TarEntryOffset ->
+  Path Abs File ->
+  Path Abs Dir ->
+  Text ->
+  IO (Path Abs File)
+resolveFile fs tarball dir target =
+  if (doesFileExist candidatePath fs)
+    then
+      throw . userError $
+        "ResolveFile: Could not find "
+          <> (toString target)
+          <> " in "
+          <> (toString tarball)
     else pure $ Path (toString candidatePath)
   where
     candidatePath :: Text
     candidatePath = (toText dir) <> "/" <> target
 
-resolveDir :: SomeFileTree TarEntryOffset -> Path Abs File -> Path Abs Dir -> Text -> IO (Path Abs Dir)
-resolveDir fs tarball dir target = do
-  dirExist <- doesDirExist candidatePath fs
-  if dirExist
-    then throw $ userError $ "ResolveDir: Could not find " <> (toString target) <> " in " <> (toString tarball)
+resolveDir ::
+  SomeFileTree TarEntryOffset ->
+  Path Abs File ->
+  Path Abs Dir ->
+  Text ->
+  IO (Path Abs Dir)
+resolveDir fs tarball dir target =
+  if doesDirExist candidatePath fs
+    then
+      throw . userError $
+        "ResolveDir: Could not find "
+          <> (toString target)
+          <> " in "
+          <> (toString tarball)
     else pure $ Path (toString candidatePath)
   where
     candidatePath :: Text
     candidatePath = (toText dir) <> "/" <> target <> "/"
 
-listDir :: SomeFileTree TarEntryOffset -> Path Abs File -> Path Abs Dir -> IO ([Path Abs Dir], [Path Abs File])
-listDir fs tarball target = do
-  dirListing <- lookupDir (toText target) fs
-  case dirListing of
-    Nothing -> throw $ userError $ "ListDir: Could not find " <> (toString target) <> " in " <> (toString tarball)
+listDir ::
+  SomeFileTree TarEntryOffset ->
+  Path Abs File ->
+  Path Abs Dir ->
+  IO ([Path Abs Dir], [Path Abs File])
+listDir fs tarball target =
+  case lookupDir (toText target) fs of
+    Nothing ->
+      throw . userError $
+        "ListDir: Could not find "
+          <> (toString target)
+          <> " in "
+          <> (toString tarball)
     Just paths -> do
-      dirs <- filterM (`doesDirExist` fs) $ Set.toList paths
-      files <- filterM (`doesDirExist` fs) $ Set.toList paths
-      pure (map (Path . toString) dirs, map (Path . toString) files)
+      let dirs = filter (`doesDirExist` fs) $ Set.toList paths
+      let files = filter (`doesDirExist` fs) $ Set.toList paths
+      pure (mapToPath dirs, mapToPath files)
+  where
+    mapToPath :: [Text] -> [Path b t]
+    mapToPath = map (Path . toString)
 
-getIdentifier :: SomeFileTree TarEntryOffset -> Path Abs File -> Path Abs Dir -> IO DirID
+getIdentifier ::
+  SomeFileTree TarEntryOffset ->
+  Path Abs File ->
+  Path Abs Dir ->
+  IO DirID
 getIdentifier fs tarball target = do
-  fileRef <- lookupFileRef (toText target) fs
-  case fileRef of
+  case lookupFileRef (toText target) fs of
     Nothing -> do
-      -- TODO: Fix when adding symbolic link support.
       -- Tarball changeset do not have inode IDs!
-      rand1 <- randomIO :: IO Int -- EVIL
-      rand2 <- randomIO :: IO Int -- EVIL
-      dirExist <- doesDirExist (toText target) fs
-      if dirExist
-        then pure $ DirID (toInteger rand1) (toInteger rand2)
-        else throw $ userError $ "GetIdentifier: Could not find directory " <> toString target <> " in " <> toString tarball
+      -- So we use hash of the filepath
+      if doesDirExist (toText target) fs
+        then pure $ DirID hashOfFilePath hashOfFilePath
+        else
+          throw . userError $
+            "GetIdentifier: Could not find directory "
+              <> toString target
+              <> " in "
+              <> toString tarball
     Just tarOffset -> pure $ DirID (toInteger tarOffset) (toInteger tarOffset)
+  where
+    hashOfFilePath :: Integer
+    hashOfFilePath = toInteger . hash . toText $ target
 
-resolvePath :: SomeFileTree TarEntryOffset -> Path Abs File -> Path Abs Dir -> FilePath -> IO SomePath
+resolvePath ::
+  SomeFileTree TarEntryOffset ->
+  Path Abs File ->
+  Path Abs Dir ->
+  FilePath ->
+  IO SomePath
 resolvePath fs tarball dir target = do
-  dirExist <- doesDirExist candidatePath fs
-  fileExist <- doesFileExist candidatePath fs
-  case (dirExist, fileExist) of
-    (True, _) -> pure $ SomeDir (Abs (Path $ toString candidatePath))
-    (_, True) -> pure $ SomeFile (Abs (Path $ toString candidatePath))
+  case (doesDirExist candidatePath fs, doesFileExist candidatePath fs) of
+    (True, _) -> pure $ SomeDir (Abs . Path . toString $ candidatePath)
+    (_, True) -> pure $ SomeFile (Abs . Path . toString $ candidatePath)
     (_, _) -> throw $ userError $ "ResolvePath: Could not find " <> target <> " in " <> (toString tarball)
   where
     candidatePath :: Text
     candidatePath = (toText dir) <> "/" <> (toText target) <> "/"
 
-runTarballReadFSIO :: Has (Lift IO) sig m => SomeFileTree TarEntryOffset -> Path Abs File -> ReadFSIOC m a -> m a
+-- | ReadFS based on virtual filetree and tarball archive for random seeks.
+runTarballReadFSIO ::
+  Has (Lift IO) sig m =>
+  SomeFileTree TarEntryOffset -> -- Virtual FileTree Containing Filepaths with reference offsets
+  Path Abs File -> -- Tarball file in which offsets are used for random seek
+  ReadFSIOC m a ->
+  m a
 runTarballReadFSIO fs tarball = interpret $ \case
   ReadContentsBS' file ->
     readContentBS fs tarball file
@@ -176,5 +243,5 @@ runTarballReadFSIO fs tarball = interpret $ \case
     resolvePath fs tarball root path
       `catchingIO` ResolveError (toString root) path
   GetCurrentDir -> pure . Left $ CurrentDirError "there is no current directory within tar!"
-  DoesFileExist file -> sendIO $ doesFileExist (toText file) fs
-  DoesDirExist dir -> sendIO $ doesDirExist (toText dir) fs
+  DoesFileExist file -> pure $ doesFileExist (toText file) fs
+  DoesDirExist dir -> pure $ doesDirExist (toText dir) fs

--- a/src/Data/FileTree/IndexFileTree.hs
+++ b/src/Data/FileTree/IndexFileTree.hs
@@ -1,0 +1,219 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Data.FileTree.IndexFileTree (
+    allLeadingPaths,
+    zippedPath,
+    SomeFileTree(..),
+    make
+) where
+
+import Control.DeepSeq (NFData)
+import Data.Maybe (fromMaybe, isNothing, isJust)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text, breakOnAll)
+import Data.Text qualified as Text
+import GHC.Generics (Generic)
+import qualified Data.HashTable.IO as H
+import Control.Monad (foldM, join)
+import Data.Hashable (Hashable, hash)
+
+type HashTable k v = H.BasicHashTable k v
+
+fixedVfsRoot :: Text
+fixedVfsRoot = "vfs-root"
+
+data SomeFileTree = SomeFileTree
+  { paths :: HashTable SomePath (Maybe Int)
+  , directories :: HashTable SomeDirPath (Set.Set SomePath)
+  }
+  deriving (Show, Generic)
+
+data SomePath
+  = SomeDir !SomeDirPath
+  | SomeFile !SomeFilePath
+  deriving (Eq, Ord, Generic, NFData)
+
+instance Show SomePath where
+  show (SomeDir dir) = show dir
+  show (SomeFile file) = show file
+
+instance Hashable SomePath where
+  hash (SomeDir (SomeDirPath dir)) = hash dir
+  hash (SomeFile (SomeFilePath file)) = hash file
+
+
+newtype SomeDirPath = SomeDirPath Text
+  deriving (Show, Eq, Ord, Generic)
+  deriving anyclass (NFData) -- explicitly use DeriveAnyClass strategy to avoid deriving-defaults warning.
+
+newtype SomeFilePath = SomeFilePath Text
+  deriving (Show, Eq, Ord, Generic)
+  deriving anyclass (NFData) -- explicitly use DeriveAnyClass strategy to avoid deriving-defaults warning.
+
+instance Hashable SomeDirPath where
+  hash (SomeDirPath dir) = hash dir
+
+instance Hashable SomeFilePath where
+  hash (SomeFilePath file) = hash file
+
+toSomePath :: Text -> SomePath
+toSomePath c =
+  if Text.isSuffixOf "/" candidate
+    then SomeDir $ SomeDirPath (withoutSlash candidate)
+    else SomeFile $ SomeFilePath candidate
+  where
+    candidate :: Text
+    candidate = fixedVfsRoot <> "/" <> c
+
+somePathToText :: SomePath -> Text
+somePathToText (SomeDir (SomeDirPath dir)) = Text.replace (fixedVfsRoot <> "/") "" dir <> "/"
+somePathToText (SomeFile (SomeFilePath file)) = Text.replace (fixedVfsRoot <> "/") "" file
+
+empty :: IO (SomeFileTree)
+empty = SomeFileTree <$> H.new <*> H.new
+
+doesFileExist :: forall a. Text -> SomeFileTree -> IO (Bool)
+doesFileExist t fsTree = f $ toSomePath t
+  where
+    f (SomeFile file) = isJust <$> H.lookup (paths fsTree) (SomeFile file) 
+    f _ = pure False
+
+doesDirExist :: forall a. Text -> SomeFileTree -> IO (Bool)
+doesDirExist t fsTree = if (t == fixedVfsRoot)
+  then pure True
+  else f (toSomePath t)
+  where
+    f (SomeDir dir) = isJust <$> H.lookup (paths fsTree) (SomeDir dir) 
+    f _ = pure False
+
+lookupFileRef :: forall a. Text -> SomeFileTree -> IO (Maybe Int)
+lookupFileRef t fsTree = do 
+  maybeVal <- f (toSomePath t)
+  case maybeVal of
+    Nothing -> pure Nothing
+    Just m_n -> pure m_n
+  where
+    f (SomeFile file) = H.lookup (paths fsTree) (SomeFile file) 
+    f _ = pure Nothing
+
+lookupDir :: forall a. Text -> SomeFileTree -> IO (Maybe (Set.Set Text))
+lookupDir t fsTree =
+  case f path of
+    Left e -> pure Nothing
+    Right x -> do 
+      dirr <- x
+      case dirr of
+        Nothing -> pure $ Just Set.empty
+        Just set -> pure $ Just $ Set.map somePathToText set
+  where
+    path = if t == fixedVfsRoot then SomeDir $ SomeDirPath fixedVfsRoot else toSomePath t
+    f (SomeDir dir) = Right $ H.lookup (directories fsTree) dir 
+    f _ = Left Nothing
+
+withoutSlash :: Text -> Text
+withoutSlash c = fromMaybe c $ Text.stripSuffix "/" c
+
+toSomeDir :: Text -> SomePath
+toSomeDir a = SomeDir (SomeDirPath a)
+
+getParentPath :: SomePath -> SomeDirPath
+getParentPath (SomeFile (SomeFilePath filepath)) = SomeDirPath (withoutSlash $ fst (Text.breakOnEnd "/" filepath))
+getParentPath (SomeDir (SomeDirPath filepath)) = SomeDirPath (withoutSlash $ fst (Text.breakOnEnd "/" filepath))
+
+foldrM :: Monad m => (a -> b -> m b) -> m b -> [a] -> m b
+foldrM f = foldr ((=<<) . f)
+
+make :: [Text] -> IO (SomeFileTree)
+make txt = foldrM (`easyI` Nothing) empty paths
+    where
+        paths = map toSomePath txt
+
+easyI :: SomePath -> Maybe Int -> SomeFileTree -> IO (SomeFileTree)
+easyI a ref st = insert a ref st
+
+insert :: SomePath -> Maybe Int -> SomeFileTree -> IO (SomeFileTree)
+insert (SomeDir (SomeDirPath dirpath)) _ tree = do
+    foldM insertNode tree $ zippedPath (allLeadingPaths dirpath)
+  where
+    insertNode :: SomeFileTree -> (Text, Text) -> IO (SomeFileTree)
+    insertNode (SomeFileTree paths dirs) (pre, post) = do
+        H.insert paths (toSomeDir post) Nothing
+        H.insert paths (toSomeDir pre) Nothing
+        
+        currentValue <- H.lookup dirs (SomeDirPath pre)
+        case currentValue of
+            Nothing -> do 
+              H.insert dirs (SomeDirPath pre) (Set.singleton $ toSomeDir post)
+              pure $ SomeFileTree paths dirs
+            Just x -> do
+                H.insert dirs (SomeDirPath pre) (Set.union x (Set.singleton $ toSomeDir post))
+                pure (SomeFileTree paths dirs)
+insert (SomeFile someFilePath) someRef tree = do
+  let parentDirPath = getParentPath (SomeFile someFilePath)
+  let dirsAddedTree = insert (SomeDir parentDirPath) Nothing tree
+  flip insertNode parentDirPath =<< dirsAddedTree
+  where
+    insertNode :: SomeFileTree -> SomeDirPath -> IO (SomeFileTree)
+    insertNode (SomeFileTree paths dirs) parentDirPath = do
+        H.insert paths (SomeFile someFilePath) someRef
+        currentValue <- H.lookup dirs parentDirPath
+        case currentValue of
+            Nothing -> do
+              H.insert dirs parentDirPath (Set.singleton (SomeFile someFilePath)) 
+              pure $ SomeFileTree paths dirs
+            Just x -> do
+                H.insert dirs parentDirPath (Set.union x (Set.singleton (SomeFile someFilePath)))
+                pure (SomeFileTree paths dirs)
+
+remove :: SomePath -> SomeFileTree -> IO (SomeFileTree)
+remove (SomeFile (SomeFilePath filepath)) (SomeFileTree paths dirs) = do
+  H.delete paths node
+  currentValue <- H.lookup dirs parent
+  case currentValue of
+    Nothing -> do
+      pure $ SomeFileTree paths dirs
+    Just x -> do
+      H.insert dirs parent (Set.filter (/= node) x)
+      pure (SomeFileTree paths dirs)
+  where
+    node = SomeFile (SomeFilePath filepath)
+    parent = getParentPath node
+remove (SomeDir (SomeDirPath dirpath)) tree = do
+  pathsWithoutDirs <- fileTreeWithoutChildren
+  H.delete (paths pathsWithoutDirs) node
+
+  dirsWithoutSubDirs <- childs
+  H.delete dirsWithoutSubDirs (SomeDirPath dirpath)
+  pure $ SomeFileTree (paths pathsWithoutDirs) (dirsWithoutSubDirs)
+  where
+    node = SomeDir (SomeDirPath dirpath)
+    
+    childrens :: IO (Maybe (Set SomePath))
+    childrens = H.lookup (directories tree) (SomeDirPath dirpath) 
+
+    fileTreeWithoutChildren :: IO (SomeFileTree)
+    fileTreeWithoutChildren = do 
+      desc <- childrens
+      case desc of
+        Nothing -> pure tree
+        Just removedChildren -> foldM (flip remove) tree removedChildren
+
+    childs :: IO (HashTable SomeDirPath (Set SomePath))
+    childs = do 
+      subTree <- fileTreeWithoutChildren
+      
+      currentValue <- H.lookup (directories subTree) (getParentPath (SomeDir $ SomeDirPath dirpath))
+
+      case currentValue of
+        Nothing -> pure $ directories subTree
+        Just x -> do
+          H.insert (directories subTree) (getParentPath (SomeDir $ SomeDirPath dirpath)) (Set.delete node x)
+          pure $ directories subTree 
+
+allLeadingPaths :: Text -> [Text]
+allLeadingPaths path = map fst $ breakOnAll "/" (path <> "/")
+
+zippedPath :: [Text] -> [(Text, Text)]
+zippedPath path = zip path (drop 1 path)

--- a/src/Data/FileTree/IndexFileTree.hs
+++ b/src/Data/FileTree/IndexFileTree.hs
@@ -1,31 +1,39 @@
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module Data.FileTree.IndexFileTree (
-    allLeadingPaths,
-    zippedPath,
-    SomeFileTree(..),
-    make
+  allLeadingPaths,
+  zippedPath,
+  SomeFileTree (..),
+  doesFileExist,
+  doesDirExist,
+  lookupFileRef,
+  lookupDir,
+  insert,
+  remove,
+  empty,
+  toSomePath,
 ) where
 
 import Control.DeepSeq (NFData)
-import Data.Maybe (fromMaybe, isNothing, isJust)
+import Control.Monad (foldM)
+import Data.HashTable.IO qualified as H
+import Data.Hashable (Hashable, hash)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text, breakOnAll)
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
-import qualified Data.HashTable.IO as H
-import Control.Monad (foldM, join)
-import Data.Hashable (Hashable, hash)
 
 type HashTable k v = H.BasicHashTable k v
 
+-- FIX ME
 fixedVfsRoot :: Text
 fixedVfsRoot = "vfs-root"
 
-data SomeFileTree = SomeFileTree
-  { paths :: HashTable SomePath (Maybe Int)
+data SomeFileTree a = SomeFileTree
+  { paths :: HashTable SomePath (Maybe a)
   , directories :: HashTable SomeDirPath (Set.Set SomePath)
   }
   deriving (Show, Generic)
@@ -42,7 +50,6 @@ instance Show SomePath where
 instance Hashable SomePath where
   hash (SomeDir (SomeDirPath dir)) = hash dir
   hash (SomeFile (SomeFilePath file)) = hash file
-
 
 newtype SomeDirPath = SomeDirPath Text
   deriving (Show, Eq, Ord, Generic)
@@ -71,45 +78,43 @@ somePathToText :: SomePath -> Text
 somePathToText (SomeDir (SomeDirPath dir)) = Text.replace (fixedVfsRoot <> "/") "" dir <> "/"
 somePathToText (SomeFile (SomeFilePath file)) = Text.replace (fixedVfsRoot <> "/") "" file
 
-empty :: IO (SomeFileTree)
+empty :: IO (SomeFileTree a)
 empty = SomeFileTree <$> H.new <*> H.new
 
-doesFileExist :: forall a. Text -> SomeFileTree -> IO (Bool)
+doesFileExist :: forall a. Text -> SomeFileTree a -> IO (Bool)
 doesFileExist t fsTree = f $ toSomePath t
   where
-    f (SomeFile file) = isJust <$> H.lookup (paths fsTree) (SomeFile file) 
+    f (SomeFile file) = isJust <$> H.lookup (paths fsTree) (SomeFile file)
     f _ = pure False
 
-doesDirExist :: forall a. Text -> SomeFileTree -> IO (Bool)
-doesDirExist t fsTree = if (t == fixedVfsRoot)
-  then pure True
-  else f (toSomePath t)
+doesDirExist :: forall a. Text -> SomeFileTree a -> IO (Bool)
+doesDirExist t fsTree = if (t == fixedVfsRoot) then pure True else f (toSomePath t)
   where
-    f (SomeDir dir) = isJust <$> H.lookup (paths fsTree) (SomeDir dir) 
+    f (SomeDir dir) = isJust <$> H.lookup (paths fsTree) (SomeDir dir)
     f _ = pure False
 
-lookupFileRef :: forall a. Text -> SomeFileTree -> IO (Maybe Int)
-lookupFileRef t fsTree = do 
+lookupFileRef :: forall a. Text -> SomeFileTree a -> IO (Maybe a)
+lookupFileRef t fsTree = do
   maybeVal <- f (toSomePath t)
   case maybeVal of
     Nothing -> pure Nothing
     Just m_n -> pure m_n
   where
-    f (SomeFile file) = H.lookup (paths fsTree) (SomeFile file) 
+    f (SomeFile file) = H.lookup (paths fsTree) (SomeFile file)
     f _ = pure Nothing
 
-lookupDir :: forall a. Text -> SomeFileTree -> IO (Maybe (Set.Set Text))
+lookupDir :: forall a. Text -> SomeFileTree a -> IO (Maybe (Set.Set Text))
 lookupDir t fsTree =
   case f path of
-    Left e -> pure Nothing
-    Right x -> do 
-      dirr <- x
-      case dirr of
+    Left _ -> pure Nothing
+    Right subDirsIO -> do
+      subDirs <- subDirsIO
+      case subDirs of
         Nothing -> pure $ Just Set.empty
-        Just set -> pure $ Just $ Set.map somePathToText set
+        Just fp -> pure $ Just $ Set.map somePathToText fp
   where
     path = if t == fixedVfsRoot then SomeDir $ SomeDirPath fixedVfsRoot else toSomePath t
-    f (SomeDir dir) = Right $ H.lookup (directories fsTree) dir 
+    f (SomeDir dir) = Right $ H.lookup (directories fsTree) dir
     f _ = Left Nothing
 
 withoutSlash :: Text -> Text
@@ -122,52 +127,57 @@ getParentPath :: SomePath -> SomeDirPath
 getParentPath (SomeFile (SomeFilePath filepath)) = SomeDirPath (withoutSlash $ fst (Text.breakOnEnd "/" filepath))
 getParentPath (SomeDir (SomeDirPath filepath)) = SomeDirPath (withoutSlash $ fst (Text.breakOnEnd "/" filepath))
 
-foldrM :: Monad m => (a -> b -> m b) -> m b -> [a] -> m b
-foldrM f = foldr ((=<<) . f)
+-- | Strict foldL
+-- from: https://stackoverflow.com/a/8919106/19573624
+foldM' :: (Monad m) => (a -> b -> m a) -> a -> [b] -> m a
+foldM' _ z [] = pure z
+foldM' f z (x : xs) = do
+  z' <- f z x
+  z' `seq` foldM' f z' xs
 
-make :: [Text] -> IO (SomeFileTree)
-make txt = foldrM (`easyI` Nothing) empty paths
-    where
-        paths = map toSomePath txt
-
-easyI :: SomePath -> Maybe Int -> SomeFileTree -> IO (SomeFileTree)
-easyI a ref st = insert a ref st
-
-insert :: SomePath -> Maybe Int -> SomeFileTree -> IO (SomeFileTree)
+insert :: forall a. SomePath -> Maybe a -> SomeFileTree a -> IO (SomeFileTree a)
 insert (SomeDir (SomeDirPath dirpath)) _ tree = do
-    foldM insertNode tree $ zippedPath (allLeadingPaths dirpath)
+  foldM' insertNode tree $ zippedPath (allLeadingPaths dirpath)
   where
-    insertNode :: SomeFileTree -> (Text, Text) -> IO (SomeFileTree)
+    insertNode :: SomeFileTree a -> (Text, Text) -> IO (SomeFileTree a)
     insertNode (SomeFileTree paths dirs) (pre, post) = do
-        H.insert paths (toSomeDir post) Nothing
-        H.insert paths (toSomeDir pre) Nothing
-        
-        currentValue <- H.lookup dirs (SomeDirPath pre)
-        case currentValue of
-            Nothing -> do 
-              H.insert dirs (SomeDirPath pre) (Set.singleton $ toSomeDir post)
-              pure $ SomeFileTree paths dirs
-            Just x -> do
-                H.insert dirs (SomeDirPath pre) (Set.union x (Set.singleton $ toSomeDir post))
-                pure (SomeFileTree paths dirs)
-insert (SomeFile someFilePath) someRef tree = do
-  let parentDirPath = getParentPath (SomeFile someFilePath)
-  let dirsAddedTree = insert (SomeDir parentDirPath) Nothing tree
-  flip insertNode parentDirPath =<< dirsAddedTree
-  where
-    insertNode :: SomeFileTree -> SomeDirPath -> IO (SomeFileTree)
-    insertNode (SomeFileTree paths dirs) parentDirPath = do
-        H.insert paths (SomeFile someFilePath) someRef
-        currentValue <- H.lookup dirs parentDirPath
-        case currentValue of
-            Nothing -> do
-              H.insert dirs parentDirPath (Set.singleton (SomeFile someFilePath)) 
-              pure $ SomeFileTree paths dirs
-            Just x -> do
-                H.insert dirs parentDirPath (Set.union x (Set.singleton (SomeFile someFilePath)))
-                pure (SomeFileTree paths dirs)
+      -- Add parent and child dir in paths
+      H.insert paths (toSomeDir post) Nothing
+      H.insert paths (toSomeDir pre) Nothing
 
-remove :: SomePath -> SomeFileTree -> IO (SomeFileTree)
+      -- If parent dir exists, add child in it's directories listing
+      subDirs <- H.lookup dirs (SomeDirPath pre)
+      case subDirs of
+        Nothing -> do
+          H.insert dirs (SomeDirPath pre) (Set.singleton $ toSomeDir post)
+          pure $ SomeFileTree paths dirs
+        Just x -> do
+          H.insert dirs (SomeDirPath pre) (Set.union x (Set.singleton $ toSomeDir post))
+          pure (SomeFileTree paths dirs)
+insert (SomeFile someFilePath) someRef tree = do
+  -- Ensure parent path exists
+  let parentDirPath = getParentPath (SomeFile someFilePath)
+  let fs = insert (SomeDir parentDirPath) Nothing tree
+
+  -- Add file path
+  insertNode parentDirPath =<< fs
+  where
+    insertNode :: SomeDirPath -> SomeFileTree a -> IO (SomeFileTree a)
+    insertNode parentDirPath (SomeFileTree paths dirs) = do
+      -- Add file path in paths listing with ref
+      H.insert paths (SomeFile someFilePath) someRef
+
+      -- Add file in it's directories listing
+      subDirs <- H.lookup dirs parentDirPath
+      case subDirs of
+        Nothing -> do
+          H.insert dirs parentDirPath (Set.singleton (SomeFile someFilePath))
+          pure $ SomeFileTree paths dirs
+        Just subDirListing -> do
+          H.insert dirs parentDirPath (Set.union subDirListing $ Set.singleton (SomeFile someFilePath))
+          pure (SomeFileTree paths dirs)
+
+remove :: forall a. SomePath -> SomeFileTree a -> IO (SomeFileTree a)
 remove (SomeFile (SomeFilePath filepath)) (SomeFileTree paths dirs) = do
   H.delete paths node
   currentValue <- H.lookup dirs parent
@@ -181,39 +191,44 @@ remove (SomeFile (SomeFilePath filepath)) (SomeFileTree paths dirs) = do
     node = SomeFile (SomeFilePath filepath)
     parent = getParentPath node
 remove (SomeDir (SomeDirPath dirpath)) tree = do
-  pathsWithoutDirs <- fileTreeWithoutChildren
+  -- Remove Dir from Paths
+  pathsWithoutDirs <- fsWithoutSubDirsAndFiles
   H.delete (paths pathsWithoutDirs) node
 
+  -- Remove sub dirs and files recursively
   dirsWithoutSubDirs <- childs
   H.delete dirsWithoutSubDirs (SomeDirPath dirpath)
+
   pure $ SomeFileTree (paths pathsWithoutDirs) (dirsWithoutSubDirs)
   where
     node = SomeDir (SomeDirPath dirpath)
-    
-    childrens :: IO (Maybe (Set SomePath))
-    childrens = H.lookup (directories tree) (SomeDirPath dirpath) 
 
-    fileTreeWithoutChildren :: IO (SomeFileTree)
-    fileTreeWithoutChildren = do 
-      desc <- childrens
-      case desc of
+    subDirsAndFiles :: IO (Maybe (Set SomePath))
+    subDirsAndFiles = H.lookup (directories tree) (SomeDirPath dirpath)
+
+    fsWithoutSubDirsAndFiles :: IO (SomeFileTree a)
+    fsWithoutSubDirsAndFiles = do
+      fs <- subDirsAndFiles
+      case fs of
         Nothing -> pure tree
         Just removedChildren -> foldM (flip remove) tree removedChildren
 
     childs :: IO (HashTable SomeDirPath (Set SomePath))
-    childs = do 
-      subTree <- fileTreeWithoutChildren
-      
-      currentValue <- H.lookup (directories subTree) (getParentPath (SomeDir $ SomeDirPath dirpath))
-
+    childs = do
+      fs <- fsWithoutSubDirsAndFiles
+      currentValue <- H.lookup (directories fs) (getParentPath (SomeDir $ SomeDirPath dirpath))
       case currentValue of
-        Nothing -> pure $ directories subTree
+        Nothing -> pure $ directories fs
         Just x -> do
-          H.insert (directories subTree) (getParentPath (SomeDir $ SomeDirPath dirpath)) (Set.delete node x)
-          pure $ directories subTree 
+          H.insert (directories fs) (getParentPath (SomeDir $ SomeDirPath dirpath)) (Set.delete node x)
+          pure $ directories fs
 
+-- | Generates all path leading up to given path
+-- >> allLeadingPaths "A/B/C" = ["A", "A/B", "A/B/C"]
 allLeadingPaths :: Text -> [Text]
 allLeadingPaths path = map fst $ breakOnAll "/" (path <> "/")
 
+-- | Zips path together in parent child pairs
+-- zippedPath ["A", "A/B", "A/B/C"] = [("A", "A/B"), ("A/B", "A/B/C")]
 zippedPath :: [Text] -> [(Text, Text)]
 zippedPath path = zip path (drop 1 path)

--- a/src/Data/FileTree/IndexFileTree.hs
+++ b/src/Data/FileTree/IndexFileTree.hs
@@ -32,15 +32,19 @@ type HashTable k v = H.BasicHashTable k v
 fixedVfsRoot :: Text
 fixedVfsRoot = "vfs-root"
 
+-- | Simple FileSystem Representation.
 data SomeFileTree a = SomeFileTree
   { paths :: HashTable SomePath (Maybe a)
   , directories :: HashTable SomeDirPath (Set.Set SomePath)
   }
   deriving (Show, Generic)
 
+empty :: IO (SomeFileTree a)
+empty = SomeFileTree <$> H.new <*> H.new
+
 data SomePath
-  = SomeDir !SomeDirPath
-  | SomeFile !SomeFilePath
+  = SomeDir SomeDirPath
+  | SomeFile SomeFilePath
   deriving (Eq, Ord, Generic, NFData)
 
 instance Show SomePath where
@@ -67,161 +71,200 @@ instance Hashable SomeFilePath where
 
 toSomePath :: Text -> SomePath
 toSomePath c =
-  if Text.isSuffixOf "/" candidate
+  if Text.isSuffixOf "/" candidate -- In POSIX, path with / suffix are directories
     then SomeDir $ SomeDirPath (withoutSlash candidate)
     else SomeFile $ SomeFilePath candidate
   where
     candidate :: Text
     candidate = fixedVfsRoot <> "/" <> c
 
+-- | Converts SomePath to Text (in POSIX format)
+-- Directories will have suffix / added
 somePathToText :: SomePath -> Text
 somePathToText (SomeDir (SomeDirPath dir)) = Text.replace (fixedVfsRoot <> "/") "" dir <> "/"
 somePathToText (SomeFile (SomeFilePath file)) = Text.replace (fixedVfsRoot <> "/") "" file
 
-empty :: IO (SomeFileTree a)
-empty = SomeFileTree <$> H.new <*> H.new
-
+-- | Returns True if File Exists, Otherwise False.
 doesFileExist :: forall a. Text -> SomeFileTree a -> IO (Bool)
 doesFileExist t fsTree = f $ toSomePath t
   where
+    f :: SomePath -> IO Bool
     f (SomeFile file) = isJust <$> H.lookup (paths fsTree) (SomeFile file)
     f _ = pure False
 
+-- | Returns True if Dir Exists, Otherwise False.
 doesDirExist :: forall a. Text -> SomeFileTree a -> IO (Bool)
 doesDirExist t fsTree = if (t == fixedVfsRoot) then pure True else f (toSomePath t)
   where
+    f :: SomePath -> IO Bool
     f (SomeDir dir) = isJust <$> H.lookup (paths fsTree) (SomeDir dir)
     f _ = pure False
 
+-- | Returns reference associated with the filepath (if any).
 lookupFileRef :: forall a. Text -> SomeFileTree a -> IO (Maybe a)
 lookupFileRef t fsTree = do
-  maybeVal <- f (toSomePath t)
-  case maybeVal of
+  refVal <- f (toSomePath t)
+  case refVal of
     Nothing -> pure Nothing
-    Just m_n -> pure m_n
+    Just rv -> pure rv
   where
+    f :: SomePath -> IO (Maybe (Maybe a))
     f (SomeFile file) = H.lookup (paths fsTree) (SomeFile file)
     f _ = pure Nothing
 
+-- | Returns List of immediate paths that are in the directory (if any)
+-- If directory does not exist, returns Nothing;
+-- If directory is empty, returns Empty Set;
 lookupDir :: forall a. Text -> SomeFileTree a -> IO (Maybe (Set.Set Text))
 lookupDir t fsTree =
   case f path of
     Left _ -> pure Nothing
-    Right subDirsIO -> do
-      subDirs <- subDirsIO
+    Right act -> do
+      subDirs <- act
       case subDirs of
         Nothing -> pure $ Just Set.empty
-        Just fp -> pure $ Just $ Set.map somePathToText fp
+        Just setPaths -> pure $ Just $ Set.map somePathToText setPaths
   where
+    path :: SomePath
     path = if t == fixedVfsRoot then SomeDir $ SomeDirPath fixedVfsRoot else toSomePath t
+
+    f :: SomePath -> Either (Maybe a) (IO (Maybe (Set SomePath)))
     f (SomeDir dir) = Right $ H.lookup (directories fsTree) dir
     f _ = Left Nothing
 
+-- | Removes suffix '/' if any.
 withoutSlash :: Text -> Text
 withoutSlash c = fromMaybe c $ Text.stripSuffix "/" c
 
+-- | Makes Directory.
 toSomeDir :: Text -> SomePath
 toSomeDir a = SomeDir (SomeDirPath a)
 
+-- | Gets parent directory of path.
 getParentPath :: SomePath -> SomeDirPath
 getParentPath (SomeFile (SomeFilePath filepath)) = SomeDirPath (withoutSlash $ fst (Text.breakOnEnd "/" filepath))
 getParentPath (SomeDir (SomeDirPath filepath)) = SomeDirPath (withoutSlash $ fst (Text.breakOnEnd "/" filepath))
 
--- | Strict foldL
--- from: https://stackoverflow.com/a/8919106/19573624
-foldM' :: (Monad m) => (a -> b -> m a) -> a -> [b] -> m a
-foldM' _ z [] = pure z
-foldM' f z (x : xs) = do
-  z' <- f z x
-  z' `seq` foldM' f z' xs
-
+-- | Inserts SomePath into FileTree with Reference.
+--
+-- If the path already exists in the FileTree, it updates to provided reference.
+-- For path which are directories, No reference is recorded.
+--
+-- >> insert "a/hello.txt" (Just 123)
+-- >> insert "a/archive/"
 insert :: forall a. SomePath -> Maybe a -> SomeFileTree a -> IO (SomeFileTree a)
-insert (SomeDir (SomeDirPath dirpath)) _ tree = do
-  foldM' insertNode tree $ zippedPath (allLeadingPaths dirpath)
+insert (SomeDir (SomeDirPath dirPath)) _ tree = foldM' insertDirNode tree $ pathPairs dirPath
   where
-    insertNode :: SomeFileTree a -> (Text, Text) -> IO (SomeFileTree a)
-    insertNode (SomeFileTree paths dirs) (pre, post) = do
-      -- Add parent and child dir in paths
+    insertDirNode :: SomeFileTree a -> (Text, Text) -> IO (SomeFileTree a)
+    insertDirNode (SomeFileTree paths dirs) (pre, post) = do
+      -- Ensure Predecessor and Successor Directory
+      -- exists in the Paths (if not already)
       H.insert paths (toSomeDir post) Nothing
       H.insert paths (toSomeDir pre) Nothing
 
-      -- If parent dir exists, add child in it's directories listing
-      subDirs <- H.lookup dirs (SomeDirPath pre)
-      case subDirs of
+      -- If Predecessor Directory exists in our Directory Listing,
+      -- Add Successor Directory into set of Successors. If Predecessor
+      -- directory does not exist, Create a listing and add Successor
+      -- directory into Set.
+      subDirListing <- H.lookup dirs (SomeDirPath pre)
+      case subDirListing of
         Nothing -> do
           H.insert dirs (SomeDirPath pre) (Set.singleton $ toSomeDir post)
           pure $ SomeFileTree paths dirs
-        Just x -> do
-          H.insert dirs (SomeDirPath pre) (Set.union x (Set.singleton $ toSomeDir post))
-          pure (SomeFileTree paths dirs)
+        Just setOfSuccessors -> do
+          H.insert dirs (SomeDirPath pre) (Set.union setOfSuccessors . Set.singleton $ toSomeDir post)
+          pure $ SomeFileTree paths dirs
 insert (SomeFile someFilePath) someRef tree = do
-  -- Ensure parent path exists
+  -- Ensure all leading directories exist in fileTree.
+  -- E.g.
+  --
+  --  A/B/hello.txt
+  --
+  -- Ensure, path A and A/B exist in fileTree, and
+  -- A's directory listing includes A/B.
   let parentDirPath = getParentPath (SomeFile someFilePath)
-  let fs = insert (SomeDir parentDirPath) Nothing tree
-
-  -- Add file path
-  insertNode parentDirPath =<< fs
+  let fs = insert (SomeDir parentDirPath) Nothing tree -- We don't store ref for Dirs
+  insertFileNode parentDirPath =<< fs
   where
-    insertNode :: SomeDirPath -> SomeFileTree a -> IO (SomeFileTree a)
-    insertNode parentDirPath (SomeFileTree paths dirs) = do
-      -- Add file path in paths listing with ref
+    insertFileNode :: SomeDirPath -> SomeFileTree a -> IO (SomeFileTree a)
+    insertFileNode parentDirPath (SomeFileTree paths dirs) = do
+      -- Add filepath in paths listing
       H.insert paths (SomeFile someFilePath) someRef
 
-      -- Add file in it's directories listing
+      -- Ensure File exists in directory listing
+      -- of it's parent directory.
       subDirs <- H.lookup dirs parentDirPath
       case subDirs of
         Nothing -> do
-          H.insert dirs parentDirPath (Set.singleton (SomeFile someFilePath))
+          H.insert dirs parentDirPath (Set.singleton $ SomeFile someFilePath)
           pure $ SomeFileTree paths dirs
         Just subDirListing -> do
-          H.insert dirs parentDirPath (Set.union subDirListing $ Set.singleton (SomeFile someFilePath))
-          pure (SomeFileTree paths dirs)
+          H.insert dirs parentDirPath (Set.union subDirListing . Set.singleton $ SomeFile someFilePath)
+          pure $ SomeFileTree paths dirs
 
+-- | Removes FilePath from File tree.
+--
+-- If the FilePath is a directory, it's removes all successor filepaths
+-- from file tree (i.e. recursively removes).
 remove :: forall a. SomePath -> SomeFileTree a -> IO (SomeFileTree a)
-remove (SomeFile (SomeFilePath filepath)) (SomeFileTree paths dirs) = do
-  H.delete paths node
-  currentValue <- H.lookup dirs parent
-  case currentValue of
-    Nothing -> do
+remove (SomeFile filepath) (SomeFileTree paths dirs) = do
+  -- Remove from Path Listing
+  H.delete paths $ SomeFile filepath
+
+  -- Remove from It's parents directory listing.
+  subDirs <- H.lookup dirs parentPath
+  case subDirs of
+    Nothing -> pure $ SomeFileTree paths dirs
+    Just subDirListing -> do
+      H.insert dirs parentPath (Set.filter (/= SomeFile filepath) subDirListing)
       pure $ SomeFileTree paths dirs
-    Just x -> do
-      H.insert dirs parent (Set.filter (/= node) x)
-      pure (SomeFileTree paths dirs)
   where
-    node = SomeFile (SomeFilePath filepath)
-    parent = getParentPath node
-remove (SomeDir (SomeDirPath dirpath)) tree = do
-  -- Remove Dir from Paths
-  pathsWithoutDirs <- fsWithoutSubDirsAndFiles
-  H.delete (paths pathsWithoutDirs) node
+    parentPath :: SomeDirPath
+    parentPath = getParentPath $ SomeFile filepath
+remove (SomeDir dirPath) tree = do
+  -- Recursively remove all successor filepaths
+  fsWoSubPaths <- fsWithoutSubPaths
 
-  -- Remove sub dirs and files recursively
-  dirsWithoutSubDirs <- childs
-  H.delete dirsWithoutSubDirs (SomeDirPath dirpath)
+  -- Remove directory filepath from paths listing
+  H.delete (paths fsWoSubPaths) dir
 
-  pure $ SomeFileTree (paths pathsWithoutDirs) (dirsWithoutSubDirs)
+  pure fsWoSubPaths
   where
-    node = SomeDir (SomeDirPath dirpath)
+    dir :: SomePath
+    dir = SomeDir dirPath
 
-    subDirsAndFiles :: IO (Maybe (Set SomePath))
-    subDirsAndFiles = H.lookup (directories tree) (SomeDirPath dirpath)
+    -- Gets all directories listing
+    subPathListing :: IO (Maybe (Set SomePath))
+    subPathListing = H.lookup (directories tree) dirPath
 
-    fsWithoutSubDirsAndFiles :: IO (SomeFileTree a)
-    fsWithoutSubDirsAndFiles = do
-      fs <- subDirsAndFiles
-      case fs of
+    fsWithoutSubPaths :: IO (SomeFileTree a)
+    fsWithoutSubPaths = do
+      subPaths <- subPathListing
+
+      -- Get FS with all sub paths removed.
+      fs <- case subPaths of
         Nothing -> pure tree
-        Just removedChildren -> foldM (flip remove) tree removedChildren
+        Just subPathsToRemove -> foldM (flip remove) tree subPathsToRemove
 
-    childs :: IO (HashTable SomeDirPath (Set SomePath))
-    childs = do
-      fs <- fsWithoutSubDirsAndFiles
-      currentValue <- H.lookup (directories fs) (getParentPath (SomeDir $ SomeDirPath dirpath))
-      case currentValue of
+      -- Get parent directory of current path
+      subDirs <- H.lookup (directories fs) (getParentPath $ SomeDir dirPath)
+
+      -- Modify Parent directories directory listing to ensure
+      -- path to be removed is not present
+      dirsRemoved <- case subDirs of
         Nothing -> pure $ directories fs
-        Just x -> do
-          H.insert (directories fs) (getParentPath (SomeDir $ SomeDirPath dirpath)) (Set.delete node x)
+        Just subDirsListing -> do
+          H.insert (directories fs) (getParentPath $ SomeDir dirPath) (Set.delete dir subDirsListing)
           pure $ directories fs
+
+      -- Remove dirpath from directory listing
+      H.delete (dirsRemoved) dirPath
+      pure $ SomeFileTree (paths fs) dirsRemoved
+
+-- | Generates paths pairs of predecessor, and successors from a path.
+-- >> pathPairs "A/B/hello.txt" = [("A", "A/B"), ("A/B", "A/B/hello.txt")]
+pathPairs :: Text -> [(Text, Text)]
+pathPairs = zippedPath . allLeadingPaths
 
 -- | Generates all path leading up to given path
 -- >> allLeadingPaths "A/B/C" = ["A", "A/B", "A/B/C"]
@@ -232,3 +275,11 @@ allLeadingPaths path = map fst $ breakOnAll "/" (path <> "/")
 -- zippedPath ["A", "A/B", "A/B/C"] = [("A", "A/B"), ("A/B", "A/B/C")]
 zippedPath :: [Text] -> [(Text, Text)]
 zippedPath path = zip path (drop 1 path)
+
+-- | Strict foldL
+-- from: https://stackoverflow.com/a/8919106/19573624
+foldM' :: (Monad m) => (a -> b -> m a) -> a -> [b] -> m a
+foldM' _ z [] = pure z
+foldM' f z (x : xs) = do
+  z' <- f z x
+  z' `seq` foldM' f z' xs

--- a/src/Data/FileTree/IndexFileTree.hs
+++ b/src/Data/FileTree/IndexFileTree.hs
@@ -302,29 +302,23 @@ resolveSymLinkRef cwd targetPath =
     (_, _, True) -> fromMaybe targetPath $ Text.stripPrefix "/" targetPath
     (False, False, False) -> cwd <> targetPath
   where
-    parentDir :: Text
-    parentDir = "./"
-
-    grandParentDir :: Text
-    grandParentDir = "../"
-
     withoutPrefix :: Text -> Text -> Text
     withoutPrefix p t = fromMaybe t $ Text.stripPrefix p t
 
     skipToGrandParentDir :: Text -> Text -> (Text, Text)
     skipToGrandParentDir currentCwd target =
-      if Text.isPrefixOf grandParentDir target
+      if Text.isPrefixOf "../" target
         then
           ( fst $ Text.breakOnEnd "/" (withoutSuffixSlash $ fst $ Text.breakOnEnd "/" cwd)
-          , withoutPrefix grandParentDir target
+          , withoutPrefix "../" target
           )
         else (currentCwd, target)
 
     skipToParentDir :: Text -> Text -> (Text, Text)
     skipToParentDir currentCwd target =
-      if Text.isPrefixOf parentDir target
+      if Text.isPrefixOf "./" target
         then
           ( fst $ Text.breakOnEnd "/" currentCwd
-          , withoutPrefix parentDir target
+          , withoutPrefix "./" target
           )
         else (currentCwd, target)

--- a/src/Data/FileTree/IndexFileTree.hs
+++ b/src/Data/FileTree/IndexFileTree.hs
@@ -22,9 +22,6 @@ module Data.FileTree.IndexFileTree (
 ) where
 
 import Control.DeepSeq (NFData)
-
--- import Data.HashTable.IO qualified as H
-
 import Data.Foldable (Foldable (foldr'), foldl')
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as H
@@ -147,8 +144,8 @@ lookupDir t fsTree =
     f _ = Left Nothing
 
 -- | Removes suffix '/' if any.
-withoutSlash :: Text -> Text
-withoutSlash c = fromMaybe c $ Text.stripSuffix "/" c
+withoutSuffixSlash :: Text -> Text
+withoutSuffixSlash c = fromMaybe c $ Text.stripSuffix "/" c
 
 -- | Makes Directory.
 toSomeDir :: Text -> SomePath
@@ -156,8 +153,8 @@ toSomeDir a = SomeDir (SomeDirPath a)
 
 -- | Gets parent directory of path.
 getParentPath :: SomePath -> SomeDirPath
-getParentPath (SomeFile (SomeFilePath filepath)) = SomeDirPath (withoutSlash $ fst (Text.breakOnEnd "/" filepath))
-getParentPath (SomeDir (SomeDirPath filepath)) = SomeDirPath (withoutSlash $ fst (Text.breakOnEnd "/" filepath))
+getParentPath (SomeFile (SomeFilePath filepath)) = SomeDirPath (withoutSuffixSlash $ fst (Text.breakOnEnd "/" filepath))
+getParentPath (SomeDir (SomeDirPath filepath)) = SomeDirPath (withoutSuffixSlash $ fst (Text.breakOnEnd "/" filepath))
 
 -- | Inserts SomePath into FileTree with Reference.
 --

--- a/src/Effect/ReadFS.hs
+++ b/src/Effect/ReadFS.hs
@@ -47,9 +47,12 @@ module Effect.ReadFS (
 
   -- * File identity information
   contentIsBinary,
-  DirID,
+  DirID (..),
   getIdentifier,
   getIdentifier',
+
+  -- * misc
+  catchingIO,
   module X,
 ) where
 

--- a/test/Container/TarballReadFSSpec.hs
+++ b/test/Container/TarballReadFSSpec.hs
@@ -36,7 +36,7 @@ spec = do
   tarFile <- runIO tarAbsFile
   let it' = itEff tarFile
 
-  describe "readContentText" $
+  describe "readContentText" $ do
     it' "should read content of file in tarball" $ do
       let feb2 :: Path Abs File = Path "logs-archive/feb/2.txt"
       feb2Content <- readContentsText feb2
@@ -47,6 +47,15 @@ spec = do
       jan1Content `shouldBe'` "1\n"
 
       let lastFile :: Path Abs File = Path "logs-archive/last.txt"
+      lastContent <- readContentsText lastFile
+      lastContent `shouldBe'` "01-01-2022\n"
+
+    it' "should read content of symbolic link's target in tarball" $ do
+      let healthFile :: Path Abs File = Path "logs-archive/feb/last_health"
+      healthFileContent <- readContentsText healthFile
+      healthFileContent `shouldBe'` "OK\n"
+
+      let lastFile :: Path Abs File = Path "last"
       lastContent <- readContentsText lastFile
       lastContent `shouldBe'` "01-01-2022\n"
 
@@ -102,4 +111,7 @@ minimalTarFsTree =
     [ ("logs-archive/feb/2.txt", Just 10)
     , ("logs-archive/jan/1.txt", Just 14)
     , ("logs-archive/last.txt", Just 16)
+    , ("logs-archive/feb/last_health", Just 66)
+    , ("health.txt", Just 76)
+    , ("last", Just 63)
     ]

--- a/test/Container/TarballReadFSSpec.hs
+++ b/test/Container/TarballReadFSSpec.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Container.TarballReadFSSpec (
+  spec,
+) where
+
+import Codec.Archive.Tar.Index (TarEntryOffset)
+import Container.TarballReadFs (runTarballReadFSIO)
+import Control.Algebra (Has)
+import Control.Carrier.Diagnostics (DiagnosticsC, runDiagnostics)
+import Control.Carrier.Stack (StackC, runStack)
+import Control.Effect.Lift (Lift, sendIO)
+import Data.FileTree.IndexFileTree (SomeFileTree, empty, insert, toSomePath)
+import Data.String.Conversion (toString)
+import Data.Text (Text)
+import Diag.Result (Result (Failure, Success), renderFailure)
+import Effect.Logger (IgnoreLoggerC, ignoreLogger, renderIt)
+import Effect.ReadFS (ReadFSIOC, listDir, readContentsText)
+import Path (Abs, Dir, File, Path, mkRelFile, (</>))
+import Path.IO qualified as PIO
+import Path.Internal (Path (..))
+import Test.Hspec (
+  Spec,
+  SpecWith,
+  describe,
+  expectationFailure,
+  it,
+  runIO,
+  shouldBe,
+  shouldMatchList,
+ )
+import Type.Operator (type ($))
+
+spec :: Spec
+spec = do
+  tarFile <- runIO tarAbsFile
+  let it' = itEff tarFile
+
+  describe "readContentText" $
+    it' "should read content of file in tarball" $ do
+      let feb2 :: Path Abs File = Path "logs-archive/feb/2.txt"
+      feb2Content <- readContentsText feb2
+      feb2Content `shouldBe'` "2\n"
+
+      let jan1 :: Path Abs File = Path "logs-archive/jan/1.txt"
+      jan1Content <- readContentsText jan1
+      jan1Content `shouldBe'` "1\n"
+
+      let lastFile :: Path Abs File = Path "logs-archive/last.txt"
+      lastContent <- readContentsText lastFile
+      lastContent `shouldBe'` "01-01-2022\n"
+
+  describe "listDir" $
+    it' "should list directories and files" $ do
+      let logsArchive :: Path Abs Dir = Path "logs-archive/"
+      (listedDirs, listedFiles) <- listDir logsArchive
+
+      listedDirs `shouldMatchList'` [Path "logs-archive/jan/", Path "logs-archive/feb/"]
+      listedFiles `shouldMatchList'` [Path "logs-archive/last.txt"]
+  where
+    itEff :: Path Abs File -> String -> EffStack () -> SpecWith ()
+    itEff tarFile msg = it msg . (runWithTarFsEff tarFile minimalTarFsTree)
+
+    shouldBe' :: (Has (Lift IO) sig m, Show a, Eq a) => a -> a -> m ()
+    shouldBe' left right = sendIO $ shouldBe left right
+
+    shouldMatchList' :: (Has (Lift IO) sig m, Show a, Eq a) => [a] -> [a] -> m ()
+    shouldMatchList' a b = sendIO $ shouldMatchList a b
+
+-- * Effect Stack For Testing
+
+type EffStack = ReadFSIOC $ DiagnosticsC $ IgnoreLoggerC $ StackC IO
+
+runWithTarFsEff :: Path Abs File -> SomeFileTree TarEntryOffset -> EffStack () -> IO ()
+runWithTarFsEff tarPath tarTree = do
+  runStack . ignoreLogger . handleDiag . runTarballReadFSIO (tarTree) (tarPath)
+  where
+    handleDiag :: (Has (Lift IO) sig m) => DiagnosticsC m () -> m ()
+    handleDiag diag =
+      runDiagnostics diag >>= \case
+        Failure ws eg ->
+          expectationFailure'
+            . toString
+            . renderIt
+            $ renderFailure ws eg "An issue occurred"
+        Success _ _ -> pure ()
+
+    expectationFailure' :: (Has (Lift IO) sig m) => String -> m ()
+    expectationFailure' = sendIO . expectationFailure
+
+mkTree :: [(Text, Maybe TarEntryOffset)] -> SomeFileTree TarEntryOffset
+mkTree = foldr (\(p, ref) tree -> insert (toSomePath p) ref tree) empty
+
+tarAbsFile :: IO (Path Abs File)
+tarAbsFile = do
+  cwd <- PIO.getCurrentDir
+  pure (cwd </> $(mkRelFile "test/Container/testdata/changeset_example.tar"))
+
+minimalTarFsTree :: SomeFileTree TarEntryOffset
+minimalTarFsTree =
+  mkTree
+    [ ("logs-archive/feb/2.txt", Just 10)
+    , ("logs-archive/jan/1.txt", Just 14)
+    , ("logs-archive/last.txt", Just 16)
+    ]

--- a/test/Container/TarballReadFSSpec.hs
+++ b/test/Container/TarballReadFSSpec.hs
@@ -11,7 +11,7 @@ import Control.Carrier.Stack (StackC, runStack)
 import Data.FileTree.IndexFileTree (SomeFileTree, empty, insert, toSomePath)
 import Data.Text (Text)
 import Effect.Logger (IgnoreLoggerC, ignoreLogger)
-import Effect.ReadFS (ReadFSIOC, listDir, readContentsText)
+import Effect.ReadFS (ReadFSIOC, listDir, readContentsText, resolveDir, resolveFile)
 import Path (Abs, Dir, File, Path, mkRelFile, (</>))
 import Path.IO qualified as PIO
 import Path.Internal (Path (..))
@@ -60,6 +60,18 @@ spec = do
 
       listedDirs `shouldMatchList'` [Path "logs-archive/jan/", Path "logs-archive/feb/"]
       listedFiles `shouldMatchList'` [Path "logs-archive/last.txt"]
+
+  describe "resolveFile" $
+    it' "should resolve file" $ do
+      let logsArchive :: Path Abs Dir = Path "logs-archive/"
+      resolvedFile <- resolveFile logsArchive "last.txt"
+      resolvedFile `shouldBe'` Path "logs-archive/last.txt"
+
+  describe "resolveDir" $
+    it' "should resolve directory" $ do
+      let logsArchive :: Path Abs Dir = Path "logs-archive/"
+      resolvedDir <- resolveDir logsArchive "jan"
+      resolvedDir `shouldBe'` Path "logs-archive/jan/"
   where
     itEff :: Path Abs File -> String -> EffStack () -> SpecWith ()
     itEff tarFile msg = it msg . (runWithTarFsEff tarFile minimalTarFsTree)

--- a/test/Data/IndexFileTreeSpec.hs
+++ b/test/Data/IndexFileTreeSpec.hs
@@ -1,0 +1,204 @@
+module Data.IndexFileTreeSpec (spec) where
+
+import Data.FileTree.IndexFileTree (
+  SomeFileTree,
+  doesDirExist,
+  doesFileExist,
+  empty,
+  insert,
+  lookupDir,
+  lookupFileRef,
+  remove,
+  toSomePath,
+ )
+
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Test.Hspec (
+  Spec,
+  describe,
+  it,
+  shouldBe,
+ )
+
+refVal1 :: Maybe Int
+refVal1 = Just 1
+
+refVal2 :: Maybe Int
+refVal2 = Just 2
+
+mkTree :: [(Text, Maybe Int)] -> IO (SomeFileTree Int)
+mkTree = foldrM (\(p, ref) tree -> insert (toSomePath p) ref tree) empty
+  where
+    -- monadic foldr
+    foldrM :: Monad m => (a -> b -> m b) -> m b -> [a] -> m b
+    foldrM f = foldr ((=<<) . f)
+
+sampleFileTree :: IO (SomeFileTree Int)
+sampleFileTree =
+  mkTree
+    [ ("root.txt", refVal1)
+    , ("archive/index.txt", refVal2)
+    , ("archive/jan/1.txt", refVal1)
+    , ("archive/feb/1.txt", refVal1)
+    , ("archive/feb/extra/info.txt", refVal1)
+    ]
+
+shouldReturn :: (Show a, Eq a) => IO a -> a -> IO ()
+shouldReturn lhs rhs = do
+  lhsActed <- lhs
+  lhsActed `shouldBe` rhs
+
+insertSpec :: Spec
+insertSpec =
+  describe "insert" $ do
+    let insertPath = insert . toSomePath
+
+    it "should insert root level filepath node" $ do
+      let fs = insertPath "a.txt" refVal1 =<< empty
+      (doesFileExist "a.txt" =<< fs) `shouldReturn` True
+
+    it "should insert nested filepath node" $ do
+      let fs =
+            insertPath "tmp/a.txt" refVal1
+              =<< empty
+
+      (doesFileExist "tmp/a.txt" =<< fs) `shouldReturn` True
+
+    it "should insert nested filepath node, when parent filepath node already exists" $ do
+      let fs =
+            insertPath "tmp/b.txt" refVal2
+              =<< insertPath "tmp/a.txt" refVal1
+              =<< empty
+
+      (doesFileExist "tmp/a.txt" =<< fs) `shouldReturn` True
+      (doesFileExist "tmp/b.txt" =<< fs) `shouldReturn` True
+
+    it "should insert (multi-level) filepath nested node" $ do
+      let fs = insertPath "tmp/archive/a.txt" refVal1 =<< empty
+      (doesFileExist "tmp/archive/a.txt" =<< fs) `shouldReturn` True
+
+    it "should insert (multi-level) filepath nested node, when parent filepath node already exists" $ do
+      let fs =
+            insertPath "tmp/archive/b.txt" refVal2
+              =<< insertPath "tmp/archive/a.txt" refVal1
+              =<< empty
+
+      (doesFileExist "tmp/archive/a.txt" =<< fs) `shouldReturn` True
+      (doesFileExist "tmp/archive/b.txt" =<< fs) `shouldReturn` True
+
+    it "should update existing root level filepath node, if filepath node already exists" $ do
+      let fs = insertPath "a.txt" refVal2 =<< (insertPath "a.txt" refVal1 =<< empty)
+      (lookupFileRef "a.txt" =<< fs) `shouldReturn` refVal2
+
+    it "should update existing nested filepath node, if filepath node already exists" $ do
+      let fs = insertPath "tmp/a.txt" refVal2 =<< insertPath "tmp/a.txt" refVal1 =<< empty
+      (lookupFileRef "tmp/a.txt" =<< fs) `shouldReturn` refVal2
+
+    it "should update existing (multi-level) nested filepath node, if filepath node already exists" $ do
+      let fs = insertPath "tmp/archive/a.txt" refVal2 =<< insertPath "tmp/archive/a.txt" refVal1 =<< empty
+      (lookupFileRef "tmp/archive/a.txt" =<< fs) `shouldReturn` refVal2
+
+doesFileExistSpec :: Spec
+doesFileExistSpec =
+  describe "doesFileExist" $ do
+    it "should return true when file exists" $
+      (doesFileExist "archive/index.txt" =<< sampleFileTree) `shouldReturn` True
+
+    it "should return false when file does not exists" $ do
+      (doesFileExist "archive/this-does-not-exist.txt" =<< sampleFileTree) `shouldReturn` False
+
+doesDirExistSpec :: Spec
+doesDirExistSpec =
+  describe "doesDirExist" $ do
+    it "should return true when dir exists" $
+      (doesDirExist "archive/" =<< sampleFileTree) `shouldReturn` True
+
+    it "should return false when dir does not exists" $ do
+      (doesDirExist "archive/this-does-not-exist/" =<< sampleFileTree) `shouldReturn` False
+      (doesDirExist "archive/this-does-not-exist.txt" =<< sampleFileTree) `shouldReturn` False
+
+lookupDirSpec :: Spec
+lookupDirSpec =
+  describe "lookupDir" $ do
+    it "should return files and dirs of root" $ do
+      (lookupDir "vfs-root" =<< sampleFileTree) `shouldReturn` Just (Set.fromList ["archive/", "root.txt"])
+
+    it "should return files and dirs" $ do
+      (lookupDir "archive/" =<< sampleFileTree) `shouldReturn` Just (Set.fromList ["archive/feb/", "archive/index.txt", "archive/jan/"])
+      (lookupDir "archive/feb/" =<< sampleFileTree) `shouldReturn` Just (Set.fromList ["archive/feb/1.txt", "archive/feb/extra/"])
+      (lookupDir "archive/feb/extra/" =<< sampleFileTree) `shouldReturn` Just (Set.fromList ["archive/feb/extra/info.txt"])
+
+lookupFileRefSpec :: Spec
+lookupFileRefSpec =
+  describe "lookupFileRef" $ do
+    it "should return Nothing when querying dir" $ do
+      (lookupFileRef "archive/" =<< sampleFileTree) `shouldReturn` Nothing
+
+    it "should return Nothing when querying non existent entry" $ do
+      (lookupFileRef "this-does-not-exit/" =<< sampleFileTree) `shouldReturn` Nothing
+      (lookupFileRef "this-does-not-exit" =<< sampleFileTree) `shouldReturn` Nothing
+
+    it "should return reference of file" $ do
+      (lookupFileRef "root.txt" =<< sampleFileTree) `shouldReturn` refVal1
+      (lookupFileRef "archive/index.txt" =<< sampleFileTree) `shouldReturn` refVal2
+
+removeSpec :: Spec
+removeSpec =
+  describe "remove" $ do
+    let removePath = remove . toSomePath
+
+    it "should remove root level filepath node" $ do
+      let fs = mkTree [("root.txt", refVal1)]
+      (doesFileExist "root.txt" =<< removePath "root.txt" =<< fs) `shouldReturn` False
+
+      let fs2 = mkTree [("root.txt", refVal1), ("a.txt", refVal2)]
+      let removedRoot2 = removePath "root.txt" =<< fs2
+      (doesFileExist "a.txt" =<< removedRoot2) `shouldReturn` True
+
+    it "should remove nested filepath node" $ do
+      let removedFs = removePath "archive/index.txt" =<< sampleFileTree
+      (doesFileExist "archive/index.txt" =<< removedFs) `shouldReturn` False
+      (doesFileExist "root.txt" =<< removedFs) `shouldReturn` True
+      (doesFileExist "archive/jan/1.txt" =<< removedFs) `shouldReturn` True
+      (doesFileExist "archive/feb/1.txt" =<< removedFs) `shouldReturn` True
+      (doesFileExist "archive/feb/extra/info.txt" =<< removedFs) `shouldReturn` True
+
+      let removedFs2 = removePath "archive/jan/1.txt" =<< sampleFileTree
+      (doesFileExist "archive/jan/1.txt" =<< removedFs2) `shouldReturn` False
+      (doesFileExist "root.txt" =<< removedFs2) `shouldReturn` True
+      (doesFileExist "archive/index.txt" =<< removedFs2) `shouldReturn` True
+      (doesFileExist "archive/feb/1.txt" =<< removedFs2) `shouldReturn` True
+      (doesFileExist "archive/feb/extra/info.txt" =<< removedFs2) `shouldReturn` True
+
+      let removedFs3 = removePath "archive/feb/extra/info.txt" =<< sampleFileTree
+      (doesFileExist "archive/feb/extra/info.txt" =<< removedFs3) `shouldReturn` False
+      (doesFileExist "root.txt" =<< removedFs3) `shouldReturn` True
+      (doesFileExist "archive/index.txt" =<< removedFs3) `shouldReturn` True
+      (doesFileExist "archive/jan/1.txt" =<< removedFs3) `shouldReturn` True
+      (doesFileExist "archive/feb/1.txt" =<< removedFs3) `shouldReturn` True
+
+      let removedFs4 = removePath "archive/feb/" =<< sampleFileTree
+      (doesFileExist "archive/feb/extra/info.txt" =<< removedFs4) `shouldReturn` False
+      (doesFileExist "archive/feb/1.txt" =<< removedFs4) `shouldReturn` False
+      (doesFileExist "root.txt" =<< removedFs4) `shouldReturn` True
+      (doesFileExist "archive/index.txt" =<< removedFs4) `shouldReturn` True
+      (doesFileExist "archive/jan/1.txt" =<< removedFs4) `shouldReturn` True
+
+      let removedFs5 = removePath "archive/" =<< sampleFileTree
+      (doesFileExist "archive/index.txt" =<< removedFs5) `shouldReturn` False
+      (doesFileExist "archive/jan/1.txt" =<< removedFs5) `shouldReturn` False
+      (doesFileExist "archive/feb/1.txt" =<< removedFs5) `shouldReturn` False
+      (doesFileExist "archive/feb/extra/info.txt" =<< removedFs5) `shouldReturn` False
+      (doesFileExist "root.txt" =<< removedFs5) `shouldReturn` True
+
+spec :: Spec
+spec = do
+  insertSpec
+  removeSpec
+
+  lookupDirSpec
+  doesDirExistSpec
+
+  lookupFileRefSpec
+  doesFileExistSpec

--- a/test/Data/IndexFileTreeSpec.hs
+++ b/test/Data/IndexFileTreeSpec.hs
@@ -27,14 +27,10 @@ refVal1 = Just 1
 refVal2 :: Maybe Int
 refVal2 = Just 2
 
-mkTree :: [(Text, Maybe Int)] -> IO (SomeFileTree Int)
-mkTree = foldrM (\(p, ref) tree -> insert (toSomePath p) ref tree) empty
-  where
-    -- monadic foldr
-    foldrM :: Monad m => (a -> b -> m b) -> m b -> [a] -> m b
-    foldrM f = foldr ((=<<) . f)
+mkTree :: [(Text, Maybe Int)] -> SomeFileTree Int
+mkTree = foldr (\(p, ref) tree -> insert (toSomePath p) ref tree) empty
 
-sampleFileTree :: IO (SomeFileTree Int)
+sampleFileTree :: SomeFileTree Int
 sampleFileTree =
   mkTree
     [ ("root.txt", refVal1)
@@ -44,104 +40,95 @@ sampleFileTree =
     , ("archive/feb/extra/info.txt", refVal1)
     ]
 
-shouldReturn :: (Show a, Eq a) => IO a -> a -> IO ()
-shouldReturn lhs rhs = do
-  lhsActed <- lhs
-  lhsActed `shouldBe` rhs
-
 insertSpec :: Spec
 insertSpec =
   describe "insert" $ do
     let insertPath = insert . toSomePath
 
     it "should insert root level filepath node" $ do
-      let fs = insertPath "a.txt" refVal1 =<< empty
-      (doesFileExist "a.txt" =<< fs) `shouldReturn` True
+      let fs = insertPath "a.txt" refVal1 empty
+      doesFileExist "a.txt" fs `shouldBe` True
 
     it "should insert nested filepath node" $ do
-      let fs =
-            insertPath "tmp/a.txt" refVal1
-              =<< empty
+      let fs = insertPath "tmp/a.txt" refVal1 empty
 
-      (doesFileExist "tmp/a.txt" =<< fs) `shouldReturn` True
+      (doesFileExist "tmp/a.txt" fs) `shouldBe` True
 
     it "should insert nested filepath node, when parent filepath node already exists" $ do
       let fs =
-            insertPath "tmp/b.txt" refVal2
-              =<< insertPath "tmp/a.txt" refVal1
-              =<< empty
+            insertPath "tmp/b.txt" refVal2 $
+              insertPath "tmp/a.txt" refVal1 empty
 
-      (doesFileExist "tmp/a.txt" =<< fs) `shouldReturn` True
-      (doesFileExist "tmp/b.txt" =<< fs) `shouldReturn` True
+      (doesFileExist "tmp/a.txt" fs) `shouldBe` True
+      (doesFileExist "tmp/b.txt" fs) `shouldBe` True
 
     it "should insert (multi-level) filepath nested node" $ do
-      let fs = insertPath "tmp/archive/a.txt" refVal1 =<< empty
-      (doesFileExist "tmp/archive/a.txt" =<< fs) `shouldReturn` True
+      let fs = insertPath "tmp/archive/a.txt" refVal1 empty
+      (doesFileExist "tmp/archive/a.txt" fs) `shouldBe` True
 
     it "should insert (multi-level) filepath nested node, when parent filepath node already exists" $ do
       let fs =
-            insertPath "tmp/archive/b.txt" refVal2
-              =<< insertPath "tmp/archive/a.txt" refVal1
-              =<< empty
+            insertPath "tmp/archive/b.txt" refVal2 $
+              insertPath "tmp/archive/a.txt" refVal1 empty
 
-      (doesFileExist "tmp/archive/a.txt" =<< fs) `shouldReturn` True
-      (doesFileExist "tmp/archive/b.txt" =<< fs) `shouldReturn` True
+      (doesFileExist "tmp/archive/a.txt" fs) `shouldBe` True
+      (doesFileExist "tmp/archive/b.txt" fs) `shouldBe` True
 
     it "should update existing root level filepath node, if filepath node already exists" $ do
-      let fs = insertPath "a.txt" refVal2 =<< (insertPath "a.txt" refVal1 =<< empty)
-      (lookupFileRef "a.txt" =<< fs) `shouldReturn` refVal2
+      let fs = insertPath "a.txt" refVal2 (insertPath "a.txt" refVal1 empty)
+      (lookupFileRef "a.txt" fs) `shouldBe` refVal2
 
     it "should update existing nested filepath node, if filepath node already exists" $ do
-      let fs = insertPath "tmp/a.txt" refVal2 =<< insertPath "tmp/a.txt" refVal1 =<< empty
-      (lookupFileRef "tmp/a.txt" =<< fs) `shouldReturn` refVal2
+      let fs = insertPath "tmp/a.txt" refVal2 $ insertPath "tmp/a.txt" refVal1 empty
+      (lookupFileRef "tmp/a.txt" fs) `shouldBe` refVal2
 
     it "should update existing (multi-level) nested filepath node, if filepath node already exists" $ do
-      let fs = insertPath "tmp/archive/a.txt" refVal2 =<< insertPath "tmp/archive/a.txt" refVal1 =<< empty
-      (lookupFileRef "tmp/archive/a.txt" =<< fs) `shouldReturn` refVal2
+      let fs = insertPath "tmp/archive/a.txt" refVal2 $ insertPath "tmp/archive/a.txt" refVal1 empty
+      (lookupFileRef "tmp/archive/a.txt" fs) `shouldBe` refVal2
 
 doesFileExistSpec :: Spec
 doesFileExistSpec =
   describe "doesFileExist" $ do
     it "should return true when file exists" $
-      (doesFileExist "archive/index.txt" =<< sampleFileTree) `shouldReturn` True
+      (doesFileExist "archive/index.txt" sampleFileTree) `shouldBe` True
 
     it "should return false when file does not exists" $ do
-      (doesFileExist "archive/this-does-not-exist.txt" =<< sampleFileTree) `shouldReturn` False
+      (doesFileExist "archive/this-does-not-exist.txt" sampleFileTree) `shouldBe` False
 
 doesDirExistSpec :: Spec
 doesDirExistSpec =
   describe "doesDirExist" $ do
     it "should return true when dir exists" $
-      (doesDirExist "archive/" =<< sampleFileTree) `shouldReturn` True
+      (doesDirExist "archive/" sampleFileTree) `shouldBe` True
 
     it "should return false when dir does not exists" $ do
-      (doesDirExist "archive/this-does-not-exist/" =<< sampleFileTree) `shouldReturn` False
-      (doesDirExist "archive/this-does-not-exist.txt" =<< sampleFileTree) `shouldReturn` False
+      (doesDirExist "archive/this-does-not-exist/" sampleFileTree) `shouldBe` False
+      (doesDirExist "archive/this-does-not-exist.txt" sampleFileTree) `shouldBe` False
 
 lookupDirSpec :: Spec
 lookupDirSpec =
   describe "lookupDir" $ do
     it "should return files and dirs of root" $ do
-      (lookupDir "vfs-root" =<< sampleFileTree) `shouldReturn` Just (Set.fromList ["archive/", "root.txt"])
+      (lookupDir "vfs-root" sampleFileTree) `shouldBe` Just (Set.fromList ["archive/", "root.txt"])
 
     it "should return files and dirs" $ do
-      (lookupDir "archive/" =<< sampleFileTree) `shouldReturn` Just (Set.fromList ["archive/feb/", "archive/index.txt", "archive/jan/"])
-      (lookupDir "archive/feb/" =<< sampleFileTree) `shouldReturn` Just (Set.fromList ["archive/feb/1.txt", "archive/feb/extra/"])
-      (lookupDir "archive/feb/extra/" =<< sampleFileTree) `shouldReturn` Just (Set.fromList ["archive/feb/extra/info.txt"])
+      (lookupDir "archive/" sampleFileTree) `shouldBe` Just (Set.fromList ["archive/feb/", "archive/index.txt", "archive/jan/"])
+      (lookupDir "archive/feb/" sampleFileTree) `shouldBe` Just (Set.fromList ["archive/feb/1.txt", "archive/feb/extra/"])
+      (lookupDir "archive/feb/extra/" sampleFileTree) `shouldBe` Just (Set.fromList ["archive/feb/extra/info.txt"])
 
 lookupFileRefSpec :: Spec
 lookupFileRefSpec =
   describe "lookupFileRef" $ do
     it "should return Nothing when querying dir" $ do
-      (lookupFileRef "archive/" =<< sampleFileTree) `shouldReturn` Nothing
+      lookupFileRef "archive/" sampleFileTree `shouldBe` Nothing
 
     it "should return Nothing when querying non existent entry" $ do
-      (lookupFileRef "this-does-not-exit/" =<< sampleFileTree) `shouldReturn` Nothing
-      (lookupFileRef "this-does-not-exit" =<< sampleFileTree) `shouldReturn` Nothing
+      (lookupFileRef "this-does-not-exit/" sampleFileTree) `shouldBe` Nothing
+      (lookupFileRef "this-does-not-exit" sampleFileTree) `shouldBe` Nothing
 
     it "should return reference of file" $ do
-      (lookupFileRef "root.txt" =<< sampleFileTree) `shouldReturn` refVal1
-      (lookupFileRef "archive/index.txt" =<< sampleFileTree) `shouldReturn` refVal2
+      (lookupFileRef "root.txt" sampleFileTree) `shouldBe` refVal1
+      (lookupFileRef "archive/index.txt" sampleFileTree) `shouldBe` refVal2
 
 removeSpec :: Spec
 removeSpec =
@@ -150,47 +137,47 @@ removeSpec =
 
     it "should remove root level filepath node" $ do
       let fs = mkTree [("root.txt", refVal1)]
-      (doesFileExist "root.txt" =<< removePath "root.txt" =<< fs) `shouldReturn` False
+      doesFileExist "root.txt" (removePath "root.txt" fs) `shouldBe` False
 
       let fs2 = mkTree [("root.txt", refVal1), ("a.txt", refVal2)]
-      let removedRoot2 = removePath "root.txt" =<< fs2
-      (doesFileExist "a.txt" =<< removedRoot2) `shouldReturn` True
+      let removedRoot2 = removePath "root.txt" fs2
+      (doesFileExist "a.txt" removedRoot2) `shouldBe` True
 
     it "should remove nested filepath node" $ do
-      let removedFs = removePath "archive/index.txt" =<< sampleFileTree
-      (doesFileExist "archive/index.txt" =<< removedFs) `shouldReturn` False
-      (doesFileExist "root.txt" =<< removedFs) `shouldReturn` True
-      (doesFileExist "archive/jan/1.txt" =<< removedFs) `shouldReturn` True
-      (doesFileExist "archive/feb/1.txt" =<< removedFs) `shouldReturn` True
-      (doesFileExist "archive/feb/extra/info.txt" =<< removedFs) `shouldReturn` True
+      let removedFs = removePath "archive/index.txt" sampleFileTree
+      (doesFileExist "archive/index.txt" removedFs) `shouldBe` False
+      (doesFileExist "root.txt" removedFs) `shouldBe` True
+      (doesFileExist "archive/jan/1.txt" removedFs) `shouldBe` True
+      (doesFileExist "archive/feb/1.txt" removedFs) `shouldBe` True
+      (doesFileExist "archive/feb/extra/info.txt" removedFs) `shouldBe` True
 
-      let removedFs2 = removePath "archive/jan/1.txt" =<< sampleFileTree
-      (doesFileExist "archive/jan/1.txt" =<< removedFs2) `shouldReturn` False
-      (doesFileExist "root.txt" =<< removedFs2) `shouldReturn` True
-      (doesFileExist "archive/index.txt" =<< removedFs2) `shouldReturn` True
-      (doesFileExist "archive/feb/1.txt" =<< removedFs2) `shouldReturn` True
-      (doesFileExist "archive/feb/extra/info.txt" =<< removedFs2) `shouldReturn` True
+      let removedFs2 = removePath "archive/jan/1.txt" sampleFileTree
+      (doesFileExist "archive/jan/1.txt" removedFs2) `shouldBe` False
+      (doesFileExist "root.txt" removedFs2) `shouldBe` True
+      (doesFileExist "archive/index.txt" removedFs2) `shouldBe` True
+      (doesFileExist "archive/feb/1.txt" removedFs2) `shouldBe` True
+      (doesFileExist "archive/feb/extra/info.txt" removedFs2) `shouldBe` True
 
-      let removedFs3 = removePath "archive/feb/extra/info.txt" =<< sampleFileTree
-      (doesFileExist "archive/feb/extra/info.txt" =<< removedFs3) `shouldReturn` False
-      (doesFileExist "root.txt" =<< removedFs3) `shouldReturn` True
-      (doesFileExist "archive/index.txt" =<< removedFs3) `shouldReturn` True
-      (doesFileExist "archive/jan/1.txt" =<< removedFs3) `shouldReturn` True
-      (doesFileExist "archive/feb/1.txt" =<< removedFs3) `shouldReturn` True
+      let removedFs3 = removePath "archive/feb/extra/info.txt" sampleFileTree
+      (doesFileExist "archive/feb/extra/info.txt" removedFs3) `shouldBe` False
+      (doesFileExist "root.txt" removedFs3) `shouldBe` True
+      (doesFileExist "archive/index.txt" removedFs3) `shouldBe` True
+      (doesFileExist "archive/jan/1.txt" removedFs3) `shouldBe` True
+      (doesFileExist "archive/feb/1.txt" removedFs3) `shouldBe` True
 
-      let removedFs4 = removePath "archive/feb/" =<< sampleFileTree
-      (doesFileExist "archive/feb/extra/info.txt" =<< removedFs4) `shouldReturn` False
-      (doesFileExist "archive/feb/1.txt" =<< removedFs4) `shouldReturn` False
-      (doesFileExist "root.txt" =<< removedFs4) `shouldReturn` True
-      (doesFileExist "archive/index.txt" =<< removedFs4) `shouldReturn` True
-      (doesFileExist "archive/jan/1.txt" =<< removedFs4) `shouldReturn` True
+      let removedFs4 = removePath "archive/feb/" sampleFileTree
+      (doesFileExist "archive/feb/extra/info.txt" removedFs4) `shouldBe` False
+      (doesFileExist "archive/feb/1.txt" removedFs4) `shouldBe` False
+      (doesFileExist "root.txt" removedFs4) `shouldBe` True
+      (doesFileExist "archive/index.txt" removedFs4) `shouldBe` True
+      (doesFileExist "archive/jan/1.txt" removedFs4) `shouldBe` True
 
-      let removedFs5 = removePath "archive/" =<< sampleFileTree
-      (doesFileExist "archive/index.txt" =<< removedFs5) `shouldReturn` False
-      (doesFileExist "archive/jan/1.txt" =<< removedFs5) `shouldReturn` False
-      (doesFileExist "archive/feb/1.txt" =<< removedFs5) `shouldReturn` False
-      (doesFileExist "archive/feb/extra/info.txt" =<< removedFs5) `shouldReturn` False
-      (doesFileExist "root.txt" =<< removedFs5) `shouldReturn` True
+      let removedFs5 = removePath "archive/" sampleFileTree
+      (doesFileExist "archive/index.txt" removedFs5) `shouldBe` False
+      (doesFileExist "archive/jan/1.txt" removedFs5) `shouldBe` False
+      (doesFileExist "archive/feb/1.txt" removedFs5) `shouldBe` False
+      (doesFileExist "archive/feb/extra/info.txt" removedFs5) `shouldBe` False
+      (doesFileExist "root.txt" removedFs5) `shouldBe` True
 
 spec :: Spec
 spec = do

--- a/test/Data/IndexFileTreeSpec.hs
+++ b/test/Data/IndexFileTreeSpec.hs
@@ -9,6 +9,7 @@ import Data.FileTree.IndexFileTree (
   lookupDir,
   lookupFileRef,
   remove,
+  resolveSymLinkRef,
   toSomePath,
  )
 
@@ -130,6 +131,34 @@ lookupFileRefSpec =
       (lookupFileRef "root.txt" sampleFileTree) `shouldBe` refVal1
       (lookupFileRef "archive/index.txt" sampleFileTree) `shouldBe` refVal2
 
+resolveSymLinkRefSpec :: Spec
+resolveSymLinkRefSpec =
+  describe "resolveSymLinkRef" $ do
+    it "should resolve to parent directory, when ./ is prefixed in target path" $ do
+      resolveSymLinkRef "a/b/c/d" "./e" `shouldBe` "a/b/c/e"
+      resolveSymLinkRef "a/b/c" "./e" `shouldBe` "a/b/e"
+      resolveSymLinkRef "a/b" "./e" `shouldBe` "a/e"
+      resolveSymLinkRef "a" "./e" `shouldBe` "e"
+      resolveSymLinkRef "" "./e" `shouldBe` "e"
+
+    it "should resolve to grand parent directory, when ../ is prefixed in target path" $ do
+      resolveSymLinkRef "a/b/c/d" "../e" `shouldBe` "a/b/e"
+      resolveSymLinkRef "a/b/c" "../e" `shouldBe` "a/e"
+      resolveSymLinkRef "a/b" "../e" `shouldBe` "e"
+      resolveSymLinkRef "a" "../e" `shouldBe` "e"
+      resolveSymLinkRef "" "../e" `shouldBe` "e"
+
+    it "should resolve when multiple ../ ./ prefix are consecutively used" $ do
+      resolveSymLinkRef "a/b/c/d" "./../e" `shouldBe` "a/b/e"
+      resolveSymLinkRef "a/b/c/d" ".././../e" `shouldBe` "a/e"
+      resolveSymLinkRef "a/b/c/d" "../../e" `shouldBe` "a/e"
+      resolveSymLinkRef "a/b/c/d" "../.././e" `shouldBe` "a/e"
+      resolveSymLinkRef "a/b/c/d" "../../../e" `shouldBe` "e"
+
+    it "should resolve to absolute path when / is prefixed in target path" $ do
+      resolveSymLinkRef "a/b/c/d" "/a/b/e" `shouldBe` "a/b/e"
+      resolveSymLinkRef "a/b/c/d" "/e" `shouldBe` "e"
+
 removeSpec :: Spec
 removeSpec =
   describe "remove" $ do
@@ -189,3 +218,5 @@ spec = do
 
   lookupFileRefSpec
   doesFileExistSpec
+
+  resolveSymLinkRefSpec

--- a/test/Test/Effect.hs
+++ b/test/Test/Effect.hs
@@ -14,6 +14,7 @@ module Test.Effect (
   fit',
   xit',
   withTempDir,
+  handleDiag,
 ) where
 
 import Control.Carrier.Diagnostics (DiagnosticsC, runDiagnostics)
@@ -77,13 +78,13 @@ runTestEffects' = runIO . runTestEffects
 
 runTestEffects :: EffectStack () -> IO ()
 runTestEffects = runStack . ignoreStickyLogger . ignoreLogger . runMockApi . handleDiag . runApiWithMock . runReadFSIO . runExecIO . runReader mempty . runFinally
-  where
-    handleDiag :: (Has (Lift IO) sig m) => DiagnosticsC m () -> m ()
-    handleDiag diag =
-      runDiagnostics diag >>= \case
-        Failure ws eg -> do
-          expectationFailure' $ toString $ renderIt $ renderFailure ws eg "An issue occurred"
-        Success _ _ -> pure ()
+
+handleDiag :: (Has (Lift IO) sig m) => DiagnosticsC m () -> m ()
+handleDiag diag =
+  runDiagnostics diag >>= \case
+    Failure ws eg -> do
+      expectationFailure' $ toString $ renderIt $ renderFailure ws eg "An issue occurred"
+    Success _ _ -> pure ()
 
 -- | Create a temporary directory with the given name.  The directory will be
 -- created in the system temporary directory.  It will be deleted after use.


### PR DESCRIPTION
# Overview

This PR adds `SomeFileTree a` implementation for tarball that allows random seek for content given entry offsets.

## Acceptance criteria

- There is an implementation that allows random seek, walk, and getting of file content within the container's tarballs.

## Testing plan

Since there is no e/e implementation yet, so there is no test as a user you can run from cli tool; But I have added unit tests for functionalities. 

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-284

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
