### PR TITLE
Use --silent when calling pod ipc spec

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- CocoaPods: Fixes error when analyzing podspecs that print non-JSON text to stdout ([#1015]https://github.com/fossas/fossa-cli/pull/1015)
+
 ## v3.3.11
 
 - `fossa test` - `fossa test --json` produces json output when there are 0 issues found. ([#999](https://github.com/fossas/fossa-cli/pull/999))

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -133,6 +133,9 @@ buildGraphStatic PodLock{lockPods, lockDeps, lockExternalSources} = staticGraph
 type PodSpecCache = Map Text PodSpecJSON
 
 -- `pod ipc spec` returns the JSON representation of a fully-evaluated Podspec.
+-- The `--silent` flag suppresses stdout printed by a podspec that calls
+-- Pod::UI.puts, which can break JSON parsing.
+--
 -- See also:
 --
 -- - Command documentation: https://guides.cocoapods.org/terminal/commands.html#pod_ipc_spec

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -141,7 +141,7 @@ podIpcSpecCmd :: Text -> Command
 podIpcSpecCmd podSpecPath =
   Command
     { cmdName = "pod"
-    , cmdArgs = ["ipc", "spec", podSpecPath]
+    , cmdArgs = ["ipc", "spec", "--silent", podSpecPath]
     , cmdAllowErr = Never
     }
 


### PR DESCRIPTION
Podspec files are just Ruby files, and as such they can print to the console by calling `Pod::UI.puts` as seen in this real-world example: https://github.com/invertase/react-native-firebase/blob/97f6e273efaac64d8a62eae4be390289e69d506b/packages/app/RNFBApp.podspec#L26

Consider this standalone `podspec` file, slightly modified from the one above:

```
Pod::Spec.new do |s|
  Pod::UI.puts 'rekt'

  s.name                = "RNFBApp"
  s.version             = "1.0.0"
  s.description         = "my description"
  s.summary             = <<-DESC
                            A well tested feature rich Firebase implementation for React Native, supporting iOS & Android.
                          DESC
  s.homepage            = "http://invertase.io/oss/react-native-firebase"
  s.license             = "MIT"
  s.authors             = "Invertase Limited"
  s.source              = { :git => "https://github.com/invertase/react-native-firebase.git", :tag => "v#{s.version}" }
  s.social_media_url    = 'http://twitter.com/invertaseio'
  s.ios.deployment_target = "10.0"
  s.cocoapods_version   = '>= 1.10.2'
  s.source_files        = "ios/**/*.{h,m}"

  # React Native dependencies
  s.dependency          'React-Core'
end
```

Notice how the output of `pod ipc spec` includes non-JSON output in stdout, which causes the CLI to break when parsing it:

```
% pod ipc spec RNFBApp.podspec 2> /dev/null
rekt
{
  "name": "RNFBApp",
  "version": "1.0.0",
  "description": "my description",
  "summary": "A well tested feature rich Firebase implementation for React Native, supporting iOS & Android.",
  "homepage": "http://invertase.io/oss/react-native-firebase",
  "license": "MIT",
  "authors": "Invertase Limited",
  "source": {
    "git": "https://github.com/invertase/react-native-firebase.git",
    "tag": "v1.0.0"
  },
  "social_media_url": "http://twitter.com/invertaseio",
  "platforms": {
    "ios": "10.0"
  },
  "cocoapods_version": ">= 1.10.2",
  "source_files": "ios/**/*.{h,m}",
  "dependencies": {
    "React-Core": [

    ]
  }
}
```

This is fixed when we add the `--silent` flag:

```
% pod ipc spec --silent RNFBApp.podspec 2> /dev/null
{
  "name": "RNFBApp",
  "version": "1.0.0",
  "description": "my description",
  "summary": "A well tested feature rich Firebase implementation for React Native, supporting iOS & Android.",
  "homepage": "http://invertase.io/oss/react-native-firebase",
  "license": "MIT",
  "authors": "Invertase Limited",
  "source": {
    "git": "https://github.com/invertase/react-native-firebase.git",
    "tag": "v1.0.0"
  },
  "social_media_url": "http://twitter.com/invertaseio",
  "platforms": {
    "ios": "10.0"
  },
  "cocoapods_version": ">= 1.10.2",
  "source_files": "ios/**/*.{h,m}",
  "dependencies": {
    "React-Core": [

    ]
  }
}
```

The [`pod ipc spec` documentation](https://guides.cocoapods.org/terminal/commands.html#pod_ipc_spec) describes this flag as "Show nothing" which is not very precise. From what I can tell, `silent` only makes `UI.puts` a no-op, which is exactly what we need: https://github.com/CocoaPods/CocoaPods/blob/e83d3264d4960d53dcb0cc921b0468f768dd3ed4/lib/cocoapods/user_interface.rb#L340