### PR TITLE
[No Ticket] Container scanning supports hardlinks in image, and increases timeout

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,23 +1,28 @@
 # FOSSA CLI Changelog
 
-## 3.4.2
+## v3.4.3
+- Container scanning: Supports hardlink file discovery for experimental scanner. ([#1047](https://github.com/fossas/fossa-cli/pull/1047))
+- Container scanning: Supports busybox. ([#1047](https://github.com/fossas/fossa-cli/pull/1047))
+- Container scanning: Increases timeout to 5 mins when extracting image from docker engine api for experimental scanner. ([#1047](https://github.com/fossas/fossa-cli/pull/1047))
+
+## v3.4.2
 
 - API: Error messages are more clear and provide user-actionable feedback. ([#1048](https://github.com/fossas/fossa-cli/pull/1048))
 - Metrics: Reports the kind of CI environment in which FOSSA is running, if any. ([#1043](https://github.com/fossas/fossa-cli/pull/1043))
 
-## 3.4.1
+## v3.4.1
 
 - Container scanning: RPM: Add support for the Sqlite backend. ([#1044](https://github.com/fossas/fossa-cli/pull/1044))
 - Container scanning: RPM: Add support for the NDB backend. ([#1046](https://github.com/fossas/fossa-cli/pull/1046))
 
-## 3.4.0
+## v3.4.0
 
 - Container scanning: New experimental scanner. ([#1001](https://github.com/fossas/fossa-cli/pull/1001), [#1002](https://github.com/fossas/fossa-cli/pull/1002), [#1003](https://github.com/fossas/fossa-cli/pull/1003), [#1004](https://github.com/fossas/fossa-cli/pull/1004), [#1005](https://github.com/fossas/fossa-cli/pull/1005), [#1006](https://github.com/fossas/fossa-cli/pull/1006), [#1010](https://github.com/fossas/fossa-cli/pull/1010), [#1011](https://github.com/fossas/fossa-cli/pull/1011), [#1012](https://github.com/fossas/fossa-cli/pull/1012), [#1014](https://github.com/fossas/fossa-cli/pull/1014), [#1016](https://github.com/fossas/fossa-cli/pull/1016), [#1017](https://github.com/fossas/fossa-cli/pull/1017), [#1021](https://github.com/fossas/fossa-cli/pull/1021), [#1025](https://github.com/fossas/fossa-cli/pull/1025), [#1026](https://github.com/fossas/fossa-cli/pull/1026), [#1029](https://github.com/fossas/fossa-cli/pull/1029), [#1031](https://github.com/fossas/fossa-cli/pull/1031), [#1032](https://github.com/fossas/fossa-cli/pull/1032), [#1034](https://github.com/fossas/fossa-cli/pull/1034))<br>
   For more information, see the [experimental container scanning documentation](./docs/references/experimental/container/experimental-scanner.md).
 - Filters: Add `dist-newstyle` to the list of automatically filtered directories. ([#1030](https://github.com/fossas/fossa-cli/pull/1035))
 - `fossa-deps`: Fix a bug in `fossa-deps.schema.json`, it is now valid JSON. ([#1030](https://github.com/fossas/fossa-cli/pull/1030))
 
-## 3.3.12
+## v3.3.12
 
 - CocoaPods: Fixes error when analyzing podspecs that print non-JSON text to stdout ([#1015](https://github.com/fossas/fossa-cli/pull/1015))
 - VSI: Executes with at least two threads even on a single core system ([#1013](https://github.com/fossas/fossa-cli/pull/1013))

--- a/src/Container/Tarball.hs
+++ b/src/Container/Tarball.hs
@@ -204,7 +204,7 @@ isSymLink :: Tar.Entry -> Bool
 isSymLink (TarEntry.Entry _ (SymbolicLink _) _ _ _ _) = True
 isSymLink _ = False
 
--- | True if tar entry is for a symbolic link, otherwise False.
+-- | True if tar entry is for a hard link, otherwise False.
 isHardLink :: Tar.Entry -> Bool
 isHardLink (TarEntry.Entry _ (HardLink _) _ _ _ _) = True
 isHardLink _ = False

--- a/src/Container/Tarball.hs
+++ b/src/Container/Tarball.hs
@@ -14,7 +14,7 @@ module Container.Tarball (
 
 import Codec.Archive.Tar (
   Entry (entryContent),
-  EntryContent (NormalFile, SymbolicLink),
+  EntryContent (HardLink, NormalFile, SymbolicLink),
  )
 import Codec.Archive.Tar qualified as Tar
 import Codec.Archive.Tar.Entry (Entry (entryTarPath), TarPath, entryPath, fromTarPathToPosixPath)
@@ -166,7 +166,7 @@ mkLayerFromOffset layerId imgOffset = build (ContainerLayer mempty 0 layerId)
     updateChangeSet :: TarEntryOffset -> Tar.Entry -> ContainerLayer -> Seq ContainerFSChangeSet
     updateChangeSet offset entry containerLayer =
       if isDoubleWhiteOut (filePathOf . entryTarPath $ entry)
-        || ( not (isFileOrSymLink entry)
+        || ( not (isFileOrLinkTarget entry)
               && not (isWhiteOut $ filePathOf . entryTarPath $ entry)
            )
         then -- Do not capture Insert for non-files or non-symbolic links, as folders
@@ -191,8 +191,8 @@ mkFsFromChangeset (ContainerLayer changeSet _ _) = foldl' (flip applyChangeSet) 
     applyChangeSet (Whiteout path) tree = remove (toSomePath . toText $ path) tree
 
 -- | True if tar entry is for a file or a symlink, otherwise False
-isFileOrSymLink :: Tar.Entry -> Bool
-isFileOrSymLink e = isFile e || isSymLink e
+isFileOrLinkTarget :: Tar.Entry -> Bool
+isFileOrLinkTarget e = isFile e || isSymLink e || isHardLink e
 
 -- | True if tar entry is for a file with content, otherwise False.
 isFile :: Tar.Entry -> Bool
@@ -203,6 +203,11 @@ isFile _ = False
 isSymLink :: Tar.Entry -> Bool
 isSymLink (TarEntry.Entry _ (SymbolicLink _) _ _ _ _) = True
 isSymLink _ = False
+
+-- | True if tar entry is for a symbolic link, otherwise False.
+isHardLink :: Tar.Entry -> Bool
+isHardLink (TarEntry.Entry _ (HardLink _) _ _ _ _) = True
+isHardLink _ = False
 
 -- | True if tar path has double whiteout marker.
 isDoubleWhiteOut :: FilePath -> Bool

--- a/src/Control/Carrier/DockerEngineApi.hs
+++ b/src/Control/Carrier/DockerEngineApi.hs
@@ -96,7 +96,7 @@ unixSocketClient socketPath = socketHttpManager
     socketHttpManager = sendIO $ HTTP.newManager socketManagerSettings
 
     fiveMinutes :: ResponseTimeout
-    fiveMinutes = ResponseTimeoutMicro 3_0000_0000
+    fiveMinutes = ResponseTimeoutMicro 300_000_000
 
     socketManagerSettings :: HTTP.ManagerSettings
     socketManagerSettings =

--- a/src/Control/Carrier/DockerEngineApi.hs
+++ b/src/Control/Carrier/DockerEngineApi.hs
@@ -15,13 +15,17 @@ import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
 import Diag.Result (resultToMaybe)
 import Network.HTTP.Client qualified as HTTP
-import Network.HTTP.Client.Internal (Connection)
+import Network.HTTP.Client.Internal (Connection, ResponseTimeout (ResponseTimeoutMicro))
 import Network.HTTP.Conduit qualified as HTTPConduit
 import Network.HTTP.Types (ok200)
 import Network.Socket qualified as Socket
 import Network.Socket.ByteString qualified as SocketByteString
 import Path (Abs, File, Path)
 
+-- TODO: Replace it with docker inspect <image>, and docker save <image> -o <filepath>?
+--
+-- We should just use `docker` executable, having docker engine is nice and all
+-- for full compatibility with other builder tools.but in practice, most users will be using docker executable.
 type DockerEngineApiC = SimpleC DockerEngineApiF
 
 runDockerEngineApi :: (Has (Lift IO) sig m, Has Diag.Diagnostics sig m) => Text -> DockerEngineApiC m a -> m a
@@ -91,8 +95,15 @@ unixSocketClient socketPath = socketHttpManager
     socketHttpManager :: Has (Lift IO) sig m => m HTTP.Manager
     socketHttpManager = sendIO $ HTTP.newManager socketManagerSettings
 
+    fiveMinutes :: ResponseTimeout
+    fiveMinutes = ResponseTimeoutMicro 3_0000_0000
+
     socketManagerSettings :: HTTP.ManagerSettings
-    socketManagerSettings = HTTP.defaultManagerSettings{HTTP.managerRawConnection = pure open}
+    socketManagerSettings =
+      HTTP.defaultManagerSettings
+        { HTTP.managerRawConnection = pure open
+        , HTTP.managerResponseTimeout = fiveMinutes
+        }
 
     open :: Maybe Socket.HostAddress -> String -> Int -> IO Connection
     open _ _ _ = do


### PR DESCRIPTION
# Overview

This PR:
- adds support for hardlinks
- increases default timeout for docker engine api

## Acceptance criteria

- Can scan very large images using docker engine api

## Testing plan

```bash
➜  fossa-cli git:(fix/experimental-scanner-issues) ✗ docker pull apache/nifi:latest                                                       
➜  fossa-cli git:(fix/experimental-scanner-issues) ✗ ./fossa container analyze apache/nifi:latest --experimental-scanner -o     
```
^ should succeed!

```bash
➜  fossa-cli git:(fix/experimental-scanner-issues) ✗ docker pull busybox:latest                                                      
➜  fossa-cli git:(fix/experimental-scanner-issues) ✗ ./fossa container analyze busybox:latest --experimental-scanner -o (yes it will not find anything, but it should not throw error)
```

^ should succeed!

## Risks

N/A

## References

N/A

## Checklist

- [] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
