### PR TITLE
[No Ticket] resilience against api errors when retrieving endpoint version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- FOSSA API: Adds resiliency against API errors occurring when retrieving endpoint versioning information. ([#1051](https://github.com/fossas/fossa-cli/pull/1051))
+
 ## v3.4.4
 - Fix a bug in the v1 installers for Windows (install-v1.ps1 and install.ps1) ([#1052](https://github.com/fossas/fossa-cli/pull/1052))
 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -78,6 +78,7 @@ import Control.Carrier.TaskPool (
   withTaskPool,
  )
 import Control.Concurrent (getNumCapabilities)
+import Control.Effect.Diagnostics (recover)
 import Control.Effect.Exception (Lift)
 import Control.Effect.FossaApiClient (FossaApiClient, getEndpointVersion)
 import Control.Effect.Git (Git)
@@ -312,7 +313,9 @@ analyze cfg = Diag.context "fossa-analyze" $ do
 
   maybeEndpointAppVersion <- case destination of
     UploadScan apiOpts _ -> runFossaApiClient apiOpts $ do
-      version <- getEndpointVersion
+      -- Using 'recovery' as API corresponding to 'getEndpointVersion',
+      -- seems to be not stable and we sometimes see TimeoutError in telemetry
+      version <- recover getEndpointVersion
       debugMetadata "FossaEndpointCoreVersion" version
       pure version
     _ -> pure Nothing

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -204,7 +204,7 @@ getEndpointVersion ::
   , Has Diagnostics sig m
   , Has (Reader ApiOpts) sig m
   ) =>
-  m (Maybe Text)
+  m Text
 getEndpointVersion = do
   apiOpts <- ask
   API.getEndpointVersion apiOpts

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -65,7 +65,7 @@ import Container.Errors (EndpointDoesNotSupportNativeContainerScan (EndpointDoes
 import Container.Types qualified as NativeContainer
 import Control.Algebra (Algebra, Has, type (:+:))
 import Control.Carrier.Empty.Maybe (Empty, EmptyC, runEmpty)
-import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (..), context, fatal, fromMaybeText, warn)
+import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (..), context, fatal, fatalText, fromMaybeText)
 import Control.Effect.Empty (empty)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Exception (Exception (displayException), SomeException)
@@ -1214,17 +1214,17 @@ vsiDownloadInferences apiOpts scanID = fossaReq $ do
   pure $ unVSIExportedInferencesBody body
 
 endpointAppManifest :: Url scheme -> Url scheme
-endpointAppManifest baseurl = baseurl /: "rest" /: "applinks" /: "*" /: "manifest"
+endpointAppManifest baseurl = baseurl /: "rest" /: "applinks" /: "*" /: "manifests"
 
 newtype AppManifest = AppManifest {endpointAppVersion :: Text} deriving (Show, Eq, Ord)
 
 instance FromXML AppManifest where
   parseElement el = AppManifest <$> child "version" el
 
-getEndpointVersion :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> m (Maybe Text)
+getEndpointVersion :: (Has (Lift IO) sig m, Has Diagnostics sig m) => ApiOpts -> m Text
 getEndpointVersion apiOpts = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
   body <- responseBody <$> req GET (endpointAppManifest baseUrl) NoReqBody bsResponse baseOpts
   case parseXML (decodeUtf8 body) of
-    Left err -> warn (xmlErrorPretty err) >> pure Nothing
-    Right (appManifest :: AppManifest) -> pure $ Just (endpointAppVersion appManifest)
+    Left err -> fatalText (xmlErrorPretty err)
+    Right (appManifest :: AppManifest) -> pure $ endpointAppVersion appManifest

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -1214,7 +1214,7 @@ vsiDownloadInferences apiOpts scanID = fossaReq $ do
   pure $ unVSIExportedInferencesBody body
 
 endpointAppManifest :: Url scheme -> Url scheme
-endpointAppManifest baseurl = baseurl /: "rest" /: "applinks" /: "*" /: "manifests"
+endpointAppManifest baseurl = baseurl /: "rest" /: "applinks" /: "*" /: "manifest"
 
 newtype AppManifest = AppManifest {endpointAppVersion :: Text} deriving (Show, Eq, Ord)
 

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -88,7 +88,7 @@ data FossaApiClientF a where
   GetApiOpts :: FossaApiClientF ApiOpts
   GetAttribution :: ProjectRevision -> ReportOutputFormat -> FossaApiClientF Text
   GetIssues :: ProjectRevision -> Maybe DiffRevision -> FossaApiClientF Issues
-  GetEndpointVersion :: FossaApiClientF (Maybe Text)
+  GetEndpointVersion :: FossaApiClientF Text
   GetLatestBuild :: ProjectRevision -> FossaApiClientF Build
   GetLatestScan :: Locator -> ProjectRevision -> FossaApiClientF ScanResponse
   GetOrganization :: FossaApiClientF Organization
@@ -221,5 +221,5 @@ getVsiScanAnalysisStatus = sendSimple . GetVsiScanAnalysisStatus
 getVsiInferences :: Has FossaApiClient sig m => VSI.ScanID -> m [Locator]
 getVsiInferences = sendSimple . GetVsiInferences
 
-getEndpointVersion :: Has FossaApiClient sig m => m (Maybe Text)
+getEndpointVersion :: Has FossaApiClient sig m => m Text
 getEndpointVersion = sendSimple GetEndpointVersion


### PR DESCRIPTION
# Overview

This PR, 

- wraps `getEndpointVersion` with recover

## Acceptance criteria

- API Error due to `getEndpointVersion` does not cause a fatal issue

## Testing plan

This is hard to test, as this error seems to occur intermittently. 
To test this PR, I intentionally modified the endpoint to include additional `s` and ran `./fossa analyze` (it should succeed)

```haskell
endpointAppManifest :: Url scheme -> Url scheme
endpointAppManifest baseurl = baseurl /: "rest" /: "applinks" /: "*" /: "manifests" -- note the additional `s`
```

## Risks

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
