### PR TITLE
[ANE-561] Consistent Project naming for Containers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.4.6
+- Container Scanning: Fixes a defect, where container registry `registry:3000/org/repo:tag` was incorrectly identifying `registry` as project name. ([#1050](https://github.com/fossas/fossa-cli/issues/1050))
+- Container Scanning: Includes registry uri in project name (experimental scanner only). ([#1050](https://github.com/fossas/fossa-cli/issues/1050))
+
 ## v3.4.5
 - FOSSA API: Adds resiliency against API errors occurring when retrieving endpoint versioning information. ([#1051](https://github.com/fossas/fossa-cli/pull/1051))
 

--- a/docs/references/experimental/container/experimental-scanner.md
+++ b/docs/references/experimental/container/experimental-scanner.md
@@ -9,12 +9,15 @@
     - [2) From Docker Engine](#2-from-docker-engine)
     - [3) From registries](#3-from-registries)
   - [Container image analysis](#container-image-analysis)
+    - [View detected projects](#view-detected-projects)
+      - [Command output](#command-output)
+    - [Utilize analysis target configuration](#utilize-analysis-target-configuration)
     - [Debugging](#debugging)
     - [Frequently Asked Questions (FAQs)](#frequently-asked-questions-faqs)
       - [How do I scan multi-platform container images with `fossa-cli`?](#how-do-i-scan-multi-platform-container-images-with-fossa-cli)
-      - [How can I only scan for system dependencies (alpine, dpkg, rpm)?](#how-can-i-only-scan-for-system-dependencies-alpine-dpkg-rpm)
-      - [How do I exclude specific projects from container scanning?](#how-do-i-exclude-specific-projects-from-container-scanning)
-    - [Limitations & Workarounds](#limitations--workarounds)
+    - [How can I only scan for system dependencies (alpine, dpkg, rpm)?](#how-can-i-only-scan-for-system-dependencies-alpine-dpkg-rpm)
+    - [How do I exclude specific projects from container scanning?](#how-do-i-exclude-specific-projects-from-container-scanning)
+  - [Limitations & Workarounds](#limitations--workarounds)
 
 ## What's new in this scanner?
 
@@ -23,7 +26,6 @@ The performance of analysis and support for container image sources is improved,
 
 FOSSA's new container scanner brings support for standard FOSSA CLI features into containers:
 - Support for configuration via `.fossa.yml`.
-- Support for `fossa-deps`.
 - Support for path filtering (exclusion and inclusion).
 
 Finally, FOSSA's new container scanner improves the user experience and reports more information to FOSSA servers,

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -141,6 +141,8 @@ analyze cfg = do
   -- Diagnose Project amd Revision Identifier
   logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
   logInfo ("Using project revision: `" <> pretty (projectRevision revision) <> "`")
+  let branchText = fromMaybe "No branch (detached HEAD)" $ projectBranch revision
+  logInfo ("Using branch: `" <> pretty branchText <> "`")
 
   case scanDestination cfg of
     OutputStdout -> logStdout . decodeUtf8 $ Aeson.encode scannedImage

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -137,6 +137,11 @@ analyze cfg = do
         analyzeFromRegistry systemDepsOnly filters registrySrc
 
   let revision = extractRevision (revisionOverride cfg) scannedImage
+
+  -- Diagnose Project amd Revision Identifier
+  logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
+  logInfo ("Using project revision: `" <> pretty (projectRevision revision) <> "`")
+
   case scanDestination cfg of
     OutputStdout -> logStdout . decodeUtf8 $ Aeson.encode scannedImage
     UploadScan apiOpts projectMeta ->
@@ -164,11 +169,6 @@ uploadScan revision projectMeta containerScan =
     if not supportsNativeScan
       then fatal EndpointDoesNotSupportNativeContainerScan
       else do
-        logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
-        logInfo ("Using project revision: `" <> pretty (projectRevision revision) <> "`")
-        let branchText = fromMaybe "No branch (detached HEAD)" $ projectBranch revision
-        logInfo ("Using branch: `" <> pretty branchText <> "`")
-
         resp <- uploadNativeContainerScan revision projectMeta containerScan
         let locator = uploadLocator resp
         buildUrl <- getFossaBuildUrl revision locator

--- a/src/App/Fossa/Container/Scan.hs
+++ b/src/App/Fossa/Container/Scan.hs
@@ -46,7 +46,7 @@ import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Set (Set)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
-import Data.Text.Extra (breakOnAndRemove)
+import Data.Text.Extra (breakOnEndAndRemove)
 import Effect.Exec (
   AllowErr (Never),
   Command (..),
@@ -239,7 +239,7 @@ convertArtifact ResponseArtifact{..} = do
 extractTag :: Has Diagnostics sig m => [Text] -> m Text
 extractTag tags = do
   firstTag <- fromMaybeText "No image tags found" $ listToMaybe tags
-  tagTuple <- fromMaybeText "Image was not in the format name:tag" $ breakOnAndRemove ":" firstTag
+  tagTuple <- fromMaybeText "Image was not in the format name:tag" $ breakOnEndAndRemove ":" firstTag
   pure $ fst tagTuple
 
 runSyft ::

--- a/src/Container/Docker/OciManifest.hs
+++ b/src/Container/Docker/OciManifest.hs
@@ -126,10 +126,11 @@ toDockerManifest (OciManifestV2 config layers) imgSrc =
 
     sanitizeRepoName :: Text
     sanitizeRepoName =
-      if ( Text.isPrefixOf "library/" repo
-            && registryHost imgSrc == defaultRegistry
-         )
-        then Text.replace "library/" "" repo
+      if (registryHost imgSrc == defaultRegistry)
+        then
+          if (Text.isPrefixOf "library/" repo)
+            then Text.replace "library/" "" repo
+            else repo
         else toRepoNameWithRegistry imgSrc
 
     repo :: Text

--- a/src/Container/Docker/SourceParser.hs
+++ b/src/Container/Docker/SourceParser.hs
@@ -46,6 +46,7 @@ module Container.Docker.SourceParser (
   defaultHttpScheme,
   suggestDockerExport,
   showReferenceWithSep,
+  toRepoNameWithRegistry,
 ) where
 
 import Control.Monad (unless, void)
@@ -186,6 +187,12 @@ parseImageUrl targetArch = do
         { registryContainerRepository =
             prefix <> registryContainerRepository imgSrc
         }
+
+toRepoNameWithRegistry :: RegistryImageSource -> Text
+toRepoNameWithRegistry imgSrc =
+  registryHost imgSrc
+    <> "/"
+    <> registryContainerRepository imgSrc
 
 parseImageUrlWithDefaultRegistry :: Text -> Text -> Parser RegistryImageSource
 parseImageUrlWithDefaultRegistry defaultHost targetArch = do

--- a/src/Data/Text/Extra.hs
+++ b/src/Data/Text/Extra.hs
@@ -2,6 +2,7 @@ module Data.Text.Extra (
   splitOnceOn,
   splitOnceOnEnd,
   breakOnAndRemove,
+  breakOnEndAndRemove,
   underBS,
   showT,
   dropPrefix,
@@ -41,6 +42,21 @@ breakOnAndRemove needle haystack = do
   let (before, after) = Text.breakOn needle haystack
   if needle `Text.isPrefixOf` after
     then pure (before, Text.drop (Text.length needle) after)
+    else Nothing
+
+-- | Removes last needle (ordering from left to right) from haystack.
+--
+-- >> breakOnEndAndRemove ":" "a:b:c"
+-- Just ("a:b", "c")
+--
+-- >> breakOnEndAndRemove ":" "a-b-c"
+-- Nothing
+-- -
+breakOnEndAndRemove :: Text -> Text -> Maybe (Text, Text)
+breakOnEndAndRemove needle haystack = do
+  let (before, after) = Text.breakOnEnd needle haystack
+  if needle `Text.isSuffixOf` before
+    then pure (Text.dropEnd (Text.length needle) before, after)
     else Nothing
 
 underBS :: (ByteString -> ByteString) -> Text -> Text

--- a/test/Container/Docker/OciManifestSpec.hs
+++ b/test/Container/Docker/OciManifestSpec.hs
@@ -53,7 +53,7 @@ spec = do
         ( NonEmpty.fromList
             [ ManifestJsonImageEntry
                 "config.json"
-                ["library/redis:alpine"]
+                ["quay.io/library/redis:alpine"]
                 $ NonEmpty.fromList ["layer.tar"]
             ]
         )

--- a/test/Extra/TextSpec.hs
+++ b/test/Extra/TextSpec.hs
@@ -24,3 +24,9 @@ spec = do
     Test.it "should leave the string unchanged when the prefix is missing" $ do
       dropPrefix "foo" "bar" `Test.shouldBe` "bar"
       dropPrefix "foo" "" `Test.shouldBe` ""
+
+  Test.describe "Text breakOnEndAndRemove" $
+    Test.it "should break a string from last needle (with last needle removed)" $ do
+      breakOnEndAndRemove ":" "a:b" `Test.shouldBe` Just ("a", "b")
+      breakOnEndAndRemove ":" "a:b:c" `Test.shouldBe` Just ("a:b", "c")
+      breakOnEndAndRemove ":" "some.registry:5000/org/app:tag" `Test.shouldBe` Just ("some.registry:5000/org/app", "tag")


### PR DESCRIPTION
# Overview

This PR ensures, 

- Logs of finalized "project" and "revision" value for both `--output` and `uploadScan` targets
- For the project name, for syft scanner, we break on last `:` to ensure port numbers are included in the project name
- For the project name, for the experimental scanner we include the registry host URL in the repository tag to match `syft` scanner's project naming
- incorrect/or/not-supported yet experimental-scanner docs re `fossa-deps` are removed

## Acceptance criteria

- Syft scanner included the host's port in the project name
- Experimental scanner includes registry URL in the project name (just like syft)

## Testing plan

1) Syft scanner included host's port in the project name

```bash
# make local container registry
docker run -d -p 6000:5000 --name registry registry:2.7

# Push an image to this registry
docker pull ubuntu
docker tag ubuntu localhost:6000/ubuntu
docker push localhost:6000/ubuntu

# Run Syft
./fossa container analyze localhost:6000/ubuntu -o # should see [ INFO] Using project name: `localhost:6000/ubuntu`

# Run Experimental Scanner
./fossa container analyze localhost:6000/ubuntu --experimental-scanner -o # should see [ INFO] Using project name: `localhost:6000/ubuntu`
```


2) Experimental scanner includes registry url in the project name (just like syft)

```bash
docker image rm ghcr.io/fossas/haskell-dev-tools:8.10.4
./fossa container analyze ghcr.io/fossas/haskell-dev-tools:8.10.4 --experimental-scanner -o # should see [ INFO] Using project name: `ghcr.io/fossas/haskell-dev-tools:8.10.4`
./fossa container analyze redis --experimental-scanner -o # should see [ INFO] Using project name: `redis`
```

## Risks

1) It's breaking change for any users who were using registry with port `:` - it may create an additional project if they upgrade to CLI with this commit. We expect that not many users (or none at all) are using `fossa-cli` to scan container image from registry with some port value in it's image input

## References

https://fossa.atlassian.net/browse/ANE-561

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
