### PR TITLE
Container Scanning: Uploads Native Scan

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -464,6 +464,7 @@ test-suite unit-tests
     App.Fossa.Config.Utils
     App.Fossa.Configuration.ConfigurationSpec
     App.Fossa.Configuration.TelemetryConfigSpec
+    App.Fossa.Container.NativeAnalyzeSpec
     App.Fossa.LicenseScannerSpec
     App.Fossa.ManualDepsSpec
     App.Fossa.ProjectInferenceSpec

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -1,37 +1,63 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module App.Fossa.Container.AnalyzeNative (
   analyzeExperimental,
+
+  -- * for testing
+  uploadScan,
 ) where
 
+import App.Fossa.API.BuildLink (getFossaBuildUrl)
 import App.Fossa.Analyze.Debug (collectDebugBundle)
 import App.Fossa.Config.Common (
   ScanDestination (OutputStdout, UploadScan),
  )
 import App.Fossa.Config.Container.Analyze (
-  ContainerAnalyzeConfig (imageLocator, scanDestination),
+  ContainerAnalyzeConfig (imageLocator, revisionOverride, scanDestination),
  )
 import App.Fossa.Config.Container.Analyze qualified as Config
 import App.Fossa.Config.Container.Common (ImageText (unImageText))
 import App.Fossa.Container.Sources.DockerTarball (analyzeExportedTarball)
+import App.Types (
+  OverrideProject (OverrideProject),
+  ProjectMetadata,
+  ProjectRevision (ProjectRevision, projectBranch, projectName, projectRevision),
+  overrideBranch,
+  overrideName,
+  overrideRevision,
+ )
 import Codec.Compression.GZip qualified as GZip
+import Container.Errors (EndpointDoesNotSupportNativeContainerScan (EndpointDoesNotSupportNativeContainerScan))
+import Container.Types (ContainerScan (..))
 import Control.Carrier.Debug (Debug, ignoreDebug)
 import Control.Carrier.Diagnostics qualified as Diag
-import Control.Effect.Diagnostics (Diagnostics, fatalText, fromEitherShow)
+import Control.Carrier.FossaApiClient (runFossaApiClient)
+import Control.Effect.Diagnostics (Diagnostics, fatal, fatalText, fromEitherShow)
+import Control.Effect.FossaApiClient (FossaApiClient, getOrganization, uploadNativeContainerScan)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Telemetry (Telemetry)
+import Control.Monad (void)
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BL
-import Data.String.Conversion (ConvertUtf8 (decodeUtf8), toString)
+import Data.Foldable (traverse_)
+import Data.Maybe (fromMaybe)
+import Data.String.Conversion (decodeUtf8, toString)
 import Data.Text (Text)
 import Effect.Exec (Exec)
 import Effect.Logger (
   Has,
   Logger,
+  Pretty (pretty),
   Severity (..),
+  logError,
   logInfo,
   logStdout,
+  viaShow,
  )
 import Effect.ReadFS (ReadFS, getCurrentDir)
+import Fossa.API.Types (Organization (orgSupportsNativeContainerScan), UploadResponse (uploadError), uploadLocator)
 import Path (Abs, File, Path, SomeBase (Abs, Rel), parseSomeFile, (</>))
+import Srclib.Types (Locator)
 
 data ContainerImageSource
   = ContainerExportedTarball (Path Abs File)
@@ -79,9 +105,50 @@ analyze cfg = do
     ContainerOCIRegistry _ _ -> fatalText "container images from oci registry are not yet supported!"
     ContainerExportedTarball tarball -> analyzeExportedTarball tarball
 
+  let revision = extractRevision (revisionOverride cfg) scannedImage
   case scanDestination cfg of
     OutputStdout -> logStdout . decodeUtf8 $ Aeson.encode scannedImage
