### PR TITLE
refactor: Update the Hackage index-state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -47,14 +47,14 @@ source-repository-package
   subdir: yarn-lock
 
 -- Current hackage distribution does not support SSL_CERT_FILE, and SSL_CERT_DIR
--- environment variable. Modified source code below, supports aforementioned environment variables. 
+-- environment variable. Modified source code below, supports aforementioned environment variables.
 source-repository-package
   type: git
   location: https://github.com/fossas/hs-certificate
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
-index-state: hackage.haskell.org 2022-04-13T23:32:58Z
+index-state: hackage.haskell.org 2022-08-15T18:24:28Z
 
 package *
   extra-include-dirs: /opt/homebrew/include

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -46,7 +46,7 @@ source-repository-package
 -- Current implementation of yarn-lock throws runtime error, as described by patches:
 -- (a) https://github.com/Profpatsch/yarn2nix/pull/73
 -- (b) https://github.com/Profpatsch/yarn2nix/pull/72
--- TODO: Remove once, both PRs are merged. 
+-- TODO: Remove once, both PRs are merged.
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
@@ -54,11 +54,11 @@ source-repository-package
   subdir: yarn-lock
 
 -- Current hackage distribution does not support SSL_CERT_FILE, and SSL_CERT_DIR
--- environment variable. Modified source code below, supports aforementioned environment variables. 
+-- environment variable. Modified source code below, supports aforementioned environment variables.
 source-repository-package
   type: git
   location: https://github.com/fossas/hs-certificate
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
-index-state: hackage.haskell.org 2022-04-13T23:32:58Z
+index-state: hackage.haskell.org 2022-08-15T18:24:28Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -44,7 +44,7 @@ source-repository-package
 -- Current implementation of yarn-lock throws runtime error, as described by patches:
 -- (a) https://github.com/Profpatsch/yarn2nix/pull/73
 -- (b) https://github.com/Profpatsch/yarn2nix/pull/72
--- TODO: Remove once, both PRs are merged. 
+-- TODO: Remove once, both PRs are merged.
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
@@ -52,11 +52,11 @@ source-repository-package
   subdir: yarn-lock
 
 -- Current hackage distribution does not support SSL_CERT_FILE, and SSL_CERT_DIR
--- environment variable. Modified source code below, supports aforementioned environment variables. 
+-- environment variable. Modified source code below, supports aforementioned environment variables.
 source-repository-package
   type: git
   location: https://github.com/fossas/hs-certificate
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
-index-state: hackage.haskell.org 2022-04-13T23:32:58Z
+index-state: hackage.haskell.org 2022-08-15T18:24:28Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -46,7 +46,7 @@ source-repository-package
 -- Current implementation of yarn-lock throws runtime error, as described by patches:
 -- (a) https://github.com/Profpatsch/yarn2nix/pull/73
 -- (b) https://github.com/Profpatsch/yarn2nix/pull/72
--- TODO: Remove once, both PRs are merged. 
+-- TODO: Remove once, both PRs are merged.
 source-repository-package
   type: git
   location: https://github.com/fossas/yarn2nix
@@ -54,11 +54,11 @@ source-repository-package
   subdir: yarn-lock
 
 -- Current hackage distribution does not support SSL_CERT_FILE, and SSL_CERT_DIR
--- environment variable. Modified source code below, supports aforementioned environment variables. 
+-- environment variable. Modified source code below, supports aforementioned environment variables.
 source-repository-package
   type: git
   location: https://github.com/fossas/hs-certificate
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
-index-state: hackage.haskell.org 2022-04-13T23:32:58Z
+index-state: hackage.haskell.org 2022-08-15T18:24:28Z


### PR DESCRIPTION
# Overview

This PR updates the Hackage index-state. This allows newer versions of dependencies to be used when solving for the dependency install plan, although it does not necessarily change the versions of dependencies if they still solve to the same version.

## Acceptance criteria

No behavior changes.

## Testing plan

I'm hoping the CI tests will suffice for this.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
