### PR TITLE
Container Scanning: Adds docker daemon source

### DIFF
--- a/docs/references/experimental/container/experimenal-scanner.md
+++ b/docs/references/experimental/container/experimenal-scanner.md
@@ -1,0 +1,66 @@
+## Experimental Scanner
+
+Usage:
+
+```bash
+fossa container analyze redis:alpine --experimental-scanner --output
+```
+
+## Current Limitation
+
+As this functionality is in active development, following is not yet supported with experimental scanner. 
+It is expected that these functionalities will be supported in future. 
+
+For backwards compatibility: 
+- Dpkg Scanning (for debian files)
+- Rpm Scanning
+- Image sourced from OCI Registry
+- Image sourced from private OCI Registry
+- Wider support for OSs.
+
+New Functionalities:
+- Application Dependencies (python, nodejs projects etc.)
+- Container Scanning in windows
+- Improved runtime performance (time spent to analyze image)
+- Path Exclusions (via configuration file)
+
+### What's new in Experimental Scanner
+
+With Experimental Scanner, FOSSA can support following:
+
+- Origin Paths (in FOSSA's dependency view) for alpine dependencies
+- Better Logging and Diagnostics Supports from FOSSA support team
+- Improved Runtime performance.
+
+### Docker Engine Supports
+
+`fossa-cli` can analyze docker image from docker engine api. This requires docker engine (daemon) to
+be running and accessible to `fossa-cli`.
+
+To retrieve docker image from docker engine api, 
+
+1) We perform `/_ping` to check if docker engine api is accessible
+
+```bash
+# Equivalent curl command is:
+curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.28/_ping"
+```
+
+2) We perform `/images/<IMAGE>/json` to see if we can identify image's total size in bytes. This also throws 404 if image is not present
+
+```bash
+# Equivalent curl command is:
+curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.28/images/redis:alpine/json"
+```
+
+3) We perform `/images/<IMAGE>/get` to retrieve raw image in tarball format, which we write to temp file in system temp folder. 
+
+```bash
+# Equivalent curl command is:
+curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.28/images/redis:alpine/get" > img.tar
+```
+
+For more information on docker engine API, refer to [docs](https://docs.docker.com/engine/api/v1.28/#). 
+
+To ensure docker engine source works, please ensure image is locally accessible: perform `docker pull IMAGE`, if it is not locally present.
+

--- a/docs/references/subcommands/container.md
+++ b/docs/references/subcommands/container.md
@@ -1,0 +1,62 @@
+## `fossa container`
+
+Fossa container subcommand lets you analyze and test container for vulnerabilities, and compliance issues. 
+
+Fossa container has following options:
+
+- `analyze`: Scans an container image
+- `test`: Check for issues from FOSSA and exit non-zero when issues are found
+
+### `fossa container analyze <Image>`
+
+Fossa container analyze, can scan container image from,
+
+1) Docker Tarball
+2) Docker Engine (accessed via unix socket /var/lib/docker.sock)
+3) OCI Registry
+
+No arguments are required to specify which kind of image you are using. Fossa will 
+automatically identifies accessible image source.
+
+For example:
+
+```bash
+
+# Exported Container Image in Tarball format (done via docker save redis:alpine > redis.tar)
+fossa container analyze redis.tar
+
+# Local Image (accessed via docker engine)
+fossa container analyze fossa
+
+# Resolved from hub.docker.com/_/debian
+fossa container analyze debian
+
+# Explicit remote image via docker.fossa.com
+fossa container analyze docker.fossa.com/fossa/fossa
+```
+
+### `fossa container test <Image>`
+
+Check for issues from FOSSA and exit non-zero when issues are found.
+
+For example:
+
+```bash
+fossa container test redis:alpine
+```
+
+### Printing results without uploading to FOSSA
+
+The `--output` flag can be used to print projects and dependency graph information to stdout, rather than uploading to FOSSA
+
+```sh
+fossa container analyze redis:alpine --output
+```
+
+### Experimental Options
+
+_Important: For support and other general information, refer to the [experimental options overview](../experimental/README.md) before using experimental options._
+
+| Name                     | Description                                                       |
+| ------------------------ | ----------------------------------------------------------------- |
+| `--experimental-scanner` | Uses native container scanner which has better debugging support. |

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -91,12 +91,14 @@ common deps
     , hashable                     >=1.0.0.1
     , hedn                         ^>=0.3.0.1
     , http-client                  ^>=0.7.1
+    , http-conduit                 ^>=2.3.0
     , http-types                   ^>=0.12.3
     , lzma                         ^>=0.0.0.3
     , lzma-conduit                 ^>=1.2.1
     , megaparsec                   ^>=9.1.0
     , modern-uri                   ^>=0.3.4
     , mtl                          ^>=2.2.2
