### PR TITLE
VSI: Better error when no deps found

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,10 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## 3.3.12
 
-- CocoaPods: Fixes error when analyzing podspecs that print non-JSON text to stdout ([#1015]https://github.com/fossas/fossa-cli/pull/1015)
+- CocoaPods: Fixes error when analyzing podspecs that print non-JSON text to stdout ([#1015](https://github.com/fossas/fossa-cli/pull/1015))
+- VSI: Executes with at least two threads even on a single core system ([#1013](https://github.com/fossas/fossa-cli/pull/1013))
+- VSI: Reports a better error when no dependencies are found ([#1023](https://github.com/fossas/fossa-cli/pull/1023)).
 
 ## v3.3.11
 

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -25,6 +25,7 @@ import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Stack (Stack)
 import Control.Effect.StickyLogger (StickyLogger, logSticky, logSticky')
 import Control.Effect.TaskPool (TaskPool, forkTask)
+import Control.Monad (when)
 import Data.Foldable (traverse_)
 import Data.Map qualified as Map
 import Data.String.Conversion (toText)
@@ -78,6 +79,8 @@ runVsiAnalysis dir projectRevision filters = context "VSI" $ do
   context "Wait for cloud analysis" $ waitForAnalysis scanID
 
   discoveredRawLocators <- context "Download analysis results" $ getVsiInferences scanID
+  when (null discoveredRawLocators) $ fatalText "No dependencies discovered with VSI"
+
   parsedLocators <- context "Parse analysis results" . fromEither $ traverse VSI.parseLocator discoveredRawLocators
 
   let userDefinedDeps = map IAT.toUserDep $ filter VSI.isUserDefined parsedLocators

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -69,7 +69,9 @@ import Data.Aeson (
   encode,
   object,
   withObject,
+  (.!=),
   (.:),
+  (.:?),
  )
 import Data.Aeson qualified as Aeson
 import Data.ByteString qualified as BS
@@ -904,7 +906,7 @@ newtype VSIExportedInferencesBody = VSIExportedInferencesBody {unVSIExportedInfe
 
 instance FromJSON VSIExportedInferencesBody where
   parseJSON = withObject "VSIExportedInferencesBody" $ \obj -> do
-    plainLocators <- obj .: "locators"
+    plainLocators <- obj .:? "locators" .!= []
     pure . VSIExportedInferencesBody $ fmap parseLocator plainLocators
 
 vsiDownloadInferencesEndpoint :: Url scheme -> VSI.ScanID -> Url scheme


### PR DESCRIPTION
# Overview

This PR updates the VSI process to report a better error when no dependencies are found.

New:
```
; cabal run fossa -- analyze experimental-scripts --experimental-enable-vsi --only-target vsi
Up to date
[ INFO] Running VSI analysis
[ INFO] Created Scan ID: 3eefbdf5-b416-4119-9d76-ea26f617db85
[ INFO] Finalizing scan
[ INFO] Waiting for cloud analysis
[ INFO] Running in VSI only mode, skipping manual source units
[ERROR] ----------
  An issue occurred

  >>> Relevant errors

    Error

      No dependencies discovered with VSI

      Traceback:
        - VSI
        - analyze-vsi
        - fossa-analyze


[ INFO] Running in VSI only mode, skipping other analyzers
[ INFO]
[ INFO] Scan Summary
[ INFO] ------------
[ INFO] fossa-cli branch vsi-api-error (revision e99457f6279f (dirty) compiled with ghc-9.0)
[ INFO] fossa endpoint server version: 4.0.37
[ INFO]
[ INFO] 1 projects scanned;  0 skipped,  0 succeeded,  1 failed,  0 analysis warnings
[ INFO]
[ INFO] -
[ INFO] * vsi analysis: failed
[ INFO]
[ INFO]
[ INFO] You can pass `--debug` option to eagerly show all warning and failure messages.
[ INFO] You can also view analysis summary with warning and error messages at: "/private/var/folders/q7/3nvvpy0d6js28m8lypw3tcx80000gn/T/fossa-analyze-scan-summary.txt"
[ INFO] ------------
[ERROR] ----------
  An issue occurred

  >>> Relevant errors

    Error

      No analysis targets found in directory.

      Make sure your project is supported. See the user guide for details:
          https://github.com/fossas/fossa-cli/blob/vsi-api-error/docs/README.md


      Traceback:
        - fossa-analyze
```

Previously, the VSI section would read:
```
An error occurred when deserializing a response from the FOSSA API: Error in $: key "locators" not found
```

## Acceptance criteria



## Testing plan

I tested a project with no dependencies (above), and a project with dependencies still works:
```
; cabal run fossa -- analyze ~/projects/cpp-vsi-demo --experimental-enable-vsi --only-target vsi
Up to date
[ INFO] Running VSI analysis
[ INFO] Created Scan ID: 9384b3f1-eb2f-4f03-822a-ced3c91deb8d
[ INFO] Finalizing scan
[ INFO] Waiting for cloud analysis
[ INFO] Running in VSI only mode, skipping manual source units
[ INFO] Running in VSI only mode, skipping other analyzers
[ INFO]
[ INFO] Scan Summary
[ INFO] ------------
[ INFO] fossa-cli branch vsi-api-error (revision e99457f6279f (dirty) compiled with ghc-9.0)
[ INFO] fossa endpoint server version: 4.0.37
[ INFO]
[ INFO] 1 projects scanned;  0 skipped,  1 succeeded,  0 failed,  0 analysis warnings
[ INFO]
[ INFO] -
[ INFO] * vsi analysis: succeeded
[ INFO]
[ INFO]
[ INFO] You can pass `--debug` option to eagerly show all warning and failure messages.
[ INFO] You can also view analysis summary with warning and error messages at: "/private/var/folders/q7/3nvvpy0d6js28m8lypw3tcx80000gn/T/fossa-analyze-scan-summary.txt"
[ INFO] ------------
[ INFO]
[ INFO] Using project name: `git@github.com:fossas/cpp-vsi-demo.git`
[ INFO] Using revision: `76987d9d364bc2c73897549a71d13371a32cd3e7`
[ INFO] Using branch: `main`
[ INFO] ============================================================
[ INFO]
[ INFO]     View FOSSA Report:
[ INFO]     https://app.fossa.com/projects/custom%2b24357%2fgit%40github.com%3afossas%2fcpp-vsi-demo.git/refs/branch/main/76987d9d364bc2c73897549a71d13371a32cd3e7
[ INFO]
[ INFO] ============================================================
```

## Risks

Not risky.

## References

None, customer complaint.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
