### PR TITLE
Includes CI environment in telemetry record

### DIFF
--- a/src/Control/Carrier/Telemetry/Types.hs
+++ b/src/Control/Carrier/Telemetry/Types.hs
@@ -70,7 +70,7 @@ data TelemetryRecord = TelemetryRecord
   , cliTotalDurationInSec :: Double
   , cliUsageCounter :: Map CountableCliFeature Int
   , cliVersion :: Text
-  , cliCIEnv :: Maybe CIEnvironment
+  , cliCIEnvironment :: Maybe CIEnvironment
   }
   deriving (Show, Eq, Ord, Generic)
 

--- a/src/Control/Carrier/Telemetry/Types.hs
+++ b/src/Control/Carrier/Telemetry/Types.hs
@@ -135,8 +135,6 @@ data CIEnvironment
   | UnknownCI
   deriving (Eq, Ord, Generic)
 
--- Modifying values below, also requires modifying value in
--- FOSSA's server's cli telemetry type for compatibility.
 instance Show CIEnvironment where
   show GithubAction = "github_action"
   show AzurePipeline = "azure_pipeline"

--- a/src/Control/Carrier/Telemetry/Types.hs
+++ b/src/Control/Carrier/Telemetry/Types.hs
@@ -8,7 +8,7 @@ module Control.Carrier.Telemetry.Types (
   TelemetryTimeSpent (..),
   TelemetryCmdConfig (..),
   CountableCliFeature (..),
-  CIEnvironment(..),
+  CIEnvironment (..),
 ) where
 
 import Control.Concurrent.STM (TMVar)

--- a/src/Control/Carrier/Telemetry/Types.hs
+++ b/src/Control/Carrier/Telemetry/Types.hs
@@ -8,6 +8,7 @@ module Control.Carrier.Telemetry.Types (
   TelemetryTimeSpent (..),
   TelemetryCmdConfig (..),
   CountableCliFeature (..),
+  CIEnvironment(..),
 ) where
 
 import Control.Concurrent.STM (TMVar)
@@ -69,6 +70,7 @@ data TelemetryRecord = TelemetryRecord
   , cliTotalDurationInSec :: Double
   , cliUsageCounter :: Map CountableCliFeature Int
   , cliVersion :: Text
+  , cliCIEnv :: Maybe CIEnvironment
   }
   deriving (Show, Eq, Ord, Generic)
 
@@ -125,3 +127,21 @@ data TelemetryTimeSpent = TelemetryTimeSpent
 
 instance ToJSON TelemetryTimeSpent where
   toEncoding = genericToEncoding defaultOptions
+
+data CIEnvironment
+  = GithubAction
+  | AzurePipeline
+  | Bamboo
+  | UnknownCI
+  deriving (Eq, Ord, Generic)
+
+-- Modifying values below, also requires modifying value in
+-- FOSSA's server's cli telemetry type for compatibility.
+instance Show CIEnvironment where
+  show GithubAction = "github_action"
+  show AzurePipeline = "azure_pipeline"
+  show Bamboo = "bamboo"
+  show UnknownCI = "unknown_ci"
+
+instance ToJSON CIEnvironment where
+  toJSON = String . showT

--- a/src/Control/Carrier/Telemetry/Utils.hs
+++ b/src/Control/Carrier/Telemetry/Utils.hs
@@ -124,8 +124,8 @@ lookupCIEnvironment = do
     -- Ref: https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html#Bamboovariables-Build-specificvariables
     isBamboo :: IO (Maybe CIEnvironment)
     isBamboo = do
-      isGH <- hasSomeValue "bamboo.buildKey"
-      pure $ if isGH then Just Bamboo else Nothing
+      isB <- hasSomeValue "bamboo.buildKey"
+      pure $ if isB then Just Bamboo else Nothing
 
    -- Catch all for CI systems, typically they set either CI or BUILD_ID environment
    -- variable. Example: Jenkins, GitlabCI, etc.