-    UploadScan _ _ -> fatalText "experimental scanner does not allow to submit projects to fossa yet!"
+    UploadScan apiOpts projectMeta ->
+      void $ runFossaApiClient apiOpts $ uploadScan revision projectMeta scannedImage
+  where
+    extractRevision :: OverrideProject -> ContainerScan -> ProjectRevision
+    extractRevision OverrideProject{..} ContainerScan{..} =
+      ProjectRevision
+        (fromMaybe imageTag overrideName)
+        (fromMaybe imageDigest overrideRevision)
+        overrideBranch
+
+uploadScan ::
+  ( Has Diagnostics sig m
+  , Has FossaApiClient sig m
+  , Has Logger sig m
+  ) =>
+  ProjectRevision ->
+  ProjectMetadata ->
+  ContainerScan ->
+  m Locator
+uploadScan revision projectMeta containerScan =
+  do
+    supportsNativeScan <- orgSupportsNativeContainerScan <$> getOrganization
+    if not supportsNativeScan
+      then fatal EndpointDoesNotSupportNativeContainerScan
+      else do
+        logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
+        logInfo ("Using project revision: `" <> pretty (projectRevision revision) <> "`")
+        let branchText = fromMaybe "No branch (detached HEAD)" $ projectBranch revision
+        logInfo ("Using branch: `" <> pretty branchText <> "`")
+
+        resp <- uploadNativeContainerScan revision projectMeta containerScan
+        let locator = uploadLocator resp
+        buildUrl <- getFossaBuildUrl revision locator
+
+        logInfo "View FOSSA Report:"
+        logInfo ("  " <> pretty buildUrl)
+        traverse_ (\err -> logError $ "FOSSA error: " <> viaShow err) (uploadError resp)
+
+        -- We return locator for purely
+        -- purpose of testing.
+        pure locator
 
 parseContainerImageSource ::
   ( Has (Lift IO) sig m

--- a/src/App/Fossa/Container/Sources/DockerTarball.hs
+++ b/src/App/Fossa/Container/Sources/DockerTarball.hs
@@ -89,10 +89,10 @@ analyzeExportedTarball tarball = do
   containerTarball <- sendIO . BS.readFile $ toString tarball
   image <- fromEither $ parse containerTarball
 
-  -- get Image Digest
-  let imageDigest = getImageDigest . rawManifest $ image
-  imageTag <- extractTag (getRepoTags . rawManifest $ image)
-  -- get Image Tag
+  -- get Image Digest and Tags
+  let manifest = rawManifest image
+  let imageDigest = getImageDigest manifest
+  imageTag <- extractTag (getRepoTags manifest)
 
   -- Analyze Base Layer
   logInfo "Analyzing Base Layer"

--- a/src/App/Fossa/Container/Sources/DockerTarball.hs
+++ b/src/App/Fossa/Container/Sources/DockerTarball.hs
@@ -15,12 +15,14 @@ import App.Fossa.Analyze.Types (
   DiscoveredProjectScan (..),
  )
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig (ExperimentalAnalyzeConfig))
+import App.Fossa.Container.Scan (extractTag)
 import Codec.Archive.Tar.Index (TarEntryOffset)
+import Container.Docker.Manifest (getImageDigest, getRepoTags)
 import Container.OsRelease (OsInfo (nameId, version), getOsInfo)
 import Container.Tarball (mkFsFromChangeset, parse)
 import Container.TarballReadFs (runTarballReadFSIO)
 import Container.Types (
-  ContainerImageRaw (rawDigest),
+  ContainerImageRaw (..),
   ContainerLayer (layerDigest),
   ContainerScan (ContainerScan),
   ContainerScanImage (ContainerScanImage),
@@ -86,7 +88,11 @@ analyzeExportedTarball tarball = do
   capabilities <- sendIO getNumCapabilities
   containerTarball <- sendIO . BS.readFile $ toString tarball
   image <- fromEither $ parse containerTarball
-  let imageDigest = rawDigest image
+
+  -- get Image Digest
+  let imageDigest = getImageDigest . rawManifest $ image
+  imageTag <- extractTag (getRepoTags . rawManifest $ image)
+  -- get Image Tag
 
   -- Analyze Base Layer
   logInfo "Analyzing Base Layer"
@@ -120,6 +126,7 @@ analyzeExportedTarball tarball = do
           ]
       )
       imageDigest
