### PR TITLE
Container Scanning: Adds podman support

### DIFF
--- a/docs/references/experimental/container/podman.md
+++ b/docs/references/experimental/container/podman.md
@@ -46,7 +46,7 @@ Now we can specify `DOCKER_HOST` when running `fossa-cli`.
 DOCKER_HOST='unix:///Users/fossa/.local/share/containers/podman/machine/podman-machine-default/podman.sock' fossa container analyze --experimental-scanner
 ```
 
-Likewise, if you are using `podman-remote`, you should be able to use generate unix socket, and use it with `fossa-cli`. Refer to documentation belows for more details.
+Likewise, if you are using `podman-remote`, you should be able to use generate unix socket, and use it with `fossa-cli`. Refer to documentation below for more details.
 
 Refer to documentation here:
 - https://podman.io/blogs/2020/07/01/rest-versioning.html
@@ -56,7 +56,7 @@ Refer to documentation here:
 
 # Integration via Podman Executables
 
-`fossa-cli` will perform, following command:
+`fossa-cli` will perform the following command:
 
 ```bash
 # check if image exists
@@ -66,9 +66,9 @@ podman image inspect <ARG>
 # and perform analysis on exported image.
 podman save --format docker-archive -o <temp-path>
 ```
-`fossa-cli`, will look for `podman` executable in `$PATH`.
+`fossa-cli` will look for `podman` executable in `$PATH`.
 
-> Note this is same approach as 'Integration via Docker Archive except that
+> Note this is same approach as integration via Docker Archive except that
 > `fossa-cli` performs necessary invocation and does cleanup of artifacts.
 
 # Integration via Docker Archive

--- a/docs/references/experimental/container/podman.md
+++ b/docs/references/experimental/container/podman.md
@@ -1,0 +1,87 @@
+## Experimental Scanner - Podman
+
+`fossa-cli` can use podman client to perform container image scanning analysis. 
+
+# Integration via Podman's Docker Compatible API
+
+`fossa-cli` will look for environment variable `DOCKER_HOST`,
+to infer docker engine api's socket location. As of now, `fossa-cli`
+only works with `unix://` socket. 
+
+For podman, you can use `podman machine start` command, to retrieve
+Docker client compatible `DOCKER_HOST`.
+
+```bash
+➜ podman machine start
+Starting machine "podman-machine-default"
+Waiting for VM ...
+Mounting volume... /Users/fossa:/Users/fossa
+
+This machine is currently configured in rootless mode. If your containers
+require root permissions (e.g. ports < 1024), or if you run into compatibility
+issues with non-podman clients, you can switch using the following command: 
+
+	podman machine set --rootful
+
+API forwarding listening on: /Users/fossa/.local/share/containers/podman/machine/podman-machine-default/podman.sock
+
+The system helper service is not installed; the default Docker API socket
+address can\'t be used by podman. If you would like to install it run the
+following commands:
+
+	sudo /usr/local/Cellar/podman/4.2.0/bin/podman-mac-helper install
+	podman machine stop; podman machine start
+
+You can still connect Docker API clients by setting DOCKER_HOST using the
+following command in your terminal session:
+
+	export DOCKER_HOST='unix:///Users/fossa/.local/share/containers/podman/machine/podman-machine-default/podman.sock'
+
+Machine "podman-machine-default" started successfully
+```
+
+Now we can specify `DOCKER_HOST` when running `fossa-cli`. 
+
+```bash
+DOCKER_HOST='unix:///Users/fossa/.local/share/containers/podman/machine/podman-machine-default/podman.sock' fossa container analyze --experimental-scanner
+```
+
+Likewise, if you are using `podman-remote`, you should be able to use generate unix socket, and use it with `fossa-cli`. Refer to documentation belows for more details.
+
+Refer to documentation here:
+- https://podman.io/blogs/2020/07/01/rest-versioning.html
+- https://docs.podman.io/en/latest/_static/api.html
+- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_using-the-container-tools-api_building-running-and-managing-containers
+
+
+# Integration via Podman Executables
+
+`fossa-cli` will perform, following command:
+
+```bash
+# check if image exists
+podman image inspect <ARG>
+
+# export said image to temporary location, 
+# and perform analysis on exported image.
+podman save --format docker-archive -o <temp-path>
+```
+`fossa-cli`, will look for `podman` executable in `$PATH`.
+
+> Note this is same approach as 'Integration via Docker Archive except that
+> `fossa-cli` performs necessary invocation and does cleanup of artifacts.
+
+# Integration via Docker Archive
+
+We can manually export image using podman, and analyze such image
+with `fossa-cli`.  
+
+```bash
+podman build . -t someImg:1.0.0
+podman save --format docker-archive -o image.tar
+
+fossa container analyze image.tar --experimental-scanner
+
+# Cleanup
+rm image.tar
+```

