### PR TITLE
refactor: Upgrade dependencies and remove unused dependencies

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -62,7 +62,7 @@ common deps
   build-depends:
     , aeson                        ^>=2.1.0.0
     , aeson-pretty                 ^>=0.8.9
-    , algebraic-graphs             ^>=0.5
+    , algebraic-graphs             ^>=0.7
     , ansi-terminal                ^>=0.11
     , async                        ^>=2.2.2
     , attoparsec                   ^>=0.14.1

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -78,7 +78,6 @@ common deps
     , cryptonite                   ^>=0.30
     , deepseq                      >=1.4.5.0
     , directory                    ^>=1.3.6.1
-    , exceptions                   ^>=0.10.4
     , file-embed                   ^>=0.0.11
     , filepath                     ^>=1.4.2.1
     , filepattern                  ^>=0.1.2
@@ -109,7 +108,6 @@ common deps
     , req                          ^>=3.13.0
     , retry                        ^>=0.9.0.0
     , semver                       ^>=0.4.0.1
-    , split                        ^>=0.2.3.4
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
     , tar                          ^>=0.5.1.1
@@ -117,7 +115,6 @@ common deps
     , text                         ^>=1.2.3
     , th-lift-instances            ^>=0.1.17
     , time                         >=1.9      && <1.11
-    , timeit                       ^>=2.0
     , tomland                      ^>=1.3.3.0
     , transformers
     , typed-process                ^>=0.2.6
@@ -589,7 +586,6 @@ test-suite unit-tests
     , hedgehog                        ^>=1.1.1
     , hspec                           ^>=2.10.0.1
     , hspec-core                      ^>=2.10.0.1
-    , hspec-expectations-pretty-diff  ^>=0.7.2.5
     , hspec-hedgehog                  ^>=0.0.1.2
     , hspec-megaparsec                ^>=2.2
     , HUnit                           ^>=1.6.0
@@ -627,10 +623,6 @@ test-suite integration-tests
   build-depends:
     , hedgehog                        ^>=1.1.1
     , hspec                           ^>=2.10.0.1
-    , hspec-core                      ^>=2.10.0.1
-    , hspec-expectations-pretty-diff  ^>=0.7.2.5
-    , hspec-hedgehog                  ^>=0.0.1.2
-    , hspec-megaparsec                ^>=2.2
     , req-conduit                     ^>=1.0.1
     , spectrometer
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -56,7 +56,7 @@ common lang
     -Wincomplete-record-updates -Wmissing-home-modules
     -Wmissing-export-lists -Wredundant-constraints
 
--- TODO: Switch `semver` back to `versions` once https://github.com/fosskers/versions/issues/47 is fixed? This package maintainer seems much more responsive. Contrast https://github.com/brendanhay/semver/issues/12.
+-- TODO: Switch `semver` back to `versions` since https://github.com/fosskers/versions/issues/47 is fixed. This package maintainer seems much more responsive. Contrast https://github.com/brendanhay/semver/issues/12.
 common deps
   build-depends:
     , aeson                        ^>=2.1.0.0

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -581,7 +581,7 @@ test-suite unit-tests
     Yarn.V2.LockfileSpec
     Yarn.V2.ResolversSpec
 
-  build-tool-depends: hspec-discover:hspec-discover ^>=2.8.2
+  build-tool-depends: hspec-discover:hspec-discover ^>=2.10.0.1
   build-depends:
     , hedgehog          ^>=1.1.1
     , hspec             ^>=2.10.0.1
@@ -619,7 +619,7 @@ test-suite integration-tests
     Analysis.RustSpec
     Analysis.ScalaSpec
 
-  build-tool-depends: hspec-discover:hspec-discover ^>=2.8.2
+  build-tool-depends: hspec-discover:hspec-discover ^>=2.10.0.1
   build-depends:
     , hedgehog      ^>=1.1.1
     , hspec         ^>=2.10.0.1

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -583,12 +583,12 @@ test-suite unit-tests
 
   build-tool-depends: hspec-discover:hspec-discover ^>=2.8.2
   build-depends:
-    , hedgehog                        ^>=1.1.1
-    , hspec                           ^>=2.10.0.1
-    , hspec-core                      ^>=2.10.0.1
-    , hspec-hedgehog                  ^>=0.0.1.2
-    , hspec-megaparsec                ^>=2.2
-    , HUnit                           ^>=1.6.0
+    , hedgehog          ^>=1.1.1
+    , hspec             ^>=2.10.0.1
+    , hspec-core        ^>=2.10.0.1
+    , hspec-hedgehog    ^>=0.0.1.2
+    , hspec-megaparsec  ^>=2.2
+    , HUnit             ^>=1.6.0
     , spectrometer
 
 test-suite integration-tests
@@ -621,9 +621,9 @@ test-suite integration-tests
 
   build-tool-depends: hspec-discover:hspec-discover ^>=2.8.2
   build-depends:
-    , hedgehog                        ^>=1.1.1
-    , hspec                           ^>=2.10.0.1
-    , req-conduit                     ^>=1.0.1
+    , hedgehog      ^>=1.1.1
+    , hspec         ^>=2.10.0.1
+    , req-conduit   ^>=1.0.1
     , spectrometer
 
 benchmark bench

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -56,7 +56,6 @@ common lang
     -Wincomplete-record-updates -Wmissing-home-modules
     -Wmissing-export-lists -Wredundant-constraints
 
--- TODO: base16-bytestring isn't a direct dep, but we need to add version bounds because cpio-conduit fails to compile with a newer version. Remove the dependency on base16-bytestring once we fix or bump cpio-conduit
 -- TODO: Switch `semver` back to `versions` once https://github.com/fosskers/versions/issues/47 is fixed? This package maintainer seems much more responsive. Contrast https://github.com/brendanhay/semver/issues/12.
 common deps
   build-depends:
@@ -66,7 +65,6 @@ common deps
     , ansi-terminal                ^>=0.11
     , async                        ^>=2.2.2
     , attoparsec                   ^>=0.14.1
-    , base16-bytestring            ^>=1.0.1.0
     , bytestring                   ^>=0.10.8
     , bzlib                        ^>=0.5.0.0
     , cgroup-rts-threads           ^>=0.2.0.0
@@ -77,7 +75,7 @@ common deps
     , conduit-zstd                 ^>=0.0.2.0
     , containers                   ^>=0.6.0
     , cpio-conduit                 ^>=0.7.0
-    , cryptonite                   ^>=0.29
+    , cryptonite                   ^>=0.30
     , deepseq                      >=1.4.5.0
     , directory                    ^>=1.3.6.1
     , exceptions                   ^>=0.10.4
@@ -95,20 +93,20 @@ common deps
     , http-types                   ^>=0.12.3
     , lzma                         ^>=0.0.0.3
     , lzma-conduit                 ^>=1.2.1
-    , megaparsec                   ^>=9.1.0
+    , megaparsec                   ^>=9.2.0
     , modern-uri                   ^>=0.3.4
     , mtl                          ^>=2.2.2
     , network                      ^>=3.1.2.0
-    , optparse-applicative         >=0.15     && <0.17
+    , optparse-applicative         ^>=0.17.0.0
     , parser-combinators           ^>=1.3
     , path                         ^>=0.9.0
-    , path-io                      ^>=1.6.0
-    , pretty-simple                ^>=4.0
+    , path-io                      ^>=1.7.0
+    , pretty-simple                ^>=4.1.1.0
     , prettyprinter                >=1.6      && <1.8
     , prettyprinter-ansi-terminal  ^>=1.1.1
     , random                       ^>=1.2.0
     , raw-strings-qq               ^>=1.1
-    , req                          ^>=3.9.1
+    , req                          ^>=3.13.0
     , retry                        ^>=0.9.0.0
     , semver                       ^>=0.4.0.1
     , split                        ^>=0.2.3.4
