### PR TITLE
Initial R support (1/2)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 # FOSSA CLI Changelog
 
-## Unreleased
-
+## v3.4.9
 - Scan Summary: Identifies project skipped due to production path filtering, or exclusion filtering. ([#1071](https://github.com/fossas/fossa-cli/pull/1071))
+- R: Adds support for `renv` package manager. ([#1062](https://github.com/fossas/fossa-cli/pull/1062))
 
 ## v3.4.8
 - Report: Fixes a defect, where `report` command was failing due to invalid dependencies cache from endpoint ([#1068](https://github.com/fossas/fossa-cli/pull/1068)).

--- a/docs/features/manual-dependencies.md
+++ b/docs/features/manual-dependencies.md
@@ -31,6 +31,7 @@ Supported dependency types:
 - `carthage` - Dependencies as specified by the [Carthage](https://github.com/Carthage/Carthage) package manager.
 - `composer` - Dependencies specified by the PHP package manager [Composer](https://getcomposer.org/), which are located on [Packagist](https://packagist.org/).
 - `cpan` - Dependencies located on the [CPAN package manager](https://www.cpan.org/).
+- `cran` - Dependencies located on the [CRAN](https://www.cran.org/) like repository.
 - `gem` - Dependencies which can be found at [RubyGems.org](https://rubygems.org/).
 - `git` - Github projects (which appear as dependencies in many package managers). Specified as the full github repository `https://github.com/fossas/fossa-cli`.
 - `go` - Go specific dependency. Many Go dependencies are located on Github, but there are some which look like the following `go.mongodb.org/mongo-driver` that have custom Go URLs.

--- a/docs/references/experimental/container/experimental-scanner.md
+++ b/docs/references/experimental/container/experimental-scanner.md
@@ -154,7 +154,7 @@ If `<IMAGE>` is not a docker image archive and is not accessible via the docker 
 `<IMAGE>` is parsed in a similar fashion to `docker pull <ARG>`:
 
 | `<IMAGE>`                                         | Registry                             | Repository                 | Manifest Reference             |
-|---------------------------------------------------|--------------------------------------|----------------------------|--------------------------------|
+| ------------------------------------------------- | ------------------------------------ | -------------------------- | ------------------------------ |
 | `redis`                                           | None (defaults to `index.docker.io`) | `library/redis`            | None (defaults to `latest`)    |
 | `redis:alpine`                                    | None (defaults to `index.docker.io`) | `library/redis`            | `alpine` (as tag)              |
 | `bitnami/wordpress:6.0.1-debian-11-r14`           | None (defaults to `index.docker.io`) | `bitnami/wordpress`        | `6.0.1-debian-11-r14` (as tag) |
@@ -231,7 +231,7 @@ The new experimental scanner scans in two steps:
 The following package managers are supported in container scanning:
 
 | Analysis                             | Supported?         | Docs                                                             |
-|--------------------------------------|--------------------|------------------------------------------------------------------|
+| ------------------------------------ | ------------------ | ---------------------------------------------------------------- |
 | Alpine (APK)                         | :white_check_mark: | [APK Docs](./../../strategies/system/apk/apk.md)                 |
 | Debian (DPKG)                        | :white_check_mark: | [DPKG Docs](./../../strategies/system/dpkg/dpkg.md)              |
 | RedHat (RPM)                         | :white_check_mark: | [RPM Docs](../../strategies/system/rpm/rpm-container.md)         |
@@ -243,6 +243,7 @@ The following package managers are supported in container scanning:
 | Swift (xcode, swift package manager) | :white_check_mark: | [Swift](./../../strategies/platforms/ios/swift.md)               |
 | Carthage                             | :white_check_mark: | [Carthage](./../../strategies/platforms/ios/carthage.md)         |
 | Fortran (fpm)                        | :white_check_mark: | [Fortran](./../../strategies/languages/fortran/fortran.md)       |
+| R (renv)                             | :white_check_mark: | [Fortran](./../../strategies/languages/r/renv.md)                |
 | Cocoapods                            | :warning:          | [CocoaPods](./../../strategies/platforms/ios/cocoapods.md)       |
 | Nim (nimble)                         | :warning:          | [Nim](./../../strategies/languages/nim/nimble.md)                |
 | Dart (pub)                           | :warning:          | [Dart](./../../strategies/languages/dart/pub.md)                 |

--- a/docs/references/files/fossa-deps.schema.json
+++ b/docs/references/files/fossa-deps.schema.json
@@ -17,6 +17,7 @@
                         "carthage",
                         "composer",
                         "cpan",
+                        "renv",
                         "gem",
                         "git",
                         "go",

--- a/docs/references/files/fossa-yml.v3.schema.json
+++ b/docs/references/files/fossa-yml.v3.schema.json
@@ -180,6 +180,10 @@
                             "description": "For rpm targets"
                         },
                         {
+                            "const": "renv",
+                            "description": "For renv targets (r)"
+                        },
+                        {
                             "const": "scala",
                             "description": "For scala targets"
                         },

--- a/docs/references/strategies/README.md
+++ b/docs/references/strategies/README.md
@@ -86,6 +86,10 @@
 - [pipenv](languages/python/pipenv.md)
 - [poetry](languages/python/poetry.md)
 
+### r
+
+- [renv](languages/r/renv.md)
+
 ### ruby
 
 - [bundler](languages/ruby/bundler.md)
@@ -116,28 +120,29 @@ It is important to note that neither type of strategy has an inherent benefit wh
 
 | Language/Package Manager                                                                                                                        | Dynamic | Static | Primary Strategy |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------------- |
-| [C#](https://github.com/fossas/fossa-cli/tree/master/docs/references/strategies/languages/dotnet)                                               | ✅      | ✅     | Dynamic          |
-| [Clojure (leiningen)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/clojure/clojure.md)                  | ✅      | ❌     | Dynamic          |
-| [Dart (pub)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/dart/dart.md)                                 | ✅      | ✅     | Dynamic          |
-| [Elixer (mix)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/elixir/elixir.md)                           | ✅      | ❌     | Dynamic          |
-| [Erlang (rebar3)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/erlang/erlang.md)                        | ✅      | ❌     | Dynamic          |
-| [Fortran](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/fortran/fortran.md)                              | ❌      | ✅     | Static           |
-| [Go (dep)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/godep.md)                                | ❌      | ✅     | Static           |
-| [Go (glide)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/glide.md)                              | ❌      | ✅     | Static           |
-| [Go (gomodules)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/gomodules.md)                      | ✅      | ✅     | Dynamic          |
-| [Gradle](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/gradle/gradle.md)                                 | ✅      | ❌     | Dynamic          |
-| [Haskell (cabal)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/haskell/cabal.md)                        | ✅      | ❌     | Dynamic          |
-| [Haskell (stack)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/haskell/stack.md)                        | ✅      | ❌     | Dynamic          |
-| [iOS (carthage)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/platforms/ios/carthage.md)                          | ❌      | ✅     | Static           |
-| [iOS (cocoapods)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/platforms/ios/cocoapods.md)                        | ❌      | ✅     | Static           |
-| [Maven](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/maven/maven.md)                                    | ✅      | ✅     | Dynamic          |
-| [NodeJS (NPM/Yarn/pnpm)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/nodejs/nodejs.md)                 | ❌      | ✅     | Static           |
-| [Perl](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/perl/perl.md)                                       | ❌      | ✅     | Static           |
-| [PHP (Composer)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/php/composer.md)                          | ❌      | ✅     | Static           |
-| [Python (Conda)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/conda.md)                          | ✅      | ✅     | Dynamic          |
-| [Python (Pipenv)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/pipenv.md)                        | ✅      | ✅     | Dynamic          |
-| [Python (Poetry)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/poetry.md)                        | ❌      | ✅     | Static           |
-| [Python (setup.py/requirements.txt)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/setuptools.md) | ❌      | ✅     | Static           |
-| [Ruby (bundler)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/ruby/ruby.md)                             | ✅      | ✅     | Static           |
-| [Rust (cargo)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/rust/rust.md)                               | ✅      | ❌     | Dynamic          |
-| [Scala (sbt)](https://github.com/fossas/fossa-cli/tree/master/docs/references/strategies/languages/scala)                                       | ✅      | ✅     | Dynamic          |
+| [C#](https://github.com/fossas/fossa-cli/tree/master/docs/references/strategies/languages/dotnet)                                               | ✅       | ✅      | Dynamic          |
+| [Clojure (leiningen)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/clojure/clojure.md)                  | ✅       | ❌      | Dynamic          |
+| [Dart (pub)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/dart/dart.md)                                 | ✅       | ✅      | Dynamic          |
+| [Elixer (mix)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/elixir/elixir.md)                           | ✅       | ❌      | Dynamic          |
+| [Erlang (rebar3)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/erlang/erlang.md)                        | ✅       | ❌      | Dynamic          |
+| [Fortran](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/fortran/fortran.md)                              | ❌       | ✅      | Static           |
+| [Go (dep)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/godep.md)                                | ❌       | ✅      | Static           |
+| [Go (glide)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/glide.md)                              | ❌       | ✅      | Static           |
+| [Go (gomodules)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/gomodules.md)                      | ✅       | ✅      | Dynamic          |
+| [Gradle](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/gradle/gradle.md)                                 | ✅       | ❌      | Dynamic          |
+| [Haskell (cabal)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/haskell/cabal.md)                        | ✅       | ❌      | Dynamic          |
+| [Haskell (stack)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/haskell/stack.md)                        | ✅       | ❌      | Dynamic          |
+| [iOS (carthage)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/platforms/ios/carthage.md)                          | ❌       | ✅      | Static           |
+| [iOS (cocoapods)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/platforms/ios/cocoapods.md)                        | ❌       | ✅      | Static           |
+| [Maven](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/maven/maven.md)                                    | ✅       | ✅      | Dynamic          |
+| [NodeJS (NPM/Yarn/pnpm)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/nodejs/nodejs.md)                 | ❌       | ✅      | Static           |
+| [Perl](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/perl/perl.md)                                       | ❌       | ✅      | Static           |
+| [PHP (Composer)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/php/composer.md)                          | ❌       | ✅      | Static           |
+| [Python (Conda)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/conda.md)                          | ✅       | ✅      | Dynamic          |
+| [Python (Pipenv)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/pipenv.md)                        | ✅       | ✅      | Dynamic          |
+| [Python (Poetry)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/poetry.md)                        | ❌       | ✅      | Static           |
+| [Python (setup.py/requirements.txt)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/setuptools.md) | ❌       | ✅      | Static           |
+| [R (renv)](./languages/r/renv.md)                                                                                                               | ❌       | ✅      | Static           |
+| [Ruby (bundler)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/ruby/ruby.md)                             | ✅       | ✅      | Static           |
+| [Rust (cargo)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/rust/rust.md)                               | ✅       | ❌      | Dynamic          |
+| [Scala (sbt)](https://github.com/fossas/fossa-cli/tree/master/docs/references/strategies/languages/scala)                                       | ✅       | ✅      | Dynamic          |

--- a/docs/references/strategies/languages/r/renv.md
+++ b/docs/references/strategies/languages/r/renv.md
@@ -1,0 +1,91 @@
+# R Analysis (renv)
+
+Currently, we only support analysis of r project which are using [renv package manager](https://rstudio.github.io/renv/index.html).
+
+| Files                       | Direct Deps        | Deep Deps          | Edges              | Classifies Dev & Test Deps | Container Scanning (experimental) |
+| --------------------------- | ------------------ | ------------------ | ------------------ | -------------------------- | --------------------------------- |
+| `DESCRIPTION`               | :white_check_mark: | :x:                | :x:                | :x:                        | :white_check_mark:                |
+| `DESCRIPTION` & `renv.lock` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                        | :white_check_mark:                |
+
+## Project Discovery
+
+Find a file named `DESCRIPTION`, and optionally look for `renv.lock` in the same directory as `DESCRIPTION`.
+
+## Analysis
+
+1. Parse `DESCRIPTION` file to identify direct dependencies - we look for packages in `Depends`, `Imports`, `Suggests`, `Enhances`, `LinkingTo`.
+2. Parse `renv.lock` file to identify deep dependencies, and edges among them.
+
+## Example
+
+1. Create `DESCRIPTION` file:
+```text
+Type: project
+Description: My project
+Depends: tidyverse
+
+```
+
+2. Create `main.R` file:
+```r
+# you may need to execute following: 
+# if you do not have renv installed
+# >> install.packages("renv", repos = "http://cran.us.r-project.org")
+
+# initiate project
+# ref: https://rstudio.github.io/renv/reference/init.html
+options(renv.config.install.verbose = TRUE)
+options(renv.config.install.transactional = FALSE)
+renv::init(bare = TRUE)
+renv::install("glue@1.2.0")
+renv::install()
+
+# some example code
+Square <- function(x) {
+  return(x^2)
+}
+print(Square(4))
+
+# create renv.lock
+# ref: https://rstudio.github.io/renv/reference/snapshot.html
+renv::snapshot()
+```
+3. execute `rscript main.R`
+4. execute `fossa analyze --only-target renv --output` (run analysis only `renv`, but do not upload result to an endpoint)
+
+## Limitations
+
+
+- `fossa-cli` cannot identify test or development dependencies, and by default includes all dependencies in the analysis.
+- `fossa-cli` will ignore version constraint if `renv.lock` file is not present.
+- `fossa-cli` cannot analyze path dependencies. <!-- renv does not have docs on local packages --> 
+  - Please refer to [vendored dependencies](./../../../../features/vendored-dependencies.md) for workaround. 
+
+## FAQ
+
+### How do I *only perform analysis* for renv?
+
+Explicitly specify an analysis target in `.fossa.yml` file. The example below excludes all other analysis targets:
+
+```yaml
+# .fossa.yml 
+
+version: 3
+targets:
+  only:
+    - type: renv
+```
+
+### FOSSA's analyzed dependencies are incorrect or missing a package. 
+
+Please file a ticket at [FOSSA support portal](https://support.fossa.com).
+
+Make sure to attach following for quick response from support or development team.
+
+* `DESCRIPTION` file
+* `renv.lock` file (if any)
+* stdout of `renv::diagnostics()`
+
+## References
+
+- [Renv Package Manager for R](https://rstudio.github.io/renv/index.html)

--- a/docs/references/strategies/languages/r/renv.md
+++ b/docs/references/strategies/languages/r/renv.md
@@ -2,10 +2,11 @@
 
 Currently, we only support analysis of r project which are using [renv package manager](https://rstudio.github.io/renv/index.html).
 
-| Files                       | Direct Deps        | Deep Deps          | Edges              | Classifies Dev & Test Deps | Container Scanning (experimental) |
-| --------------------------- | ------------------ | ------------------ | ------------------ | -------------------------- | --------------------------------- |
-| `DESCRIPTION`               | :white_check_mark: | :x:                | :x:                | :x:                        | :white_check_mark:                |
-| `DESCRIPTION` & `renv.lock` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                        | :white_check_mark:                |
+| Files                       | Direct Deps                             | Deep Deps          | Edges              | Classifies Dev & Test Deps | Container Scanning (experimental) |
+| --------------------------- | --------------------------------------- | ------------------ | ------------------ | -------------------------- | --------------------------------- |
+| `renv.lock`                 | (included but not classified as direct) | :white_check_mark: | :white_check_mark: | :x:                        | :white_check_mark:                |
+| `DESCRIPTION` & `renv.lock` | :white_check_mark:                      | :white_check_mark: | :white_check_mark: | :x:                        | :white_check_mark:                |
+
 
 ## Project Discovery
 

--- a/docs/references/strategies/languages/r/renv.md
+++ b/docs/references/strategies/languages/r/renv.md
@@ -10,12 +10,17 @@ Currently, we only support analysis of r project which are using [renv package m
 
 ## Project Discovery
 
-Find a file named `DESCRIPTION`, and optionally look for `renv.lock` in the same directory as `DESCRIPTION`.
+Find a file named `DESCRIPTION`, and optionally look for `renv.lock` in the same directory as `DESCRIPTION`. Discovery will not look for
+projects inside `renv` directory, if `renv.lock` or `DESCRIPTION` files are discovered.
 
 ## Analysis
 
 1. Parse `DESCRIPTION` file to identify direct dependencies - we look for packages in `Depends`, `Imports`, `Suggests`, `Enhances`, `LinkingTo`.
 2. Parse `renv.lock` file to identify deep dependencies, and edges among them.
+
+## Limitations
+
+- If only `DESCRIPTION` file is accessible, FOSSA CLI will ignore version constraints, and will always default to latest version.
 
 ## Example
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -431,6 +431,10 @@ library
     Strategy.Python.SetupPy
     Strategy.Python.Setuptools
     Strategy.Python.Util
+    Strategy.R
+    Strategy.R.Description
+    Strategy.R.Errors
+    Strategy.R.Renv
     Strategy.Rebar3
     Strategy.RPM
     Strategy.Ruby.BundleShow
@@ -596,6 +600,8 @@ test-suite unit-tests
     Python.ReqTxtSpec
     Python.RequirementsSpec
     Python.SetupPySpec
+    R.DescriptionSpec
+    R.RenvSpec
     ResultUtil
     RPM.SpecFileSpec
     Ruby.BundleShowSpec

--- a/src/App/Fossa/Analyze/Discover.hs
+++ b/src/App/Fossa/Analyze/Discover.hs
@@ -38,6 +38,7 @@ import Strategy.Pub qualified as Pub
 import Strategy.Python.Pipenv qualified as Pipenv
 import Strategy.Python.Poetry qualified as Poetry
 import Strategy.Python.Setuptools qualified as Setuptools
+import Strategy.R qualified as R
 import Strategy.RPM qualified as RPM
 import Strategy.Rebar3 qualified as Rebar3
 import Strategy.Scala qualified as Scala
@@ -73,6 +74,7 @@ discoverFuncs =
   , DiscoverFunc ProjectAssetsJson.discover
   , DiscoverFunc ProjectJson.discover
   , DiscoverFunc Pub.discover
+  , DiscoverFunc R.discover
   , DiscoverFunc RPM.discover
   , DiscoverFunc Rebar3.discover
   , DiscoverFunc RepoManifest.discover

--- a/src/App/Fossa/Container/Sources/Discovery.hs
+++ b/src/App/Fossa/Container/Sources/Discovery.hs
@@ -47,6 +47,7 @@ import Strategy.Pub qualified as Pub
 import Strategy.Python.Pipenv qualified as Pipenv
 import Strategy.Python.Poetry qualified as Poetry
 import Strategy.Python.Setuptools qualified as Setuptools
+import Strategy.R qualified as R
 import Strategy.RPM qualified as RPM
 import Strategy.Sqlite qualified as Sqlite
 import Strategy.SwiftPM qualified as SwiftPM
@@ -93,6 +94,7 @@ managedDepsDiscoveryF =
   , DiscoverFunc ProjectAssetsJson.discover
   , DiscoverFunc ProjectJson.discover
   , DiscoverFunc Pub.discover
+  , DiscoverFunc R.discover
   , DiscoverFunc RPM.discover
   , DiscoverFunc RepoManifest.discover
   , DiscoverFunc Setuptools.discover

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -336,6 +336,7 @@ depTypeFromText text = case text of
   "carthage" -> Just CarthageType
   "composer" -> Just ComposerType
   "cpan" -> Just CpanType
+  "cran" -> Just CranType
   "gem" -> Just GemType
   "git" -> Just GitType
   "go" -> Just GoType

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -75,6 +75,8 @@ data DepType
     CondaType
   | -- | CPAN dependency
     CpanType
+  | -- | CRAN dependency
+    CranType
   | -- | Custom dependency
     CustomType
   | -- | Repository in Github

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -133,6 +133,7 @@ depTypeToFetcher = \case
   ComposerType -> "comp"
   CondaType -> "conda"
   CpanType -> "cpan"
+  CranType -> "cran"
   CustomType -> "custom"
   GemType -> "gem"
   GitType -> "git"
@@ -164,6 +165,7 @@ fetcherToDepType fetcher | depTypeToFetcher CargoType == fetcher = Just CargoTyp
 fetcherToDepType fetcher | depTypeToFetcher ComposerType == fetcher = Just ComposerType
 fetcherToDepType fetcher | depTypeToFetcher CondaType == fetcher = Just CondaType
 fetcherToDepType fetcher | depTypeToFetcher CpanType == fetcher = Just CpanType
+fetcherToDepType fetcher | depTypeToFetcher CranType == fetcher = Just CranType
 fetcherToDepType fetcher | depTypeToFetcher CustomType == fetcher = Just CustomType
 fetcherToDepType fetcher | depTypeToFetcher GemType == fetcher = Just GemType
 fetcherToDepType fetcher | depTypeToFetcher GitType == fetcher = Just GitType

--- a/src/Strategy/R.hs
+++ b/src/Strategy/R.hs
@@ -1,0 +1,119 @@
+module Strategy.R (
+  discover,
+  findProjects,
+  mkProject,
+) where
+
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProject'))
+import Control.Effect.Diagnostics (Diagnostics, errCtx, fatalText, recover, warnOnErr)
+import Control.Effect.Reader (Reader)
+import Control.Monad (void)
+import Data.Aeson (ToJSON)
+import Diag.Common (
+  MissingDeepDeps (MissingDeepDeps),
+  MissingEdges (MissingEdges),
+ )
+import Discovery.Filters (AllFilters)
+import Discovery.Simple (simpleDiscover)
+import Discovery.Walk (
+  WalkStep (WalkContinue, WalkSkipSome),
+  findFileNamed,
+  walkWithFilters',
+ )
+import Effect.ReadFS (Has, ReadFS)
+import GHC.Generics (Generic)
+import Path (Abs, Dir, File, Path)
+import Strategy.R.Errors (
+  MissingRenvLockFile (MissingRenvLockFile),
+  VersionConstraintsIgnored (VersionConstraintsIgnored),
+ )
+import Strategy.R.Renv (analyze)
+import Types (
+  DependencyResults (..),
+  DiscoveredProject (..),
+  DiscoveredProjectType (RProjectType),
+ )
+
+newtype RDescriptionFile = RDescriptionFile (Path Abs File)
+  deriving (Show, Eq, Ord, Generic)
+
+data RProject
+  = Renv (Path Abs Dir) RDescriptionFile (Path Abs File)
+  | ManifestOnly (Path Abs Dir) RDescriptionFile
+  deriving (Show, Eq, Ord, Generic)
+
+instance ToJSON RDescriptionFile
+instance ToJSON RProject
+
+instance AnalyzeProject RProject where
+  analyzeProject _ = getDeps
+  analyzeProject' _ = getDeps
+
+discover ::
+  ( Has ReadFS sig m
+  , Has Diagnostics sig m
+  , Has (Reader AllFilters) sig m
+  ) =>
+  Path Abs Dir ->
+  m [DiscoveredProject RProject]
+discover = simpleDiscover findProjects mkProject RProjectType
+
+findProjects ::
+  ( Has ReadFS sig m
+  , Has Diagnostics sig m
+  , Has (Reader AllFilters) sig m
+  ) =>
+  Path Abs Dir ->
+  m [RProject]
+findProjects = walkWithFilters' $ \dir _ files -> do
+  let lockFile = findFileNamed "renv.lock" files
+  let descriptionFile = findFileNamed "DESCRIPTION" files
+  let skipRenvLibs = WalkSkipSome ["renv"]
+
+  case (lockFile, descriptionFile) of
+    (Just lockFile', Just description') -> do
+      let project' = Renv dir (RDescriptionFile description') lockFile'
+      pure ([project'], skipRenvLibs)
+    (Nothing, Just description') -> do
+      let project = ManifestOnly dir (RDescriptionFile description')
+      pure ([project], skipRenvLibs)
+    _ -> pure ([], WalkContinue)
+
+mkProject :: RProject -> DiscoveredProject RProject
+mkProject project =
+  DiscoveredProject
+    { projectType = RProjectType
+    , projectBuildTargets = mempty
+    , projectPath = projectDir project
+    , projectData = project
+    }
+  where
+    projectDir :: RProject -> Path Abs Dir
+    projectDir (Renv dir _ _) = dir
+    projectDir (ManifestOnly dir _) = dir
+
+getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => RProject -> m DependencyResults
+getDeps (Renv _ (RDescriptionFile manifestFile) lockFile) = do
+  (graph, graphBreadth) <- analyze manifestFile (Just lockFile)
+  pure $
+    DependencyResults
+      { dependencyGraph = graph
+      , dependencyGraphBreadth = graphBreadth
+      , dependencyManifestFiles = [manifestFile]
+      }
+getDeps (ManifestOnly _ (RDescriptionFile manifestFile)) = do
+  void
+    . recover
+    . warnOnErr MissingEdges
+    . warnOnErr MissingDeepDeps
+    . warnOnErr VersionConstraintsIgnored
+    . errCtx MissingRenvLockFile
+    $ fatalText "renv.lock file is missing."
+
+  (graph, graphBreadth) <- analyze manifestFile Nothing
+  pure $
+    DependencyResults
+      { dependencyGraph = graph
+      , dependencyGraphBreadth = graphBreadth
+      , dependencyManifestFiles = [manifestFile]
+      }

--- a/src/Strategy/R.hs
+++ b/src/Strategy/R.hs
@@ -77,15 +77,15 @@ findProjects = walkWithFilters' $ \dir _ files -> do
   let skipRenvLibs = WalkSkipSome ["renv"]
 
   case (lockFile, descriptionFile) of
-    (Nothing, Just description') -> do
-      let project = DescriptionOnly dir (RDescriptionFile description')
+    (Nothing, Just description) -> do
+      let project = DescriptionOnly dir (RDescriptionFile description)
       pure ([project], skipRenvLibs)
     (Just lockFile', Nothing) -> do
-      let project' = RenvLockOnly dir lockFile'
-      pure ([project'], skipRenvLibs)
-    (Just lockFile', Just description') -> do
-      let project' = Renv dir (RDescriptionFile description') lockFile'
-      pure ([project'], skipRenvLibs)
+      let project = RenvLockOnly dir lockFile'
+      pure ([project], skipRenvLibs)
+    (Just lockFile', Just description) -> do
+      let project = Renv dir (RDescriptionFile description) lockFile'
+      pure ([project], skipRenvLibs)
     _ -> pure ([], WalkContinue)
 
 mkProject :: RProject -> DiscoveredProject RProject

--- a/src/Strategy/R/Description.hs
+++ b/src/Strategy/R/Description.hs
@@ -73,7 +73,9 @@ data RDescription = RDescription
   deriving (Eq, Ord, Show)
 
 -- | Retrieves package name without version constraints.
--- renv does not support version constraints
+-- renv does not support version constraints, nor does cran fetcher, so
+-- we remove constraint and fallback to LATEST version.
+-- -
 -- ref: https://github.com/rstudio/renv/issues/767
 allPkgNames :: RDescription -> Set Text
 allPkgNames d =

--- a/src/Strategy/R/Description.hs
+++ b/src/Strategy/R/Description.hs
@@ -1,0 +1,145 @@
+-- | R's DESCRIPTION FILE.
+--
+-- Example:
+--
+-- >> Package: pkgname
+-- >> Version: 0.5-1
+-- >> Date: 2015-01-01
+-- >> Title: My First Collection of Functions
+-- >> Authors@R: c(person("Joe", "Developer", role = c("aut", "cre"),
+-- >>                      email = "Joe.Developer@some.domain.net"),
+-- >>               person("Pat", "Developer", role = "aut"),
+-- >>               person("A.", "User", role = "ctb",
+-- >>                      email = "A.User@whereever.net"))
+-- >> Author: Joe Developer [aut, cre],
+-- >>   Pat Developer [aut],
+-- >>   A. User [ctb]
+-- >> Maintainer: Joe Developer <Joe.Developer@some.domain.net>
+-- >> Depends: R (>= 3.1.0), nlme
+-- >> Suggests: MASS
+-- >> Description: A (one paragraph) description of what
+-- >>   the package does and why it may be useful.
+-- >> License: GPL (>= 2)
+-- >> URL: https://www.r-project.org, http://www.another.url
+-- >> BugReports: https://pkgname.bugtracker.url
+--
+-- R's description file follows debian control file like format.
+--
+-- Refer to:
+--    https://cran.r-project.org/doc/manuals/R-exts.html#The-DESCRIPTION-file
+-- -
+module Strategy.R.Description (
+  RDescription (..),
+  descriptionParser,
+  allPkgNames,
+) where
+
+import Control.Monad (void)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Set (Set, fromList)
+import Data.String.Conversion (toText)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Void (Void)
+import Text.Megaparsec (
+  MonadParsec (eof, notFollowedBy, takeWhileP),
+  Parsec,
+  anySingle,
+  chunk,
+  empty,
+  manyTill,
+  single,
+  some,
+  someTill,
+  try,
+  (<|>),
+ )
+import Text.Megaparsec.Char.Lexer (lexeme)
+import Text.Megaparsec.Char.Lexer qualified as Lexer
+
+type Parser = Parsec Void Text
+
+-- | Represents R's DESCRIPTION file.
+-- Ref: https://cran.r-project.org/doc/manuals/R-exts.html#The-DESCRIPTION-file
+data RDescription = RDescription
+  { depends :: [Text] -- list of package names which this package depends on
+  , imports :: [Text] -- lists packages whose namespaces are imported
+  , suggests :: [Text] -- lists packages that are not necessarily needed, but are maybe used in test, docs, etc.
+  , enhances :: [Text] -- lists packages “enhanced” by the package at hand
+  , linkingTo :: [Text] -- list of package who may are used for linking, for c/c++ compilation
+  }
+  deriving (Eq, Ord, Show)
+
+-- | Retrieves package name without version constraints.
+-- renv does not support version constraints
+-- ref: https://github.com/rstudio/renv/issues/767
+allPkgNames :: RDescription -> Set Text
+allPkgNames d =
+  fromList $
+    map rmVersionConstraint $
+      depends d
+        <> imports d
+        <> suggests d
+        <> enhances d
+        <> linkingTo d
+  where
+    rmVersionConstraint :: Text -> Text
+    rmVersionConstraint t = fst $ Text.breakOnEnd "(" t
+
+-- | Parses R's DESCRIPTION file.
+descriptionParser :: Parser RDescription
+descriptionParser = do
+  properties <- propertiesParser
+  pure $
+    RDescription
+      (itemized properties "Depends")
+      (itemized properties "Imports")
+      (itemized properties "Suggests")
+      (itemized properties "Enhances")
+      (itemized properties "LinkingTo")
+  where
+    -- Itemizes from attribute
+    -- >> itemized $ fromList [("key", "a, b, \n k")] == ["a", "b", "k"]
+    itemized :: Map Text Text -> Text -> [Text]
+    itemized props key =
+      filter (/= "") $
+        map Text.strip $
+          Text.splitOn "," $
+            Text.replace "\n" "" $
+              Text.replace "\r\n" "" $
+                fromMaybe "" $
+                  Map.lookup key props
+
+    -- Each entry is separated by a blank line.
+    propertiesParser :: Parser (Map Text Text)
+    propertiesParser = Map.fromList <$> manyTill (lexeme sc propertyParser) eov
+
+    -- Key is separated from value by ":".
+    propertyParser :: Parser (Text, Text)
+    propertyParser = (,) <$> (keyParser <* symbol ":") <*> valueParser
+
+    keyParser :: Parser Text
+    keyParser = takeWhileP Nothing (/= ':')
+
+    -- Value fields are either single line or multi line.
+    valueParser :: Parser Text
+    valueParser = toText <$> someTill anySingle eov
+
+    -- The end of a value: A newline not followed by a space,
+    -- or the end of the input.
+    eov :: Parser ()
+    eov = try (eol <* notFollowedBy (single ' ')) <|> eof
+
+    -- The end of a line.
+    eol :: Parser ()
+    eol = try (void (chunk "\r\n")) <|> void (chunk "\n")
+
+-- | Consume spaces, not including newlines.
+sc :: Parser ()
+sc = Lexer.space (void $ some (single ' ' <|> single '\t')) empty empty
+
+-- | Parse for the provided symbol, then consume any trailing spaces.
+symbol :: Text -> Parser Text
+symbol = Lexer.symbol sc

--- a/src/Strategy/R/Description.hs
+++ b/src/Strategy/R/Description.hs
@@ -86,7 +86,7 @@ allPkgNames d =
         <> linkingTo d
   where
     rmVersionConstraint :: Text -> Text
-    rmVersionConstraint t = fst $ Text.breakOnEnd "(" t
+    rmVersionConstraint = Text.strip . fst . Text.breakOn "("
 
 -- | Parses R's DESCRIPTION file.
 descriptionParser :: Parser RDescription

--- a/src/Strategy/R/Errors.hs
+++ b/src/Strategy/R/Errors.hs
@@ -20,7 +20,7 @@ data MissingDescriptionFile = MissingDescriptionFile
 instance ToDiagnostic MissingDescriptionFile where
   renderDiagnostic (MissingDescriptionFile) =
     vsep
-      [ "Provide DESCRIPTION file in same path as `renv.lock`, so fossa-cli can infer direct dependencies."
+      [ "Provide DESCRIPTION file in same path as `renv.lock`, so FOSSA CLI can infer direct dependencies."
       ]
 
 data VersionConstraintsIgnored = VersionConstraintsIgnored

--- a/src/Strategy/R/Errors.hs
+++ b/src/Strategy/R/Errors.hs
@@ -1,5 +1,6 @@
 module Strategy.R.Errors (
   MissingRenvLockFile (..),
+  MissingDescriptionFile (..),
   VersionConstraintsIgnored (..),
   rEnvLockFileDocUrl,
   rEnvLockFileGenerateDocUrl,
@@ -14,6 +15,13 @@ rEnvLockFileDocUrl = "https://rstudio.github.io/renv/"
 
 rEnvLockFileGenerateDocUrl :: Text
 rEnvLockFileGenerateDocUrl = "https://rstudio.github.io/renv/reference/snapshot.html"
+
+data MissingDescriptionFile = MissingDescriptionFile
+instance ToDiagnostic MissingDescriptionFile where
+  renderDiagnostic (MissingDescriptionFile) =
+    vsep
+      [ "Provide DESCRIPTION file in same path as `renv.lock`, so fossa-cli can infer direct dependencies."
+      ]
 
 data VersionConstraintsIgnored = VersionConstraintsIgnored
 instance ToDiagnostic VersionConstraintsIgnored where

--- a/src/Strategy/R/Errors.hs
+++ b/src/Strategy/R/Errors.hs
@@ -1,0 +1,44 @@
+module Strategy.R.Errors (
+  MissingRenvLockFile (..),
+  VersionConstraintsIgnored (..),
+  rEnvLockFileDocUrl,
+  rEnvLockFileGenerateDocUrl,
+) where
+
+import Data.Text (Text)
+import Diag.Diagnostic (ToDiagnostic, renderDiagnostic)
+import Prettyprinter (Pretty (pretty), indent, vsep)
+
+rEnvLockFileDocUrl :: Text
+rEnvLockFileDocUrl = "https://rstudio.github.io/renv/"
+
+rEnvLockFileGenerateDocUrl :: Text
+rEnvLockFileGenerateDocUrl = "https://rstudio.github.io/renv/reference/snapshot.html"
+
+data VersionConstraintsIgnored = VersionConstraintsIgnored
+instance ToDiagnostic VersionConstraintsIgnored where
+  renderDiagnostic (VersionConstraintsIgnored) =
+    vsep
+      [ "Version constraints (if specified) in the DESCRIPTION file will be ignored."
+      , "Please use renv to create renv.lock file, so package versions as pinned, can be analyzed."
+      ]
+
+data MissingRenvLockFile = MissingRenvLockFile
+instance ToDiagnostic MissingRenvLockFile where
+  renderDiagnostic (MissingRenvLockFile) =
+    vsep
+      [ "We could not perform lockfile analysis for your r project."
+      , ""
+      , indent 2 $
+          vsep
+            [ "Ensure valid lockfile exist and is readable prior to running fossa."
+            , "If you are using renv, you will likely need to run: renv::snapshot() to create renv.lock"
+            ]
+      , ""
+      , "Refer to:"
+      , indent 2 $
+          vsep
+            [ pretty $ "- " <> rEnvLockFileDocUrl
+            , pretty $ "- " <> rEnvLockFileGenerateDocUrl
+            ]
+      ]

--- a/src/Strategy/R/Renv.hs
+++ b/src/Strategy/R/Renv.hs
@@ -1,0 +1,260 @@
+module Strategy.R.Renv (
+  analyze,
+
+  -- * for testing
+  RenvLock (..),
+  RenvLockRepository (..),
+  RenvLockPackage (..),
+  RenvPackageSource (..),
+  buildGraph,
+  toDependency,
+) where
+
+import Control.Effect.Diagnostics (Diagnostics, Has)
+import Control.Monad (when)
+import Data.Aeson (
+  FromJSON (parseJSON),
+  withObject,
+  (.!=),
+  (.:),
+  (.:?),
+ )
+import Data.Aeson.Types (Key, Object, Parser)
+import Data.Foldable (for_)
+import Data.List (find)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
+import Data.Set (toList)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as Text
+import DepTypes (
+  DepType (CranType, GitType, URLType),
+  Dependency (..),
+  VerConstraint (CEq),
+ )
+import Effect.Grapher (deep, direct, edge, evalGrapher, run)
+import Effect.Logger (logWarn)
+import Effect.ReadFS (ReadFS, readContentsJson, readContentsParser)
+import Graphing (Graphing)
+import Path (Abs, File, Path)
+import Strategy.R.Description (RDescription, allPkgNames, descriptionParser)
+import Types (GraphBreadth (Complete, Partial))
+
+-- | Represents lockfile of: https://github.com/rstudio/renv.
+-- ref: https://rstudio.github.io/renv/articles/lockfile.html
+data RenvLock = RenvLock
+  { repositories :: [RenvLockRepository]
+  , packages :: Map Text RenvLockPackage
+  }
+  deriving (Show, Eq, Ord)
+
+instance FromJSON RenvLock where
+  parseJSON = withObject "RenvLock" $ \obj ->
+    RenvLock
+      <$> (obj .: "R" |> "Repositories")
+      <*> (obj .: "Packages")
+    where
+      (|>) :: FromJSON a => Parser Object -> Key -> Parser a
+      (|>) parser key = do
+        obj <- parser
+        obj .: key
+
+data RenvLockRepository = RenvLockRepository
+  { repoName :: Text
+  , repoUrl :: Text
+  }
+  deriving (Show, Eq, Ord)
+
+instance FromJSON RenvLockRepository where
+  parseJSON = withObject "RenvLockRepository" $ \o ->
+    RenvLockRepository
+      <$> (o .: "Name")
+      <*> (o .: "URL")
+
+data RenvLockPackage = RenvLockPackage
+  { pkgName :: Text
+  , pkgVersion :: Text
+  , pkgRequirements :: [Text]
+  , pkgSource :: RenvPackageSource
+  }
+  deriving (Show, Eq, Ord)
+
+-- | Package source.
+-- ref: https://github.com/rstudio/renv/blob/e7c288f83927fba23aa33fbefd858aa462d19ac1/R/remotes.R#L71
+data RenvPackageSource
+  = RemoteCran Text
+  | Git Text Text
+  | Github Text Text Text
+  | Gitlab Text Text Text
+  | Bitbucket Text Text Text
+  | Url Text
+  | Repository Text
+  | Unknown
+  deriving (Show, Eq, Ord)
+
+instance FromJSON RenvLockPackage where
+  parseJSON = withObject "RenvLockPackage" $ \o -> do
+    pkg <- o .: "Package"
+    pkgVersion <- o .: "Version"
+    pkgRequirements <- o .:? "Requirements" .!= []
+
+    pkgSource' :: Text <- o .: "Source"
+    pkgSource <- case pkgSource' of
+      "Bioconductor" ->
+        Git
+          <$> (o .: "git_url")
+          <*> (o .: "git_branch")
+      "git" ->
+        Git
+          <$> (o .: "RemoteUrl")
+          <*> (o .: "RemoteRef")
+      "GitHub" ->
+        Github
+          <$> (o .: "RemoteUsername")
+          <*> (o .: "RemoteRepo")
+          <*> (o .: "RemoteSha")
+      "Gitlab" ->
+        Gitlab
+          <$> (o .: "RemoteUsername")
+          <*> (o .: "RemoteRepo")
+          <*> (o .: "RemoteSha")
+      "Bitbucket" ->
+        Bitbucket
+          <$> (o .: "RemoteUsername")
+          <*> (o .: "RemoteRepo")
+          <*> (o .: "RemoteSha")
+      "URL" ->
+        Url
+          <$> (o .: "RemoteUrl")
+      "Repository" -> do
+        -- some times remote repository referenced
+        -- in the 'repositories' are not used for
+        -- resolving, this behavior depends on the
+        -- API of renv user used.
+        --
+        -- refer to:
+        --  https://github.com/rstudio/renv/issues/120#issue-474858634
+        -- -
+        pkgRepository <- o .: "Repository"
+        remoteRepo <- o .:? "RemoteRepos"
+
+        -- if it is repository sourced, and user
+        -- prefer remore repos attribute, if any.
+        pure $ case remoteRepo of
+          Just rr ->
+            if Text.isPrefixOf "http" rr
+              then RemoteCran rr
+              else Repository pkgRepository
+          Nothing -> Repository pkgRepository
+      _ -> pure Unknown
+
+    pure $
+      RenvLockPackage
+        pkg
+        pkgVersion
+        pkgRequirements
+        pkgSource
+
+-- | Builds dependency graph.
+-- ref: https://github.com/rstudio/renv/issues/474#issuecomment-656252759
+buildGraph :: RDescription -> RenvLock -> Graphing Dependency
+buildGraph description renvLock = run . evalGrapher $ do
+  let allLockPackages = packages renvLock
+  let allRepositories = repositories renvLock
+  let allDirectPkgs = allPkgNames description
+
+  if null $ Map.toList allLockPackages
+    then -- We have empty lock file, and only description manifest
+    -- create direct dependencies
+
+    for_ (toList allDirectPkgs) $ \pkgReq -> do
+      direct $ toCranDependency pkgReq
+    else -- We have non-empty lock file, and description manifest
+    -- create complete dependency graph. Any dependency that
+    -- is mentioned in description is considered to be direct
+
+    for_ (Map.toList allLockPackages) $ \(_, pkgMetadata) -> do
+      let currentDep = toDependency allRepositories pkgMetadata
+      let childDeps =
+            map (toDependency allRepositories) $
+              mapMaybe (`Map.lookup` allLockPackages) (pkgRequirements pkgMetadata)
+
+      if Set.member (pkgName pkgMetadata) allDirectPkgs
+        then direct currentDep
+        else deep currentDep
+
+      for_ childDeps $
+        edge currentDep
+
+toCranDependency :: Text -> Dependency
+toCranDependency pkg = Dependency CranType pkg Nothing mempty mempty mempty
+
+toDependency :: [RenvLockRepository] -> RenvLockPackage -> Dependency
+toDependency repos pkg =
+  Dependency
+    { dependencyType = depType
+    , dependencyName = depName
+    , dependencyVersion = CEq <$> depVersion
+    , dependencyLocations = mempty
+    , dependencyEnvironments = mempty
+    , dependencyTags = mempty
+    }
+  where
+    depType :: DepType
+    depType = case pkgSource pkg of
+      Git{} -> GitType
+      Github{} -> GitType
+      Gitlab{} -> GitType
+      Bitbucket{} -> GitType
+      Url{} -> URLType
+      RemoteCran{} -> CranType
+      Repository{} -> CranType
+      Unknown -> CranType
+
+    depName :: Text
+    depName = case pkgSource pkg of
+      Git url _ -> url
+      Github user repo _ -> "https://github.com/" <> user <> "/" <> repo <> ".git"
+      Gitlab user repo _ -> "https://gitlab.com/" <> user <> "/" <> repo <> ".git"
+      Bitbucket user repo _ -> "https://bitbucket.com/" <> user <> "/" <> repo <> ".git"
+      Url url -> url
+      RemoteCran url -> url <> ":" <> pkgName pkg
+      Repository repoSpecified ->
+        case find (\repo -> repoName repo == repoSpecified) (repos) of
+          Just rr -> repoUrl rr <> ":" <> pkgName pkg
+          Nothing -> pkgName pkg
+      Unknown -> pkgName pkg
+
+    depVersion :: Maybe Text
+    depVersion = case pkgSource pkg of
+      Git _ ref -> Just ref
+      Github _ _ ref -> Just ref
+      Gitlab _ _ ref -> Just ref
+      Bitbucket _ _ ref -> Just ref
+      Url _ -> Nothing
+      _ -> Just $ pkgVersion pkg
+
+analyze ::
+  ( Has ReadFS sig m
+  , Has Diagnostics sig m
+  ) =>
+  Path Abs File ->
+  Maybe (Path Abs File) ->
+  m (Graphing Dependency, GraphBreadth)
+analyze descriptionPath lockFilePath = do
+  description <- readContentsParser descriptionParser descriptionPath
+  lockFile <- case lockFilePath of
+    Just lockFilePath' -> do
+      lock <- readContentsJson lockFilePath'
+      pure . Just $ lock
+    Nothing -> pure Nothing
+
+  pure
+    ( buildGraph description (fromMaybe emptyLockFile lockFile)
+    , if isJust lockFile then Complete else Partial
+    )
+  where
+    emptyLockFile :: RenvLock
+    emptyLockFile = RenvLock mempty mempty

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -95,6 +95,7 @@ data DiscoveredProjectType
   | ProjectJsonProjectType
   | PubProjectType
   | Rebar3ProjectType
+  | RProjectType
   | RepoManifestProjectType
   | RpmProjectType
   | ScalaProjectType
@@ -142,6 +143,7 @@ projectTypeToText = \case
   ProjectJsonProjectType -> "projectjson"
   PubProjectType -> "pub"
   Rebar3ProjectType -> "rebar3"
+  RProjectType -> "renv"
   RepoManifestProjectType -> "repomanifest"
   RpmProjectType -> "rpm"
   ScalaProjectType -> "scala"

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -28,6 +28,7 @@ import Strategy.Node.Errors (
   yarnV2LockfileDocUrl,
  )
 import Strategy.Python.Errors (commitPoetryLockToVCS)
+import Strategy.R.Errors (rEnvLockFileDocUrl, rEnvLockFileGenerateDocUrl)
 import Strategy.Ruby.Errors (bundlerLockFileRationaleUrl, rubyFossaDocUrl)
 import Strategy.Scala.Errors (sbtDepsGraphPluginUrl, scalaFossaDocUrl)
 import Strategy.Swift.Errors (
@@ -60,6 +61,8 @@ urlsToCheck =
   , swiftFossaDocUrl
   , swiftPackageResolvedRef
   , xcodeCoordinatePkgVersion
+  , rEnvLockFileDocUrl
+  , rEnvLockFileGenerateDocUrl
   , refPodDocUrl
   , refGradleDocUrl
   , containerScanningDocUrl

--- a/test/App/Fossa/AnalyzeSpec.hs
+++ b/test/App/Fossa/AnalyzeSpec.hs
@@ -20,5 +20,5 @@ spec :: Spec
 spec =
   -- this test only exists to prevent merging the commented out analyzers
   describe "Discovery function list" $
-    it "should be length 34" $
-      length (discoverFuncs :: [DiscoverFunc SomeMonad]) `shouldBe` 34
+    it "should be length 35" $
+      length (discoverFuncs :: [DiscoverFunc SomeMonad]) `shouldBe` 35

--- a/test/R/DescriptionSpec.hs
+++ b/test/R/DescriptionSpec.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module R.DescriptionSpec (
+  spec,
+) where
+
+import Data.Text (Text)
+import Data.Void (Void)
+import Strategy.R.Description (
+  RDescription (RDescription),
+  descriptionParser,
+ )
+import Test.Hspec (
+  Expectation,
+  Spec,
+  describe,
+  it,
+ )
+import Test.Hspec.Megaparsec (shouldParse)
+import Text.Megaparsec (
+  Parsec,
+  parse,
+ )
+import Text.RawString.QQ (r)
+
+parseMatch :: (Show a, Eq a) => Parsec Void Text a -> Text -> a -> Expectation
+parseMatch parser input expected = parse parser "" input `shouldParse` expected
+
+spec :: Spec
+spec = do
+  describe "descriptionParser" $ do
+    let shouldParseInto = parseMatch descriptionParser
+
+    it "should parse description file with no requirements" $
+      descriptionWithoutPkgs
+        `shouldParseInto` RDescription
+          mempty
+          mempty
+          mempty
+          mempty
+          mempty
+
+    it "should parse description file with single line requirements" $
+      descriptionSingleLine
+        `shouldParseInto` RDescription
+          ["nlme"]
+          mempty
+          ["MASS"]
+          mempty
+          mempty
+
+    it "should parse description file with multi-line requirements" $
+      descriptionMultiLine
+        `shouldParseInto` RDescription
+          mempty
+          ["utils"]
+          [ "BiocManager"
+          , "cli"
+          , "covr"
+          , "devtools"
+          , "jsonlite"
+          , "knitr"
+          , "miniUI"
+          , "packrat"
+          , "pak"
+          , "R6"
+          , "remotes"
+          , "reticulate"
+          , "rmarkdown"
+          , "rstudioapi"
+          , "shiny"
+          , "testthat"
+          , "uuid"
+          , "yaml"
+          ]
+          mempty
+          mempty
+
+descriptionWithoutPkgs :: Text
+descriptionWithoutPkgs =
+  [r|Package: pkgname
+Version: 0.5-1
+Date: 2015-01-01
+Title: My First Collection of Functions
+Authors@R: c(person("Joe", "Developer", role = c("aut", "cre"),
+                     email = "Joe.Developer@some.domain.net"),
+              person("Pat", "Developer", role = "aut"),
+              person("A.", "User", role = "ctb",
+                     email = "A.User@whereever.net"))
+Author: Joe Developer [aut, cre],
+  Pat Developer [aut],
+  A. User [ctb]
+Maintainer: Joe Developer <Joe.Developer@some.domain.net>
+Description: A (one paragraph) description of what
+  the package does and why it may be useful.
+License: GPL (>= 2)
+URL: https://www.r-project.org, http://www.another.url
+BugReports: https://pkgname.bugtracker.url
+|]
+
+descriptionSingleLine :: Text
+descriptionSingleLine =
+  [r|Package: pkgname
+Version: 0.5-1
+Date: 2015-01-01
+Depends: nlme
+Suggests: MASS
+Description: A (one paragraph) description of what
+  the package does and why it may be useful.
+License: GPL (>= 2)
+|]
+
+descriptionMultiLine :: Text
+descriptionMultiLine =
+  [r|Package: renv
+Type: Package
+Title: Project Environments
+Version: 0.15.5-68
+Authors@R: c(
+    person("Kevin", "Ushey", role = c("aut", "cre"), email = "kevin@rstudio.com"),
+    person("RStudio, PBC", role = c("cph"))
+    )
+Description: A dependency management toolkit for R. Using 'renv', you can create
+    and manage project-local R libraries, save the state of these libraries to
+    a 'lockfile', and later restore your library as required. Together, these
+    tools can help make your projects more isolated, portable, and reproducible.
+License: MIT + file LICENSE
+URL: https://rstudio.github.io/renv/
+BugReports: https://github.com/rstudio/renv/issues
+Imports: utils
+Suggests: BiocManager, cli, covr, devtools, jsonlite, knitr, miniUI, packrat, pak,
+    R6, remotes, reticulate, rmarkdown, rstudioapi, shiny, testthat, uuid, yaml
+Encoding: UTF-8
+RoxygenNote: 7.2.1
+Roxygen: list(markdown = TRUE)
+VignetteBuilder: knitr
+|]

--- a/test/R/DescriptionSpec.hs
+++ b/test/R/DescriptionSpec.hs
@@ -4,10 +4,12 @@ module R.DescriptionSpec (
   spec,
 ) where
 
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Void (Void)
 import Strategy.R.Description (
   RDescription (RDescription),
+  allPkgNames,
   descriptionParser,
  )
 import Test.Hspec (
@@ -15,6 +17,7 @@ import Test.Hspec (
   Spec,
   describe,
   it,
+  shouldBe,
  )
 import Test.Hspec.Megaparsec (shouldParse)
 import Text.Megaparsec (
@@ -48,6 +51,10 @@ spec = do
           ["MASS"]
           mempty
           mempty
+
+    it "should not parse version constraint from the description file" $
+      allPkgNames (RDescription ["nlme (>= 2.0.0)"] mempty ["MASS"] mempty mempty)
+        `shouldBe` Set.fromList ["nlme", "MASS"]
 
     it "should parse description file with multi-line requirements" $
       descriptionMultiLine

--- a/test/R/RenvSpec.hs
+++ b/test/R/RenvSpec.hs
@@ -1,0 +1,166 @@
+module R.RenvSpec (
+  spec,
+) where
+
+import Data.Aeson (decodeFileStrict')
+import Data.Map (fromList)
+import Data.Text (Text)
+import DepTypes (
+  DepType (
+    CranType,
+    GitType,
+    URLType
+  ),
+  Dependency (Dependency),
+  VerConstraint (CEq),
+ )
+import GraphUtil (expectDeps, expectDirect, expectEdge)
+import Strategy.R.Description (RDescription (RDescription))
+import Strategy.R.Renv (
+  RenvLock (RenvLock),
+  RenvLockPackage (RenvLockPackage),
+  RenvLockRepository (RenvLockRepository),
+  RenvPackageSource (..),
+  buildGraph,
+  toDependency,
+ )
+import Test.Hspec (
+  Spec,
+  describe,
+  it,
+  shouldBe,
+ )
+
+spec :: Spec
+spec = do
+  describe "renv.lock" $ do
+    it "should parse renv.lock file" $ do
+      lockFile <- decodeFileStrict' "test/R/testdata/renv.lock"
+      lockFile `shouldBe` Just expRenvLock
+
+  describe "buildGraph" $ do
+    it "should graph all packages as deep when description file is not present or empty" $ do
+      let graph = buildGraph (RDescription mempty mempty mempty mempty mempty) fxLock
+      expectDirect [] graph
+      expectDeps [depA, depB, depC, depD] graph
+
+    it "should graph packages in description file as direct" $ do
+      let graph = buildGraph (RDescription ["a"] mempty mempty mempty mempty) fxLock
+      expectDirect [depA] graph
+      expectDeps [depA, depB, depC, depD] graph
+
+    it "should graph package's requirements as edges" $ do
+      let graph = buildGraph (RDescription mempty mempty mempty mempty mempty) fxLock
+      expectDirect [] graph
+      expectDeps [depA, depB, depC, depD] graph
+      expectEdge graph depA depB
+      expectEdge graph depC depD
+
+  describe "toDependency" $ do
+    it "should make git dependency for git source" $ do
+      let dep = toDependency [] $ mkRPkg (Git "repoUrl" "ref")
+      let expectedDep = mkDep GitType "repoUrl" (Just "ref")
+      dep `shouldBe` expectedDep
+
+    it "should make git dependency for github source" $ do
+      let dep = toDependency [] $ mkRPkg (Github "user" "repo" "ref")
+      let expectedDep = mkDep GitType "https://github.com/user/repo.git" (Just "ref")
+      dep `shouldBe` expectedDep
+
+    it "should make git dependency for gitlab source" $ do
+      let dep = toDependency [] $ mkRPkg (Gitlab "user" "repo" "ref")
+      let expectedDep = mkDep GitType "https://gitlab.com/user/repo.git" (Just "ref")
+      dep `shouldBe` expectedDep
+
+    it "should make git dependency for bitbucket source" $ do
+      let dep = toDependency [] $ mkRPkg (Bitbucket "user" "repo" "ref")
+      let expectedDep = mkDep GitType "https://bitbucket.com/user/repo.git" (Just "ref")
+      dep `shouldBe` expectedDep
+
+    it "should make url dependency for url source" $ do
+      let dep = toDependency [] $ mkRPkg (Url "someUrl")
+      let expectedDep = mkDep URLType "someUrl" Nothing
+      dep `shouldBe` expectedDep
+
+    it "should make cran dependency with repository url, when remote repo is found for cran" $ do
+      let dep = toDependency [] $ mkRPkg (RemoteCran "someUrl")
+      let expectedDep = mkDep CranType ("someUrl:" <> fxPkgId) (Just fxPkgVersion)
+      dep `shouldBe` expectedDep
+
+    it "should make cran dependency" $ do
+      let dep = toDependency [] $ mkRPkg (Unknown)
+      let expectedDep = mkDep CranType fxPkgId (Just fxPkgVersion)
+      dep `shouldBe` expectedDep
+
+expRenvLock :: RenvLock
+expRenvLock =
+  RenvLock
+    [ RenvLockRepository "CRAN" "https://cran.rstudio.com"
+    , RenvLockRepository "EXAMPLE-REPO" "https://EXAMPLE-REPO"
+    ]
+    $ fromList
+      [ ("BiocManager", RenvLockPackage "BiocManager" "1.30.17" mempty $ Repository "CRAN")
+      , ("emo", RenvLockPackage "emo" "0.0.0.9000" mempty $ Github "hadley" "emo" "3f03b11491ce3d6fc5601e210927eff73bf8e350")
+      , ("nkbcgeneral", RenvLockPackage "nkbcgeneral" "0.8.0" mempty $ Bitbucket "cancercentrum" "nkbcgeneral" "db8e9206e7be44c53c5e7017900f38d506cf08a6")
+      , ("BiocGenerics", RenvLockPackage "BiocGenerics" "0.40.0" mempty $ Git "https://git.bioconductor.org/packages/BiocGenerics" "RELEASE_3_14")
+      , ("R6", RenvLockPackage "R6" "2.5.1" mempty $ Repository "EXAMPLE-REPO")
+      , ("SOME-GITLAB-PKG", RenvLockPackage "some-gitlab-pkg" "0" mempty $ Gitlab "someUser" "someRepo" "someSha")
+      , ("SOME-URL-PKG", RenvLockPackage "some-url-pkg" "1" mempty $ Url "https://some-url")
+      , ("SOME-REMOTE-REF-PKG", RenvLockPackage "some-remote-ref-pkg" "2" mempty $ RemoteCran "http://some-custom-repo")
+      ]
+
+fxLock :: RenvLock
+fxLock =
+  RenvLock [] $
+    fromList
+      [ ("a", pkgA)
+      , ("b", pkgB)
+      , ("c", pkgC)
+      , ("d", pkgD)
+      ]
+
+pkgA :: RenvLockPackage
+pkgA = mkRPkg' "a" "0" ["b"]
+
+depA :: Dependency
+depA = toDependency [] pkgA
+
+pkgB :: RenvLockPackage
+pkgB = mkRPkg' "b" "1" []
+
+depB :: Dependency
+depB = toDependency [] pkgB
+
+pkgC :: RenvLockPackage
+pkgC = mkRPkg' "c" "2" ["d"]
+
+depC :: Dependency
+depC = toDependency [] pkgC
+
+pkgD :: RenvLockPackage
+pkgD = mkRPkg' "d" "3" []
+
+depD :: Dependency
+depD = toDependency [] pkgD
+
+fxPkgId :: Text
+fxPkgId = "a"
+
+fxPkgVersion :: Text
+fxPkgVersion = "0"
+
+mkRPkg' :: Text -> Text -> [Text] -> RenvLockPackage
+mkRPkg' pkg version reqs = RenvLockPackage pkg version reqs Unknown
+
+mkRPkg :: RenvPackageSource -> RenvLockPackage
+mkRPkg = RenvLockPackage fxPkgId fxPkgVersion mempty
+
+mkDep :: DepType -> Text -> Maybe Text -> Dependency
+mkDep dType dName dVersion =
+  Dependency
+    dType
+    dName
+    (CEq <$> dVersion)
+    mempty
+    mempty
+    mempty

--- a/test/R/testdata/renv.lock
+++ b/test/R/testdata/renv.lock
@@ -1,0 +1,101 @@
+{
+	"R": {
+		"Version": "4.2.0",
+		"Repositories": [
+			{
+				"Name": "CRAN",
+				"URL": "https://cran.rstudio.com"
+			},
+			{
+				"Name": "EXAMPLE-REPO",
+				"URL": "https://EXAMPLE-REPO"
+			}
+		]
+	},
+	"Bioconductor": {
+		"Version": "3.15"
+	},
+	"Packages": {
+		"BiocManager": {
+			"Package": "BiocManager",
+			"Version": "1.30.17",
+			"Source": "Repository",
+			"Repository": "CRAN",
+			"Hash": "0ab5f6e14502755ca875f938781909af",
+			"Requirements": []
+		},
+		"emo": {
+			"Package": "emo",
+			"Version": "0.0.0.9000",
+			"Source": "GitHub",
+			"RemoteType": "github",
+			"RemoteHost": "api.github.com",
+			"RemoteRepo": "emo",
+			"RemoteUsername": "hadley",
+			"RemoteRef": "master",
+			"RemoteSha": "3f03b11491ce3d6fc5601e210927eff73bf8e350",
+			"Hash": "5ece31a6c0f94811e6bef59482d87164"
+		},
+		"nkbcgeneral": {
+			"Package": "nkbcgeneral",
+			"Version": "0.8.0",
+			"Source": "Bitbucket",
+			"RemoteType": "bitbucket",
+			"RemoteHost": "api.bitbucket.org/2.0",
+			"RemoteUsername": "cancercentrum",
+			"RemoteRepo": "nkbcgeneral",
+			"RemoteRef": "master",
+			"RemoteSha": "db8e9206e7be44c53c5e7017900f38d506cf08a6",
+			"Hash": "d9e272efa3a8cb27069aa91fab7aa49f",
+			"Requirements": []
+		},
+		"BiocGenerics": {
+			"Package": "BiocGenerics",
+			"Version": "0.40.0",
+			"Source": "Bioconductor",
+			"git_url": "https://git.bioconductor.org/packages/BiocGenerics",
+			"git_branch": "RELEASE_3_14",
+			"git_last_commit": "0bc1e0e",
+			"git_last_commit_date": "2021-10-26",
+			"Hash": "ddc1d29bbe66aaef34b0d17620b61a69",
+			"Requirements": []
+		},
+		"R6": {
+			"Package": "R6",
+			"Version": "2.5.1",
+			"Source": "Repository",
+			"Repository": "EXAMPLE-REPO",
+			"RemoteType": "standard",
+			"Hash": "470851b6d5d0ac559e9d01bb352b4021",
+			"Requirements": []
+		},
+		"SOME-GITLAB-PKG": {
+			"Package": "some-gitlab-pkg",
+			"Version": "0",
+			"Source": "Gitlab",
+			"RemoteType": "Gitlab",
+			"RemoteHost": "api.Gitlab.com",
+			"RemoteRepo": "someRepo",
+			"RemoteUsername": "someUser",
+			"RemoteRef": "master",
+			"RemoteSha": "someSha",
+			"Hash": "5ece31a6c0f94811e6bef59482d87164"
+		},
+		"SOME-URL-PKG": {
+			"Package": "some-url-pkg",
+			"Version": "1",
+			"Source": "URL",
+			"RemoteUrl": "https://some-url"
+		},
+		"SOME-REMOTE-REF-PKG": {
+			"Package": "some-remote-ref-pkg",
+			"Version": "2",
+			"Source": "Repository",
+			"Repository": "CRAN",
+			"RemoteRepos": "http://some-custom-repo",
+			"RemoteType": "standard",
+			"Hash": "470851b6d5d0ac559e9d01bb352b4021",
+			"Requirements": []
+		}
+	}
+}


### PR DESCRIPTION
# Overview

This PR, add _initial_ support for R (with renv package manager).

Sibling: https://github.com/fossas/FOSSA/pull/8452

## Acceptance criteria

- R package with `DESCRIPTION` and `renv.lock` can be analyzed.

## Testing plan

1) You can create renv project or find one on Github
```bash
git checkout feat/adds-r-support
make install-local
mkdir sandbox
cd sandbox
git clone https://github.com/leofontenelle/authorship-concentration
cd ..
./fossa analyze sandbox --only-target renv --output | jq
```

## Risks

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
