### PR TITLE
Update manual dependencies docs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -91,7 +91,7 @@ jobs:
       - name: json-syntax-check
         uses: limitusus/json-syntax-check@v1
         with:
-          pattern: "\\.schema.json$"
+          pattern: "docs.*\\.schema\\.json$"
 
   common-verbiage-check:
     name: "Check for correct spelling of FOSSA"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,28 +9,28 @@ jobs:
     container: ghcr.io/fossas/haskell-dev-tools:9.0.2
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Run hlint
-      run: |
-        make lint
+      - name: Run hlint
+        run: |
+          make lint
 
   link-check:
     name: link-check
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Check Markdown links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-quiet-mode: 'yes'
-        config-file: '.markdown-link-check.json'
+      - name: Check Markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: "yes"
+          config-file: ".markdown-link-check.json"
 
-    - name: Disallow empty Markdown links
-      run: |
-        ! grep ']()' **/*.md
+      - name: Disallow empty Markdown links
+        run: |
+          ! grep ']()' **/*.md
 
   format-check:
     name: formatter-check
@@ -38,12 +38,12 @@ jobs:
     container: ghcr.io/fossas/haskell-dev-tools:9.0.2
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    # Run the formatter
-    - name: run fourmolu
-      run: |
-        make check-fmt
+      # Run the formatter
+      - name: run fourmolu
+        run: |
+          make check-fmt
 
   cabal-format-check:
     name: cabal-format-check
@@ -51,12 +51,12 @@ jobs:
     container: ghcr.io/fossas/haskell-dev-tools:9.0.2
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    # Run the formatter
-    - name: "run cabal-fmt"
-      run: |
-        cabal-fmt --check spectrometer.cabal
+      # Run the formatter
+      - name: "run cabal-fmt"
+        run: |
+          cabal-fmt --check spectrometer.cabal
 
   cabal-install-check:
     name: cabal-install-check
@@ -64,24 +64,34 @@ jobs:
     container: ghcr.io/fossas/haskell-dev-tools:9.0.2
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    # Run `cabal install`.
-    - uses: actions/cache@v2
-      name: Cache cabal store
-      with:
-        path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.cabal/store' }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-${{ hashFiles('**/*.cabal') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-
-          ${{ runner.os }}-${{ matrix.ghc }}-
-          ${{ runner.os }}-
+      # Run `cabal install`.
+      - uses: actions/cache@v2
+        name: Cache cabal store
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.cabal/store' }}
+          key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-${{ hashFiles('**/*.cabal') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-
+            ${{ runner.os }}-${{ matrix.ghc }}-
+            ${{ runner.os }}-
 
-    - name: Run `cabal install`
-      run: |
-        apk add xz-dev bzip2-dev bzip2-static
-        cabal update
-        cabal install
+      - name: Run `cabal install`
+        run: |
+          apk add xz-dev bzip2-dev bzip2-static
+          cabal update
+          cabal install
+
+  schema-lint-check:
+    name: "schema lint check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: json-syntax-check
+        uses: limitusus/json-syntax-check@v1
+        with:
+          pattern: "docs/references/files/*.schema.json$"
 
   common-verbiage-check:
     name: "Check for correct spelling of FOSSA"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -91,7 +91,7 @@ jobs:
       - name: json-syntax-check
         uses: limitusus/json-syntax-check@v1
         with:
