### PR TITLE
Container Scanning: Docker Exported Tarball (1/2)

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -52,7 +52,7 @@
   - {name: Data.Text.last, within: []}
     # TODO: remove special-case
   - {name: Data.List.NonEmpty.fromList, within: ["App.Fossa.Analyze.Filter", "Test.Fixtures", "**.*Spec"], message: "Pattern-match on nonEmpty instead of forcing the list."}
-  - {name: "Prelude.!!", within: []}
+  - {name: "Prelude.!!", within: ["**.*Spec"]}
   - {name: "Data.Map.!", within: []}
     # TODO: remove the need to special-case this test module.
   - {name: fromJust, within: [App.DocsSpec]}

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -182,6 +182,7 @@ library
     App.Fossa.Container.Analyze
     App.Fossa.Container.AnalyzeNative
     App.Fossa.Container.Scan
+    App.Fossa.Container.Sources.DockerTarball
     App.Fossa.Container.Test
     App.Fossa.DumpBinaries
     App.Fossa.EmbeddedBinary

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -227,6 +227,7 @@ library
     App.Version
     App.Version.TH
     Console.Sticky
+    Container.Docker.ImageJson
     Container.Docker.Manifest
     Container.Errors
     Container.OsRelease

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -490,6 +490,7 @@ test-suite unit-tests
     Composer.ComposerLockSpec
     Conda.CondaListSpec
     Conda.EnvironmentYmlSpec
+    Container.Docker.ImageJsonSpec
     Container.Docker.ManifestSpec
     Container.OsReleaseSpec
     Container.TarballReadFSSpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -8,6 +8,7 @@ module App.Fossa.Analyze (
   analyzeSubCommand,
 
   -- * Helpers
+  toProjectResult,
   applyFiltersToProject,
 ) where
 

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -24,6 +24,7 @@ import Control.Effect.Diagnostics (
   fromEitherShow,
  )
 import Control.Effect.Lift (Lift, sendIO)
+import Control.Effect.Telemetry (Telemetry)
 import Data.Aeson (FromJSON (parseJSON), Value, encode)
 import Data.Aeson.Types (parseEither)
 import Data.ByteString.Lazy qualified as BL
@@ -46,6 +47,7 @@ dispatch ::
   , Has (Lift IO) sig m
   , Has Logger sig m
   , Has ReadFS sig m
+  , Has Telemetry sig m
   ) =>
   ContainerScanConfig ->
   m ()

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -1,26 +1,34 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module App.Fossa.Container.AnalyzeNative (
   analyzeExperimental,
 ) where
 
-import App.Fossa.Config.Container.Analyze (
-  ContainerAnalyzeConfig (
-    ContainerAnalyzeConfig,
-    imageLocator,
-    revisionOverride,
-    scanDestination
-  ),
+import App.Fossa.Analyze.Debug (collectDebugBundle)
+import App.Fossa.Config.Common (
+  ScanDestination (OutputStdout, UploadScan),
  )
+import App.Fossa.Config.Container.Analyze (
+  ContainerAnalyzeConfig (imageLocator, scanDestination),
+ )
+import App.Fossa.Config.Container.Analyze qualified as Config
 import App.Fossa.Config.Container.Common (ImageText (unImageText))
+import App.Fossa.Container.Sources.DockerTarball (analyzeExportedTarball)
+import Codec.Compression.GZip qualified as GZip
+import Control.Carrier.Debug (Debug, ignoreDebug)
+import Control.Carrier.Diagnostics qualified as Diag
 import Control.Effect.Diagnostics (Diagnostics, fatalText, fromEitherShow)
-import Control.Effect.Lift (Lift)
-import Data.String.Conversion (toString)
+import Control.Effect.Lift (Lift, sendIO)
+import Control.Effect.Telemetry (Telemetry)
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as BL
+import Data.String.Conversion (ConvertUtf8 (decodeUtf8), toString)
 import Data.Text (Text)
+import Effect.Exec (Exec)
 import Effect.Logger (
   Has,
   Logger,
+  Severity (..),
   logInfo,
+  logStdout,
  )
 import Effect.ReadFS (ReadFS, getCurrentDir)
 import Path (Abs, File, Path, SomeBase (Abs, Rel), parseSomeFile, (</>))
@@ -31,21 +39,49 @@ data ContainerImageSource
   | ContainerOCIRegistry Text Text
   deriving (Show, Eq)
 
+debugBundlePath :: FilePath
+debugBundlePath = "fossa.container.debug.json.gz"
+
 analyzeExperimental ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
   , Has Logger sig m
   , Has ReadFS sig m
+  , Has Exec sig m
+  , Has Telemetry sig m
   ) =>
   ContainerAnalyzeConfig ->
   m ()
-analyzeExperimental ContainerAnalyzeConfig{..} = do
+analyzeExperimental cfg =
+  case Config.severity cfg of
+    SevDebug -> do
+      (scope, res) <- collectDebugBundle cfg $ Diag.errorBoundaryIO $ analyze cfg
+      sendIO . BL.writeFile debugBundlePath . GZip.compress $ Aeson.encode scope
+      Diag.rethrow res
+    _ -> ignoreDebug $ analyze cfg
+
+analyze ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has ReadFS sig m
+  , Has Exec sig m
+  , Has Telemetry sig m
+  , Has Debug sig m
+  ) =>
+  ContainerAnalyzeConfig ->
+  m ()
+analyze cfg = do
   logInfo "Running container scanning with fossa experimental-scanner!"
-  parsedSource <- parseContainerImageSource (unImageText imageLocator)
-  case parsedSource of
+  parsedSource <- parseContainerImageSource (unImageText $ imageLocator cfg)
+  scannedImage <- case parsedSource of
     ContainerDockerImage _ -> fatalText "container images from daemon are not yet supported!"
     ContainerOCIRegistry _ _ -> fatalText "container images from oci registry are not yet supported!"