--- a/src/Control/Carrier/Telemetry/Utils.hs
+++ b/src/Control/Carrier/Telemetry/Utils.hs
@@ -15,7 +15,7 @@ import Control.Carrier.Telemetry.Types (
   SystemInfo (SystemInfo),
   TelemetryCmdConfig (TelemetryCmdConfig),
   TelemetryCtx (TelemetryCtx, telCounters, telFossaConfig, telId, telLogsQ, telStartUtcTime, telTimeSpentQ),
-  TelemetryRecord (..),
+  TelemetryRecord (..), CIEnvironment(..),
  )
 import Control.Concurrent.STM (STM, atomically, newEmptyTMVarIO, tryReadTMVar)
 import Control.Concurrent.STM.TBMQueue (TBMQueue, newTBMQueueIO, tryReadTBMQueue)
@@ -31,6 +31,11 @@ import Data.UUID.V4 (nextRandom)
 import GHC.Conc.Sync qualified as Conc
 import System.Args (getCommandArgs)
 import System.Info qualified as Info
+import System.Environment (lookupEnv)
+import qualified Data.Text as Text
+import Data.String.Conversion (toText)
+import Data.Functor.Extra ((<$$>))
+import Data.Foldable (asum)
 
 maxQueueSize :: Int
 maxQueueSize = 1000
@@ -55,6 +60,7 @@ mkTelemetryRecord seenFatalException ctx = sendIO $ do
   cliTimedDurations <- atomically $ getItems (telTimeSpentQ ctx)
   cliUsageCounter <- atomically $ getCounterRegistry (telCounters ctx)
   finalTime <- getCurrentTime
+  cliCIEnv <- lookupCIEnvironment
 
   pure $
     TelemetryRecord
@@ -70,6 +76,7 @@ mkTelemetryRecord seenFatalException ctx = sendIO $ do
       , cliTotalDurationInSec = realToFrac $ nominalDiffTimeToSeconds $ diffUTCTime finalTime (telStartUtcTime ctx)
       , cliUsageCounter = cliUsageCounter
       , cliVersion = getCurrentCliVersion
+      , cliCIEnv = cliCIEnv
       }
   where
     getItems :: TBMQueue a -> STM [a]
@@ -91,3 +98,58 @@ getSystemInfo =
     Info.arch
     <$> Conc.getNumCapabilities
     <*> Conc.getNumProcessors
+
+lookupCIEnvironment :: IO (Maybe CIEnvironment)
+lookupCIEnvironment = do
+  asum
+    <$> sequence
+      [ isGithubAction
+      , isAzurePipeline
+      , isBamboo
+      , isSomeCI
+      ]
+  where
+    -- Ref: https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+    isGithubAction :: IO (Maybe CIEnvironment)
+    isGithubAction = do
+      isGH <- isTrue "GITHUB_ACTIONS"
+      pure $ if isGH then Just GithubAction else Nothing
+
+    -- Ref: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&viewFallbackFrom=vsts&tabs=yaml#system-variables
+    isAzurePipeline :: IO (Maybe CIEnvironment)
+    isAzurePipeline = do
+      isAzure <- isTrue "TF_BUILD"
+      pure $ if isAzure then Just AzurePipeline else Nothing
+
+    -- Ref: https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html#Bamboovariables-Build-specificvariables
+    isBamboo :: IO (Maybe CIEnvironment)
+    isBamboo = do
+      isGH <- hasSomeValue "bamboo.buildKey"
+      pure $ if isGH then Just Bamboo else Nothing
+
+   -- Catch all for CI systems, typically they set either CI or BUILD_ID environment
+   -- variable. Example: Jenkins, GitlabCI, etc.
+    isSomeCI :: IO (Maybe CIEnvironment)
+    isSomeCI = do
+      hasCIEnv <- hasSomeValue "CI"
+      hasBuildIdEnv <- hasSomeValue "BUILD_ID"
+      pure $ if (hasCIEnv || hasBuildIdEnv) then Just UnknownCI else Nothing
+
+lookupName :: String -> IO (Maybe Text)
+lookupName name = toText <$$> lookupEnv name
+
+-- | True if environment variable has non empty value, otherwise False.
+hasSomeValue :: String -> IO Bool
+hasSomeValue name = do
+  value <- lookupName name
+  pure $ case value of
+    Nothing -> False
+    Just txt -> not $ Text.null txt
+
+-- | True if environment variable represents 'true' boolean value, otherwise False.
+isTrue :: String -> IO Bool
+isTrue name = do
+  value <- lookupName name
+  pure $ case value of
+    Nothing -> False
+    Just txt -> Text.toLower txt == "true"