-          pattern: "docs/references/files/*.schema.json$"
+          pattern: "\\.schema.json$"
 
   common-verbiage-check:
     name: "Check for correct spelling of FOSSA"

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix a bug in fossa-deps.schema.json. It is now valid JSON.
+- Fix a bug in fossa-deps.schema.json. It is now valid JSON. ([#1030](https://github.com/fossas/fossa-cli/pull/1030))
 
 ## 3.3.12
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Fix a bug in fossa-deps.schema.json. It is now valid JSON.
+
 ## 3.3.12
 
 - CocoaPods: Fixes error when analyzing podspecs that print non-JSON text to stdout ([#1015](https://github.com/fossas/fossa-cli/pull/1015))

--- a/docs/contributing/HACKING.md
+++ b/docs/contributing/HACKING.md
@@ -67,14 +67,14 @@ Both test suites will be run when you execute `cabal test`.
 
 ## Tools
 
-| name | description |
-| ---- | ----------- |
-| [ghcup][ghcup] | Used to manage installed versions of ghc and cabal-install |
-| ghc | The haskell compiler (installed via ghcup) |
-| cabal-install | The package manager we use (installed via ghcup). Accessed via `cabal` on most setups. |
-| [haskell-language-server][hls] ("HLS") | LSP server for haskell projects |
-| [hlint][hlint] | A linting + hints tool for haskell code. It provides really useful suggestions.  `hlint` is bundled with HLS |
-| [fourmolu][fourmolu] | A haskell source code formatter. `fourmolu` is bundled with HLS |
+| name                                   | description                                                                                                  |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [ghcup][ghcup]                         | Used to manage installed versions of ghc and cabal-install                                                   |
+| ghc                                    | The haskell compiler (installed via ghcup)                                                                   |
+| cabal-install                          | The package manager we use (installed via ghcup). Accessed via `cabal` on most setups.                       |
+| [haskell-language-server][hls] ("HLS") | LSP server for haskell projects                                                                              |
+| [hlint][hlint]                         | A linting + hints tool for haskell code. It provides really useful suggestions.  `hlint` is bundled with HLS |
+| [fourmolu][fourmolu]                   | A haskell source code formatter. `fourmolu` is bundled with HLS                                              |
 
 ### Installing haskell-language-server
 
@@ -122,9 +122,9 @@ or having to install the formatter yourself.  This also makes sure you're using 
 
 ## Docs
 
-| name | description |
-| ---- | ----------- |
-| [hoogle][hoogle] | Search for type signatures or symbols |
+| name               | description                                                                    |
+| ------------------ | ------------------------------------------------------------------------------ |
+| [hoogle][hoogle]   | Search for type signatures or symbols                                          |
 | [hackage][hackage] | Package repository; can be used to browse individual package docs ("haddocks") |
 
 If on macOS, [dash](https://kapeli.com/dash) is a great tool that allows for downloading searchable package haddocks
@@ -135,23 +135,23 @@ On linux, you can use [zeal](https://zealdocs.org/).  (Currently there is an iss
 
 ### Cabal cheatsheet
 
-| command | description |
-| ------- | ----------- |
-| `cabal repl` | opens the ghci repl on the project |
-| `cabal build` | build spectrometer |
-| `cabal test` | build + run tests |
+| command                              | description                                                                |
+| ------------------------------------ | -------------------------------------------------------------------------- |
+| `cabal repl`                         | opens the ghci repl on the project                                         |
+| `cabal build`                        | build fossa-cli                                                            |
+| `cabal test`                         | build + run tests                                                          |
 | `cabal run binary-name -- arg1 arg2` | build + run an executable named `binary-name`, and with args `arg1` `arg2` |
 
 ### GHCI cheatsheet
 
 Use `cabal repl` to open ghci.
 
-| command | description |
-| ------- | ----------- |
-| `:r`/`:reload` | reload the project |
-| `:t`/`:type <symbol>` | query the type of a symbol |
-| `:i`/`:info <symbol>` | query info about a symbol -- docs, where it was defined, etc |
-| `:l`/`:load <Module.Name>` | load a specific file into the repl |
+| command                    | description                                                  |
+| -------------------------- | ------------------------------------------------------------ |
+| `:r`/`:reload`             | reload the project                                           |
+| `:t`/`:type <symbol>`      | query the type of a symbol                                   |
+| `:i`/`:info <symbol>`      | query info about a symbol -- docs, where it was defined, etc |
+| `:l`/`:load <Module.Name>` | load a specific file into the repl                           |
 
 ## FAQ/Troubleshooting
 

--- a/docs/features/manual-dependencies.md
+++ b/docs/features/manual-dependencies.md
@@ -42,6 +42,7 @@ Supported dependency types:
 - `paket` - .NET dependencies found at [fsprojects.github.io/Paket/](https://fsprojects.github.io/Paket/).
 - `pub` - Dart dependencies found at [pub.dev](https://www.pub.dev/).
 - `pypi` - Python dependencies that are typically found at [Pypi.org](https://pypi.org/).
+- `swift` - Swift dependencies using the [Swift Package Manager](https://www.swift.org/package-manager/).
 - `cocoapods` - Swift and Objective-C dependencies found at [Cocoapods.org](https://cocoapods.org/).
 - `url` - The URL type allows you to specify only the download location of an archive (e.g.: `.zip`, .`tar.gz`, etc.) in the `name` field and the FOSSA backend will attempt to download and scan it. Example for a github source dependency `https://github.com/fossas/spectrometer/archive/refs/tags/v2.7.2.tar.gz`. The `version` field will be silently ignored for `url` type dependencies.
 

--- a/docs/features/manual-dependencies.md
+++ b/docs/features/manual-dependencies.md
@@ -32,7 +32,7 @@ Supported dependency types:
 - `composer` - Dependencies specified by the PHP package manager [Composer](https://getcomposer.org/), which are located on [Packagist](https://packagist.org/).
 - `cpan` - Dependencies located on the [CPAN package manager](https://www.cpan.org/).
 - `gem` - Dependencies which can be found at [RubyGems.org](https://rubygems.org/).
-- `git` - Github projects (which appear as dependencies in many package managers). Specified as the full github repository `https://github.com/fossas/spectrometer`.
+- `git` - Github projects (which appear as dependencies in many package managers). Specified as the full github repository `https://github.com/fossas/fossa-cli`.
 - `go` - Golang specific dependency. Many golang dependencies are located on Github, but there are some which look like the following `go.mongodb.org/mongo-driver` that have custom golang URLs.
 - `hackage` - Haskell dependencies found at [Hackage](https://hackage.haskell.org/).
 - `hex` - Erlang and Elixir dependencies that are found at [Hex.pm](https://hex.pm/).
@@ -44,7 +44,7 @@ Supported dependency types:
 - `pypi` - Python dependencies that are typically found at [Pypi.org](https://pypi.org/).
 - `swift` - Swift dependencies using the [Swift Package Manager](https://www.swift.org/package-manager/).
 - `cocoapods` - Swift and Objective-C dependencies found at [Cocoapods.org](https://cocoapods.org/).
-- `url` - The URL type allows you to specify only the download location of an archive (e.g.: `.zip`, .`tar.gz`, etc.) in the `name` field and the FOSSA backend will attempt to download and scan it. Example for a github source dependency `https://github.com/fossas/spectrometer/archive/refs/tags/v2.7.2.tar.gz`. The `version` field will be silently ignored for `url` type dependencies.
+- `url` - The URL type allows you to specify only the download location of an archive (e.g.: `.zip`, .`tar.gz`, etc.) in the `name` field and the FOSSA backend will attempt to download and scan it. Example for a github source dependency `https://github.com/fossas/fossa-cli/archive/refs/tags/v3.3.12.tar.gz`. The `version` field will be silently ignored for `url` type dependencies.
 
 ### Custom dependencies
 
@@ -77,7 +77,7 @@ FOSSA also supports dependencies that can't be automatically discovered or ident
 
 To specify a remote dependency, you must provide the name, version, and download URL of the dependency. The FOSSA backend will attempt to download and scan any source code contained in an archive hosted at this URL.
 
-For example, for a dependency released on a GitHub release, your URL might look like: `https://github.com/fossas/spectrometer/archive/refs/tags/v2.7.2.tar.gz`.
+For example, for a dependency released on a GitHub release, your URL might look like: `https://github.com/fossas/fossa-cli/archive/refs/tags/v3.3.12.tar.gz`.
 
 You can also optionally add metadata fields ("description" and "homepage") to populate these fields in the FOSSA web UI (these fields can be displayed when generating reports).
 

--- a/docs/references/files/fossa-deps.schema.json
+++ b/docs/references/files/fossa-deps.schema.json
@@ -97,7 +97,7 @@
                 },
                 "version": {
                     "type": "string",
-                    "description": "Version of the dependency. This will be the version associated with this vendored dependency in FOSSA's dashboard"
+                    "description": "Version of the dependency. This will be the version associated with this vendored dependency in FOSSA's dashboard",
                 }
             },
             "required": [

--- a/docs/references/files/fossa-deps.schema.json
+++ b/docs/references/files/fossa-deps.schema.json
@@ -97,7 +97,7 @@
                 },
                 "version": {
                     "type": "string",
-                    "description": "Version of the dependency. This will be the version associated with this vendored dependency in FOSSA's dashboard",
+                    "description": "Version of the dependency. This will be the version associated with this vendored dependency in FOSSA's dashboard"
                 }
             },
             "required": [

--- a/docs/references/files/fossa-deps.schema.json
+++ b/docs/references/files/fossa-deps.schema.json
@@ -12,6 +12,7 @@
                 },
                 "type": {
                     "enum": [
+                        "bower",
                         "cargo",
                         "carthage",
                         "composer",

--- a/docs/references/files/fossa-yml.md
+++ b/docs/references/files/fossa-yml.md
@@ -17,7 +17,7 @@ project:
   team: cli-team
   policy: custom-cli-policy
   link: fossa.com
-  url: github.com/fossas/spectrometer
+  url: github.com/fossas/fossa-cli
   jiraProjectKey: jira-key
   releaseGroup:
     name: release-group-name

--- a/docs/walkthroughs/custom-integrating-with-bower-example.md
+++ b/docs/walkthroughs/custom-integrating-with-bower-example.md
@@ -7,9 +7,9 @@ With `fossa-deps.{yml, json, yaml}` file, FOSSA CLI can be integrated to support
 
 ## Example with Bower
 
-For an example, we will look at [Bower](https://bower.io/). 
+For an example, we will look at [Bower](https://bower.io/).
 
-We can usually identify a list of dependencies from our custom tool by looking at configuration files or executing a command. Bower provides both of these options, we can inspect (1) `bower.json` or (2) parse the output from the `bower list` command. 
+We can usually identify a list of dependencies from our custom tool by looking at configuration files or executing a command. Bower provides both of these options, we can inspect (1) `bower.json` or (2) parse the output from the `bower list` command.
 
 From an example `bower.json` file, lists direct dependencies:
 
@@ -31,7 +31,7 @@ From an example `bower.json` file, lists direct dependencies:
     "tests"
   ],
   "dependencies": {
-    "font-awsome": "^5.0.0",
+    "font-awesome": "^5.0.0",
     "jquery": "^3.6.0"
   }
 }
@@ -41,15 +41,15 @@ We can execute `bower list` command to list all of the resolved bower dependenci
 
 ```
 example-project /Users/example-user/path
-├── font-awsome#5.15.4
+├── font-awesome#5.15.4
 └── jquery#3.6.0
 ```
 
-We have two dependencies (1) jquery and (2) font-awsome.
+We have two dependencies (1) jquery and (2) font-awesome.
 
 From [manual dependencies](./../features/manual-dependencies.md) documentation, we know that `bower` type dependencies are supported type as reference dependency.
 
-We can include all listed dependencies in fossa-deps.json. 
+We can include all listed dependencies in fossa-deps.json.
 
 ```json
 {
@@ -61,7 +61,7 @@ We can include all listed dependencies in fossa-deps.json.
     },
     {
       "type": "bower",
-      "name": "font-awsome",
+      "name": "font-awesome",
       "version": "5.15.4"
     }
   ]


### PR DESCRIPTION
# Overview

closes https://github.com/fossas/fossa-cli/issues/1027

- fix some discrepancies between the documentation for manual-deps and the schema
- fix a trailing comma in the schema for fossa-deps.yml
- Add a lint-check for the schemas
- Fix a miss-spelling of "fontawesome"
- Change spectrometer => fossa-cli in a few spots

## Acceptance criteria

- the fossa-deps.yml schema should be valid
- invalid schemas should fail the lint-check
- we should use fossa-cli instead of spectrometer in our example URLs where possible
- The fetchers in the manual-dependencies documentation should match those in the schema

## Testing plan

I tested that the linter caught an invalid schema by reverting the fix to the schema and checking that the linter failed.

Everything else is a documentation fix.

## Risks

None

## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