--- a/docs/references/subcommands/container.md
+++ b/docs/references/subcommands/container.md
@@ -11,7 +11,7 @@ Fossa container has following options:
 
 Fossa container analyze, can scan container image from,
 
-1) Docker Tarball
+1) Docker archive
 2) Docker Engine (accessed via unix socket /var/lib/docker.sock)
 3) OCI Registry
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -180,8 +180,9 @@ library
     App.Fossa.Container.Analyze
     App.Fossa.Container.AnalyzeNative
     App.Fossa.Container.Scan
+    App.Fossa.Container.Sources.DockerArchive
     App.Fossa.Container.Sources.DockerEngine
-    App.Fossa.Container.Sources.DockerTarball
+    App.Fossa.Container.Sources.Podman
     App.Fossa.Container.Sources.Registry
     App.Fossa.Container.Test
     App.Fossa.DumpBinaries

--- a/src/App/Fossa/Config/Container/Analyze.hs
+++ b/src/App/Fossa/Config/Container/Analyze.hs
@@ -121,7 +121,6 @@ mergeOpts cfgfile envvars cliOpts@ContainerAnalyzeOptions{..} = do
   let scanDest = collectScanDestination cfgfile envvars cliOpts
       severity = getSeverity cliOpts
       imageLoc = containerAnalyzeImage
-      dockerHost = collectDockerHost envvars
       arch = collectArch
       revOverride =
         collectRevisionOverride cfgfile $
@@ -134,7 +133,7 @@ mergeOpts cfgfile envvars cliOpts@ContainerAnalyzeOptions{..} = do
     <*> pure revOverride
     <*> pure imageLoc
     <*> pure containerExperimentalScanner
-    <*> pure dockerHost
+    <*> collectDockerHost envvars
     <*> pure arch
     <*> pure severity
 

