### PR TITLE
refactor: Upgrade Aeson to 2.1.0.0

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -60,7 +60,7 @@ common lang
 -- TODO: Switch `semver` back to `versions` once https://github.com/fosskers/versions/issues/47 is fixed? This package maintainer seems much more responsive. Contrast https://github.com/brendanhay/semver/issues/12.
 common deps
   build-depends:
-    , aeson                        ^>=1.5.2.0
+    , aeson                        ^>=2.1.0.0
     , aeson-pretty                 ^>=0.8.9
     , algebraic-graphs             ^>=0.5
     , ansi-terminal                ^>=0.11
@@ -130,7 +130,7 @@ common deps
     , versions                     ^>=5.0.0
     , word8                        ^>=0.1.3
     , xml                          ^>=1.3.14
-    , yaml                         ^>=0.11.1
+    , yaml                         ^>=0.11.8
     , yarn-lock                    ^>=0.6.5
     , zip                          ^>=1.7.1
     , zlib                         ^>=0.6.2.1

--- a/src/Control/Carrier/Debug.hs
+++ b/src/Control/Carrier/Debug.hs
@@ -13,39 +13,10 @@ module Control.Carrier.Debug (
 ) where
 
 import Control.Carrier.AtomicState (AtomicStateC, modify, runAtomicState)
-import Control.Carrier.Diagnostics (
-  Algebra (..),
-  Diagnostics,
-  Handler,
-  Has,
-  SomeDiagnostic (..),
-  ToDiagnostic (renderDiagnostic),
-  errorBoundaryIO,
-  rethrow,
-  run,
-  send,
-  thread,
-  (~<~),
-  type (:+:) (..),
- )
+import Control.Carrier.Diagnostics
 import Control.Carrier.Output.IO (OutputC, output, runOutput)
 import Control.Carrier.Simple (Simple, sendSimple)
-import Control.Effect.Debug as X (
-  Algebra (..),
-  Debug (..),
-  Handler,
-  Has,
-  debugEffect,
-  debugError,
-  debugLog,
-  debugMetadata,
-  debugScope,
-  run,
-  send,
-  thread,
-  (~<~),
-  type (:+:) (..),
- )
+import Control.Effect.Debug as X
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Record (Recordable, SomeEffectResult (SomeEffectResult), recordEff)
 import Control.Monad.IO.Class (MonadIO)

--- a/src/Data/Aeson/Extra.hs
+++ b/src/Data/Aeson/Extra.hs
@@ -47,7 +47,7 @@ forbidMembers :: Text -> [Key] -> Object -> Parser ()
 forbidMembers typename names obj = traverse_ (badMember obj) names
   where
     badMember hashmap name =
-      when (Object.member (name) hashmap) $
+      when (Object.member name hashmap) $
         fail . toString $
           "Invalid field name for " <> typename <> ": " <> toText name
 