+      imageTag
 
 analyzeLayer ::
   ( Has Diagnostics sig m

--- a/src/Container/Docker/Manifest.hs
+++ b/src/Container/Docker/Manifest.hs
@@ -11,6 +11,7 @@ module Container.Docker.Manifest (
   manifestFilename,
   getImageJsonConfigFilePath,
   getImageDigest,
+  getRepoTags,
 ) where
 
 import Control.DeepSeq (NFData)
@@ -78,3 +79,8 @@ getImageJsonConfigFilePath (ManifestJson mjEntries) = config $ NonEmpty.head mjE
 -- Exported docker tarball's config filename is digest of the image.
 getImageDigest :: ManifestJson -> Text
 getImageDigest mj = "sha256:" <> Text.replace ".json" "" (getImageJsonConfigFilePath mj)
+
+-- | Gets the image digest.
+-- Exported docker tarball's config filename is digest of the image.
+getRepoTags :: ManifestJson -> [Text]
+getRepoTags (ManifestJson mjEntries) = repoTags $ NonEmpty.head mjEntries

--- a/src/Container/Errors.hs
+++ b/src/Container/Errors.hs
@@ -1,10 +1,14 @@
-module Container.Errors (ContainerImgParsingError (..)) where
+module Container.Errors (
+  ContainerImgParsingError (..),
+  EndpointDoesNotSupportNativeContainerScan (..),
+) where
 
 import Codec.Archive.Tar qualified as Tar
 import Control.Exception (Exception)
 import Data.List.NonEmpty (NonEmpty)
 import Diag.Diagnostic (ToDiagnostic (renderDiagnostic))
 import Effect.Logger (pretty)
+import Prettyprinter (vsep)
 
 -- | Errors that can be encountered when parsing a container image.
 data ContainerImgParsingError
@@ -35,3 +39,16 @@ instance ToDiagnostic ContainerImgParsingError where
 
 instance ToDiagnostic (NonEmpty ContainerImgParsingError) where
   renderDiagnostic = pretty . show
+
+data EndpointDoesNotSupportNativeContainerScan = EndpointDoesNotSupportNativeContainerScan
+instance ToDiagnostic EndpointDoesNotSupportNativeContainerScan where
+  renderDiagnostic (EndpointDoesNotSupportNativeContainerScan) =
+    vsep
+      [ "Provided endpoint does not support native container scans."
+      , ""
+      , "If you are using, --experimental-scanner option, it is not supported for your"
+      , "FOSSA instance. Try without using --experimental-scanner."
+      , ""
+      , "If your instance of FOSSA is on-premise, it likely needs to be updated to latest version."
+      , "Please contact FOSSA support for more assistance."
+      ]

--- a/src/Container/Tarball.hs
+++ b/src/Container/Tarball.hs
@@ -65,7 +65,7 @@ parse content = case mkEntries $ Tar.read content of
         -- layer and image hash
         case getImageJson (getImageJsonConfigFilePath manifest) te of
           Left err -> Left $ NLE.singleton err
-          Right imgJson -> mkImage (getImageDigest manifest) imgJson te (getLayerPaths manifest)
+          Right imgJson -> mkImage manifest imgJson te (getLayerPaths manifest)
   where
     getManifest :: TarEntries -> Either ContainerImgParsingError ManifestJson
     getManifest te = parseManifest =<< getFileContent te (toString manifestFilename)
@@ -109,7 +109,7 @@ mkEntries = build (TarEntries mempty 0)
         }
 
 mkImage ::
-  Text ->
+  ManifestJson ->
   ImageJson ->
   TarEntries ->
   NLE.NonEmpty FilePath ->