--- a/src/Control/Carrier/Telemetry/Utils.hs
+++ b/src/Control/Carrier/Telemetry/Utils.hs
@@ -60,7 +60,7 @@ mkTelemetryRecord seenFatalException ctx = sendIO $ do
   cliTimedDurations <- atomically $ getItems (telTimeSpentQ ctx)
   cliUsageCounter <- atomically $ getCounterRegistry (telCounters ctx)
   finalTime <- getCurrentTime
-  cliCIEnv <- lookupCIEnvironment
+  ciEnv <- lookupCIEnvironment
 
   pure $
     TelemetryRecord
@@ -76,7 +76,7 @@ mkTelemetryRecord seenFatalException ctx = sendIO $ do
       , cliTotalDurationInSec = realToFrac $ nominalDiffTimeToSeconds $ diffUTCTime finalTime (telStartUtcTime ctx)
       , cliUsageCounter = cliUsageCounter
       , cliVersion = getCurrentCliVersion
-      , cliCIEnv = cliCIEnv
+      , cliCIEnvironment = ciEnv
       }
   where
     getItems :: TBMQueue a -> STM [a]
@@ -135,21 +135,21 @@ lookupCIEnvironment = do
       hasBuildIdEnv <- hasSomeValue "BUILD_ID"
       pure $ if (hasCIEnv || hasBuildIdEnv) then Just UnknownCI else Nothing
 
-lookupName :: String -> IO (Maybe Text)
-lookupName name = toText <$$> lookupEnv name
+    lookupName :: String -> IO (Maybe Text)
+    lookupName name = toText <$$> lookupEnv name
 
--- | True if environment variable has non empty value, otherwise False.
-hasSomeValue :: String -> IO Bool
-hasSomeValue name = do
-  value <- lookupName name
-  pure $ case value of
-    Nothing -> False
-    Just txt -> not $ Text.null txt
+    -- | True if environment variable has non empty value, otherwise False.
+    hasSomeValue :: String -> IO Bool
+    hasSomeValue name = do
+      value <- lookupName name
+      pure $ case value of
+        Nothing -> False
+        Just txt -> not $ Text.null txt
 
--- | True if environment variable represents 'true' boolean value, otherwise False.
-isTrue :: String -> IO Bool
-isTrue name = do
-  value <- lookupName name
-  pure $ case value of
-    Nothing -> False
-    Just txt -> Text.toLower txt == "true"
+    -- | True if environment variable represents 'true' boolean value, otherwise False.
+    isTrue :: String -> IO Bool
+    isTrue name = do
+      value <- lookupName name
+      pure $ case value of
+        Nothing -> False
+        Just txt -> Text.toLower txt == "true"


### PR DESCRIPTION
# Overview

This PR, 
- adds CI environment identifier in the telemetry record.

## Acceptance criteria

- When CLI is ran in github actions, telemetry include github_action ci indicator
- When CLI is ran in bamboo (bitbucket), telemetry include bamboo ci indicator
- When CLI is ran in azure pipeline, telemetry include azure ci indicator
- When CLI is ran in generic CI, telemetry includes ci indicator

## Testing plan

```bash
mkdir sandbox

# should be unknown_ci
CI='some-ci' ./fossa analyze sandbox --debug && cat fossa.telemetry.json | jq '.cliCIEnvironment' 

# should be github_action
GITHUB_ACTIONS=true ./fossa analyze sandbox --debug && cat fossa.telemetry.json | jq '.cliCIEnvironment'

# should be azure_pipeline
TF_BUILD=true ./fossa analyze sandbox --debug && cat fossa.telemetry.json | jq '.cliCIEnvironment'

# should be bamboo
bamboo.buildKey=123 ./fossa analyze sandbox --debug && cat fossa.telemetry.json | jq '.cliCIEnvironment'
```

Sibling PR:
- https://github.com/fossas/FOSSA/pull/8362

## Risks

N/A

## References

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
