### PR TITLE
Download tar.gz when installing on Linux

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## v3.4.7
-- Linux releases are now packaged as both tar.gz and to improve compatibility when installing ([#1066](https://github.com/fossas/fossa-cli/pull/1066))
+- Linux releases are now packaged as both tar.gz and zip to improve compatibility when installing ([#1066](https://github.com/fossas/fossa-cli/pull/1066))
 
 ## v3.4.6
 - Container Scanning: Fixes a defect, where container registry `registry:3000/org/repo:tag` was incorrectly identifying `registry` as project name. ([#1050](https://github.com/fossas/fossa-cli/issues/1050))

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -46,7 +46,7 @@ execute() {
   # http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
   # hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
   srcdir="${tmpdir}"
-  (cd "${tmpdir}" && unzip -o "${TARBALL}")
+  (cd "${tmpdir}" && untar "${TARBALL}")
   log_debug "setting up bindir: $BINDIR"
   mkdir -p "$BINDIR" 2> /dev/null || sudo mkdir -p "$BINDIR"
   for binexe in "fossa" ; do
@@ -102,6 +102,9 @@ adjust_format() {
 }
 adjust_os() {
   # adjust archive name based on OS
+  case $(uname_os) in
+   linux) FORMAT=tar.gz ;;
+  esac
   true
 }
 adjust_arch() {
@@ -232,7 +235,7 @@ untar() {
   case "${tarball}" in
     *.tar.gz | *.tgz) tar -xzf "${tarball}" ;;
     *.tar) tar -xf "${tarball}" ;;
-    *.zip) unzip "${tarball}" ;;
+    *.zip) unzip -o "${tarball}" ;;
     *)
       log_err "untar unknown archive format for ${tarball}"
       return 1

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -251,38 +251,50 @@ http_download_curl() {
   local_file=$1
   source_url=$2
   header=$3
-  if [ -z "$header" ]; then
-    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url") || (log_debug "curl command failed." && return 1)
-  else
-    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url") || (log_debug "curl command failed." && return 1)
+  if [ ! -z "$3" ]; then
+    header="-H $header"
   fi
-  if [ "$code" != "200" ]; then
-    log_debug "http_download_curl received HTTP status $code"
-    return 1
-  fi
+  HTTP_CODE=$(curl -w '%{HTTP_CODE}' -sL $header -o "$local_file" "$source_url") || (log_debug "curl command failed." && return 1)
   return 0
 }
 http_download_wget() {
   local_file=$1
   source_url=$2
-  header=$3
-  if [ -z "$header" ]; then
-    wget -q -O "$local_file" "$source_url" || (log_debug "wget command failed." && return 1)
-  else
-    wget -q --header "$header" -O "$local_file" "$source_url" || (log_debug "wget command failed." && return 1)
+  if [ ! -z $3 ]; then
+    header="--header $3"
   fi
+  HTTP_CODE=$(wget -q $header --server-response -O "$local_file" "$source_url" 2>&1 | awk 'NR==1{print $2}') || (log_debug "wget command failed." && return 1)
+  return 0
 }
 http_download() {
-  log_debug "http_download $2"
+  log_info "http_download $2"
   if is_command curl; then
     http_download_curl "$@"
-    return
   elif is_command wget; then
     http_download_wget "$@"
-    return
+  else
+    log_crit "http_download unable to find wget or curl"
+    return 1
   fi
-  log_crit "http_download unable to find wget or curl"
-  return 1
+
+  # tar.gz releases were added starting from v3.4.7.
+  # Context: https://github.com/fossas/fossa-cli/pull/1066
+  case $source_url in
+    *.tar.gz) if [ "$HTTP_CODE" = "404" ]; then
+      log_debug "http_download received 404 from $source_url, trying to download a zip file instead..."
+      FORMAT="zip"
+      TARBALL=${NAME}.${FORMAT}
+      TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
+      http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}" "$3"
+    fi ;;
+  esac
+
+  # wget returns the first status code it finds even if it redirected. Checking
+  # for 302 seems to work consistently with GitHub's API.
+  if [ -n "$HTTP_CODE" ] && [ "$HTTP_CODE" != 200 ] && [ "$HTTP_CODE" != 302 ]; then
+    log_err "http_download received HTTP status $HTTP_CODE from $2"
+    return 1
+  fi
 }
 http_copy() {
   tmp=$(mktemp)


### PR DESCRIPTION
# Overview

Changes the install script to download tar.gz archives instead of zip when running on Linux. See https://github.com/fossas/fossa-cli/pull/1066 for more context.

## Acceptance criteria

1. Running `install-latest.sh` successfully downloads and extracts the CLI binary from a tarball instead of a zip file when running on Linux.
2. Running `install-latest.sh` for a specific version that was not published with a tarball succeeds

## Testing plan

Manually ran `./install-latest.sh -d` and confirmed that it works on Linux:

```
$ ./install-latest.sh -d
fossas/fossa-cli info checking GitHub for latest tag
fossas/fossa-cli debug http_download https://github.com/fossas/fossa-cli/releases/latest
fossas/fossa-cli info found fossa-cli 3.4.7 binary for linux/amd64 at https://github.com/fossas/fossa-cli/releases/download/v3.4.7/fossa_3.4.7_linux_amd64.tar.gz
fossas/fossa-cli info
fossas/fossa-cli info ------
fossas/fossa-cli info Notice
fossas/fossa-cli info ------
fossas/fossa-cli info
fossas/fossa-cli info FOSSA collects warnings, errors, and usage data to improve
fossas/fossa-cli info the FOSSA CLI and your experience.
fossas/fossa-cli info
fossas/fossa-cli info Read more: https://github.com/fossas/fossa-cli/blob/master/docs/telemetry.md
fossas/fossa-cli info
fossas/fossa-cli info If you want to prevent any telemetry data from being sent to
fossas/fossa-cli info the server, you can opt out of telemetry by setting
fossas/fossa-cli info FOSSA_TELEMETRY_SCOPE environment variable to 'off' in your shell.
fossas/fossa-cli info
fossas/fossa-cli info For example:
fossas/fossa-cli info    FOSSA_TELEMETRY_SCOPE=off fossa analyze
fossas/fossa-cli info
fossas/fossa-cli info
fossas/fossa-cli debug downloading files into /tmp/tmp.4Tu40wXnhu
fossas/fossa-cli debug http_download https://github.com/fossas/fossa-cli/releases/download/v3.4.7/fossa_3.4.7_linux_amd64.tar.gz
fossas/fossa-cli debug setting up bindir: /usr/local/bin
fossas/fossa-cli debug installing binary: fossa
[sudo] password for rolodato:
fossas/fossa-cli info installed /usr/local/bin/fossa
$ /usr/local/bin/fossa --version
fossa-cli version 3.4.7 (revision 7949e2a9c1e5 compiled with ghc-9.0)
```

## Risks

As soon as this commit lands on master, all Linux users will be immediately be using this code. It's a simple change but the potential impact is large. We will notice any problems immediately and are ready to revert if anything breaks. We already have a CI step that tests the install script so this is unlikely to go unnoticed.

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] ~If this PR introduced a user-visible change, I added documentation into `docs/`.~
- [ ] ~If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.~
- [ ] ~If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).~