@@ -123,10 +121,10 @@ common deps
     , tomland                      ^>=1.3.3.0
     , transformers
     , typed-process                ^>=0.2.6
-    , unix-compat                  ^>=0.5.4
+    , unix-compat                  ^>=0.6
     , unordered-containers         ^>=0.2.10
     , uuid                         ^>=1.3.15
-    , vector                       ^>=0.12.0.3
+    , vector                       ^>=0.13.0.0
     , versions                     ^>=5.0.0
     , word8                        ^>=0.1.3
     , xml                          ^>=1.3.14
@@ -588,9 +586,9 @@ test-suite unit-tests
 
   build-tool-depends: hspec-discover:hspec-discover ^>=2.8.2
   build-depends:
-    , hedgehog                        ^>=1.0.2
-    , hspec                           ^>=2.8.2
-    , hspec-core                      ^>=2.8.2
+    , hedgehog                        ^>=1.1.1
+    , hspec                           ^>=2.10.0.1
+    , hspec-core                      ^>=2.10.0.1
     , hspec-expectations-pretty-diff  ^>=0.7.2.5
     , hspec-hedgehog                  ^>=0.0.1.2
     , hspec-megaparsec                ^>=2.2
@@ -627,9 +625,9 @@ test-suite integration-tests
 
   build-tool-depends: hspec-discover:hspec-discover ^>=2.8.2
   build-depends:
-    , hedgehog                        ^>=1.0.2
-    , hspec                           ^>=2.8.2
-    , hspec-core                      ^>=2.8.2
+    , hedgehog                        ^>=1.1.1
+    , hspec                           ^>=2.10.0.1
+    , hspec-core                      ^>=2.10.0.1
     , hspec-expectations-pretty-diff  ^>=0.7.2.5
     , hspec-hedgehog                  ^>=0.0.1.2
     , hspec-megaparsec                ^>=2.2

--- a/src/Algebra/Graph/AdjacencyMap/Extra.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Extra.hs
@@ -73,4 +73,4 @@ takeReachable :: forall a. Ord a => a -> AM.AdjacencyMap a -> AM.AdjacencyMap a
 takeReachable x gr = AM.induce (`Set.member` vertices) gr
   where
     vertices :: Set a
-    vertices = Set.fromList $ AMA.reachable x gr
+    vertices = Set.fromList $ AMA.reachable gr x

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -321,7 +321,7 @@ pruneUnreachable (Graphing gr) =
     directNodes = Set.toList $ AM.postSet Root gr
 
     reachableNodes :: Set.Set (Node ty)
-    reachableNodes = Set.fromList $ AMA.dfs directNodes gr
+    reachableNodes = Set.fromList $ AMA.dfs gr directNodes
 
     keepPredicate :: Node ty -> Bool
     keepPredicate Root = True
@@ -352,7 +352,7 @@ getRootsOf :: forall ty. (Ord ty) => Graphing ty -> ty -> [ty]
 getRootsOf (Graphing gr) from = Prelude.filter (/= from) $ mapMaybe withoutRoots (Prelude.filter predecessorIsRoot reachableNodes)
   where
     reachableNodes :: [Node ty]
-    reachableNodes = AMA.reachable (Node from) (AM.transpose gr)
+    reachableNodes = AMA.reachable (AM.transpose gr) (Node from)
 
     predecessorIsRoot :: Node ty -> Bool
     predecessorIsRoot node = Root `Set.member` AM.preSet node gr
@@ -390,7 +390,7 @@ subGraphOf n (Graphing gr) =
     nodes = Prelude.filter (== Node n) $ AM.vertexList gr
 
     reachableNodes :: Set.Set (Node ty)
-    reachableNodes = Set.fromList $ AMA.dfs nodes gr
+    reachableNodes = Set.fromList $ AMA.dfs gr nodes
 
     keepPredicate :: Node ty -> Bool
     keepPredicate Root = True

