### PR TITLE
Package Linux binaries as both tar.gz and zip

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -218,7 +218,10 @@ jobs:
 
         cat *.sha256 | sha256sum --check --status
 
-    - name: Upload release artifacts
+    # Uploads the generated archives (tar.gz/zip) as build artifacts to allow
+    # verifying them without needing to do an actual release. This step does not
+    # need to run for tagged release versions.
+    - name: Upload release archives
       if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -171,6 +171,12 @@ jobs:
         [ "$(Linux-binaries/fossa --version)" = "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
 
     # This uses names compatible with our install script.
+    #
+    # Originally, CLI >=2.x Linux releases were only packaged as zip files, but
+    # we added tar.gz to improve compatibility. Our install script depends on
+    # the unzip command, which is not installed in most Linux distributions by
+    # default. To avoid breaking compatibility with older install scripts, we
+    # release both formats but default to using tar.gz when installing.
     - name: Bundle binaries
       run: |
         mkdir release
@@ -180,6 +186,8 @@ jobs:
         chmod +x Linux-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/fossa
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/pathfinder
+        tar --create --gzip --verbose --file release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz Linux-binaries/fossa
+        tar --create --gzip --verbose --file release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz Linux-binaries/pathfinder
 
         chmod +x macOS-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/fossa
@@ -194,6 +202,7 @@ jobs:
       run: |
         cd release
         sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip.sha256"
+        sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz" > "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz.sha256"
         sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip.sha256"
         sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip.sha256"
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -159,7 +159,7 @@ jobs:
             echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
             ;;
           *)
-            echo ::set-output name=VERSION::${GITHUB_REF}
+            echo ::set-output name=VERSION::${GITHUB_SHA}
             ;;
         esac
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -194,8 +194,8 @@ jobs:
         chmod +x Linux-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/fossa
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/pathfinder
-        tar --create --gzip --verbose --file release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz Linux-binaries/fossa
-        tar --create --gzip --verbose --file release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz Linux-binaries/pathfinder
+        tar --create --gzip --verbose --file release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz --directory Linux-binaries fossa
+        tar --create --gzip --verbose --file release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz --directory Linux-binaries pathfinder
 
         chmod +x macOS-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/fossa

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -144,7 +144,6 @@ jobs:
 
   create-release:
     name: create-release
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     needs: ['build-all']
 
@@ -153,10 +152,19 @@ jobs:
 
     - name: Get version
       id: get-version
-      # This strips the 'v' prefix from the tag.
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+      run: |
+        case $GITHUB_REF in
+          refs/tags/v*)
+            # This strips the 'v' prefix from the tag.
+            echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+            ;;
+          *)
+            echo ::set-output name=VERSION::${GITHUB_REF}
+            ;;
+        esac
 
     - name: Check that version info was embedded correctly
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       run: |
         chmod +x Linux-binaries/fossa
 
@@ -210,7 +218,15 @@ jobs:
 
         cat *.sha256 | sha256sum --check --status
 
+    - name: Upload release artifacts
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: release-archives
+        path: release
+
     - name: Release
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       uses: softprops/action-gh-release@v1
       with:
         files: release/*

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## v3.4.7
-- Linux releases are now packaged as both tar.gz and to improve compatibility when installing
+- Linux releases are now packaged as both tar.gz and to improve compatibility when installing ([#1066](https://github.com/fossas/fossa-cli/pull/1066))
 
 ## v3.4.6
 - Container Scanning: Fixes a defect, where container registry `registry:3000/org/repo:tag` was incorrectly identifying `registry` as project name. ([#1050](https://github.com/fossas/fossa-cli/issues/1050))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Linux releases are now packaged as tar.gz to improve compatibility when installing
+
 ## v3.4.5
 - FOSSA API: Adds resiliency against API errors occurring when retrieving endpoint versioning information. ([#1051](https://github.com/fossas/fossa-cli/pull/1051))
 


### PR DESCRIPTION
# Overview

This PR changes our GitHub Actions workflow to release Linux binaries packaged as both tar.gz and zip. This improves compatibility for installing fossa-cli under Linux distributions that do not come with the `unzip` command installed by default.

**Note**: This PR does not yet change `install-latest.sh` to use tar.gz files, as this would immediately break when trying to download the current latest release. An additional change should be merged after this PR is released to actually start using the tar.gz files when installing:

```diff
diff --git a/install-latest.sh b/install-latest.sh
index 1ec9c3de..10dcdbbf 100755
--- a/install-latest.sh
+++ b/install-latest.sh
@@ -102,6 +102,9 @@ adjust_format() {
 }
 adjust_os() {
   # adjust archive name based on OS
+  case $(uname_os) in
+    linux) FORMAT=tar.gz ;;
+  esac
   true
 }
 adjust_arch() {
```

## Acceptance criteria

After this PR and the above diff are merged, using `install-latest.sh` should work under Linux distributions that do not come with `unzip` installed.

## Testing plan

This depends on GitHub Actions so I haven't been able to test it directly yet.

## Risks

It's technically possible that some customers might be running the install script from a Linux environment that has `unzip` but not `tar` installed, but this seems extremely unlikely. CLI 1.x Linux releases were originally released as tar.gz.

We might want to add a fallback in the install script to try the zip release if the tar.gz release fails for some reason, but IMO this is unnecessary complexity for an extremely unlikely scenario.

## References

- [ANE-79](https://fossa.atlassian.net/browse/ANE-79)

## Checklist

- [ ] ~I added tests for this PR's change (or explained in the PR description why tests don't make sense).~
- [ ] ~If this PR introduced a user-visible change, I added documentation into `docs/`.~
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] ~If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).~