+    , network                      ^>=3.1.2.0
     , optparse-applicative         >=0.15     && <0.17
     , parser-combinators           ^>=1.3
     , path                         ^>=0.9.0
@@ -182,6 +184,7 @@ library
     App.Fossa.Container.Analyze
     App.Fossa.Container.AnalyzeNative
     App.Fossa.Container.Scan
+    App.Fossa.Container.Sources.DockerEngine
     App.Fossa.Container.Sources.DockerTarball
     App.Fossa.Container.Test
     App.Fossa.DumpBinaries
@@ -239,6 +242,7 @@ library
     Control.Carrier.AtomicState
     Control.Carrier.Debug
     Control.Carrier.Diagnostics
+    Control.Carrier.DockerEngineApi
     Control.Carrier.Finally
     Control.Carrier.FossaApiClient
     Control.Carrier.FossaApiClient.Internal.Core
@@ -265,6 +269,7 @@ library
     Control.Effect.ConsoleRegion
     Control.Effect.Debug
     Control.Effect.Diagnostics
+    Control.Effect.DockerEngineApi
     Control.Effect.Finally
     Control.Effect.FossaApiClient
     Control.Effect.Git

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -470,7 +470,8 @@ test-suite unit-tests
     App.Fossa.Config.Utils
     App.Fossa.Configuration.ConfigurationSpec
     App.Fossa.Configuration.TelemetryConfigSpec
-    App.Fossa.Container.NativeAnalyzeSpec
+    App.Fossa.Container.AnalyzeNativeSpec
+    App.Fossa.Container.AnalyzeNativeUploadSpec
     App.Fossa.LicenseScannerSpec
     App.Fossa.ManualDepsSpec
     App.Fossa.ProjectInferenceSpec
@@ -580,6 +581,7 @@ test-suite unit-tests
     Test.Effect
     Test.Fixtures
     Test.MockApi
+    Test.MockDockerEngineApi
     Yarn.V1.YarnLockV1Spec
     Yarn.V2.LockfileSpec
     Yarn.V2.ResolversSpec

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -34,7 +34,13 @@ import Control.Carrier.Debug (Debug, ignoreDebug)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.DockerEngineApi (runDockerEngineApi)
 import Control.Carrier.FossaApiClient (runFossaApiClient)
-import Control.Effect.Diagnostics (Diagnostics, fatal, fatalText, fromEitherShow, (<||>))
+import Control.Effect.Diagnostics (
+  Diagnostics,
+  fatal,
+  fatalText,
+  fromEitherShow,
+  (<||>),
+ )
 import Control.Effect.DockerEngineApi (getDockerImageSize, isDockerEngineAccessible)
 import Control.Effect.FossaApiClient (FossaApiClient, getOrganization, uploadNativeContainerScan)
 import Control.Effect.Lift (Lift, sendIO)
@@ -44,7 +50,12 @@ import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)
 import Data.Maybe (fromMaybe)
-import Data.String.Conversion (ConvertUtf8 (decodeUtf8), decodeUtf8, toString, toText)
+import Data.String.Conversion (
+  ConvertUtf8 (decodeUtf8),
+  decodeUtf8,
+  toString,
+  toText,
+ )
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Effect.Exec (Exec)
@@ -161,7 +172,7 @@ parseContainerImageSource ::
   , Has Logger sig m
   ) =>
   Text ->
-  m (ContainerImageSource)
+  m ContainerImageSource
 parseContainerImageSource src =
   parseExportedTarballSource src
     <||> parseDockerEngineSource src
@@ -172,7 +183,7 @@ parseDockerEngineSource ::
   , Has Logger sig m
   ) =>
   Text ->
-  m (ContainerImageSource)
+  m ContainerImageSource
 parseDockerEngineSource imgTag = runDockerEngineApi $ do
   canAccessDockerEngine <- isDockerEngineAccessible
 
@@ -196,7 +207,7 @@ parseExportedTarballSource ::
   , Has ReadFS sig m
   ) =>
   Text ->
-  m (ContainerImageSource)
+  m ContainerImageSource
 parseExportedTarballSource path = do
   cwd <- getCurrentDir
   someTarballFile <- fromEitherShow $ parseSomeFile (toString path)