--- a/src/Graphing/Hydrate.hs
+++ b/src/Graphing/Hydrate.hs
@@ -24,7 +24,7 @@ hydrate extractList update gr = Graphing.gmap doPromotion gr
     topVia subItem = AM.vertexList $ AM.induce (elem subItem . extractList) adjMap
     -- Get all nodes reachable from a list of nodes
     allFrom :: b -> Set a
-    allFrom item = Set.fromList $ concatMap (`AMA.reachable` adjMap) (topVia item)
+    allFrom item = Set.fromList $ concatMap (adjMap `AMA.reachable`) (topVia item)
 
     -- Dedup'd sub-items from all vertices in the AdjMap
     allSubItems :: Set b

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -61,7 +61,7 @@ buildProjectClosures basedir global = closures
 
 -- Find reachable nodes both below (children, grandchildren, ...) and above (parents, grandparents) the node
 bidirectionalReachable :: Ord a => a -> AM.AdjacencyMap a -> Set.Set a
-bidirectionalReachable node gr = Set.fromList $ AM.reachable node gr ++ AM.reachable node (AM.transpose gr)
+bidirectionalReachable node gr = Set.fromList $ AM.reachable gr node ++ AM.reachable (AM.transpose gr) node
 
 sourceVertices :: Ord a => AM.AdjacencyMap a -> [a]
 sourceVertices graph = [v | v <- AM.vertexList graph, Set.null (AM.preSet v graph)]
@@ -99,10 +99,10 @@ determineProjectRoots rootDir closure = go . Set.fromList
         frontier = Set.unions $ Set.map (\coord -> AM.postSet coord (globalGraph closure)) remainingCoords
 
 data MavenProjectClosure = MavenProjectClosure
-  { closureAnalysisRoot :: Path Abs Dir
-  -- ^ the root of global fossa-analyze analysis; needed for pathfinder license scan
-  , closurePath :: Path Abs File
-  -- ^ path of the pom file used as the root of this project closure
+  { -- | the root of global fossa-analyze analysis; needed for pathfinder license scan
+    closureAnalysisRoot :: Path Abs Dir
+  , -- | path of the pom file used as the root of this project closure
+    closurePath :: Path Abs File
   , closureRootCoord :: MavenCoordinate
   , closureRootPom :: Pom
   , closureGraph :: AM.AdjacencyMap MavenCoordinate

--- a/src/Strategy/Maven/Pom/Closure.hs
+++ b/src/Strategy/Maven/Pom/Closure.hs
@@ -99,10 +99,10 @@ determineProjectRoots rootDir closure = go . Set.fromList
         frontier = Set.unions $ Set.map (\coord -> AM.postSet coord (globalGraph closure)) remainingCoords
 
 data MavenProjectClosure = MavenProjectClosure
-  { -- | the root of global fossa-analyze analysis; needed for pathfinder license scan
-    closureAnalysisRoot :: Path Abs Dir
-  , -- | path of the pom file used as the root of this project closure
-    closurePath :: Path Abs File
+  { closureAnalysisRoot :: Path Abs Dir
+  -- ^ the root of global fossa-analyze analysis; needed for pathfinder license scan
+  , closurePath :: Path Abs File
+  -- ^ path of the pom file used as the root of this project closure
   , closureRootCoord :: MavenCoordinate
   , closureRootPom :: Pom
   , closureGraph :: AM.AdjacencyMap MavenCoordinate


### PR DESCRIPTION
# Overview

This PR blocks on #1018 and #1019.

This PR upgrades the remaining dependencies that `packdeps` indicated were out-of-date, and removes dependencies that `prune-juice` indicated were unused. There were basically no code changes needed for these upgrades, except that `algebraic-graphs` changed some argument orders around.

## Acceptance criteria

No behavior changes.

## Testing plan

I am once again asking for CI's support in confirming the correctness of this PR.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