--- a/src/Container/Tarball.hs
+++ b/src/Container/Tarball.hs
@@ -21,7 +21,7 @@ import Codec.Archive.Tar.Entry (Entry (entryTarPath), TarPath, entryPath, fromTa
 import Codec.Archive.Tar.Entry qualified as TarEntry
 import Codec.Archive.Tar.Index (TarEntryOffset, nextEntryOffset)
 import Container.Docker.ImageJson (ImageJson, decodeImageJson, getLayerIds)
-import Container.Docker.Manifest (ManifestJson (..), decodeManifestJson, getImageDigest, getImageJsonConfigFilePath, getLayerPaths, manifestFilename)
+import Container.Docker.Manifest (ManifestJson (..), decodeManifestJson, getImageJsonConfigFilePath, getLayerPaths, manifestFilename)
 import Container.Errors (ContainerImgParsingError (..))
 import Container.Types (
   ContainerFSChangeSet (InsertOrUpdate, Whiteout),
@@ -114,11 +114,11 @@ mkImage ::
   TarEntries ->
   NLE.NonEmpty FilePath ->
   Either (NLE.NonEmpty ContainerImgParsingError) ContainerImageRaw
-mkImage imgDigest imgJson entries layerTarballPaths =
+mkImage manifest imgJson entries layerTarballPaths =
   case (errs, parsedLayers) of
     ((e : es), _) -> Left $ e NLE.:| es
     (_, []) -> Left $ NLE.singleton ContainerNoLayersDiscovered
-    (_, (l : ls)) -> Right $ ContainerImageRaw (l NLE.:| ls) imgDigest
+    (_, (l : ls)) -> Right $ ContainerImageRaw (l NLE.:| ls) manifest
   where
     errs :: [ContainerImgParsingError]
     errs = lefts layers

--- a/src/Container/Types.hs
+++ b/src/Container/Types.hs
@@ -15,6 +15,7 @@ module Container.Types (
 ) where
 
 import Codec.Archive.Tar.Index (TarEntryOffset)
+import Container.Docker.Manifest (ManifestJson)
 import Control.DeepSeq (NFData)
 import Data.Aeson (object)
 import Data.Aeson.Types (ToJSON, toJSON, (.=))
@@ -28,7 +29,7 @@ import Srclib.Types (SourceUnit)
 
 data ContainerImageRaw = ContainerImageRaw
   { layers :: NonEmpty.NonEmpty ContainerLayer
-  , rawDigest :: Text
+  , rawManifest :: ManifestJson
   }
   deriving (Show, Generic, Eq)
   deriving anyclass (NFData)
@@ -66,6 +67,7 @@ data ContainerFSChangeSet
 data ContainerScan = ContainerScan
   { imageData :: ContainerScanImage
   , imageDigest :: Text
+  , imageTag :: Text
   }
   deriving (Show, Eq, Ord)
 

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -55,6 +55,7 @@ runFossaApiClient apiOpts =
           UploadAnalysis rev metadata units -> Core.uploadAnalysis rev metadata units
           UploadArchive url path -> Core.uploadArchive url path
           UploadContainerScan revision metadata scan -> Core.uploadContainerScan revision metadata scan
+          UploadNativeContainerScan revision metadata scan -> Core.uploadNativeContainerScan revision metadata scan
           UploadContributors locator contributors -> Core.uploadContributors locator contributors
           UploadLicenseScanResult signedUrl licenseSourceUnit -> LicenseScanning.uploadLicenseScanResult signedUrl licenseSourceUnit
       )

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -12,6 +12,7 @@ module Control.Carrier.FossaApiClient.Internal.Core (
   uploadAnalysis,
   uploadArchive,
   uploadContainerScan,
+  uploadNativeContainerScan,
   uploadContributors,
   getEndpointVersion,
 ) where
@@ -21,6 +22,7 @@ import App.Fossa.Config.Test (DiffRevision)
 import App.Fossa.Container.Scan (ContainerScan)
 import App.Fossa.VendoredDependency (VendoredDependency (..))
 import App.Types (ProjectMetadata, ProjectRevision (..))
+import Container.Types qualified as NativeContainer
 import Control.Algebra (Has)
 import Control.Carrier.FossaApiClient.Internal.FossaAPIV1 qualified as API
 import Control.Effect.Diagnostics (Diagnostics)
@@ -104,6 +106,19 @@ uploadContainerScan ::
 uploadContainerScan revision metadata scan = do
   apiOpts <- ask
   API.uploadContainerScan apiOpts revision metadata scan
+
+uploadNativeContainerScan ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has (Reader ApiOpts) sig m
+  ) =>
+  ProjectRevision ->
+  ProjectMetadata ->
+  NativeContainer.ContainerScan ->
+  m UploadResponse
+uploadNativeContainerScan revision metadata scan = do
+  apiOpts <- ask
+  API.uploadNativeContainerScan apiOpts revision metadata scan
 
 uploadContributors ::
   ( Has (Lift IO) sig m

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -30,6 +30,7 @@ module Control.Effect.FossaApiClient (
   uploadAnalysis,
   uploadArchive,
   uploadContainerScan,
+  uploadNativeContainerScan,
   uploadContributors,
   uploadLicenseScanResult,
 ) where
@@ -43,6 +44,7 @@ import App.Fossa.VSI.IAT.Types qualified as IAT
 import App.Fossa.VSI.Types qualified as VSI
 import App.Fossa.VendoredDependency (VendoredDependency)
 import App.Types (ProjectMetadata, ProjectRevision)
+import Container.Types qualified as NativeContainer
 import Control.Algebra (Has)
 import Control.Carrier.Simple (Simple, sendSimple)
 import Data.ByteString.Char8 qualified as C8
@@ -111,6 +113,11 @@ data FossaApiClientF a where
     ProjectMetadata ->
     ContainerScan ->
     FossaApiClientF UploadResponse
+  UploadNativeContainerScan ::
+    ProjectRevision ->
+    ProjectMetadata ->
+    NativeContainer.ContainerScan ->
+    FossaApiClientF UploadResponse
   UploadContributors ::
     Locator ->
     Contributors ->
@@ -142,6 +149,10 @@ uploadAnalysis revision metadata units = sendSimple (UploadAnalysis revision met
 -- | Uploads results of container analysis to a project
 uploadContainerScan :: (Has FossaApiClient sig m) => ProjectRevision -> ProjectMetadata -> ContainerScan -> m UploadResponse
 uploadContainerScan revision metadata scan = sendSimple (UploadContainerScan revision metadata scan)
+
+-- | Uploads results of container analysis performed by native scanner to a project
+uploadNativeContainerScan :: (Has FossaApiClient sig m) => ProjectRevision -> ProjectMetadata -> NativeContainer.ContainerScan -> m UploadResponse
+uploadNativeContainerScan revision metadata scan = sendSimple (UploadNativeContainerScan revision metadata scan)
 
 -- | Associates contributors to a specific locator
 uploadContributors :: (Has FossaApiClient sig m) => Locator -> Contributors -> m ()

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -295,6 +295,7 @@ data Organization = Organization
   , orgSupportsAnalyzedRevisionsQuery :: Bool
   , orgDefaultVendoredDependencyScanType :: ArchiveUploadType
   , orgSupportsIssueDiffs :: Bool
+  , orgSupportsNativeContainerScan :: Bool
   }
   deriving (Eq, Ord, Show)
 
@@ -307,6 +308,7 @@ instance FromJSON Organization where
       <*> obj .:? "supportsAnalyzedRevisionsQuery" .!= False
       <*> obj .:? "defaultVendoredDependencyScanType" .!= CLILicenseScan
       <*> obj .:? "supportsIssueDiffs" .!= False
+      <*> obj .:? "supportsNativeContainerScans" .!= False
 
 data Project = Project
   { projectId :: Text

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -41,7 +41,7 @@ spec = do
     describe "SAML URL builder" $ do
       it' "should render simple locators" $ do
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
-            org = Just $ Organization (OrgId 1) True False True CLILicenseScan True
+            org = Just $ Organization (OrgId 1) True False True CLILicenseScan True True
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -49,7 +49,7 @@ spec = do
 
       it' "should render git@ locators" $ do
         let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
-            org = Just $ Organization (OrgId 103) True False True CLILicenseScan True
+            org = Just $ Organization (OrgId 103) True False True CLILicenseScan True True
             revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -57,7 +57,7 @@ spec = do
 
       it' "should render full url correctly" $ do
         let locator = Locator "a" "b" $ Just "c"
-            org = Just $ Organization (OrgId 33) True False True CLILicenseScan True
+            org = Just $ Organization (OrgId 33) True False True CLILicenseScan True True
             revision = ProjectRevision "" "not this revision" $ Just "master"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -74,7 +74,7 @@ spec = do
     describe "Fossa URL Builder" $
       it' "should render from API info" $ do
         GetApiOpts `returnsOnce` Fixtures.apiOpts
-        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True
+        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True True
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getFossaBuildUrl revision locator

--- a/test/App/Fossa/Container/NativeAnalyzeSpec.hs
+++ b/test/App/Fossa/Container/NativeAnalyzeSpec.hs
@@ -1,0 +1,47 @@
+module App.Fossa.Container.NativeAnalyzeSpec (spec) where
+
+import App.Fossa.Container.AnalyzeNative (uploadScan)
+import App.Types (ProjectMetadata (..), ProjectRevision (..))
+import Container.Types (ContainerScan (..), ContainerScanImage (..))
+import Control.Algebra (Has)
+import Control.Effect.FossaApiClient (FossaApiClientF (..))
+import Fossa.API.Types (Organization (..), uploadLocator)
+import Srclib.Types (Locator)
+import Test.Effect (expectFatal', it', shouldBe')
+import Test.Fixtures qualified as Fixtures
+import Test.Hspec (Spec, describe)
+import Test.MockApi (MockApi, alwaysReturns)
+
+spec :: Spec
+spec = do
+  describe "Native Container Upload" $ do
+    it' "should upload native container upload, when org supports native container scanning" $ do
+      let org = Fixtures.organization{orgSupportsNativeContainerScan = True}
+      GetOrganization `alwaysReturns` org
+      GetApiOpts `alwaysReturns` Fixtures.apiOpts
+      expectUploadSuccess
+      locator <- uploadScan fixtureRevision fixtureProjectMetadata fixtureContainerScan
+      locator `shouldBe'` expectedLocator
+
+    it' "should fail uploading native container scan, when org does not supports native container scanning" $ do
+      let org = Fixtures.organization{orgSupportsNativeContainerScan = False}
+      GetOrganization `alwaysReturns` org
+      GetApiOpts `alwaysReturns` Fixtures.apiOpts
+      expectFatal' $ uploadScan fixtureRevision fixtureProjectMetadata fixtureContainerScan
+
+fixtureProjectMetadata :: ProjectMetadata
+fixtureProjectMetadata = ProjectMetadata Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+
+fixtureContainerScan :: ContainerScan
+fixtureContainerScan = ContainerScan (ContainerScanImage "alpine" "3.1.4" []) "some-digest" "some-tag"
+
+fixtureRevision :: ProjectRevision
+fixtureRevision = ProjectRevision "some-tag" "some-digest" $ Just "master"
+
+expectUploadSuccess :: Has MockApi sig m => m ()
+expectUploadSuccess =
+  UploadNativeContainerScan fixtureRevision fixtureProjectMetadata fixtureContainerScan
+    `alwaysReturns` Fixtures.uploadResponse
+
+expectedLocator :: Locator
+expectedLocator = uploadLocator Fixtures.uploadResponse

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -71,7 +71,7 @@ apiOpts =
     }
 
 organization :: API.Organization
-organization = API.Organization (API.OrgId 42) True True True CLILicenseScan True
+organization = API.Organization (API.OrgId 42) True True True CLILicenseScan True True
 
 project :: API.Project
 project =

--- a/test/Test/MockApi.hs
+++ b/test/Test/MockApi.hs
@@ -225,6 +225,7 @@ matchExpectation a@(ResolveUserDefinedBinary{}) (ApiExpectation _ requestExpecta
 matchExpectation a@(UploadAnalysis{}) (ApiExpectation _ requestExpectation b@(UploadAnalysis{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(UploadArchive{}) (ApiExpectation _ requestExpectation b@(UploadArchive{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(UploadContainerScan{}) (ApiExpectation _ requestExpectation b@(UploadContainerScan{}) resp) = checkResult requestExpectation a b resp
+matchExpectation a@(UploadNativeContainerScan{}) (ApiExpectation _ requestExpectation b@(UploadNativeContainerScan{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(UploadContributors{}) (ApiExpectation _ requestExpectation b@(UploadContributors{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(UploadLicenseScanResult{}) (ApiExpectation _ requestExpectation b@(UploadLicenseScanResult{}) resp) = checkResult requestExpectation a b resp
 matchExpectation _ _ = Nothing


### PR DESCRIPTION
# Overview

This PR, adds,
- uploads scan capability when using `--experimental-scanner` 

With this PR, fossa-cli can submit the generated analysis to an endpoint.

Sibling PR: https://github.com/fossas/FOSSA/pull/8174

## Acceptance criteria

- When `endpoint` does not support native scan, we do not analyze container image
- When `endpoint` does support native scan, we analyze container image (project gets created, and all dependencies are displayed like with non experimental scanner)

## Testing plan

1. I relied on automated testing for 

For end-to-end testing: you will need to use the core branch: https://github.com/fossas/FOSSA/pull/8174

0. (screen 1) `yarn boot:dev`
1. (screen 2) `make install-dev`
2. (screen 2) `docker save redis:alpine > redis.tar`
3. (screen 2) `fossa-dev container analyze redis.tar --project myproject --revision myrevision --endpoint http://localhost:9578 --fossa-api-key <FOSSA-API-KEY>`

You should see successful results. 

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-276

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