-    ContainerExportedTarball _ -> fatalText "exported container images are not yet supported!"
+    ContainerExportedTarball tarball -> analyzeExportedTarball tarball
+
+  case scanDestination cfg of
+    OutputStdout -> logStdout . decodeUtf8 $ Aeson.encode scannedImage
+    UploadScan _ _ -> fatalText "experimental scanner does not allow to submit projects"
 
 parseContainerImageSource ::
   ( Has (Lift IO) sig m

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -40,7 +40,7 @@ data ContainerImageSource
   deriving (Show, Eq)
 
 debugBundlePath :: FilePath
-debugBundlePath = "fossa.container.debug.json.gz"
+debugBundlePath = "fossa.debug.json.gz"
 
 analyzeExperimental ::
   ( Has Diagnostics sig m
@@ -81,7 +81,7 @@ analyze cfg = do
 
   case scanDestination cfg of
     OutputStdout -> logStdout . decodeUtf8 $ Aeson.encode scannedImage
-    UploadScan _ _ -> fatalText "experimental scanner does not allow to submit projects"
+    UploadScan _ _ -> fatalText "experimental scanner does not allow to submit projects to fossa yet!"
 
 parseContainerImageSource ::
   ( Has (Lift IO) sig m

--- a/src/App/Fossa/Container/Scan.hs
+++ b/src/App/Fossa/Container/Scan.hs
@@ -8,6 +8,9 @@ module App.Fossa.Container.Scan (
   extractRevision,
   SyftResponse,
   ContainerScan (..),
+
+  -- * Helpers
+  LayerTarget (..),
 ) where
 
 import App.Fossa.Config.Container.Common (ImageText (ImageText))

--- a/src/App/Fossa/Container/Sources/DockerTarball.hs
+++ b/src/App/Fossa/Container/Sources/DockerTarball.hs
@@ -1,0 +1,1 @@
+module App.Fossa.Container.Sources.DockerTarball () where

--- a/src/App/Fossa/Container/Sources/DockerTarball.hs
+++ b/src/App/Fossa/Container/Sources/DockerTarball.hs
@@ -65,7 +65,7 @@ import Effect.Logger (
  )
 import Effect.ReadFS (ReadFS)
 import Path (Abs, Dir, File, Path, toFilePath)
-import Path.Internal.Posix (Path (Path))
+import Path.Internal (Path (Path))
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (SourceUnit)
 import Strategy.ApkDatabase qualified as Apk

--- a/src/App/Fossa/Container/Sources/DockerTarball.hs
+++ b/src/App/Fossa/Container/Sources/DockerTarball.hs
@@ -159,6 +159,7 @@ analyzeLayer capabilities osInfo layerFs tarball =
     noUnusedDeps :: Bool
     noUnusedDeps = False
 
+    -- TODO: Implement filters from .fossa.yml file
     noFilters :: AllFilters
     noFilters = mempty
 

--- a/src/App/Fossa/Container/Sources/DockerTarball.hs
+++ b/src/App/Fossa/Container/Sources/DockerTarball.hs
@@ -1,1 +1,189 @@
-module App.Fossa.Container.Sources.DockerTarball () where
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.Container.Sources.DockerTarball (
+  analyzeExportedTarball,
+) where
+
+import App.Fossa.Analyze (applyFiltersToProject, toProjectResult, updateProgress)
+import App.Fossa.Analyze.Debug (diagToDebug)
+import App.Fossa.Analyze.Discover (DiscoverFunc (DiscoverFunc))
+import App.Fossa.Analyze.Project (mkResult)
+import App.Fossa.Analyze.Types (
+  AnalyzeProject (analyzeProject),
+  AnalyzeTaskEffs,
+  DiscoveredProjectIdentifier (..),
+  DiscoveredProjectScan (..),
+ )
+import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig (ExperimentalAnalyzeConfig))
+import Codec.Archive.Tar.Index (TarEntryOffset)
+import Container.OsRelease (OsInfo (nameId, version), getOsInfo)
+import Container.Tarball (mkFsFromChangeset, parse)
+import Container.TarballReadFs (runTarballReadFSIO)
+import Container.Types (
+  ContainerImageRaw (rawDigest),
+  ContainerLayer (layerDigest),
+  ContainerScan (ContainerScan),
+  ContainerScanImage (ContainerScanImage),
+  ContainerScanImageLayer (ContainerScanImageLayer),
+  baseLayer,
+  otherLayersSquashed,
+ )
+import Control.Carrier.AtomicCounter (runAtomicCounter)
+import Control.Carrier.Diagnostics qualified as Diag
+import Control.Carrier.Finally (runFinally)
+import Control.Carrier.Output.IO (output, runOutput)
+import Control.Carrier.Reader (runReader)
+import Control.Carrier.Stack.StickyLog (stickyLogStack)
+import Control.Carrier.StickyLogger (runStickyLogger)
+import Control.Carrier.TaskPool (withTaskPool)
+import Control.Concurrent (getNumCapabilities)
+import Control.Effect.AtomicCounter (AtomicCounter)
+import Control.Effect.Debug (Debug)
+import Control.Effect.Diagnostics (Diagnostics, fromEither)
+import Control.Effect.Lift (Lift, sendIO)
+import Control.Effect.Output (Output)
+import Control.Effect.Reader (Reader)
+import Control.Effect.Stack (Stack, withEmptyStack)
+import Control.Effect.TaskPool (TaskPool)
+import Control.Effect.Telemetry (Telemetry)
+import Data.ByteString.Lazy qualified as BS
+import Data.FileTree.IndexFileTree (SomeFileTree)
+import Data.Foldable (traverse_)
+import Data.Maybe (mapMaybe)
+import Data.String.Conversion (ToString (toString))
+import Data.Text.Extra (showT)
+import Discovery.Filters (AllFilters)
+import Discovery.Projects (withDiscoveredProjects)
+import Effect.Exec (Exec)
+import Effect.Logger (
+  Has,
+  Logger,
+  Pretty (pretty),
+  Severity (..),
+  logInfo,
+  viaShow,
+ )
+import Effect.ReadFS (ReadFS)
+import Path (Abs, Dir, File, Path, toFilePath)
+import Path.Internal.Posix (Path (Path))
+import Srclib.Converter qualified as Srclib
+import Srclib.Types (SourceUnit)
+import Strategy.ApkDatabase qualified as Apk
+import Types (DiscoveredProject (..))
+
+analyzeExportedTarball ::
+  ( Has Diagnostics sig m
+  , Has Exec sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has Telemetry sig m
+  , Has Debug sig m
+  ) =>
+  Path Abs File ->
+  m ContainerScan
+analyzeExportedTarball tarball = do
+  containerTarball <- sendIO $ BS.readFile (toString tarball)
+  containerImage <- fromEither $ parse containerTarball
+
+  let baseFs = mkFsFromChangeset $ baseLayer containerImage
+  let squashedFs = mkFsFromChangeset $ otherLayersSquashed containerImage
+
+  osInfo <- runTarballReadFSIO baseFs tarball getOsInfo
+  capabilities <- sendIO getNumCapabilities
+
+  baseUnits <- analyzeLayer capabilities osInfo baseFs tarball
+  otherUnits <- analyzeLayer capabilities osInfo squashedFs tarball
+
+  pure $
+    ContainerScan
+      ( ContainerScanImage
+          (nameId osInfo)
+          (version osInfo)
+          [ ContainerScanImageLayer (layerDigest . baseLayer $ containerImage) baseUnits
+          , ContainerScanImageLayer (layerDigest . otherLayersSquashed $ containerImage) otherUnits
+          ]
+      )
+      (rawDigest containerImage)
+
+analyzeLayer ::
+  ( Has Diagnostics sig m
+  , Has Exec sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has Telemetry sig m
+  , Has Debug sig m
+  ) =>
+  Int ->
+  OsInfo ->
+  SomeFileTree TarEntryOffset ->
+  Path Abs File ->
+  m [SourceUnit]
+analyzeLayer capabilities osInfo layerFs tarball =
+  map (Srclib.toSourceUnit False)
+    . mapMaybe toProjectResult
+    <$> runReader
+      (mempty :: AllFilters)
+      ( do
+          (projectResults, ()) <-
+            runTarballReadFSIO (layerFs) tarball
+              . runReader (ExperimentalAnalyzeConfig Nothing)
+              . Diag.context "discovery/analysis tasks"
+              . runOutput @DiscoveredProjectScan
+              . runStickyLogger SevInfo
+              . runFinally
+              . withTaskPool capabilities updateProgress
+              . runAtomicCounter
+              $ do
+                runAnalyzers osInfo mempty
+          pure projectResults
+      )
+
+runAnalyzers ::
+  ( AnalyzeTaskEffs sig m
+  , Has (Output DiscoveredProjectScan) sig m
+  , Has TaskPool sig m
+  , Has AtomicCounter sig m
+  ) =>
+  OsInfo ->
+  AllFilters ->
+  m ()
+runAnalyzers osInfo filters = do
+  traverse_
+    single
+    [ DiscoverFunc (Apk.discover osInfo)
+    ]
+  where
+    single (DiscoverFunc f) = withDiscoveredProjects f basedir (runDependencyAnalysis basedir filters)
+    basedir = Path "vfs-root"
+
+runDependencyAnalysis ::
+  ( AnalyzeProject proj
+  , Has (Lift IO) sig m
+  , Has AtomicCounter sig m
+  , Has Debug sig m
+  , Has Logger sig m
+  , Has ReadFS sig m
+  , Has Exec sig m
+  , Has (Output DiscoveredProjectScan) sig m
+  , Has (Reader ExperimentalAnalyzeConfig) sig m
+  , Has (Reader AllFilters) sig m
+  , Has Stack sig m
+  , Has Telemetry sig m
+  ) =>
+  Path Abs Dir ->
+  AllFilters ->
+  DiscoveredProject proj ->
+  m ()
+runDependencyAnalysis basedir filters project@DiscoveredProject{..} = do
+  let dpi = DiscoveredProjectIdentifier projectPath projectType
+  case applyFiltersToProject basedir filters project of
+    Nothing -> do
+      logInfo $ "Skipping " <> pretty projectType <> " project at " <> viaShow projectPath <> ": no filters matched"
+      output $ SkippedDueToProvidedFilter dpi
+    Just targets -> do
+      logInfo $ "Analyzing " <> pretty projectType <> " project at " <> pretty (toFilePath projectPath)
+      let ctxMessage = "Project Analysis: " <> showT projectType
+      graphResult <- Diag.runDiagnosticsIO . diagToDebug . stickyLogStack . withEmptyStack . Diag.context ctxMessage $ do
+        analyzeProject targets projectData
+      Diag.flushLogs SevError SevDebug graphResult
+      output $ Scanned dpi (mkResult basedir project <$> graphResult)

--- a/src/Container/Docker/ImageJson.hs
+++ b/src/Container/Docker/ImageJson.hs
@@ -30,7 +30,7 @@ newtype ImageJson = ImageJson ImageJsonRootFs
   deriving anyclass (NFData) -- explicitly use DeriveAnyClass strategy to avoid deriving-defaults warning.
 
 instance FromJSON ImageJson where
-  parseJSON = withObject "" $ \o ->
+  parseJSON = withObject "image json" $ \o ->
     ImageJson <$> o .: "rootfs"
 
 newtype ImageJsonRootFs = ImageJsonRootFs {diffIds :: NonEmpty.NonEmpty Text}
@@ -38,7 +38,7 @@ newtype ImageJsonRootFs = ImageJsonRootFs {diffIds :: NonEmpty.NonEmpty Text}
   deriving anyclass (NFData) -- explicitly use DeriveAnyClass strategy to avoid deriving-defaults warning.
 
 instance FromJSON ImageJsonRootFs where
-  parseJSON = withObject "" $ \o -> do
+  parseJSON = withObject "root fs" $ \o -> do
     diffIds <- o .: "diff_ids"
     diffType <- o .: "type"
     when (diffType /= "layers") $

--- a/src/Container/Docker/ImageJson.hs
+++ b/src/Container/Docker/ImageJson.hs
@@ -23,6 +23,8 @@ import Data.Text (Text)
 import GHC.Generics (Generic)
 
 -- | Image Description Json.
+-- Refer to: https://github.com/moby/moby/blob/master/image/spec/v1.2.md#image-json-description
+-- Refer to: https://github.com/moby/moby/blob/master/image/spec/v1.1.md#image-json-description
 newtype ImageJson = ImageJson ImageJsonRootFs
   deriving (Show, Eq, Ord, Generic)
   deriving anyclass (NFData) -- explicitly use DeriveAnyClass strategy to avoid deriving-defaults warning.
@@ -48,5 +50,6 @@ instance FromJSON ImageJsonRootFs where
 decodeImageJson :: ByteStringLazy.ByteString -> Either String ImageJson
 decodeImageJson = eitherDecode
 
+-- | Gets all layer Ids.
 getLayerIds :: ImageJson -> [Text]
 getLayerIds (ImageJson (ImageJsonRootFs diffIds)) = NonEmpty.toList diffIds

--- a/src/Container/Docker/ImageJson.hs
+++ b/src/Container/Docker/ImageJson.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Container.Docker.ImageJson (
+  ImageJson (..),
+  ImageJsonRootFs (..),
+  decodeImageJson,
+  getLayerIds,
+) where
+
+import Control.DeepSeq (NFData)
+import Control.Monad (when)
+import Data.Aeson (
+  FromJSON,
+  eitherDecode,
+  parseJSON,
+  withObject,
+  (.:),
+ )
+import Data.ByteString.Lazy qualified as ByteStringLazy
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+-- | Image Description Json.
+newtype ImageJson = ImageJson ImageJsonRootFs
+  deriving (Show, Eq, Ord, Generic)
+  deriving anyclass (NFData) -- explicitly use DeriveAnyClass strategy to avoid deriving-defaults warning.
+
+instance FromJSON ImageJson where
+  parseJSON = withObject "" $ \o ->
+    ImageJson <$> o .: "rootfs"
+
+newtype ImageJsonRootFs = ImageJsonRootFs {diffIds :: NonEmpty.NonEmpty Text}
+  deriving (Show, Eq, Ord, Generic)
+  deriving anyclass (NFData) -- explicitly use DeriveAnyClass strategy to avoid deriving-defaults warning.
+
+instance FromJSON ImageJsonRootFs where
+  parseJSON = withObject "" $ \o -> do
+    diffIds <- o .: "diff_ids"
+    diffType <- o .: "type"
+    when (diffType /= "layers") $
+      fail $
+        "expected to have diff_ids of type: layer, but got: " <> diffType
+
+    pure $ ImageJsonRootFs diffIds
+
+decodeImageJson :: ByteStringLazy.ByteString -> Either String ImageJson
+decodeImageJson = eitherDecode
+
+getLayerIds :: ImageJson -> [Text]
+getLayerIds (ImageJson (ImageJsonRootFs diffIds)) = NonEmpty.toList diffIds

--- a/src/Container/Docker/Manifest.hs
+++ b/src/Container/Docker/Manifest.hs
@@ -75,6 +75,6 @@ getImageJsonConfigFilePath :: ManifestJson -> Text
 getImageJsonConfigFilePath (ManifestJson mjEntries) = config $ NonEmpty.head mjEntries
 
 -- | Gets the image digest.
--- Exported docker ball's config filename is digest of the image.
+-- Exported docker tarball's config filename is digest of the image.
 getImageDigest :: ManifestJson -> Text
 getImageDigest mj = "sha256:" <> Text.replace ".json" "" (getImageJsonConfigFilePath mj)

--- a/src/Container/Docker/Manifest.hs
+++ b/src/Container/Docker/Manifest.hs
@@ -9,6 +9,8 @@ module Container.Docker.Manifest (
   decodeManifestJson,
   getLayerPaths,
   manifestFilename,
+  getImageJsonConfigFilePath,
+  getImageDigest,
 ) where
 
 import Control.DeepSeq (NFData)
@@ -26,6 +28,7 @@ import Data.Aeson (
 import Data.ByteString.Lazy qualified as ByteStringLazy
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Text (Text)
+import Data.Text qualified as Text
 import GHC.Generics (Generic)
 
 manifestFilename :: Text
@@ -67,3 +70,9 @@ getLayerPaths (ManifestJson mjEntries) = layers $ NonEmpty.head mjEntries
 
 decodeManifestJson :: ByteStringLazy.ByteString -> Either String ManifestJson
 decodeManifestJson = eitherDecode
+
+getImageJsonConfigFilePath :: ManifestJson -> Text
+getImageJsonConfigFilePath (ManifestJson mjEntries) = config $ NonEmpty.head mjEntries
+
+getImageDigest :: ManifestJson -> Text
+getImageDigest mj = "sha256:" <> Text.replace ".json" "" (getImageJsonConfigFilePath mj)

--- a/src/Container/Docker/Manifest.hs
+++ b/src/Container/Docker/Manifest.hs
@@ -74,5 +74,7 @@ decodeManifestJson = eitherDecode
 getImageJsonConfigFilePath :: ManifestJson -> Text
 getImageJsonConfigFilePath (ManifestJson mjEntries) = config $ NonEmpty.head mjEntries
 
+-- | Gets the image digest.
+-- Exported docker ball's config filename is digest of the image.
 getImageDigest :: ManifestJson -> Text
 getImageDigest mj = "sha256:" <> Text.replace ".json" "" (getImageJsonConfigFilePath mj)

--- a/src/Container/Errors.hs
+++ b/src/Container/Errors.hs
@@ -2,6 +2,7 @@ module Container.Errors (ContainerImgParsingError (..)) where
 
 import Codec.Archive.Tar qualified as Tar
 import Control.Exception (Exception)
+import Data.List.NonEmpty (NonEmpty)
 import Diag.Diagnostic (ToDiagnostic (renderDiagnostic))
 import Effect.Logger (pretty)
 
@@ -13,6 +14,7 @@ data ContainerImgParsingError
   | TarParserError Tar.FormatError
   | TarMissingLayerTar FilePath
   | TarLayerNotAFile FilePath
+  | TarballFileNotFound FilePath
   | ContainerNoLayersDiscovered
   deriving (Eq)
 
@@ -23,9 +25,13 @@ instance Show ContainerImgParsingError where
   show (TarParserError err) = "TarParserError: " <> show err
   show (TarMissingLayerTar path) = "TarMissingLayerTar: " <> show path
   show (TarLayerNotAFile path) = "TarLayerNotAFile: " <> show path
+  show (TarballFileNotFound path) = "TarballFileNotFound: " <> show path
   show (ContainerNoLayersDiscovered) = "ContainerNoLayersDiscovered - could not analyze or detect any layer."
 
 instance Exception ContainerImgParsingError
 
 instance ToDiagnostic ContainerImgParsingError where
+  renderDiagnostic = pretty . show
+
+instance ToDiagnostic (NonEmpty ContainerImgParsingError) where
   renderDiagnostic = pretty . show

--- a/src/Container/OsRelease.hs
+++ b/src/Container/OsRelease.hs
@@ -62,6 +62,7 @@ module Container.OsRelease (
 
 import Control.Effect.Diagnostics (Diagnostics, fatal, (<||>))
 import Control.Monad (void)
+import Data.Aeson (ToJSON)
 import Data.Foldable (asum)
 import Data.Map qualified as Map
 import Data.SemVer qualified as SemVer
@@ -77,6 +78,7 @@ import Effect.ReadFS (
   readContentsBS,
   readContentsParser,
  )
+import GHC.Generics (Generic)
 import Path (Abs, File)
 import Path.Internal (Path (Path))
 import Text.Megaparsec (
@@ -116,7 +118,9 @@ data OsInfo = OsInfo
   { nameId :: Text -- name identifier, e.g. alpine
   , version :: Text -- version identifier e.g. 3.1.4
   }
-  deriving (Show, Eq)
+  deriving (Show, Ord, Eq, Generic)
+
+instance ToJSON OsInfo
 
 getOsInfo :: (Has ReadFS sig m, Has Diagnostics sig m) => m OsInfo
 getOsInfo = parseEtcOsRelease <||> parseSystemReleaseCpe <||> parseBinBusyBox

--- a/src/Container/Tarball.hs
+++ b/src/Container/Tarball.hs
@@ -56,9 +56,13 @@ parse :: ByteStringLazy.ByteString -> Either (NLE.NonEmpty ContainerImgParsingEr
 parse content = case mkEntries $ Tar.read content of
   Left err -> Left $ NLE.singleton err
   Right te -> do
+    -- Exported docker image must have
+    -- manifest file
     case getManifest te of
       Left err -> Left $ NLE.singleton err
       Right manifest -> do
+        -- Use manifest to get image config which has
+        -- layer and image hash
         case getImageJson (getImageJsonConfigFilePath manifest) te of
           Left err -> Left $ NLE.singleton err
           Right imgJson -> mkImage (getImageDigest manifest) imgJson te (getLayerPaths manifest)

--- a/src/Container/Types.hs
+++ b/src/Container/Types.hs
@@ -1,22 +1,35 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Container.Types (
   ContainerImageRaw (..),
   ContainerLayer (..),
   ContainerFSChangeSet (..),
   baseLayer,
+  otherLayersSquashed,
+  ContainerScan (..),
+  ContainerScanImage (..),
+  ContainerScanImageLayer (..),
 ) where
 
 import Codec.Archive.Tar.Index (TarEntryOffset)
 import Control.DeepSeq (NFData)
-import Data.List.NonEmpty as NonEmpty (NonEmpty, head)
+import Data.Aeson (object)
+import Data.Aeson.Types (ToJSON, toJSON, (.=))
+import Data.Foldable (fold)
+import Data.List.NonEmpty as NonEmpty (NonEmpty, head, tail)
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
+import Data.Text (Text)
 import GHC.Generics (Generic)
+import Srclib.Types (SourceUnit)
 
-newtype ContainerImageRaw = ContainerImageRaw {layers :: NonEmpty.NonEmpty ContainerLayer}
+data ContainerImageRaw = ContainerImageRaw
+  { layers :: NonEmpty.NonEmpty ContainerLayer
+  , rawDigest :: Text
+  }
   deriving (Show, Generic, Eq)
   deriving anyclass (NFData)
 
@@ -26,15 +39,22 @@ baseLayer img = NonEmpty.head $ layers img
 data ContainerLayer = ContainerLayer
   { layerChangeSets :: Seq ContainerFSChangeSet
   , lastOffset :: TarEntryOffset
+  , layerDigest :: Text
   }
   deriving (Show, Eq, Generic, NFData)
 
+otherLayersSquashed :: ContainerImageRaw -> ContainerLayer
+otherLayersSquashed containerImage = fold $! restOfLayers
+  where
+    restOfLayers :: [ContainerLayer]
+    restOfLayers = NonEmpty.tail (layers containerImage)
+
 instance Semigroup ContainerLayer where
-  ContainerLayer lhs _ <> ContainerLayer rhs offset =
-    ContainerLayer (lhs <> rhs) offset
+  ContainerLayer lhs _ _ <> ContainerLayer rhs offset digest =
+    ContainerLayer (lhs <> rhs) offset digest
 
 instance Monoid ContainerLayer where
-  mempty = ContainerLayer Seq.empty 0
+  mempty = ContainerLayer Seq.empty 0 mempty
 
 -- | Record indicating a change fs event, with filepath and reference.
 data ContainerFSChangeSet
@@ -43,3 +63,40 @@ data ContainerFSChangeSet
   | -- | Record which is to be removed
     Whiteout FilePath
   deriving (Show, Generic, Eq, NFData)
+
+data ContainerScan = ContainerScan
+  { imageData :: ContainerScanImage
+  , imageDigest :: Text
+  }
+  deriving (Show, Eq, Ord)
+
+instance ToJSON ContainerScan where
+  toJSON scan = object ["image" .= imageData scan]
+
+data ContainerScanImage = ContainerScanImage
+  { imageOs :: Text
+  , imageOsRelease :: Text
+  , imageLayers :: [ContainerScanImageLayer]
+  }
+  deriving (Show, Eq, Ord)
+
+instance ToJSON ContainerScanImage where
+  toJSON ContainerScanImage{..} =
+    object
+      [ "os" .= imageOs
+      , "osRelease" .= imageOsRelease
+      , "layers" .= imageLayers
+      ]
+
+data ContainerScanImageLayer = ContainerScanImageLayer
+  { layerId :: Text
+  , srcUnits :: [SourceUnit]
+  }
+  deriving (Show, Eq, Ord)
+
+instance ToJSON ContainerScanImageLayer where
+  toJSON ContainerScanImageLayer{..} =
+    object
+      [ "layerId" .= layerId
+      , "srcUnits" .= srcUnits
+      ]

--- a/src/Container/Types.hs
+++ b/src/Container/Types.hs
@@ -18,7 +18,7 @@ import Codec.Archive.Tar.Index (TarEntryOffset)
 import Control.DeepSeq (NFData)
 import Data.Aeson (object)
 import Data.Aeson.Types (ToJSON, toJSON, (.=))
-import Data.Foldable (fold)
+import Data.Foldable (foldl')
 import Data.List.NonEmpty as NonEmpty (NonEmpty, head, tail)
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
@@ -44,14 +44,13 @@ data ContainerLayer = ContainerLayer
   deriving (Show, Eq, Generic, NFData)
 
 otherLayersSquashed :: ContainerImageRaw -> ContainerLayer
-otherLayersSquashed containerImage = fold $! restOfLayers
+otherLayersSquashed containerImage = foldl' (<>) mempty restOfLayers
   where
     restOfLayers :: [ContainerLayer]
     restOfLayers = NonEmpty.tail (layers containerImage)
 
 instance Semigroup ContainerLayer where
-  ContainerLayer lhs _ _ <> ContainerLayer rhs offset digest =
-    ContainerLayer (lhs <> rhs) offset digest
+  ContainerLayer lhs _ _ <> ContainerLayer rhs offset digest = ContainerLayer (lhs <> rhs) offset digest
 
 instance Monoid ContainerLayer where
   mempty = ContainerLayer Seq.empty 0 mempty

--- a/src/Data/FileTree/IndexFileTree.hs
+++ b/src/Data/FileTree/IndexFileTree.hs
@@ -10,6 +10,7 @@ module Data.FileTree.IndexFileTree (
   lookupFileRef,
   lookupDir,
   resolveSymLinkRef,
+  fixedVfsRoot,
 
   -- * modifiers
   insert,

--- a/src/Data/FileTree/IndexFileTree.hs
+++ b/src/Data/FileTree/IndexFileTree.hs
@@ -114,7 +114,7 @@ doesFileExist t fsTree = f $ toSomePath t
 
 -- | Returns True if Dir Exists, Otherwise False.
 doesDirExist :: forall a. Text -> SomeFileTree a -> Bool
-doesDirExist t fsTree = (t == fixedVfsRoot) || f (toSomePath t)
+doesDirExist t fsTree = (t == fixedVfsRoot <> "/") || f (toSomePath t)
   where
     f :: SomePath -> Bool
     f (SomeDir dir) = isJust $ H.lookup (SomeDir dir) (paths fsTree)

--- a/test/Container/Docker/ImageJsonSpec.hs
+++ b/test/Container/Docker/ImageJsonSpec.hs
@@ -17,5 +17,5 @@ spec :: Spec
 spec = do
   describe "Docker Image Description Json" $
     it "should parse image description json" $ do
-      manifest <- decodeFileStrict' "test/Container/Docker/testdata/config.json"
-      manifest `shouldBe` Just expectedImageJson
+      imgJson <- decodeFileStrict' "test/Container/Docker/testdata/config.json"
+      imgJson `shouldBe` Just expectedImageJson

--- a/test/Container/Docker/ImageJsonSpec.hs
+++ b/test/Container/Docker/ImageJsonSpec.hs
@@ -1,0 +1,21 @@
+module Container.Docker.ImageJsonSpec (spec) where
+
+import Container.Docker.ImageJson (ImageJson (..), ImageJsonRootFs (..))
+import Data.Aeson (decodeFileStrict')
+import Data.List.NonEmpty qualified as NonEmpty
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+expectedImageJson :: ImageJson
+expectedImageJson =
+  ImageJson . ImageJsonRootFs $
+    NonEmpty.fromList
+      [ "sha256:c6f988f4874bb0add23a778f753c65efe992244e148a1d2ec2a8b664fb66bbd1"
+      , "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      ]
+
+spec :: Spec
+spec = do
+  describe "Docker Image Description Json" $
+    it "should parse image description json" $ do
+      manifest <- decodeFileStrict' "test/Container/Docker/testdata/config.json"
+      manifest `shouldBe` Just expectedImageJson

--- a/test/Container/Docker/testdata/config.json
+++ b/test/Container/Docker/testdata/config.json
@@ -1,0 +1,51 @@
+{  
+    "created": "2015-10-31T22:22:56.015925234Z",
+    "author": "Alyssa P. Hacker &ltalyspdev@example.com&gt",
+    "architecture": "amd64",
+    "os": "linux",
+    "config": {
+        "User": "alice",
+        "Memory": 2048,
+        "MemorySwap": 4096,
+        "CpuShares": 8,
+        "ExposedPorts": {  
+            "8080/tcp": {}
+        },
+        "Env": [  
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "FOO=docker_is_a_really",
+            "BAR=great_tool_you_know"
+        ],
+        "Entrypoint": [
+            "/bin/my-app-binary"
+        ],
+        "Cmd": [
+            "--foreground",
+            "--config",
+            "/etc/my-app.d/default.cfg"
+        ],
+        "Volumes": {
+            "/var/job-result-data": {},
+            "/var/log/my-app-logs": {},
+        },
+        "WorkingDir": "/home/alice"
+    },
+    "rootfs": {
+      "diff_ids": [
+        "sha256:c6f988f4874bb0add23a778f753c65efe992244e148a1d2ec2a8b664fb66bbd1",
+        "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      ],
+      "type": "layers"
+    },
+    "history": [
+      {
+        "created": "2015-10-31T22:22:54.690851953Z",
+        "created_by": "/bin/sh -c #(nop) ADD file:a3bc1e842b69636f9df5256c49c5374fb4eef1e281fe3f282c65fb853ee171c5 in /"
+      },
+      {
+        "created": "2015-10-31T22:22:55.613815829Z",
+        "created_by": "/bin/sh -c #(nop) CMD [\"sh\"]",
+        "empty_layer": true
+      }
+    ]
+}

--- a/test/Container/Docker/testdata/config.json
+++ b/test/Container/Docker/testdata/config.json
@@ -1,51 +1,45 @@
-{  
-    "created": "2015-10-31T22:22:56.015925234Z",
-    "author": "Alyssa P. Hacker &ltalyspdev@example.com&gt",
-    "architecture": "amd64",
-    "os": "linux",
-    "config": {
-        "User": "alice",
-        "Memory": 2048,
-        "MemorySwap": 4096,
-        "CpuShares": 8,
-        "ExposedPorts": {  
-            "8080/tcp": {}
-        },
-        "Env": [  
-            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-            "FOO=docker_is_a_really",
-            "BAR=great_tool_you_know"
-        ],
-        "Entrypoint": [
-            "/bin/my-app-binary"
-        ],
-        "Cmd": [
-            "--foreground",
-            "--config",
-            "/etc/my-app.d/default.cfg"
-        ],
-        "Volumes": {
-            "/var/job-result-data": {},
-            "/var/log/my-app-logs": {},
-        },
-        "WorkingDir": "/home/alice"
+{
+  "created": "2015-10-31T22:22:56.015925234Z",
+  "author": "Alyssa P. Hacker &ltalyspdev@example.com&gt",
+  "architecture": "amd64",
+  "os": "linux",
+  "config": {
+    "User": "alice",
+    "Memory": 2048,
+    "MemorySwap": 4096,
+    "CpuShares": 8,
+    "ExposedPorts": {
+      "8080/tcp": {}
     },
-    "rootfs": {
-      "diff_ids": [
-        "sha256:c6f988f4874bb0add23a778f753c65efe992244e148a1d2ec2a8b664fb66bbd1",
-        "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
-      ],
-      "type": "layers"
+    "Env": [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "FOO=docker_is_a_really",
+      "BAR=great_tool_you_know"
+    ],
+    "Entrypoint": ["/bin/my-app-binary"],
+    "Cmd": ["--foreground", "--config", "/etc/my-app.d/default.cfg"],
+    "Volumes": {
+      "/var/job-result-data": {},
+      "/var/log/my-app-logs": {}
     },
-    "history": [
-      {
-        "created": "2015-10-31T22:22:54.690851953Z",
-        "created_by": "/bin/sh -c #(nop) ADD file:a3bc1e842b69636f9df5256c49c5374fb4eef1e281fe3f282c65fb853ee171c5 in /"
-      },
-      {
-        "created": "2015-10-31T22:22:55.613815829Z",
-        "created_by": "/bin/sh -c #(nop) CMD [\"sh\"]",
-        "empty_layer": true
-      }
-    ]
+    "WorkingDir": "/home/alice"
+  },
+  "rootfs": {
+    "diff_ids": [
+      "sha256:c6f988f4874bb0add23a778f753c65efe992244e148a1d2ec2a8b664fb66bbd1",
+      "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+    ],
+    "type": "layers"
+  },
+  "history": [
+    {
+      "created": "2015-10-31T22:22:54.690851953Z",
+      "created_by": "/bin/sh -c #(nop) ADD file:a3bc1e842b69636f9df5256c49c5374fb4eef1e281fe3f282c65fb853ee171c5 in /"
+    },
+    {
+      "created": "2015-10-31T22:22:55.613815829Z",
+      "created_by": "/bin/sh -c #(nop) CMD [\"sh\"]",
+      "empty_layer": true
+    }
+  ]
 }

--- a/test/Container/TarballSpec.hs
+++ b/test/Container/TarballSpec.hs
@@ -10,12 +10,13 @@ import Container.Tarball (
   TarEntries (TarEntries),
   mkEntries,
   mkImage,
+  parse,
   removeWhiteOut,
  )
 import Container.Types (
   ContainerFSChangeSet (InsertOrUpdate, Whiteout),
   ContainerImageRaw (ContainerImageRaw),
-  ContainerLayer (layerChangeSets),
+  ContainerLayer (layerChangeSets, layerDigest),
  )
 import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as ByteStringLazy
@@ -123,9 +124,68 @@ mockImageJson =
       , "sha256:3892250d356b09c234bb80bd28a6a2aad35e0049be30391d5bff03c2674be3d2"
       ]
 
+expectedLayerChangeSets :: [[ContainerFSChangeSet]]
+expectedLayerChangeSets =
+  [ -- Layer 1 - Adds a file and directory
+
+    [ InsertOrUpdate "health.txt" 76
+    , InsertOrUpdate "status.txt" 80
+    ]
+  , -- Layer 2 - Adds a nested file and a nested directory
+
+    [ InsertOrUpdate "logs-archive/feb/2.txt" 10
+    , InsertOrUpdate "logs-archive/jan/1.txt" 14
+    , InsertOrUpdate "logs-archive/last.txt" 16
+    ]
+  , -- Layer 3 - Removes a file and directories
+
+    [ Whiteout "logs-archive/jan/1.txt"
+    , Whiteout "logs-archive/march"
+    , Whiteout "status.txt"
+    ]
+  , -- Layer 4 - Adds an absolute symbolic link and relative symbolic link
+
+    [ InsertOrUpdate "last" 63
+    , InsertOrUpdate "logs-archive/feb/last_health" 66
+    ]
+  , -- Layer 5 - Removes symbolic link
+
+    [ Whiteout "last"
+    , Whiteout "logs-archive/feb/last_health"
+    ]
+  , -- # Layer 6 - Removes a nested directory
+
+    [ Whiteout "logs-archive"
+    ]
+  , -- # Layer 7 - Empty layer
+    []
+  ]
+
 mkImageSpec :: Spec
 mkImageSpec = do
-  tarFile <- runIO $ Tar.read <$> ByteStringLazy.readFile exampleImg
+  tarFileBs <- runIO $ ByteStringLazy.readFile exampleImg
+  let tarFile = Tar.read tarFileBs
+
+  describe "parse" $
+    it "should parse image with all layers and correct layer Ids" $ do
+      case parse tarFileBs of
+        Left errs -> expectationFailure (show errs)
+        Right (ContainerImageRaw neLayers imgDigest) -> do
+          let l = NLE.toList neLayers
+          let otherLayers = NLE.fromList . NLE.tail $ neLayers
+
+          imgDigest `shouldBe` "sha256:7b27f90216d827d7b4ad2b679c276201b250d10408481b81d0c0a42d37e177e9"
+          layerDigest (head l) `shouldBe` "sha256:b541d28bf3b491aeb424c61353c8c92476ecc2cd603a6c09ee5c2708f1a4b258"
+          layerDigest (l !! 1) `shouldBe` "sha256:690b9450535c0e7db4f6a9f41a15e3260abfec49d0430f4a853185d15af89f20"
+          layerDigest (l !! 2) `shouldBe` "sha256:3859b16f69447c6a8e59659d7d6e629dba1c5a87dba6b9374fad0e1d98ede98d"
+          layerDigest (l !! 3) `shouldBe` "sha256:80169933fb42b41773031cab68d4688c96dd69e094507a8fe8b74e253f047648"
+          layerDigest (l !! 4) `shouldBe` "sha256:1ed3dd0e0a49ff255a219191ea3bfffa1e3d5ff99647b732923237e87d548cce"
+          layerDigest (l !! 5) `shouldBe` "sha256:f362a8928301b2ba83eb44d9e729c8f9cdabce2049b14f164637ae6fffbb8800"
+          layerDigest (l !! 6) `shouldBe` "sha256:33552eb17ad8ae902c15a8037e0fe69c85bc8c1af6c3bbc7258f41feafb2e082"
+          layerDigest (l !! 7) `shouldBe` "sha256:3892250d356b09c234bb80bd28a6a2aad35e0049be30391d5bff03c2674be3d2"
+
+          toChangeSets (ContainerImageRaw otherLayers imgDigest)
+            `shouldBe` expectedLayerChangeSets
 
   describe "mkImage" $
     it "should build image with layers with all change sets" $
@@ -134,43 +194,7 @@ mkImageSpec = do
         Right entries -> do
           case (mkImage mempty mockImageJson entries exampleImgLayers) of
             Left errs -> expectationFailure (show errs)
-            Right img ->
-              toChangeSets img
-                `shouldBe` [
-                             -- Layer 1 - Adds a file and directory
-
-                             [ InsertOrUpdate "health.txt" 76
-                             , InsertOrUpdate "status.txt" 80
-                             ]
-                           , -- Layer 2 - Adds a nested file and a nested directory
-
-                             [ InsertOrUpdate "logs-archive/feb/2.txt" 10
-                             , InsertOrUpdate "logs-archive/jan/1.txt" 14
-                             , InsertOrUpdate "logs-archive/last.txt" 16
-                             ]
-                           , -- Layer 3 - Removes a file and directories
-
-                             [ Whiteout "logs-archive/jan/1.txt"
-                             , Whiteout "logs-archive/march"
-                             , Whiteout "status.txt"
-                             ]
-                           , -- Layer 4 - Adds an absolute symbolic link and relative symbolic link
-
-                             [ InsertOrUpdate "last" 63
-                             , InsertOrUpdate "logs-archive/feb/last_health" 66
-                             ]
-                           , -- Layer 5 - Removes symbolic link
-
-                             [ Whiteout "last"
-                             , Whiteout "logs-archive/feb/last_health"
-                             ]
-                           , -- # Layer 6 - Removes a nested directory
-
-                             [ Whiteout "logs-archive"
-                             ]
-                           , -- # Layer 7 - Empty layer
-                             []
-                           ]
+            Right img -> toChangeSets img `shouldBe` expectedLayerChangeSets
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
# Overview

This PR adds the ability to analyze exported docker tarball files.

## Acceptance criteria

- When running `--experiemental-scanner --output` works for docker exported tarball
- When running `--experiemental-scanner` throws an error (since this requires CORE changes to be merged upstream)

## Testing plan

```
docker save redis:alpine > redis.tar
fossa-dev container analyze redis.tar --experimental-scanner -o
fossa-dev container analyze redis.tar --experimental-scanner -o --debug # see the debug logs
``` 

## Risks

None

## References

https://fossa.atlassian.net/browse/ANE-276

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
