### PR TITLE
[No Ticket] Track counts of experimental gradle config usage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Telemetry: Counts experimental feature usage for experimental gradle config, binary discovery, and container scanner functionalities. ([#1063](https://github.com/fossas/fossa-cli/pull/1063))
+
 ## v3.4.5
 - FOSSA API: Adds resiliency against API errors occurring when retrieving endpoint versioning information. ([#1051](https://github.com/fossas/fossa-cli/pull/1051))
 

--- a/docs/contributing/telemetry.md
+++ b/docs/contributing/telemetry.md
@@ -54,12 +54,12 @@ When `--output` is used, we do not emit telemetry.
 1. Counting feature usage via counters
 
 ```haskell
--- >> :t countUsage
--- countUsage :: Has Telemetry sig m => CountableAnalysisMetric -> m ()
+-- >> :t trackUsage
+-- trackUsage :: Has Telemetry sig m => CountableCliFeature -> m ()
 
 experimental :: (Has Telemetry sig m) => SomeProj -> m ()
 experimental (SomeProject manifestDir manifestFile) = do
-  countUsage SomeProjectAnalyzedExperimentally
+  trackUsage SomeProjectAnalyzedExperimentally
   pure ()
 ```
 

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -40,11 +40,12 @@ import Control.Carrier.Debug (Debug, ignoreDebug)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.DockerEngineApi (runDockerEngineApi)
 import Control.Carrier.FossaApiClient (runFossaApiClient)
+import Control.Carrier.Telemetry.Types (CountableCliFeature (ExperimentalContainerScanner))
 import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic, context, errCtx, fatal, fatalText, fromEitherShow, (<||>))
 import Control.Effect.DockerEngineApi (DockerEngineApi, getDockerImageSize, isDockerEngineAccessible)
 import Control.Effect.FossaApiClient (FossaApiClient, getOrganization, uploadNativeContainerScan)
 import Control.Effect.Lift (Lift, sendIO)
-import Control.Effect.Telemetry (Telemetry)
+import Control.Effect.Telemetry (Telemetry, trackUsage)
 import Control.Monad (unless, void)
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BL
@@ -118,6 +119,7 @@ analyze ::
   m ()
 analyze cfg = do
   logInfo "Running container scanning with fossa experimental-scanner!"
+  trackUsage ExperimentalContainerScanner
 
   let filters = filterSet cfg
   let systemDepsOnly = onlySystemDeps cfg

--- a/src/Control/Carrier/Telemetry/Types.hs
+++ b/src/Control/Carrier/Telemetry/Types.hs
@@ -48,7 +48,9 @@ data TelemetryCtx = TelemetryCtx
   }
 
 data CountableCliFeature
-  = ExperimentalGradleSingleConfigurationUsage
+  = ExperimentalGradleConfigurationUsage
+  | ExperimentalContainerScanner
+  | ExperimentalBinaryDiscovery
   deriving (Show, Eq, Ord, Generic)
 
 instance ToJSONKey CountableCliFeature where


### PR DESCRIPTION
# Overview

This PR, 
- tracks experimental Gradle configuration usage
- tracks experimental binary discovery usage
- tracks experimental scanner usage

## Acceptance criteria

1. Tracks usage of experimental Gradle config usage
2. Tracks usage of experimental binary discovery
3. Tracks usage of the experimental scanner
 
## Testing plan

1. Create `sandbox`
```
mkdir sandbox
echo 'numpy' > sandbox/reqs.txt
```

4. Create `sandbox/.fossa.yml`
```
# file: sandbox/.fossa.yml
version: 3
experimental:
  gradle:
    configurations-only:
      - example-1-config-to-include
```

5. Analyze

```bash
./fossa analyze sandbox --debug --project cliPr1063 --revision 0
cat fossa.telemetry.json | jq  '.cliUsageCounter' 
# should see:
# {
#  "ExperimentalGradleConfigurationUsage": 1
# }
```

## Risks

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