--- a/src/App/Fossa/Config/Container/Analyze.hs
+++ b/src/App/Fossa/Config/Container/Analyze.hs
@@ -21,6 +21,8 @@ import App.Fossa.Config.Common (
 import App.Fossa.Config.ConfigFile (ConfigFile)
 import App.Fossa.Config.Container.Common (
   ImageText,
+  collectArch,
+  collectDockerHost,
   imageTextArg,
  )
 import App.Fossa.Config.EnvironmentVars (EnvVars)
@@ -57,7 +59,10 @@ data ContainerAnalyzeConfig = ContainerAnalyzeConfig
   { scanDestination :: ScanDestination
   , revisionOverride :: OverrideProject
   , imageLocator :: ImageText
-  , usesExperimentalScanner :: Bool
+  , -- \* For Experimental Scanner
+    usesExperimentalScanner :: Bool
+  , dockerHost :: Text
+  , arch :: Text
   , severity :: Severity
   }
   deriving (Eq, Ord, Show, Generic)
@@ -116,6 +121,8 @@ mergeOpts cfgfile envvars cliOpts@ContainerAnalyzeOptions{..} = do
   let scanDest = collectScanDestination cfgfile envvars cliOpts
       severity = getSeverity cliOpts
       imageLoc = containerAnalyzeImage
+      dockerHost = collectDockerHost envvars
+      arch = collectArch
       revOverride =
         collectRevisionOverride cfgfile $
           OverrideProject
@@ -127,6 +134,8 @@ mergeOpts cfgfile envvars cliOpts@ContainerAnalyzeOptions{..} = do
     <*> pure revOverride
     <*> pure imageLoc
     <*> pure containerExperimentalScanner
+    <*> pure dockerHost
+    <*> pure arch
     <*> pure severity
 
 collectScanDestination ::

--- a/src/App/Fossa/Config/Container/Common.hs
+++ b/src/App/Fossa/Config/Container/Common.hs
@@ -1,12 +1,18 @@
 module App.Fossa.Config.Container.Common (
   ImageText (..),
   imageTextArg,
+  collectDockerHost,
+  collectArch,
 ) where
 
+import App.Fossa.Config.EnvironmentVars (EnvVars (EnvVars, envDockerHost))
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
+import Data.String.Conversion (toText)
 import Data.Text (Text)
+import Data.Text qualified as Text
 import GHC.Generics (Generic)
 import Options.Applicative (Parser, argument, help, metavar, str)
+import System.Info (arch)
 
 newtype ImageText = ImageText
   { unImageText :: Text
@@ -18,3 +24,30 @@ instance ToJSON ImageText where
 
 imageTextArg :: Parser ImageText
 imageTextArg = ImageText <$> argument str (metavar "IMAGE" <> help "The image to scan")
+
+-- | Get current runtime arch, We use this to find suitable image,
+-- if multi-platform image is discovered. This is similar to
+-- how docker pull, and existing behavior works
+--
+-- Ref: https://docs.docker.com/desktop/multi-arch/
+collectArch :: Text
+collectArch =
+  toText $
+    if arch == "x86_64" -- x86_64 is equivalent to amd64
+      then "amd64"
+      else arch
+
+collectDockerHost :: EnvVars -> Text
+collectDockerHost EnvVars{envDockerHost} =
+  case envDockerHost of
+    Nothing -> defaultDockerHost
+    Just host ->
+      if Text.isPrefixOf "unix://" host
+        then withoutUnixSocketScheme host
+        else defaultDockerHost
+  where
+    withoutUnixSocketScheme :: Text -> Text
+    withoutUnixSocketScheme = Text.replace "unix://" ""
+
+    defaultDockerHost :: Text
+    defaultDockerHost = "/var/run/docker.sock"

--- a/src/App/Fossa/Config/EnvironmentVars.hs
+++ b/src/App/Fossa/Config/EnvironmentVars.hs
@@ -17,6 +17,7 @@ data EnvVars = EnvVars
   , envConfigDebug :: Bool
   , envTelemetryDebug :: Bool
   , envTelemetryScope :: Maybe ConfigTelemetryScope
+  , envDockerHost :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 
@@ -32,6 +33,9 @@ telemetryDebugName = "FOSSA_TELEMETRY_DEBUG"
 telemetryScopeKeyName :: String
 telemetryScopeKeyName = "FOSSA_TELEMETRY_SCOPE"
 
+dockerHostName :: String
+dockerHostName = "DOCKER_HOST"
+
 getEnvVars :: (Has (Lift IO) sig m, Has Logger sig m) => m EnvVars
 getEnvVars =
   EnvVars
@@ -39,6 +43,7 @@ getEnvVars =
     <*> lookupBool configDebugName
     <*> lookupBool telemetryDebugName
     <*> lookUpTelemetryScope telemetryScopeKeyName
+    <*> lookupName dockerHostName
 
 lookupName :: Has (Lift IO) sig m => String -> m (Maybe Text)
 lookupName name = toText <$$> sendIO (lookupEnv name)

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -117,21 +117,14 @@ analyze ::
   m ()
 analyze cfg = do
   logInfo "Running container scanning with fossa experimental-scanner!"
-
-  let host :: Text
-      host = (dockerHost cfg)
-
-  let defaultArch :: Text
-      defaultArch = arch cfg
-
   parsedSource <-
-    runDockerEngineApi host $
+    runDockerEngineApi (dockerHost cfg) $
       parseContainerImageSource
         (unImageText $ imageLocator cfg)
-        defaultArch
+        (arch cfg)
   scannedImage <- case parsedSource of
     DockerArchive tarball -> context "Analyzing via tarball" $ analyzeFromDockerArchive tarball
-    DockerEngine imgTag -> context "Analyzing via Docker engine API" $ analyzeFromDockerEngine imgTag host
+    DockerEngine imgTag -> context "Analyzing via Docker engine API" $ analyzeFromDockerEngine imgTag (dockerHost cfg)
     Podman img -> context "Analyzing via podman" $ analyzeFromPodman img
     Registry registrySrc -> context "Analyzing via registry" $ analyzeFromRegistry registrySrc
 

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -15,12 +15,13 @@ import App.Fossa.Config.Common (
   ScanDestination (OutputStdout, UploadScan),
  )
 import App.Fossa.Config.Container.Analyze (
-  ContainerAnalyzeConfig (imageLocator, revisionOverride, scanDestination),
+  ContainerAnalyzeConfig (arch, dockerHost, imageLocator, revisionOverride, scanDestination),
  )
 import App.Fossa.Config.Container.Analyze qualified as Config
 import App.Fossa.Config.Container.Common (ImageText (unImageText))
+import App.Fossa.Container.Sources.DockerArchive (analyzeFromDockerArchive)
 import App.Fossa.Container.Sources.DockerEngine (analyzeFromDockerEngine)
-import App.Fossa.Container.Sources.DockerTarball (analyzeExportedTarball)
+import App.Fossa.Container.Sources.Podman (analyzeFromPodman, podmanInspectImage)
 import App.Fossa.Container.Sources.Registry (analyzeFromRegistry)
 import App.Types (
   OverrideProject (OverrideProject),
@@ -47,6 +48,7 @@ import Control.Monad (unless, void)
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)
+import Data.Functor (($>))
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (
   ConvertUtf8 (decodeUtf8),
@@ -56,7 +58,7 @@ import Data.String.Conversion (
  )
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Effect.Exec (Exec)
+import Effect.Exec (Exec, execThrow')
 import Effect.Logger (
   Has,
   Logger,
@@ -72,13 +74,13 @@ import Effect.ReadFS (ReadFS, doesFileExist, getCurrentDir)
 import Fossa.API.Types (Organization (orgSupportsNativeContainerScan), UploadResponse (uploadError), uploadLocator)
 import Path (Abs, File, Path, SomeBase (Abs, Rel), parseSomeFile, (</>))
 import Srclib.Types (Locator)
-import System.Info (arch)
 import Text.Megaparsec (errorBundlePretty, parse)
 
 data ContainerImageSource
-  = ContainerExportedTarball (Path Abs File)
-  | ContainerDockerImage Text
-  | ContainerOCIRegistry RegistryImageSource
+  = DockerArchive (Path Abs File)
+  | DockerEngine Text
+  | Podman Text
+  | Registry RegistryImageSource
   deriving (Show, Eq)
 
 debugBundlePath :: FilePath
@@ -115,11 +117,23 @@ analyze ::
   m ()
 analyze cfg = do
   logInfo "Running container scanning with fossa experimental-scanner!"
-  parsedSource <- runDockerEngineApi $ parseContainerImageSource (unImageText $ imageLocator cfg)
+
+  let host :: Text
+      host = (dockerHost cfg)
+
+  let defaultArch :: Text
+      defaultArch = arch cfg
+
+  parsedSource <-
+    runDockerEngineApi host $
+      parseContainerImageSource
+        (unImageText $ imageLocator cfg)
+        defaultArch
   scannedImage <- case parsedSource of
-    ContainerDockerImage imgTag -> context "Analyzing via Docker engine API" $ analyzeFromDockerEngine imgTag
-    ContainerOCIRegistry registrySrc -> context "Analyzing via registry" $ analyzeFromRegistry registrySrc
-    ContainerExportedTarball tarball -> context "Analyzing via tarball" $ analyzeExportedTarball tarball
+    DockerArchive tarball -> context "Analyzing via tarball" $ analyzeFromDockerArchive tarball
+    DockerEngine imgTag -> context "Analyzing via Docker engine API" $ analyzeFromDockerEngine imgTag host
+    Podman img -> context "Analyzing via podman" $ analyzeFromPodman img
+    Registry registrySrc -> context "Analyzing via registry" $ analyzeFromRegistry registrySrc
 
   let revision = extractRevision (revisionOverride cfg) scannedImage
   case scanDestination cfg of
@@ -171,14 +185,17 @@ parseContainerImageSource ::
   , Has Diagnostics sig m
   , Has ReadFS sig m
   , Has Logger sig m
+  , Has Exec sig m
   , Has DockerEngineApi sig m
   ) =>
   Text ->
+  Text ->
   m ContainerImageSource
-parseContainerImageSource src =
-  parseExportedTarballSource src
+parseContainerImageSource src defaultArch =
+  parseDockerArchiveSource src
     <||> parseDockerEngineSource src
-    <||> parseOciRegistrySource src
+    <||> parsePodmanSource src
+    <||> parseRegistrySource defaultArch src
 
 parseDockerEngineSource ::
   ( Has (Lift IO) sig m
@@ -203,16 +220,16 @@ parseDockerEngineSource imgTag = do
   imgSize <- toText . show <$> errCtx (DockerEngineImageNotPresentLocally imgTag) (getDockerImageSize imgTag)
   logInfo . pretty $ "Discovered image for: " <> imgTag <> " (of " <> imgSize <> " bytes) via docker engine api."
 
-  pure $ ContainerDockerImage imgTag
+  pure $ DockerEngine imgTag
 
-parseExportedTarballSource ::
+parseDockerArchiveSource ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
   , Has ReadFS sig m
   ) =>
   Text ->
   m ContainerImageSource
-parseExportedTarballSource path = do
+parseDockerArchiveSource path = do
   cwd <- getCurrentDir
   someTarballFile <- fromEitherShow $ parseSomeFile (toString path)
   resolvedAbsPath <- case someTarballFile of
@@ -222,7 +239,7 @@ parseExportedTarballSource path = do
   unless doesFileExist' $
     fatalText $
       "Could not locate tarball source at filepath: " <> toText resolvedAbsPath
-  pure $ ContainerExportedTarball resolvedAbsPath
+  pure $ DockerArchive resolvedAbsPath
 
 newtype DockerEngineImageNotPresentLocally = DockerEngineImageNotPresentLocally Text
 instance ToDiagnostic DockerEngineImageNotPresentLocally where
@@ -232,24 +249,23 @@ instance ToDiagnostic DockerEngineImageNotPresentLocally where
       , pretty $ "Perform: docker pull " <> (toString tag) <> ", prior to running fossa."
       ]
 
-parseOciRegistrySource ::
+parsePodmanSource ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has Exec sig m
+  , Has ReadFS sig m
+  ) =>
+  Text ->
+  m ContainerImageSource
+parsePodmanSource img = execThrow' (podmanInspectImage img) $> Podman img
+
+parseRegistrySource ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
   ) =>
   Text ->
+  Text ->
   m ContainerImageSource
-parseOciRegistrySource tag = case parse (parseImageUrl defaultArch) "" tag of
+parseRegistrySource defaultArch tag = case parse (parseImageUrl defaultArch) "" tag of
   Left err -> fatal $ errorBundlePretty err
-  Right registrySource -> pure $ ContainerOCIRegistry registrySource
-  where
-    -- Get current runtime arch, We use this to find suitable image,
-    -- if multi-platform image is discovered. This is similar to
-    -- how docker pull, and existing behavior works
-    --
-    -- Ref: https://docs.docker.com/desktop/multi-arch/
-    defaultArch :: Text
-    defaultArch =
-      toText $
-        if arch == "x86_64" -- x86_64 is equivalent to amd64
-          then "amd64"
-          else arch
+  Right registrySource -> pure $ Registry registrySource

--- a/src/App/Fossa/Container/Sources/DockerArchive.hs
+++ b/src/App/Fossa/Container/Sources/DockerArchive.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module App.Fossa.Container.Sources.DockerTarball (
-  analyzeExportedTarball,
+module App.Fossa.Container.Sources.DockerArchive (
+  analyzeFromDockerArchive,
 ) where
 
 import App.Fossa.Analyze (applyFiltersToProject, toProjectResult, updateProgress)
@@ -77,7 +77,7 @@ import Strategy.Dpkg qualified as Dpkg
 import Types (DiscoveredProject (..))
 
 -- | Analyzes Docker Image from Exported Tarball Source.
-analyzeExportedTarball ::
+analyzeFromDockerArchive ::
   ( Has Diagnostics sig m
   , Has Exec sig m
   , Has (Lift IO) sig m
@@ -87,7 +87,7 @@ analyzeExportedTarball ::
   ) =>
   Path Abs File ->
   m ContainerScan
-analyzeExportedTarball tarball = do
+analyzeFromDockerArchive tarball = do
   capabilities <- sendIO getNumCapabilities
   containerTarball <- sendIO . BS.readFile $ toString tarball
   image <- fromEither $ parse containerTarball

--- a/src/App/Fossa/Container/Sources/DockerEngine.hs
+++ b/src/App/Fossa/Container/Sources/DockerEngine.hs
@@ -2,7 +2,7 @@
 
 module App.Fossa.Container.Sources.DockerEngine (analyzeFromDockerEngine) where
 
-import App.Fossa.Container.Sources.DockerTarball (analyzeExportedTarball)
+import App.Fossa.Container.Sources.DockerArchive (analyzeFromDockerArchive)
 import Container.Types (ContainerScan)
 import Control.Carrier.DockerEngineApi (runDockerEngineApi)
 import Control.Carrier.Lift (Lift)
@@ -26,16 +26,17 @@ analyzeFromDockerEngine ::
   , Has Debug sig m
   ) =>
   Text ->
+  Text ->
   m ContainerScan
-analyzeFromDockerEngine imgTag = do
-  withSystemTempDir "fossa-docker-engine-tmp-" $ \dir -> do
+analyzeFromDockerEngine imgTag dockerHost = do
+  withSystemTempDir "fossa-docker-engine-tmp" $ \dir -> do
     let tempTarFile = dir </> $(mkRelFile "image.tar")
 
     logInfo . pretty $
       "Exporting docker image to temp file: "
         <> toString tempTarFile
         <> "! This may take a while!"
-    runDockerEngineApi $ getDockerImage imgTag tempTarFile
+    runDockerEngineApi dockerHost $ getDockerImage imgTag tempTarFile
 
     logInfo . pretty $ "Analyzing exported docker tarball: " <> toString tempTarFile
-    analyzeExportedTarball tempTarFile
+    analyzeFromDockerArchive tempTarFile

--- a/src/App/Fossa/Container/Sources/DockerEngine.hs
+++ b/src/App/Fossa/Container/Sources/DockerEngine.hs
@@ -38,5 +38,5 @@ analyzeFromDockerEngine imgTag dockerHost = do
         <> "! This may take a while!"
     runDockerEngineApi dockerHost $ getDockerImage imgTag tempTarFile
 
-    logInfo . pretty $ "Analyzing exported docker tarball: " <> toString tempTarFile
+    logInfo . pretty $ "Analyzing exported docker archive: " <> toString tempTarFile
     analyzeFromDockerArchive tempTarFile

--- a/src/App/Fossa/Container/Sources/Podman.hs
+++ b/src/App/Fossa/Container/Sources/Podman.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.Fossa.Container.Sources.Podman (analyzeFromPodman, podmanInspectImage) where
+
+import App.Fossa.Container.Sources.DockerArchive (analyzeFromDockerArchive)
+import Container.Types (ContainerScan)
+import Control.Carrier.Lift (Lift)
+import Control.Effect.Debug (Debug, Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Path (withSystemTempDir)
+import Control.Effect.Telemetry (Telemetry)
+import Control.Monad (void)
+import Data.String.Conversion (ToText (toText), toString)
+import Data.Text (Text)
+import Effect.Exec (AllowErr (Never), Command (..), Exec, execThrow')
+import Effect.Logger (Logger, logInfo, pretty)
+import Effect.ReadFS (ReadFS)
+import Path (Abs, File, Path, mkRelFile, toFilePath, (</>))
+
+-- | Inspects a image, if image does not exist throws an error.
+-- Refer to: https://docs.podman.io/en/latest/markdown/podman-image-inspect.1.html
+podmanInspectImage :: Text -> Command
+podmanInspectImage img =
+  Command
+    { cmdName = "podman"
+    , cmdArgs = ["image", "inspect", img]
+    , cmdAllowErr = Never
+    }
+
+-- | Saves container image to a location in docker archive (tarball) format.
+-- Refer to: https://docs.podman.io/en/latest/markdown/podman-save.1.html
+podmanExtractImage :: Text -> Path Abs File -> Command
+podmanExtractImage img dest =
+  Command
+    { cmdName = "podman"
+    , cmdArgs = ["save", "--format", "docker-archive", img, "-o", toText . toFilePath $ dest]
+    , cmdAllowErr = Never
+    }
+
+analyzeFromPodman ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  , Has Telemetry sig m
+  , Has Debug sig m
+  , Has Exec sig m
+  , Has ReadFS sig m
+  ) =>
+  Text ->
+  m ContainerScan
+analyzeFromPodman img = do
+  withSystemTempDir "fossa-podman-tmp" $ \dir -> do
+    let tempTarFile = dir </> $(mkRelFile "image.tar")
+    logInfo . pretty $
+      "Exporting image to temp file: "
+        <> toString tempTarFile
+        <> "! This may take a while!"
+    void $ execThrow' (podmanExtractImage img tempTarFile)
+    logInfo . pretty $ "Analyzing exported container image: " <> toString tempTarFile
+    analyzeFromDockerArchive tempTarFile

--- a/src/App/Fossa/Container/Sources/Registry.hs
+++ b/src/App/Fossa/Container/Sources/Registry.hs
@@ -1,6 +1,6 @@
 module App.Fossa.Container.Sources.Registry (analyzeFromRegistry) where
 
-import App.Fossa.Container.Sources.DockerTarball (analyzeExportedTarball)
+import App.Fossa.Container.Sources.DockerArchive (analyzeFromDockerArchive)
 import Container.Docker.Credentials (useCredentialFromConfig)
 import Container.Docker.SourceParser (RegistryImageSource (RegistryImageSource), defaultRegistry)
 import Container.Types (ContainerScan)
@@ -35,7 +35,7 @@ analyzeFromRegistry imgSrc = do
     logInfo $ "Inferred registry source: " <> pretty imgSrc'
     tempTarFile <- runContainerRegistryApi $ exportImage imgSrc' dir
     logInfo . pretty $ "Analyzing exported container tarball: " <> toString tempTarFile
-    analyzeExportedTarball tempTarFile
+    analyzeFromDockerArchive tempTarFile
   where
     hasCred :: RegistryImageSource -> Bool
     hasCred (RegistryImageSource _ _ (Just _) _ _ _) = True

--- a/src/Container/Docker/Manifest.hs
+++ b/src/Container/Docker/Manifest.hs
@@ -82,11 +82,11 @@ getImageJsonConfigFilePath :: ManifestJson -> Text
 getImageJsonConfigFilePath (ManifestJson mjEntries) = config $ NonEmpty.head mjEntries
 
 -- | Gets the image digest.
--- Exported docker tarball's config filename is digest of the image.
+-- Exported docker archive's config filename is digest of the image.
 getImageDigest :: ManifestJson -> Text
 getImageDigest mj = "sha256:" <> Text.replace ".json" "" (getImageJsonConfigFilePath mj)
 
 -- | Gets the image digest.
--- Exported docker tarball's config filename is digest of the image.
+-- Exported docker archive's config filename is digest of the image.
 getRepoTags :: ManifestJson -> [Text]
 getRepoTags (ManifestJson mjEntries) = repoTags $ NonEmpty.head mjEntries

--- a/src/Control/Carrier/DockerEngineApi.hs
+++ b/src/Control/Carrier/DockerEngineApi.hs
@@ -24,18 +24,19 @@ import Path (Abs, File, Path)
 
 type DockerEngineApiC = SimpleC DockerEngineApiF
 
-runDockerEngineApi :: (Has (Lift IO) sig m, Has Diag.Diagnostics sig m) => DockerEngineApiC m a -> m a
-runDockerEngineApi = interpret $ \case
-  ExportImage img path -> exportDockerImage img path
-  GetImageSize img -> getDockerImageSize img
-  IsDockerEngineAccessible -> isDockerEngineAccessible
+runDockerEngineApi :: (Has (Lift IO) sig m, Has Diag.Diagnostics sig m) => Text -> DockerEngineApiC m a -> m a
+runDockerEngineApi socketHost = do
+  interpret $ \case
+    ExportImage img path -> exportDockerImage socketHost img path
+    GetImageSize img -> getDockerImageSize socketHost img
+    IsDockerEngineAccessible -> isDockerEngineAccessible socketHost
 
 -- | Exports Docker Image to a given path.
 -- Refer to: https://docs.docker.com/engine/api/v1.28/#tag/Image/operation/ImageGet
-exportDockerImage :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => Text -> Path Abs File -> m ()
-exportDockerImage img sinkTarget = do
+exportDockerImage :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => Text -> Text -> Path Abs File -> m ()
+exportDockerImage socketHost img sinkTarget = do
   let request = HTTP.parseRequest_ $ baseApi <> "images/" <> (toString img) <> "/get"
-  manager <- sendIO dockerClient
+  manager <- sendIO $ dockerClient socketHost
   -- Performs equivalent of for given image:
   -- >> curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.28/images/redis:alpine/get" > img.tar
   sendIO . runResourceT $ do
@@ -44,13 +45,13 @@ exportDockerImage img sinkTarget = do
 
 -- | Gets Image Size from Image Description Json
 -- Refer to: https://docs.docker.com/engine/api/v1.28/#tag/Image/operation/ImageInspect
-getDockerImageSize :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => Text -> m Int
-getDockerImageSize img = do
+getDockerImageSize :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => Text -> Text -> m Int
+getDockerImageSize socketHost img = do
   let request = HTTP.parseRequest_ $ baseApi <> "images/" <> (toString img) <> "/json"
 
   -- Performs equivalent of for given image:
   -- >> curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.28/images/redis:alpine/json"
-  response <- sendIO $ HTTP.httpLbs request =<< dockerClient
+  response <- sendIO $ HTTP.httpLbs request =<< dockerClient socketHost
 
   let body = HTTP.responseBody response
   case eitherDecode body of
@@ -59,16 +60,16 @@ getDockerImageSize img = do
 
 -- | True if Docker Engine API is accessible, otherwise False.
 -- Refer to: https://docs.docker.com/engine/api/v1.28/#tag/System/operation/SystemPing
-isDockerEngineAccessible :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => m Bool
-isDockerEngineAccessible = do
+isDockerEngineAccessible :: (Has Diag.Diagnostics sig m, Has (Lift IO) sig m) => Text -> m Bool
+isDockerEngineAccessible socketHost = do
   -- Performs equivalent of for given image:
   -- >> curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.28/_ping"
 
   -- `Network.Socket.connect` throws async IO exception, only when socket does not
   -- exist at /var/run/docker.sock location, If daemon is running but refusing connection,
   -- then we receive nominal error code (as expected).
-  response <- errorBoundaryIO $ sendIO (HTTP.httpLbs (HTTP.parseRequest_ $ baseApi <> "_ping") =<< dockerClient)
-  response' <- fromMaybeText ("Could not connect to docker daemon at: " <> toText daemonLocation) $ resultToMaybe response
+  response <- errorBoundaryIO $ sendIO (HTTP.httpLbs (HTTP.parseRequest_ $ baseApi <> "_ping") =<< dockerClient socketHost)
+  response' <- fromMaybeText ("Could not connect to docker daemon at: " <> toText socketHost) $ resultToMaybe response
   pure $ (HTTP.responseStatus response') == ok200
 
 newtype DockerImageInspectJson = DockerImageInspectJson {imageSize :: Int}
@@ -81,13 +82,10 @@ instance FromJSON DockerImageInspectJson where
 baseApi :: String
 baseApi = "http://localhost/v1.28/"
 
-daemonLocation :: FilePath
-daemonLocation = "/var/run/docker.sock"
+dockerClient :: Has (Lift IO) sig m => Text -> m HTTP.Manager
+dockerClient = unixSocketClient . toString
 
-dockerClient :: Has (Lift IO) sig m => m HTTP.Manager
-dockerClient = unixSocketClient daemonLocation
-
-unixSocketClient :: FilePath -> Has (Lift IO) sig m => m HTTP.Manager
+unixSocketClient :: Has (Lift IO) sig m => FilePath -> m HTTP.Manager
 unixSocketClient socketPath = socketHttpManager
   where
     socketHttpManager :: Has (Lift IO) sig m => m HTTP.Manager

--- a/test/App/Fossa/Configuration/TelemetryConfigSpec.hs
+++ b/test/App/Fossa/Configuration/TelemetryConfigSpec.hs
@@ -34,6 +34,7 @@ defaultEnvVars =
     , envConfigDebug = False
     , envTelemetryDebug = False
     , envTelemetryScope = Nothing
+    , envDockerHost = Nothing
     }
 
 defaultCommonOpts :: CommonOpts

--- a/test/App/Fossa/Container/AnalyzeNativeSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeSpec.hs
@@ -1,6 +1,6 @@
 module App.Fossa.Container.AnalyzeNativeSpec (spec) where
 
-import App.Fossa.Container.AnalyzeNative (ContainerImageSource (ContainerDockerImage), parseDockerEngineSource)
+import App.Fossa.Container.AnalyzeNative (ContainerImageSource (DockerEngine), parseDockerEngineSource)
 import Control.Carrier.Diagnostics (DiagnosticsC, Has)
 import Control.Carrier.Stack (StackC, runStack)
 import Control.Effect.DockerEngineApi (DockerEngineApiF (GetImageSize, IsDockerEngineAccessible))
@@ -31,7 +31,7 @@ spec = do
       expectDockerSdkToBeAccessible
       expectGetImageSizeToSucceed
       src <- parseDockerEngineSource exampleImgWithTag
-      src `shouldBe'` ContainerDockerImage exampleImgWithTag
+      src `shouldBe'` DockerEngine exampleImgWithTag
 
 exampleImgWithoutTag :: Text
 exampleImgWithoutTag = "redis"


### PR DESCRIPTION
# Overview

This PR, 
- Adds podman support for experimental container scanning.

## Acceptance criteria

- `fossa-cli` can use podman for container scanning

## Testing plan

#### Setup
```bash
git checkout feat/adds-podman-support
make install-local
./fossa --version
```

- Make sure you have podman installed, and docker engine/client is not accessible.

#### Test

1. Use podman to build the image (so only podman knows about it)
```bash
echo 'FROM alpine:latest\n\nRUN apk add tree' > Dockerfile
podman build . -t testpodman:1.0.0
```

2. Use fossa-container analyzer:
```bash
fossa container analyze testpodman:1.0.0 --experimental-scanner
```

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-279
## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
