### PR TITLE
fix the v1 installer for windows

### DIFF
--- a/install-v1.ps1
+++ b/install-v1.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5
+﻿#Requires -Version 5
 
 <#
     .SYNOPSIS
@@ -11,8 +11,8 @@ Param()
 $OldEAP = $ErrorActionPreference #Preserve the original value
 $ErrorActionPreference = "Stop"
 $release_v1_upperbound="v1.1.10"
+$releaseVersionSemver = $release_v1_upperbound.TrimStart("v");
 $github = "https://github.com"
-$latestUri = "$github/fossas/fossa-cli/releases/$release_v1_upperbound"
 $extractDir = "$env:ALLUSERSPROFILE\fossa-cli"
 
 Write-host "`n"
@@ -21,12 +21,12 @@ Write-Host "Deprecation Warning"
 Write-Host "-------------------"
 Write-host "`n"
 Write-Host "You are installing FOSSA CLI v1, which is no longer in active"
-Write-Host "development. FOSSA will not address new defects found in CLI v1."  
+Write-Host "development. FOSSA will not address new defects found in CLI v1."
 Write-host "`n"
 Write-Host "Please upgrade to the latest FOSSA CLI."
 Write-host "`n"
 Write-Host "Please upgrade to FOSSA CLI v3 by using install-latest script:"
-Write-Host "--------------------------------------------------------------" 
+Write-Host "--------------------------------------------------------------"
 Write-Host "    Set-ExecutionPolicy Bypass -Scope Process -Force; iex  ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.ps1'))"
 Write-host "`n"
 Write-Host "Migration guide for FOSSA CLI v3:"
@@ -34,18 +34,10 @@ Write-Host "---------------------------------"
 Write-Host "    https://github.com/fossas/fossa-cli/blob/master/docs/differences-from-v1.md#how-to-upgrade-to-fossa-3x"
 Write-host "`n"
 
-Write-Verbose "Looking up latest v1 release..."
-
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 
-$releasePage = Invoke-RestMethod $latestUri
-
-if ($releasePage -inotmatch 'href=\"(.*?releases\/download\/.*?windows.*?)\"')
-{
-    throw "Did not find latest Windows release at $latestUri"
-}
-
-$downloadUri = "$github/$($Matches[1])"
+$downloadPath = "fossas/fossa-cli/releases/download/$($release_v1_upperbound)/fossa-cli_$($releaseVersionSemver)_windows_amd64.zip"
+$downloadUri = "$github/$downloadPath"
 Write-Verbose "Downloading from: $downloadUri"
 
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "fossa-cli"

--- a/install.ps1
+++ b/install.ps1
@@ -11,8 +11,8 @@ Param()
 $OldEAP = $ErrorActionPreference #Preserve the original value
 $ErrorActionPreference = "Stop"
 $release_v1_upperbound="v1.1.10"
+$releaseVersionSemver = $release_v1_upperbound.TrimStart("v");
 $github = "https://github.com"
-$latestUri = "$github/fossas/fossa-cli/releases/$release_v1_upperbound"
 $extractDir = "$env:ALLUSERSPROFILE\fossa-cli"
 
 Write-host "`n"
@@ -21,12 +21,12 @@ Write-Host "Deprecation Warning"
 Write-Host "-------------------"
 Write-host "`n"
 Write-Host "You are installing FOSSA CLI v1, which is no longer in active"
-Write-Host "development. FOSSA will not address new defects found in CLI v1."  
+Write-Host "development. FOSSA will not address new defects found in CLI v1."
 Write-host "`n"
 Write-Host "Please upgrade to the latest FOSSA CLI."
 Write-host "`n"
 Write-Host "Please upgrade to FOSSA CLI v3 by using install-latest script:"
-Write-Host "--------------------------------------------------------------" 
+Write-Host "--------------------------------------------------------------"
 Write-Host "    Set-ExecutionPolicy Bypass -Scope Process -Force; iex  ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.ps1'))"
 Write-host "`n"
 Write-Host "Migration guide for FOSSA CLI v3:"