--- a/src/Data/Aeson/Extra.hs
+++ b/src/Data/Aeson/Extra.hs
@@ -6,11 +6,10 @@ module Data.Aeson.Extra (
 
 import Control.Applicative ((<|>))
 import Control.Monad (when)
-import Data.Aeson (ToJSON)
 import Data.Aeson qualified as Aeson
-import Data.Aeson.Types (FromJSON (parseJSON), Object, Parser)
+import Data.Aeson.KeyMap qualified as Object
+import Data.Aeson.Types (FromJSON (parseJSON), Key, Object, Parser, ToJSON)
 import Data.Foldable (traverse_)
-import Data.HashMap.Strict (member)
 import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
 
@@ -39,18 +38,18 @@ instance FromJSON TextLike where
       parseAsDouble = TextLike . toText . show <$> parseJSON @Double val
 
 -- | Parser insert to prevent specific fields from being used in parsers
--- Primarily useful for rejecting aeson fields which should be reported with custom error messages
+-- Primarily useful for rejecting Aeson fields which should be reported with custom error messages
 --
 -- >  parseJSON = withObject "MyDataType" $ \obj ->
 -- >   MyDataType <$> obj .: "my-data-field"
 -- >     <* forbidMembers "Custom error message" ["badfield1", "badfield2"] obj
-forbidMembers :: Text -> [Text] -> Object -> Parser ()
+forbidMembers :: Text -> [Key] -> Object -> Parser ()
 forbidMembers typename names obj = traverse_ (badMember obj) names
   where
     badMember hashmap name =
-      when (member name hashmap) $
+      when (Object.member (name) hashmap) $
         fail . toString $
-          "Invalid field name for " <> typename <> ": " <> name
+          "Invalid field name for " <> typename <> ": " <> toText name
 
 -- | Like 'Data.Aeson.encode', but produces @Text@ instead of @ByteString@
 encodeJSONToText :: ToJSON a => a -> Text

--- a/src/Data/String/Conversion.hs
+++ b/src/Data/String/Conversion.hs
@@ -11,6 +11,8 @@ module Data.String.Conversion (
   LazyStrict (..),
 ) where
 
+import Data.Aeson.Key (Key)
+import Data.Aeson.Key qualified as Key
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
 import Data.Text qualified as Text
@@ -83,6 +85,9 @@ instance ToText (SomeBase t) where
     Path.Abs p -> toText p
     Path.Rel p -> toText p
 
+instance ToText Key where
+  toText = Key.toText
+
 ----- ToLText
 
 class ToLText a where
@@ -130,6 +135,9 @@ instance ToString (SomeBase t) where
   toString = \case
     Path.Rel p -> toString p
     Path.Abs p -> toString p
+
+instance ToString Key where
+  toString = Key.toString
 
 ----- LazyStrict
 

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -27,12 +27,12 @@ import Control.Effect.State (State, get, put)
 import Control.Monad (when)
 import Data.Aeson (FromJSON (parseJSON), (.!=))
 import Data.Aeson qualified as JSON
+import Data.Aeson.KeyMap qualified as Object
 import Data.Aeson.Types (FromJSONKey)
 import Data.Bifunctor (first)
 import Data.Char qualified as C
 import Data.Foldable (asum, find, traverse_)
 import Data.Functor (void)
-import Data.HashMap.Lazy qualified as HashMap (toList)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.SemVer qualified as SemVer
@@ -352,8 +352,8 @@ instance FromJSON PodLock where
 
 instance FromJSON Pod where
   parseJSON (Yaml.String p) = parserPod p Nothing
-  parseJSON (Yaml.Object obj) = case HashMap.toList obj of
-    [(podEntry, podDepsListing)] -> parserPod podEntry $ Just podDepsListing
+  parseJSON (Yaml.Object obj) = case Object.toList obj of
+    [(podEntry, podDepsListing)] -> parserPod (toText podEntry) $ Just podDepsListing
     [] -> fail "Expected non empty list of dependencies, but received empty list"
     _ -> fail $ "Expected list of dependencies, but received: " <> show obj
   parseJSON notSupported = fail $ "Expected string, but received: " <> show notSupported

--- a/src/Strategy/Dart/PubSpec.hs
+++ b/src/Strategy/Dart/PubSpec.hs
@@ -13,6 +13,7 @@ module Strategy.Dart.PubSpec (
 
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context)
+import Data.Aeson qualified as Aeson
 import Data.Foldable (asum, for_)
 import Data.Map (Map, toList)
 import Data.Map.Strict qualified as Map
@@ -103,7 +104,7 @@ instance FromJSON PubSpecDepSource where
       parsePathSource :: Yaml.Object -> Yaml.Parser PubSpecDepSource
       parsePathSource po = PathSource . PubSpecDepPathSource <$> po .: "path"
 
-      (|>) :: FromJSON a => Yaml.Parser Yaml.Object -> Text -> Yaml.Parser a
+      (|>) :: FromJSON a => Yaml.Parser Yaml.Object -> Aeson.Key -> Yaml.Parser a
       (|>) parser key = do
         obj <- parser
         obj .: key

--- a/src/Strategy/Nim/NimbleLock.hs
+++ b/src/Strategy/Nim/NimbleLock.hs
@@ -30,12 +30,13 @@ import Data.Aeson (
   withText,
   (.:),
  )
+import Data.Aeson.KeyMap qualified as Object
 import Data.Aeson.Types (Parser)
-import Data.HashMap.Strict qualified as HM
 import Data.Map (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Set qualified as Set
+import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Traversable (for)
 import DepTypes (
@@ -85,8 +86,8 @@ instance FromJSON NimbleLock where
     where
       parsePkgs :: Value -> Parser [NimPackage]
       parsePkgs = withObject "NimPackage" $ \o ->
-        for (HM.toList o) $ \(pkgName, pkgMeta) -> do
-          parseNimPackageWithName (PackageName pkgName) pkgMeta
+        for (Object.toList o) $ \(pkgName, pkgMeta) ->
+          parseNimPackageWithName (PackageName $ toText pkgName) pkgMeta
 
       parseNimPackageWithName :: PackageName -> Value -> Parser NimPackage
       parseNimPackageWithName name = withObject "parseNimPackageWithName" $ \metaO ->

--- a/src/Strategy/Perl.hs
+++ b/src/Strategy/Perl.hs
@@ -11,7 +11,7 @@ import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject)
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Reader (Reader)
-import Data.Aeson (Object, ToJSON)
+import Data.Aeson (Key, Object, ToJSON)
 import Data.Aeson.Extra (TextLike (unTextLike))
 import Data.Aeson.Types (FromJSONKey, Parser, withObject)
 import Data.Aeson.Types qualified as AesonTypes
@@ -138,12 +138,12 @@ instance FromJSON PerlMeta where
       then parseAboveV1_4 o specVersion
       else parseBelowV1_5 o specVersion
     where
-      (|>) :: FromJSON a => Parser Object -> Text -> Parser a
+      (|>) :: FromJSON a => Parser Object -> Key -> Parser a
       (|>) parser key = do
         obj <- parser
         obj .: key
 
-      (|?>) :: FromJSON a => Parser (Maybe Object) -> Text -> Parser (Maybe a)
+      (|?>) :: FromJSON a => Parser (Maybe Object) -> Key -> Parser (Maybe a)
       (|?>) parser key = do
         obj <- parser
         case obj of

--- a/src/Strategy/Swift/PackageResolved.hs
+++ b/src/Strategy/Swift/PackageResolved.hs
@@ -6,6 +6,7 @@ module Strategy.Swift.PackageResolved (
 
 import Data.Aeson (
   FromJSON (parseJSON),
+  Key,
   Object,
   withObject,
   (.:),
@@ -39,12 +40,12 @@ instance FromJSON SwiftPackageResolvedFile where
       2 -> SwiftPackageResolvedFile version <$> ((obj .: "pins") >>= traverse (withObject "Package.resolved v2 pin" parseV2Pin))
       _ -> fail $ "unknown Package.resolved version: " <> show version
 
-(|>) :: FromJSON a => Parser Object -> Text -> Parser a
+(|>) :: FromJSON a => Parser Object -> Key -> Parser a
 (|>) parser key = do
   obj <- parser
   obj .: key
 
-(|?>) :: FromJSON a => Parser (Maybe Object) -> Text -> Parser (Maybe a)
+(|?>) :: FromJSON a => Parser (Maybe Object) -> Key -> Parser (Maybe a)
 (|?>) parser key = do
   obj <- parser
   case obj of


### PR DESCRIPTION
# Overview

This PR builds on top of #1018.

This PR upgrades Aeson to the latest version, 2.1.0.0. This unblocks a dependency upgrade that Hubble requires.

The main interface change for `aeson-2.1.0.0` is a change to `Object`s to be an ADT instead of literally a `HashMap`. Accordingly, I've fixed some usages of accessors and done some type conversions between `Text` and the new `Key` type where needed.

I've also made import lists explicit where I came across implicit ones.

## Acceptance criteria

No behavior changes.

## Testing plan

I'm banking on CI to be sufficient for this.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