--- a/src/App/Fossa/Container/Sources/DockerEngine.hs
+++ b/src/App/Fossa/Container/Sources/DockerEngine.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.Fossa.Container.Sources.DockerEngine (analyzeFromDockerEngine) where
+
+import App.Fossa.Container.Sources.DockerTarball (analyzeExportedTarball)
+import Container.Types (ContainerScan)
+import Control.Carrier.DockerEngineApi (runDockerEngineApi)
+import Control.Carrier.Lift (Lift)
+import Control.Effect.Debug (Debug, Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.DockerEngineApi (getDockerImage)
+import Control.Effect.Path (withSystemTempDir)
+import Control.Effect.Telemetry (Telemetry)
+import Data.String.Conversion (toString)
+import Data.Text (Text)
+import Effect.Exec (Exec)
+import Effect.Logger (Logger, logInfo, pretty)
+import Path (mkRelFile, (</>))
+
+analyzeFromDockerEngine ::
+  ( Has Diagnostics sig m
+  , Has Exec sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has Telemetry sig m
+  , Has Debug sig m
+  ) =>
+  Text ->
+  m ContainerScan
+analyzeFromDockerEngine imgTag = do
+  withSystemTempDir "fossa-docker-engine-tmp-" $ \dir -> do
+    let tempTarFile = dir </> $(mkRelFile "image.tar")
+
+    logInfo . pretty $
+      "Exporting docker image to temp file: "
+        <> toString tempTarFile
+        <> "! This may take a while!"
+    runDockerEngineApi $ getDockerImage imgTag tempTarFile
+
+    logInfo . pretty $ "Analyzing exported docker tarball: " <> toString tempTarFile
+    analyzeExportedTarball tempTarFile

--- a/src/Container/Types.hs
+++ b/src/Container/Types.hs
@@ -44,7 +44,7 @@ baseLayer :: ContainerImageRaw -> ContainerLayer
 baseLayer img = NonEmpty.head $ layers img
 
 hasOtherLayers :: ContainerImageRaw -> Bool
-hasOtherLayers img = NonEmpty.length (layers img) > 1
+hasOtherLayers img = not . null . NonEmpty.tail . layers
 
 data ContainerLayer = ContainerLayer
   { layerChangeSets :: Seq ContainerFSChangeSet

--- a/src/Container/Types.hs
+++ b/src/Container/Types.hs
@@ -4,14 +4,20 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Container.Types (
+  -- * Raw Image
   ContainerImageRaw (..),
   ContainerLayer (..),
   ContainerFSChangeSet (..),
-  baseLayer,
-  otherLayersSquashed,
+
+  -- * Scanned Image
   ContainerScan (..),
   ContainerScanImage (..),
   ContainerScanImageLayer (..),
+
+  -- * helpers
+  baseLayer,
+  otherLayersSquashed,
+  hasOtherLayers,
 ) where
 
 import Codec.Archive.Tar.Index (TarEntryOffset)
@@ -20,7 +26,7 @@ import Control.DeepSeq (NFData)
 import Data.Aeson (object)
 import Data.Aeson.Types (ToJSON, toJSON, (.=))
 import Data.Foldable (foldl')
-import Data.List.NonEmpty as NonEmpty (NonEmpty, head, tail)
+import Data.List.NonEmpty as NonEmpty (NonEmpty, head, length, tail)
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import Data.Text (Text)
@@ -36,6 +42,9 @@ data ContainerImageRaw = ContainerImageRaw
 
 baseLayer :: ContainerImageRaw -> ContainerLayer
 baseLayer img = NonEmpty.head $ layers img
+
+hasOtherLayers :: ContainerImageRaw -> Bool
+hasOtherLayers img = NonEmpty.length (layers img) > 1
 
 data ContainerLayer = ContainerLayer
   { layerChangeSets :: Seq ContainerFSChangeSet

--- a/src/Container/Types.hs
+++ b/src/Container/Types.hs
@@ -26,7 +26,7 @@ import Control.DeepSeq (NFData)
 import Data.Aeson (object)
 import Data.Aeson.Types (ToJSON, toJSON, (.=))
 import Data.Foldable (foldl')
-import Data.List.NonEmpty as NonEmpty (NonEmpty, head, length, tail)
+import Data.List.NonEmpty as NonEmpty (NonEmpty, head, tail)
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import Data.Text (Text)
@@ -44,7 +44,7 @@ baseLayer :: ContainerImageRaw -> ContainerLayer
 baseLayer img = NonEmpty.head $ layers img
 
 hasOtherLayers :: ContainerImageRaw -> Bool
-hasOtherLayers img = not . null . NonEmpty.tail . layers
+hasOtherLayers = not . null . NonEmpty.tail . layers
 
 data ContainerLayer = ContainerLayer
   { layerChangeSets :: Seq ContainerFSChangeSet

--- a/src/Control/Carrier/DockerEngineApi.hs
+++ b/src/Control/Carrier/DockerEngineApi.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 
 module Control.Carrier.DockerEngineApi (runDockerEngineApi) where
@@ -16,7 +15,7 @@ import Data.Text (Text)
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Client.Internal (Connection)
 import Network.HTTP.Conduit qualified as HTTPConduit
-import Network.HTTP.Types (Status (statusCode))
+import Network.HTTP.Types (Status (statusCode), ok200)
 import Network.Socket qualified as Socket
 import Network.Socket.ByteString qualified as SocketByteString
 import Path (Abs, File, Path)
@@ -63,7 +62,7 @@ isDockerEngineAccessible = do
   -- Performs equivalent of for given image:
   -- >> curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.28/_ping"
   response <- sendIO $ HTTP.httpLbs (HTTP.parseRequest_ $ baseApi <> "_ping") =<< dockerClient
-  pure $ statusCode (HTTP.responseStatus response) == 200
+  pure $ statusCode (HTTP.responseStatus response) == ok200
 
 newtype DockerImageInspectJson = DockerImageInspectJson {imageSize :: Int}
   deriving (Eq, Ord, Show)

--- a/src/Control/Carrier/DockerEngineApi.hs
+++ b/src/Control/Carrier/DockerEngineApi.hs
@@ -15,7 +15,7 @@ import Data.Text (Text)
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Client.Internal (Connection)
 import Network.HTTP.Conduit qualified as HTTPConduit
-import Network.HTTP.Types (Status (statusCode), ok200)
+import Network.HTTP.Types (ok200)
 import Network.Socket qualified as Socket
 import Network.Socket.ByteString qualified as SocketByteString
 import Path (Abs, File, Path)
@@ -62,7 +62,7 @@ isDockerEngineAccessible = do
   -- Performs equivalent of for given image:
   -- >> curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.28/_ping"
   response <- sendIO $ HTTP.httpLbs (HTTP.parseRequest_ $ baseApi <> "_ping") =<< dockerClient
-  pure $ statusCode (HTTP.responseStatus response) == ok200
+  pure $ (HTTP.responseStatus response) == ok200
 
 newtype DockerImageInspectJson = DockerImageInspectJson {imageSize :: Int}
   deriving (Eq, Ord, Show)

--- a/src/Control/Carrier/DockerEngineApi.hs
+++ b/src/Control/Carrier/DockerEngineApi.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+
+module Control.Carrier.DockerEngineApi (runDockerEngineApi) where
+
+import Conduit (runConduit, runResourceT, (.|))
+import Control.Carrier.Simple (Has, SimpleC, interpret)
+import Control.Effect.Diagnostics (fatalText)
+import Control.Effect.Diagnostics qualified as Diag (Diagnostics)
+import Control.Effect.DockerEngineApi (DockerEngineApiF (ExportImage, GetImageSize, IsAccessible))
+import Control.Effect.Lift (Lift, sendIO)
+import Data.Aeson (FromJSON (parseJSON), eitherDecode, withObject, (.:))
+import Data.Conduit.Binary (sinkFile)
+import Data.String.Conversion (toString, toText)
+import Data.Text (Text)
+import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Client.Internal (Connection)
+import Network.HTTP.Conduit qualified as HTTPConduit
+import Network.HTTP.Types (Status (statusCode))
+import Network.Socket qualified as Socket
+import Network.Socket.ByteString qualified as SocketByteString
+import Path (Abs, File, Path)
+
+type DockerEngineApiC = SimpleC DockerEngineApiF
+
+runDockerEngineApi :: (Has (Lift IO) sig m, Has Diag.Diagnostics sig m) => DockerEngineApiC m a -> m a
+runDockerEngineApi = interpret $ \case
+  ExportImage img path -> exportDockerImage img path
+  GetImageSize img -> getDockerImageSize img
+  IsAccessible -> isAccessible
+
+-- | Exports Docker Image to a given path.
+-- Refer to: https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageGet
+exportDockerImage :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => Text -> Path Abs File -> m ()
+exportDockerImage img sinkTarget = do
+  let request = HTTP.parseRequest_ $ "http://localhost/v1.41/images/" <> (toString img) <> "/get"
+  manager <- sendIO dockerClient
+  -- Performs equivalent of for given image:
+  -- >> curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.41/images/redis:alpine/get" > img.tar
+  sendIO . runResourceT $ do
+    response <- HTTPConduit.http request manager
+    runConduit $ HTTPConduit.responseBody response .| sinkFile (toString sinkTarget)
+
+-- | Gets Image Size from Image Description Json
+-- Refer to: https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageInspect
+getDockerImageSize :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => Text -> m Int
+getDockerImageSize img = do
+  let request = HTTP.parseRequest_ $ "http://localhost/v1.41/images/" <> (toString img) <> "/json"
+
+  -- Performs equivalent of for given image:
+  -- >> curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.41/images/redis:alpine/json"
+  response <- sendIO $ HTTP.httpLbs request =<< dockerClient
+
+  let body = HTTP.responseBody response
+  case eitherDecode body of
+    Left err -> fatalText . toText $ err
+    Right (DockerImageInspectJson imgSize) -> pure imgSize
+
+-- | True if Docker Engine API is accessible, otherwise False.
+-- Refer to: https://docs.docker.com/engine/api/v1.41/#tag/System/operation/SystemPing
+isAccessible :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => m Bool
+isAccessible = do
+  -- Performs equivalent of for given image:
+  -- >> curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.41/_ping"
+  response <- sendIO $ HTTP.httpLbs (HTTP.parseRequest_ "http://localhost/v1.41/_ping") =<< dockerClient
+  pure $ statusCode (HTTP.responseStatus response) == 200
+
+newtype DockerImageInspectJson = DockerImageInspectJson {imageSize :: Int}
+  deriving (Eq, Ord, Show)
+
+instance FromJSON DockerImageInspectJson where
+  parseJSON = withObject "image inspect json" $ \o ->
+    DockerImageInspectJson <$> o .: "Size"
+
+dockerClient :: Has (Lift IO) sig m => m HTTP.Manager
+dockerClient = unixSocketClient "/var/run/docker.sock"
+
+unixSocketClient :: FilePath -> Has (Lift IO) sig m => m HTTP.Manager
+unixSocketClient socketPath = socketHttpManager
+  where
+    socketHttpManager :: Has (Lift IO) sig m => m HTTP.Manager
+    socketHttpManager = sendIO $ HTTP.newManager socketManagerSettings
+
+    socketManagerSettings :: HTTP.ManagerSettings
+    socketManagerSettings = HTTP.defaultManagerSettings{HTTP.managerRawConnection = pure open}
+
+    open :: Maybe Socket.HostAddress -> String -> Int -> IO Connection
+    open _ _ _ = do
+      sock <-
+        Socket.socket
+          Socket.AF_UNIX -- We want unix domain socket
+          Socket.Stream -- We want TCP based connection
+          Socket.defaultProtocol -- Default of 0 (will defer based on socket type)
+      Socket.connect sock (Socket.SockAddrUnix socketPath)
+      HTTP.makeConnection
+        (SocketByteString.recv sock chunkBytes)
+        (SocketByteString.sendAll sock)
+        (Socket.close sock)
+
+    chunkBytes :: Int
+    chunkBytes = 4096

--- a/src/Control/Effect/DockerEngineApi.hs
+++ b/src/Control/Effect/DockerEngineApi.hs
@@ -1,0 +1,30 @@
+module Control.Effect.DockerEngineApi (
+  DockerEngineApiF (..),
+  DockerEngineApi,
+  getDockerImage,
+  getDockerImageSize,
+  isDockerEngineAccessible,
+) where
+
+import Control.Carrier.Simple (Has, Simple, sendSimple)
+import Data.Text (Text)
+import Path (Abs, File, Path)
+
+data DockerEngineApiF a where
+  ExportImage :: Text -> Path Abs File -> DockerEngineApiF ()
+  GetImageSize :: Text -> DockerEngineApiF Int
+  IsAccessible :: DockerEngineApiF Bool
+
+type DockerEngineApi = Simple DockerEngineApiF
+
+-- | Exports Docker Image Tarball to given path.
+getDockerImage :: (Has DockerEngineApi sig m) => Text -> Path Abs File -> m ()
+getDockerImage img path = sendSimple (ExportImage img path)
+
+-- | Gets Docker Image Size in Bytes.
+getDockerImageSize :: (Has DockerEngineApi sig m) => Text -> m Int
+getDockerImageSize = sendSimple . GetImageSize
+
+-- | True if Docker Engine is Accessible
+isDockerEngineAccessible :: (Has DockerEngineApi sig m) => m Bool
+isDockerEngineAccessible = sendSimple IsAccessible

--- a/src/Control/Effect/DockerEngineApi.hs
+++ b/src/Control/Effect/DockerEngineApi.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 module Control.Effect.DockerEngineApi (
   DockerEngineApiF (..),
   DockerEngineApi,
@@ -13,9 +15,12 @@ import Path (Abs, File, Path)
 data DockerEngineApiF a where
   ExportImage :: Text -> Path Abs File -> DockerEngineApiF ()
   GetImageSize :: Text -> DockerEngineApiF Int
-  IsAccessible :: DockerEngineApiF Bool
+  IsDockerEngineAccessible :: DockerEngineApiF Bool
 
 type DockerEngineApi = Simple DockerEngineApiF
+
+deriving instance Show (DockerEngineApiF a)
+deriving instance Eq (DockerEngineApiF a)
 
 -- | Exports Docker Image Tarball to given path.
 getDockerImage :: (Has DockerEngineApi sig m) => Text -> Path Abs File -> m ()
@@ -27,4 +32,4 @@ getDockerImageSize = sendSimple . GetImageSize
 
 -- | True if Docker Engine is Accessible
 isDockerEngineAccessible :: (Has DockerEngineApi sig m) => m Bool
-isDockerEngineAccessible = sendSimple IsAccessible
+isDockerEngineAccessible = sendSimple IsDockerEngineAccessible

--- a/test/App/Fossa/Container/AnalyzeNativeSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeSpec.hs
@@ -1,0 +1,67 @@
+module App.Fossa.Container.AnalyzeNativeSpec (spec) where
+
+import App.Fossa.Container.AnalyzeNative (ContainerImageSource (ContainerDockerImage), parseDockerEngineSource)
+import Control.Carrier.Diagnostics (DiagnosticsC, Has)
+import Control.Carrier.Stack (StackC, runStack)
+import Control.Effect.DockerEngineApi (DockerEngineApiF (GetImageSize, IsDockerEngineAccessible))
+import Data.Text (Text)
+import Effect.Logger (IgnoreLoggerC, ignoreLogger)
+import Test.Effect (expectFatal', handleDiag, shouldBe')
+import Test.Hspec (Spec, SpecWith, describe, it)
+import Test.MockDockerEngineApi (DockerEngineApiMockC, MockApi, MockApiC, alwaysReturns, fails, runApiWithMock, runMockApi)
+import Type.Operator (type ($))
+
+spec :: Spec
+spec = do
+  describe "parseDockerEngineSource" $ do
+    it' "should fail if docker engine is not accessible" $ do
+      expectDockerSdkNotAccessible
+      expectFatal' $ parseDockerEngineSource exampleImgWithTag
+
+    it' "should fail if text lacks tag signifier " $ do
+      expectDockerSdkToBeAccessible
+      expectFatal' $ parseDockerEngineSource exampleImgWithoutTag
+
+    it' "should fail if image's size cannot be retrieved" $ do
+      expectDockerSdkToBeAccessible
+      expectGetImageSizeToFail
+      expectFatal' $ parseDockerEngineSource exampleImgWithTag
+
+    it' "should parse image source if image size can be inferred via docker api" $ do
+      expectDockerSdkToBeAccessible
+      expectGetImageSizeToSucceed
+      src <- parseDockerEngineSource exampleImgWithTag
+      src `shouldBe'` ContainerDockerImage exampleImgWithTag
+
+exampleImgWithoutTag :: Text
+exampleImgWithoutTag = "redis"
+
+exampleImgWithTag :: Text
+exampleImgWithTag = "redis:alpine"
+
+expectDockerSdkNotAccessible :: Has MockApi sig m => m ()
+expectDockerSdkNotAccessible =
+  IsDockerEngineAccessible `alwaysReturns` False
+
+expectDockerSdkToBeAccessible :: Has MockApi sig m => m ()
+expectDockerSdkToBeAccessible =
+  IsDockerEngineAccessible `alwaysReturns` True
+
+expectGetImageSizeToFail :: Has MockApi sig m => m ()
+expectGetImageSizeToFail = fails (GetImageSize exampleImgWithTag) "fails"
+
+expectGetImageSizeToSucceed :: Has MockApi sig m => m ()
+expectGetImageSizeToSucceed = (GetImageSize exampleImgWithTag) `alwaysReturns` 100
+
+type EffStack = DockerEngineApiMockC $ DiagnosticsC $ MockApiC $ IgnoreLoggerC $ StackC IO
+
+it' :: String -> EffStack () -> SpecWith ()
+it' msg = it msg . runWithMockDockerEngineEff
+
+runWithMockDockerEngineEff :: EffStack () -> IO ()
+runWithMockDockerEngineEff =
+  runStack
+    . ignoreLogger
+    . runMockApi
+    . handleDiag
+    . runApiWithMock

--- a/test/App/Fossa/Container/AnalyzeNativeUploadSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeUploadSpec.hs
@@ -1,4 +1,4 @@
-module App.Fossa.Container.NativeAnalyzeSpec (spec) where
+module App.Fossa.Container.AnalyzeNativeUploadSpec (spec) where
 
 import App.Fossa.Container.AnalyzeNative (uploadScan)
 import App.Types (ProjectMetadata (..), ProjectRevision (..))

--- a/test/Test/MockDockerEngineApi.hs
+++ b/test/Test/MockDockerEngineApi.hs
@@ -108,7 +108,7 @@ instance (Algebra sig m, Has (Lift IO) sig m) => Algebra (MockApi :+: sig) (Mock
 
 isSingular :: ApiExpectation -> Bool
 isSingular (ApiExpectation Once _ _ _) = True
-isSingular (ApiExpectation Always _ _ _) = False
+isSingular _ = False
 
 checkResult :: ExpectationRequestType -> DockerEngineApiF a -> DockerEngineApiF a -> ApiResult a -> Maybe (ApiResult a)
 checkResult ExpectingExactRequest a b resp = resp <$ guard (a == b)

--- a/test/Test/MockDockerEngineApi.hs
+++ b/test/Test/MockDockerEngineApi.hs
@@ -1,0 +1,179 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.MockDockerEngineApi (
+  ApiExpectation,
+  DockerEngineApiMockC,
+  MockApi (..),
+  MockApiC (runMockApiC),
+  alwaysReturns,
+  assertAllSatisfied,
+  fails,
+  runMockApi,
+  runApiWithMock,
+) where
+
+import Control.Algebra (Algebra (..), Has, send, type (:+:) (..))
+import Control.Carrier.Simple (SimpleC, interpret)
+import Control.Carrier.State.Strict (StateC (StateC), evalState)
+import Control.Effect.Diagnostics (Diagnostics, fatalText)
+import Control.Effect.DockerEngineApi (DockerEngineApiF (ExportImage, GetImageSize, IsDockerEngineAccessible))
+import Control.Effect.Lift (Lift, sendIO)
+import Control.Effect.State (State, get, modify, put)
+import Control.Monad (guard)
+import Control.Monad.Trans (MonadIO)
+import Data.Kind (Type)
+import Data.List (intercalate)
+import Data.Text (Text)
+import Test.HUnit (assertFailure)
+
+type DockerEngineApiMockC = SimpleC DockerEngineApiF
+
+data MockApi (m :: Type -> Type) a where
+  MockApiAlways :: DockerEngineApiF a -> a -> MockApi m ()
+  MockApiFails :: DockerEngineApiF a -> Text -> MockApi m ()
+  MockApiRunExpectations :: DockerEngineApiF a -> MockApi m (Maybe (ApiResult a))
+  AssertUnexpectedCall :: DockerEngineApiF a -> MockApi m a
+  AssertAllSatisfied :: MockApi m ()
+
+data ExpectationRepetition
+  = Once
+  | Always
+  deriving (Eq, Ord, Show)
+
+data ExpectationRequestType
+  = ExpectingExactRequest
+  | ExpectingAnyRequest
+  deriving (Eq, Ord, Show)
+
+newtype ApiResult a = ApiResult (Either ApiFail a)
+newtype ApiFail = ApiFail {unApiFail :: Text}
+
+-- | An expectation of an API call made up of the request and response.
+data ApiExpectation where
+  ApiExpectation :: ExpectationRepetition -> ExpectationRequestType -> DockerEngineApiF a -> ApiResult a -> ApiExpectation
+
+alwaysReturns :: Has MockApi sig m => DockerEngineApiF a -> a -> m ()
+alwaysReturns req resp = send $ MockApiAlways req resp
+
+fails :: Has MockApi sig m => DockerEngineApiF a -> Text -> m ()
+fails req msg = send $ MockApiFails req msg
+
+assertAllSatisfied :: Has MockApi sig m => m ()
+assertAllSatisfied = send AssertAllSatisfied
+
+assertUnexpectedCall :: Has MockApi sig m => DockerEngineApiF a -> m a
+assertUnexpectedCall = send . AssertUnexpectedCall
+
+runExpectations :: Has MockApi sig m => DockerEngineApiF a -> m (Maybe (ApiResult a))
+runExpectations = send . MockApiRunExpectations
+
+newtype MockApiC m a = MockApiC
+  { runMockApiC :: StateC [ApiExpectation] m a
+  }
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+instance (Algebra sig m, Has (Lift IO) sig m) => Algebra (MockApi :+: sig) (MockApiC m) where
+  alg hdl sig ctx = MockApiC $ case sig of
+    L (MockApiAlways req resp) -> do
+      let expectation = ApiExpectation Always ExpectingExactRequest req (ApiResult (Right resp))
+      modify (++ [expectation])
+      pure ctx
+    L (MockApiFails req msg) -> do
+      let expectation = ApiExpectation Once ExpectingExactRequest req (ApiResult (Left (ApiFail msg)))
+      modify (++ [expectation])
+      pure ctx
+    L (MockApiRunExpectations req) -> do
+      (<$ ctx) <$> handleRequest req
+    L (AssertUnexpectedCall req) -> do
+      expectations <- get
+      a <-
+        sendIO . assertFailure $
+          "Unexpected call: \n  "
+            <> show req
+            <> "\n"
+            <> "Unsatisfied expectations: \n  "
+            <> intercalate "\n  " (map (\(ApiExpectation _ _ expectedReq _) -> show expectedReq) expectations)
+      pure (a <$ ctx)
+    L AssertAllSatisfied -> do
+      remainingExpectations <- get
+      let unsatisfiedSingleExpectations = filter isSingular remainingExpectations
+      if null unsatisfiedSingleExpectations
+        then pure ctx
+        else
+          sendIO . assertFailure $
+            "Test completed with unsatisfied expectations: \n  "
+              <> intercalate "\n  " (map (\(ApiExpectation _ _ req _) -> show req) unsatisfiedSingleExpectations)
+    R other -> alg (runMockApiC . hdl) (R other) ctx
+
+isSingular :: ApiExpectation -> Bool
+isSingular (ApiExpectation Once _ _ _) = True
+isSingular (ApiExpectation Always _ _ _) = False
+
+checkResult :: ExpectationRequestType -> DockerEngineApiF a -> DockerEngineApiF a -> ApiResult a -> Maybe (ApiResult a)
+checkResult ExpectingExactRequest a b resp = resp <$ guard (a == b)
+checkResult ExpectingAnyRequest _ _ resp = pure resp
+
+matchExpectation :: DockerEngineApiF a -> ApiExpectation -> Maybe (ApiResult a)
+matchExpectation a@(ExportImage{}) (ApiExpectation _ requestExpectation b@(ExportImage{}) resp) = checkResult requestExpectation a b resp
+matchExpectation a@(GetImageSize{}) (ApiExpectation _ requestExpectation b@(GetImageSize{}) resp) = checkResult requestExpectation a b resp
+matchExpectation a@(IsDockerEngineAccessible{}) (ApiExpectation _ requestExpectation b@(IsDockerEngineAccessible{}) resp) = checkResult requestExpectation a b resp
+matchExpectation _ _ = Nothing
+
+handleRequest ::
+  ( Has (State [ApiExpectation]) sig m
+  ) =>
+  forall a.
+  DockerEngineApiF a ->
+  m (Maybe (ApiResult a))
+handleRequest req = do
+  expectations <- get
+  case testExpectations req expectations of
+    Just (resp, expectations') -> do
+      put expectations'
+      pure (Just resp)
+    Nothing ->
+      pure Nothing
+
+testExpectations :: DockerEngineApiF a -> [ApiExpectation] -> Maybe (ApiResult a, [ApiExpectation])
+testExpectations _ [] = Nothing
+testExpectations req (expectation : rest) =
+  case matchExpectation req expectation of
+    Nothing -> fmap (expectation :) <$> testExpectations req rest
+    Just resp ->
+      if isSingular expectation
+        then Just (resp, rest)
+        else Just (resp, expectation : rest)
+
+runApiWithMock ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has MockApi sig m
+  ) =>
+  DockerEngineApiMockC m a ->
+  m a
+runApiWithMock f = do
+  result <- interpret runRequest f
+  assertAllSatisfied
+  pure result
+  where
+    runRequest ::
+      ( Has Diagnostics sig m
+      , Has MockApi sig m
+      ) =>
+      DockerEngineApiF a ->
+      m a
+    runRequest req = do
+      apiResult <- runExpectations req
+      case apiResult of
+        Just (ApiResult result) -> either (fatalText . unApiFail) pure result
+        Nothing ->
+          assertUnexpectedCall req
+
+runMockApi ::
+  ( Has (Lift IO) sig m
+  ) =>
+  MockApiC m a ->
+  m a
+runMockApi =
+  evalState [] . runMockApiC


### PR DESCRIPTION
# Overview

This PR, 
- Adds docker daemon image source
- Fixes err noise when only base layer image is analyzed 

## Acceptance criteria

When docker daemon is running and image exists locally (in `docker images` output) 
- fossa-cli can analyze local images from daemon
- temporary exported tarballs are deleted after use

## Testing plan

```bash
# Setup
git checkout feat/container-scanning/docker-sdk
make install-local
docker pull redis:alpine 

# Act
./fossa container analyze redis:alpine --experimental-scanner -o | jq
```

## Risks / Notes

N/A

## References

https://fossa.atlassian.net/browse/ANE-277

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