@@ -34,18 +34,10 @@ Write-Host "---------------------------------"
 Write-Host "    https://github.com/fossas/fossa-cli/blob/master/docs/differences-from-v1.md#how-to-upgrade-to-fossa-3x"
 Write-host "`n"
 
-Write-Verbose "Looking up latest v1 release..."
-
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 
-$releasePage = Invoke-RestMethod $latestUri
-
-if ($releasePage -inotmatch 'href=\"(.*?releases\/download\/.*?windows.*?)\"')
-{
-    throw "Did not find latest Windows release at $latestUri"
-}
-
-$downloadUri = "$github/$($Matches[1])"
+$downloadPath = "fossas/fossa-cli/releases/download/$($release_v1_upperbound)/fossa-cli_$($releaseVersionSemver)_windows_amd64.zip"
+$downloadUri = "$github/$downloadPath"
 Write-Verbose "Downloading from: $downloadUri"
 
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "fossa-cli"


### PR DESCRIPTION
# Overview

The Windows v1 installers (`install.ps1` and `install-v1.ps1`) were downloading the HTML for a release page and extracting the download URL for the windows version from it.

The HTML no longer contains the download URL, so the installer broke.

The `install-latest.ps1` script does not have this bug. This only needs to be fixed for the v1 installers.

## Acceptance criteria

- `install.ps1` and `install-v1.ps1` should work when tested on a Windows machine
- The `test-installation-scripts` test for Windows should pass again. Here's a link to a run before this fix: https://github.com/fossas/fossa-cli/actions/runs/3086005620/jobs/4989967136

## Testing plan

I tested by creating a windows instance on EC2, connecting using "Microsoft Remote Desktop" and then running both scripts on it.

The original script looks like this when you run it:

```
 .\install-original.ps1


-------------------
Deprecation Warning
-------------------


You are installing FOSSA CLI v1, which is no longer in active
development. FOSSA will not address new defects found in CLI v1.


Please upgrade to the latest FOSSA CLI.


Please upgrade to FOSSA CLI v3 by using install-latest script:
--------------------------------------------------------------
    Set-ExecutionPolicy Bypass -Scope Process -Force; iex  ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.ps1'))


Migration guide for FOSSA CLI v3:
---------------------------------
    https://github.com/fossas/fossa-cli/blob/master/docs/differences-from-v1.md#how-to-upgrade-to-fossa-3x


Did not find latest Windows release at https://github.com/fossas/fossa-cli/releases/v1.1.10
At C:\Users\Administrator\Documents\install-original.ps1:45 char:5
+     throw "Did not find latest Windows release at $latestUri"
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Did not find la...eleases/v1.1.10:String) [], RuntimeException
    + FullyQualifiedErrorId : Did not find latest Windows release at https://github.com/fossas/fossa-cli/releases/v1.1.10
```

The new scripts run fine:

```
PS C:\Users\Administrator\Documents> .\install-v1.ps1


-------------------
Deprecation Warning
-------------------


You are installing FOSSA CLI v1, which is no longer in active
development. FOSSA will not address new defects found in CLI v1.


Please upgrade to the latest FOSSA CLI.


Please upgrade to FOSSA CLI v3 by using install-latest script:
--------------------------------------------------------------
    Set-ExecutionPolicy Bypass -Scope Process -Force; iex  ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.ps1'))


Migration guide for FOSSA CLI v3:
---------------------------------
    https://github.com/fossas/fossa-cli/blob/master/docs/differences-from-v1.md#how-to-upgrade-to-fossa-3x


Installed fossa-cli at: C:\ProgramData\fossa-cli\fossa.exe
Get started by running: fossa.exe --help
C:\ProgramData\fossa-cli\fossa.exe
```

I only tested `install-v1.ps1`, as it is exactly the same as `install.ps1`, so there's no need to test both.

## Risks

I did this by hard-coding the download URL, which is safe because this URL is not going to change. 

Another fix would be to copy the approach used by `install-latest.ps1`, which downloads a JSON blob and grabs the download URL from there. I'm happy to go with that approach if anyone feels strongly about it, but I think I like the slightly lazy way I did this fix better.

## References

https://teamfossa.slack.com/archives/C039KE5ERNE/p1663626413126779

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
