### PR TITLE
be more specific about how unversioned vendored deps work

### DIFF
--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -21,7 +21,7 @@ The path to a vendored dependency can either be a path to an archive or a path t
 
 If it is a path to an archive, then we recursively unarchive and scan the archive. If it is a directory, then we scan the directory and recursively unarchive and scan any archives contained in the directory.
 
-If the version is not specified, then FOSSA CLI calculates the version by generating a hash of the contents of the archive or directory. This is often desired, as it means that the version automatically changes when the contents of the vendored dependency change. It also avoids conflicts across an organization when two different projects contain a vendored dependency with the same name and version, as described in [Vendored Dependency Names and Scope](#vendored-dependency-names-and-scope).
+If the version is not specified, FOSSA CLI calculates the version by generating a hash of the contents of the archive or directory. This is often desired, as it means that the version automatically changes when the contents of the vendored dependency change. It also avoids conflicts across an organization when two different projects contain a vendored dependency with the same name and version, as described in [Vendored Dependency Names and Scope](#vendored-dependency-names-and-scope).
 
 Note: When parsed, YAML considers text that could be a decimal number (such as 1.0 or 2.0) to be a number, not a string. This means that we'd parse the version 1.0 as 1. This probably isn't what you want. To avoid this, surround your version with quotes, as in "1.0".
 

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -82,7 +82,22 @@ We also support json-formatted dependencies:
 
 The name of a vendored dependency is scoped to an organization.
 
-This means that if two different projects in your organization have the same name and version, they will be treated as the same dependency by FOSSA even if they have different contents. The one that was scanned first will be used by FOSSA. If you use the `--force-vendored-dependency-rescans` flag, then the current scan will overwrite the original one. But this will cause the data for the original scan to be incorrect now.
+This means that if two different projects in your organization have the same name and version, they will be treated as the same dependency by FOSSA. The one that was scanned first will be used by FOSSA. Here's an example.
+
+Project A defines a vendored dependency like this in its fossa-deps.yml, and the contents of that vendored dependency has an MIT license:
+
+```yaml
+vendored-dependencies:
+- name: Django
+  path: vendor/Django-3.4.16.zip # path can be either a file or a folder.
+  version: "3.4.16" # revision will be set to the MD5 hash of the filepath if left unspecified.
+```
+
+Project B has exactly the same contents in `fossa-deps.yml`, but the contents of Project B's vendored dependency have an Apache 2.0 license.
+
+If Project A is scanned first, then both Project A and Project B will report that their vendored dependency has an MIT license.
+
+If Project B is scanned first, then both Project A and Project B will report that their vendored dependency has an Apache 2.0 license.
 
 This can cause unexpected behavior, and we are working on changing this so that vendored dependencies are scoped to projects rather than organizations.
 

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -82,26 +82,27 @@ We also support json-formatted dependencies:
 
 The name of a vendored dependency is scoped to an organization.
 
-This means that if two different projects in your organization have the same name and version, they will be treated as the same dependency by FOSSA. The one that was scanned first will be used by FOSSA. Here's an example.
+This means that if two different projects in an organization have the same name and version, they are treated as the same dependency by FOSSA, and the one that was scanned first is reported. As an example:
 
-Project A defines a vendored dependency like this in its fossa-deps.yml, and the contents of that vendored dependency has an MIT license:
+Project A defines a vendored dependency like this in its fossa-deps.yml, and the contents of that vendored dependency contain an MIT license:
 
 ```yaml
 vendored-dependencies:
 - name: Django
-  path: vendor/Django-3.4.16.zip # path can be either a file or a folder.
-  version: "3.4.16" # revision will be set to the MD5 hash of the filepath if left unspecified.
+  path: vendor/Django-3.4.16.zip
+  version: "3.4.16"
 ```
 
-Project B has exactly the same contents in `fossa-deps.yml`, but the contents of Project B's vendored dependency have an Apache 2.0 license.
+Project B has exactly the same contents in fossa-deps.yml, but the contents of Project B's vendored dependency contain an Apache 2.0 license.
 
-If Project A is scanned first, then both Project A and Project B will report that their vendored dependency has an MIT license.
+If Project A is scanned first, then both Project A and Project B report that their vendored dependency has an MIT license.
 
-If Project B is scanned first, then both Project A and Project B will report that their vendored dependency has an Apache 2.0 license.
+If Project B is scanned first, then both Project A and Project B report that their vendored dependency has an Apache 2.0 license.
 
-This can cause unexpected behavior, and we are working on changing this so that vendored dependencies are scoped to projects rather than organizations.
+This can cause unexpected behavior. (Note: FOSSA is working on changing this so that vendored dependencies are scoped to projects rather than organizations.)
 
-Our suggested workaround is to not set a version on your vendored dependency. When you omit the version, FOSSA will calculate a version based on the contents of the vendored dependency, thus avoiding any conflicts. This also has the added benefit of automatically changing the version when the contents of the vendored dependency change.
+The suggested workaround is to not set a version in the vendored dependency entry. When the version is omitted, FOSSA calculates a version based on the contents of the vendored dependency, thus avoiding any conflicts. This also has the added benefit of automatically changing the version when the contents of the vendored dependency change.
+
 
 ## How Vendored Dependencies are scanned
 

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -21,7 +21,7 @@ The path to a vendored dependency can either be a path to an archive or a path t
 
 If it is a path to an archive, then we recursively unarchive and scan the archive. If it is a directory, then we scan the directory and recursively unarchive and scan any archives contained in the directory.
 
-If the version is not specified, then we calculate the version by calculating a hash of the contents of the archive or directory. This is often what you actually want, as it means that the version will automatically change when the contents of the vendored dependency change. It also avoids conflicts across your organization when two different projects contain a vendored dependency with the same name and version, as described in [Vendored Dependency Names and Scope](#vendored-dependency-names-and-scope).
+If the version is not specified, then FOSSA CLI calculates the version by generating a hash of the contents of the archive or directory. This is often desired, as it means that the version automatically changes when the contents of the vendored dependency change. It also avoids conflicts across an organization when two different projects contain a vendored dependency with the same name and version, as described in [Vendored Dependency Names and Scope](#vendored-dependency-names-and-scope).
 
 Note: When parsed, YAML considers text that could be a decimal number (such as 1.0 or 2.0) to be a number, not a string. This means that we'd parse the version 1.0 as 1. This probably isn't what you want. To avoid this, surround your version with quotes, as in "1.0".
 

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -86,7 +86,7 @@ This means that if two different projects in your organization have the same nam
 
 This can cause unexpected behavior, and we are working on changing this so that vendored dependencies are scoped to projects rather than organizations.
 
-Our suggested workaround is to not set an explicit version on your vendored dependency. When you omit the version, FOSSA will calculate a version based on the contents of the vendored dependency, thus avoiding any conflicts. This also has the added benefit of automatically changing the version when the contents of the vendored dependency change.
+Our suggested workaround is to not set a version on your vendored dependency. When you omit the version, FOSSA will calculate a version based on the contents of the vendored dependency, thus avoiding any conflicts. This also has the added benefit of automatically changing the version when the contents of the vendored dependency change.
 
 ## How Vendored Dependencies are scanned
 

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -21,6 +21,8 @@ The path to a vendored dependency can either be a path to an archive or a path t
 
 If it is a path to an archive, then we recursively unarchive and scan the archive. If it is a directory, then we scan the directory and recursively unarchive and scan any archives contained in the directory.
 
+If the version is not specified, then we calculate the version by calculating a hash of the contents of the archive or directory. This is often what you actually want, as it means that the version will automatically change when the contents of the vendored dependency change. It also avoids conflicts across your organization when two different projects contain a vendored dependency with the same name and version, as described in [Vendored Dependency Names and Scope](#vendored-dependency-names-and-scope).
+
 Note: When parsed, YAML considers text that could be a decimal number (such as 1.0 or 2.0) to be a number, not a string. This means that we'd parse the version 1.0 as 1. This probably isn't what you want. To avoid this, surround your version with quotes, as in "1.0".
 
 We also support json-formatted dependencies:
@@ -75,6 +77,17 @@ We also support json-formatted dependencies:
   ]
 }
 ```
+
+## Vendored Dependency Names and Scope
+
+The name of a vendored dependency is scoped to an organization.
+
+This means that if two different projects in your organization have the same name and version, they will be treated as the same dependency by FOSSA even if they have different contents. The one that was scanned first will be used by FOSSA. If you use the `--force-vendored-dependency-rescans` flag, then the current scan will overwrite the original one. But this will cause the data for the original scan to be incorrect now.
+
+This can cause unexpected behavior, and we are working on changing this so that vendored dependencies are scoped to projects rather than organizations.
+
+Our suggested workaround is to not set an explicit version on your vendored dependency. When you omit the version, FOSSA will calculate a version based on the contents of the vendored dependency, thus avoiding any conflicts. This also has the added benefit of automatically changing the version when the contents of the vendored dependency change.
+
 ## How Vendored Dependencies are scanned
 
 There are two methods of vendored dependency scanning: "CLI license scan" and "archive upload".


### PR DESCRIPTION
# Overview

Deepak pointed out that we can have conflicts between vendored dependencies if two vendored dependencies in the same org with the same name and version exist.

This PR just documents the behavior for this case, and suggests a workaround.

https://teamfossa.slack.com/archives/C0155DTGWB1/p1663701455275469

Link to the rendered Markdown: https://github.com/fossas/fossa-cli/blob/c285b4fcbd8640061f02271e6e662ea58f0b0e6b/docs/features/vendored-dependencies.md

## Acceptance criteria

- The documentation makes the current behavior more clear

## Testing plan

This is a documentation only PR

## Risks

_Highlight any areas that you're unsure of, want feedback on, or want reviewers to pay particular attention to._

_Example: I'm not sure I did X correctly, can reviewers please double-check that for me?_

## References

https://teamfossa.slack.com/archives/C0155DTGWB1/p1663701455275469

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
