### PR TITLE
Automatically filter dist-newstyle from target discovery

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `dist-newstyle` to the list of automatically filtered directories. ([#1030](https://github.com/fossas/fossa-cli/pull/1035))
 - Fix a bug in fossa-deps.schema.json. It is now valid JSON. ([#1030](https://github.com/fossas/fossa-cli/pull/1030))
 
 ## 3.3.12

--- a/src/App/Fossa/Analyze/Filter.hs
+++ b/src/App/Fossa/Analyze/Filter.hs
@@ -84,7 +84,8 @@ isProductionPath path = not $ any (`isInfixOf` path) ignoredPaths
 
 ignoredPaths :: [[Char]]
 ignoredPaths =
-  [ "doc/"
+  [ "dist-newstyle"
+  , "doc/"
   , "docs/"
   , "test/"
   , "example/"


### PR DESCRIPTION
# Overview

This PR addresses https://fossa.atlassian.net/browse/ANE-538

`dist-newstyle` is a directory used exclusively by Haskell projects to store build artifacts.

> This PR makes me realize that we should probably address or better document how these automatic filters operate. Thankfully we have not seen too many issues pop up related to them.

## Acceptance criteria

Targets from `dist-newstyle` are automatically excluded from the analysis.

## Testing plan

I manually compiled the CLI and validated that targets in dist-newstyle are not picked up. The array of filters does not have an accompanying test suite, and while I think it would be great to build one, I don't think thats necessary for this fix.

## Risks

A user _could_ be relying on targets in `dist-newstyle`, however, this is very unlikely and we have very few customers using Haskell.

## References

[ANE-538](https://fossa.atlassian.net/browse/ANE-538)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
