### PR TITLE
[Docs Only] Fixes minor ambiguity in SSL docs, adds docs on submodule filtering

### DIFF
--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -309,7 +309,7 @@ Type   Path         Path   Target      Target
        separator           separator
 ```
 
-1) Now to analyze only `utilities`, use a `.fossa.yml` file in the project root.
+2) Now to analyze only `utilities`, use a `.fossa.yml` file in the project root.
 
 ```yaml
 # filename: .fossa.yml

--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -31,6 +31,7 @@ Gradle users generally specify their builds using a `build.gradle`/`settings.gra
   - [Manually specifying Gradle dependencies](#manually-specifying-gradle-dependencies)
   - [Configurations For Development and Testing](#configurations-for-development-and-testing)
   - [Android Gradle Configurations For Development and Testing](#android-gradle-configurations-for-development-and-testing)
+  - [Only analyzing specific sub project](#only-analyzing-specific-sub-project)
   - [(Experimental) Only Selecting Set of Configurations For Analysis](#experimental-only-selecting-set-of-configurations-for-analysis)
 
 ## Concepts
@@ -281,6 +282,58 @@ We classify following configurations, and dependencies originating from it as a 
 - kotlinKlibCommonizerClasspath
 - kotlinNativeCompilerPluginClasspath
 ```
+
+## Only analyzing specific sub project
+
+If you have gradle project which has one or more subprojects, you may
+only want to analyze a specific set of subprojects in some cases.
+
+
+In `fossa-cli`, this can be achieved by using [exclusion filtering](./../../../files/fossa-yml.md).
+
+1) Run `fossa list-targets`, to identify project directory and identifier of subprojects.
+```bash
+[ INFO] Found project: gradle@./
+[ INFO] Found target: gradle@./::app
+[ INFO] Found target: gradle@./::list
+[ INFO] Found target: gradle@./::utilities
+```
+
+2) Now to analyze only `utilities`, use a `.fossa.yml` file in the project root.
+
+```yaml
+# filename: .fossa.yml
+#
+# analyze only gradle@./::utilities
+version: 3
+targets:
+  only:
+    - type: gradle
+      path: ./
+      target: ':utilities'
+```
+
+Likewise, if you want to exclude specific set of subprojects, you can do following:
+
+```yaml
+# filename: .fossa.yml
+#
+# do not analyze gradle@./::app, and gradle@./::utilities
+version: 3
+targets:
+  only:
+    - type: gradle
+  exclude:
+    - type: gradle
+      path: ./
+      target: ':app'
+    - type: gradle
+      path: ./
+      target: ':utilities'
+```
+
+
+1) Running `fossa analyze --output -c .fossa.yml`, will only analyze `utilities` submodule.
 
 ## (Experimental) Only Selecting Set of Configurations For Analysis
 

--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -299,7 +299,17 @@ In `fossa-cli`, this can be achieved by using [exclusion filtering](./../../../f
 [ INFO] Found target: gradle@./::utilities
 ```
 
-2) Now to analyze only `utilities`, use a `.fossa.yml` file in the project root.
+Note that, targets are denoted in following format `type@path:target`. For 
+example `gradle@./::utilities`:
+
+```
+gradle  @           ./      :         :utilities
+------ ---          ---    ---        -----------
+Type   Path         Path   Target      Target
+       separator           separator
+```
+
+1) Now to analyze only `utilities`, use a `.fossa.yml` file in the project root.
 
 ```yaml
 # filename: .fossa.yml

--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -302,6 +302,7 @@ In `fossa-cli`, this can be achieved by using [exclusion filtering](./../../../f
 Note that, targets are denoted in following format `type@path:target`. For 
 example `gradle@./::utilities`:
 
+Note: gradle attaches leading colons to submodules, so the utilities submodule here is referenced by ":utilities"
 ```
 gradle  @           ./      :         :utilities
 ------ ---          ---    ---        -----------

--- a/docs/walkthroughs/analysis-target-configuration.md
+++ b/docs/walkthroughs/analysis-target-configuration.md
@@ -151,3 +151,31 @@ targets:
     - type: setuptools
       path: utils/helpers/
 ```
+
+## Target Filtering for Submodules
+
+For some package managers, you may have submodules or sub-projects within a single project
+that you are analyzing and you may want to analyze only specifics sub project in some cases.
+
+Here is an example with gradle:
+
+1) Running `fossa list-targets`
+```bash
+[ INFO] Found project: gradle@./
+[ INFO] Found target: gradle@./::app
+[ INFO] Found target: gradle@./::list
+[ INFO] Found target: gradle@./::utilities
+```
+
+2) Now to analyze only `utilities`, use `.fossa.yml` file.
+
+```yaml
+version: 3
+targets:
+  only:
+    - type: gradle
+      path: ./
+      target: ':utilities'
+```
+
+3) Running `fossa analyze --output -c .fossa.yml`, will only analyze `utilities` submodule.

--- a/docs/walkthroughs/analysis-target-configuration.md
+++ b/docs/walkthroughs/analysis-target-configuration.md
@@ -167,6 +167,16 @@ Here is an example with gradle:
 [ INFO] Found target: gradle@./::utilities
 ```
 
+Note that, targets are denoted in following format `type@path:target`. For 
+example `gradle@./::utilities`:
+
+```
+gradle  @           ./      :         :utilities
+------ ---          ---    ---        -----------
+Type   Path         Path   Target      Target
+       separator           separator
+```
+
 2) Now to analyze only `utilities`, use `.fossa.yml` file.
 
 ```yaml

--- a/docs/walkthroughs/analysis-target-configuration.md
+++ b/docs/walkthroughs/analysis-target-configuration.md
@@ -170,6 +170,8 @@ Here is an example with gradle:
 Note that, targets are denoted in following format `type@path:target`. For 
 example `gradle@./::utilities`:
 
+Note: gradle attaches leading colons to submodules, so the utilities submodule here is referenced by ":utilities"
+
 ```
 gradle  @           ./      :         :utilities
 ------ ---          ---    ---        -----------

--- a/docs/walkthroughs/ssl-cert.md
+++ b/docs/walkthroughs/ssl-cert.md
@@ -40,7 +40,7 @@ _We recommended that you leverage the operating system's certificate store inste
 
 In Windows:
 ```
-$Env:SSL_CERT_FILE = "C:\Users\example-user\AppData\Local\mkcert\"
+$Env:SSL_CERT_FILE = "\path\to\rootCa"
 fossa analyze
 ```
 


### PR DESCRIPTION
# Overview

This PR, 
- Adds docs on submodule filtering
- Fixes minor SSL doc on windows which was ambiguous for windows users

## Testing plan

1) Get https://docs.gradle.org/current/samples/zips/sample_building_java_applications_multi_project-kotlin-dsl.zip
2) Update `utilities/build.gradle.kts` to following:

```kts
plugins {
    id("demo.java-library-conventions")
}

dependencies {
    api(project(":list"))

    // Adding dependency for testing
    // https://mvnrepository.com/artifact/org.flywaydb/flyway-core
    implementation("org.flywaydb:flyway-core:9.3.0")
}
```
3) Run `fossa analyze -o | jq`, and observe that `mvn+org.apache.commons:commons-text$1.9` is included from `:app`
4) Create `.fossa.yml`
```yml
version: 3

targets:
  only:
    - type: gradle
      path: ./
      target: ':utilities'
```
5) Run `fossa analyze -o | jq`, and observe that `mvn+org.apache.commons:commons-text$1.9` is not included, only `mvn+org.flywaydb:flyway-core$9.3.0`

## Risks

N/A
