### PR TITLE
[ANE-380] Waits for revision cache before producing report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ integration-test/artifacts/
 # One offs
 test/App/Fossa/VSI/DynLinked/testdata/hello_standard*
 test/App/Fossa/VSI/DynLinked/testdata/hello_setuid*
-sandbox/
 
 # Rust
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ vendor-bins/
 /fossa
 /fossa-?dev
 /release
+/fourmolu
 
 # Debug output
 fossa.debug.json
@@ -29,6 +30,7 @@ integration-test/artifacts/
 # One offs
 test/App/Fossa/VSI/DynLinked/testdata/hello_standard*
 test/App/Fossa/VSI/DynLinked/testdata/hello_setuid*
+sandbox/
 
 # Rust
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.4.8
+- Report: Fixes a defect, where `report` command was failing due to invalid dependencies cache from endpoint ([#1068](https://github.com/fossas/fossa-cli/pull/1068)).
+
 ## v3.4.7
 - Linux releases are now packaged as both tar.gz and to improve compatibility when installing ([#1066](https://github.com/fossas/fossa-cli/pull/1066))
 

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -2,7 +2,7 @@ module App.Fossa.API.BuildWait (
   waitForScanCompletion,
   waitForIssues,
   waitForBuild,
-  waitForReport,
+  waitForReportReadiness,
 ) where
 
 import App.Fossa.Config.Test (DiffRevision)
@@ -200,7 +200,7 @@ pauseForRetry = do
   apiOpts <- getApiOpts
   delay $ apiOptsPollDelay apiOpts
 
-waitForReport ::
+waitForReportReadiness ::
   ( Has Diagnostics sig m
   , Has Logger sig m
   , Has StickyLogger sig m
@@ -210,7 +210,7 @@ waitForReport ::
   ProjectRevision ->
   Cancel ->
   m ()
-waitForReport revision cancelFlag = do
+waitForReportReadiness revision cancelFlag = do
   void $ waitForIssues revision Nothing cancelFlag
 
   supportsDepCacheReadinessPolling <- orgSupportsDependenciesCachePolling <$> getOrganization

--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -2,6 +2,7 @@ module App.Fossa.API.BuildWait (
   waitForScanCompletion,
   waitForIssues,
   waitForBuild,
+  waitForReport,
 ) where
 
 import App.Fossa.Config.Test (DiffRevision)
@@ -23,9 +24,11 @@ import Control.Effect.FossaApiClient (
   getLatestScan,
   getOrganization,
   getProject,
+  getRevisionDependencyCacheStatus,
   getScan,
  )
 import Control.Effect.StickyLogger (StickyLogger, logSticky')
+import Control.Monad (void, when)
 import Control.Timeout (Cancel, checkForCancel, delay)
 import Data.Text (Text)
 import Data.Text.Extra (showT)
@@ -37,8 +40,10 @@ import Fossa.API.Types (
   BuildTask (buildTaskStatus),
   Issues (issuesStatus),
   OrgId,
-  Organization (organizationId),
+  Organization (orgSupportsDependenciesCachePolling, organizationId),
   Project (projectIsMonorepo),
+  RevisionDependencyCache (status),
+  RevisionDependencyCacheStatus (Ready, UnknownDependencyCacheStatus, Waiting),
   ScanId,
   ScanResponse (..),
  )
@@ -194,3 +199,42 @@ pauseForRetry ::
 pauseForRetry = do
   apiOpts <- getApiOpts
   delay $ apiOptsPollDelay apiOpts
+
+waitForReport ::
+  ( Has Diagnostics sig m
+  , Has Logger sig m
+  , Has StickyLogger sig m
+  , Has FossaApiClient sig m
+  , Has (Lift IO) sig m
+  ) =>
+  ProjectRevision ->
+  Cancel ->
+  m ()
+waitForReport revision cancelFlag = do
+  void $ waitForIssues revision Nothing cancelFlag
+
+  supportsDepCacheReadinessPolling <- orgSupportsDependenciesCachePolling <$> getOrganization
+  when supportsDepCacheReadinessPolling $
+    waitForValidDependenciesCache revision cancelFlag
+
+waitForValidDependenciesCache ::
+  ( Has Diagnostics sig m
+  , Has Logger sig m
+  , Has StickyLogger sig m
+  , Has FossaApiClient sig m
+  , Has (Lift IO) sig m
+  ) =>
+  ProjectRevision ->
+  Cancel ->
+  m ()
+waitForValidDependenciesCache revision cancelFlag = do
+  checkForTimeout cancelFlag
+  cacheStatus <- getRevisionDependencyCacheStatus revision
+
+  case status cacheStatus of
+    Ready -> pure ()
+    Waiting -> do
+      logSticky' $ "[ Waiting for revision's dependency cache... last status: " <> viaShow Waiting <> " ]"
+      pauseForRetry
+      waitForValidDependenciesCache revision cancelFlag
+    UnknownDependencyCacheStatus status -> fatalText $ "unknown status of " <> status <> " received for revision's dependency cache"

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -7,7 +7,7 @@ module App.Fossa.Report (
 ) where
 
 import App.Fossa.API.BuildWait (
-  waitForReport,
+  waitForReportReadiness,
   waitForScanCompletion,
  )
 import App.Fossa.Config.Report (ReportCliOptions, ReportConfig (..), ReportOutputFormat (ReportJson), mkSubCommand)
@@ -78,7 +78,7 @@ fetchReport ReportConfig{..} =
       waitForScanCompletion revision cancelToken
       logSticky "[ Waiting for scan completion... ]"
 
-      waitForReport revision cancelToken
+      waitForReportReadiness revision cancelToken
       logSticky $ "[ Fetching " <> showT reportType <> " report... ]"
 
       renderedReport <- getAttribution revision outputFormat

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -7,7 +7,7 @@ module App.Fossa.Report (
 ) where
 
 import App.Fossa.API.BuildWait (
-  waitForIssues,
+  waitForReport,
   waitForScanCompletion,
  )
 import App.Fossa.Config.Report (ReportCliOptions, ReportConfig (..), ReportOutputFormat (ReportJson), mkSubCommand)
@@ -76,13 +76,10 @@ fetchReport ReportConfig{..} =
       logSticky "[ Waiting for build completion... ]"
 
       waitForScanCompletion revision cancelToken
+      logSticky "[ Waiting for scan completion... ]"
 
-      logSticky "[ Waiting for issue scan completion... ]"
-
-      _ <- waitForIssues revision Nothing cancelToken
-
+      waitForReport revision cancelToken
       logSticky $ "[ Fetching " <> showT reportType <> " report... ]"
 
       renderedReport <- getAttribution revision outputFormat
-
       logStdout renderedReport

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -40,6 +40,7 @@ runFossaApiClient apiOpts =
           GetIssues rev diffRev -> Core.getIssues rev diffRev
           GetEndpointVersion -> Core.getEndpointVersion
           GetLatestBuild rev -> Core.getLatestBuild rev
+          GetRevisionDependencyCacheStatus rev -> Core.getRevisionDependencyCacheStatus rev
           GetLatestScan locator rev -> ScotlandYard.getLatestScan locator rev
           GetOrganization -> Core.getOrganization
           GetProject rev -> Core.getProject rev

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -7,6 +7,7 @@ module Control.Carrier.FossaApiClient.Internal.Core (
   getOrganization,
   getProject,
   getAnalyzedRevisions,
+  getRevisionDependencyCacheStatus,
   getSignedUploadUrl,
   queueArchiveBuild,
   uploadAnalysis,
@@ -41,6 +42,7 @@ import Fossa.API.Types (
   Issues,
   Organization,
   Project,
+  RevisionDependencyCache,
   SignedURL,
   UploadResponse,
  )
@@ -166,6 +168,17 @@ getAttribution ::
 getAttribution revision format = do
   apiOpts <- ask
   API.getAttribution apiOpts revision format
+
+getRevisionDependencyCacheStatus ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has (Reader ApiOpts) sig m
+  ) =>
+  ProjectRevision ->
+  m RevisionDependencyCache
+getRevisionDependencyCacheStatus rev = do
+  apiOpts <- ask
+  API.getRevisionDependencyCacheStatus apiOpts rev
 
 getSignedUploadUrl ::
   ( Has (Lift IO) sig m

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -18,6 +18,7 @@ module Control.Effect.FossaApiClient (
   getEndpointVersion,
   getOrganization,
   getProject,
+  getRevisionDependencyCacheStatus,
   getAnalyzedRevisions,
   getScan,
   getSignedLicenseScanUrl,
@@ -61,6 +62,7 @@ import Fossa.API.Types (
   Issues,
   Organization,
   Project,
+  RevisionDependencyCache,
   ScanId,
   ScanResponse,
   SignedURL,
@@ -89,6 +91,7 @@ data FossaApiClientF a where
   GetAttribution :: ProjectRevision -> ReportOutputFormat -> FossaApiClientF Text
   GetIssues :: ProjectRevision -> Maybe DiffRevision -> FossaApiClientF Issues
   GetEndpointVersion :: FossaApiClientF Text
+  GetRevisionDependencyCacheStatus :: ProjectRevision -> FossaApiClientF RevisionDependencyCache
   GetLatestBuild :: ProjectRevision -> FossaApiClientF Build
   GetLatestScan :: Locator -> ProjectRevision -> FossaApiClientF ScanResponse
   GetOrganization :: FossaApiClientF Organization
@@ -160,6 +163,9 @@ uploadContributors locator contributors = sendSimple $ UploadContributors locato
 
 getLatestBuild :: (Has FossaApiClient sig m) => ProjectRevision -> m Build
 getLatestBuild = sendSimple . GetLatestBuild
+
+getRevisionDependencyCacheStatus :: (Has FossaApiClient sig m) => ProjectRevision -> m RevisionDependencyCache
+getRevisionDependencyCacheStatus = sendSimple . GetRevisionDependencyCacheStatus
 
 getIssues :: (Has FossaApiClient sig m) => ProjectRevision -> Maybe DiffRevision -> m Issues
 getIssues projectRevision diffRevision = sendSimple $ GetIssues projectRevision diffRevision

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -18,6 +18,8 @@ module Fossa.API.Types (
   OrgId (..),
   Organization (..),
   Project (..),
+  RevisionDependencyCache (..),
+  RevisionDependencyCacheStatus (..),
   SignedURL (..),
   UploadResponse (..),
   ScanId (..),
@@ -296,6 +298,7 @@ data Organization = Organization
   , orgDefaultVendoredDependencyScanType :: ArchiveUploadType
   , orgSupportsIssueDiffs :: Bool
   , orgSupportsNativeContainerScan :: Bool
+  , orgSupportsDependenciesCachePolling :: Bool
   }
   deriving (Eq, Ord, Show)
 
@@ -309,6 +312,7 @@ instance FromJSON Organization where
       <*> obj .:? "defaultVendoredDependencyScanType" .!= CLILicenseScan
       <*> obj .:? "supportsIssueDiffs" .!= False
       <*> obj .:? "supportsNativeContainerScans" .!= False
+      <*> obj .:? "supportsDependenciesCachePolling" .!= False
 
 data Project = Project
   { projectId :: Text
@@ -352,6 +356,26 @@ instance FromJSON ScanResponse where
     ScanResponse
       <$> obj .: "id"
       <*> obj .:? "status"
+
+data RevisionDependencyCacheStatus
+  = Ready
+  | Waiting
+  | UnknownDependencyCacheStatus Text
+  deriving (Eq, Ord, Show)
+
+newtype RevisionDependencyCache = RevisionDependencyCache {status :: RevisionDependencyCacheStatus}
+  deriving (Eq, Ord, Show)
+
+instance FromJSON RevisionDependencyCache where
+  parseJSON = withObject "RevisionDependencyCache" $ \obj ->
+    RevisionDependencyCache
+      <$> obj .: "status"
+
+instance FromJSON RevisionDependencyCacheStatus where
+  parseJSON = withText "RevisionDependencyCacheStatus" $ \case
+    "WAITING" -> pure Waiting
+    "READY" -> pure Ready
+    other -> pure $ UnknownDependencyCacheStatus other
 
 ---------------
 

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -372,7 +372,7 @@ instance FromJSON RevisionDependencyCache where
       <$> obj .: "status"
 
 instance FromJSON RevisionDependencyCacheStatus where
-  parseJSON = withText "RevisionDependencyCacheStatus" $ \case
+  parseJSON = withText "RevisionDependencyCacheStatus" $ \txt -> case Text.toUpper txt of
     "WAITING" -> pure Waiting
     "READY" -> pure Ready
     other -> pure $ UnknownDependencyCacheStatus other

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -41,7 +41,7 @@ spec = do
     describe "SAML URL builder" $ do
       it' "should render simple locators" $ do
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
-            org = Just $ Organization (OrgId 1) True False True CLILicenseScan True True
+            org = Just $ Organization (OrgId 1) True False True CLILicenseScan True True True
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -49,7 +49,7 @@ spec = do
 
       it' "should render git@ locators" $ do
         let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
-            org = Just $ Organization (OrgId 103) True False True CLILicenseScan True True
+            org = Just $ Organization (OrgId 103) True False True CLILicenseScan True True True
             revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -57,7 +57,7 @@ spec = do
 
       it' "should render full url correctly" $ do
         let locator = Locator "a" "b" $ Just "c"
-            org = Just $ Organization (OrgId 33) True False True CLILicenseScan True True
+            org = Just $ Organization (OrgId 33) True False True CLILicenseScan True True True
             revision = ProjectRevision "" "not this revision" $ Just "master"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -74,7 +74,7 @@ spec = do
     describe "Fossa URL Builder" $
       it' "should render from API info" $ do
         GetApiOpts `returnsOnce` Fixtures.apiOpts
-        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True True
+        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True True True
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getFossaBuildUrl revision locator

--- a/test/App/Fossa/API/BuildWaitSpec.hs
+++ b/test/App/Fossa/API/BuildWaitSpec.hs
@@ -1,6 +1,6 @@
 module App.Fossa.API.BuildWaitSpec (spec) where
 
-import App.Fossa.API.BuildWait (waitForBuild, waitForIssues, waitForReport, waitForScanCompletion)
+import App.Fossa.API.BuildWait (waitForBuild, waitForIssues, waitForReportReadiness, waitForScanCompletion)
 import Control.Algebra (Has)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
 import Control.Effect.Lift (Lift)
@@ -137,14 +137,14 @@ spec =
         expectFatal' . runWithTimeout $
           waitForBuild Fixtures.projectRevision
 
-    describe "waitForReport" $ do
+    describe "waitForReportReadiness" $ do
       it' "should return when the dependency cache are ready" $ do
         expectGetApiOpts
         expectGetOrganization
         expectIssuesAvailable
         expectGetRevisionCache Ready
         runWithTimeout $
-          waitForReport Fixtures.projectRevision
+          waitForReportReadiness Fixtures.projectRevision
 
       it' "should retry periodically if the revision's dependency cache is in waiting state" $ do
         expectGetApiOpts
@@ -155,7 +155,7 @@ spec =
         expectGetRevisionCache Waiting
         expectGetRevisionCache Ready
         runWithTimeout $
-          waitForReport Fixtures.projectRevision
+          waitForReportReadiness Fixtures.projectRevision
 
       it' "should cancel when the timeout expires" $ do
         expectGetApiOpts
@@ -163,7 +163,7 @@ spec =
         expectIssuesAvailable
         expectRevisionDependencyCacheAlwaysWaiting
         expectFatal' . runWithTimeout $
-          waitForReport Fixtures.projectRevision
+          waitForReportReadiness Fixtures.projectRevision
 
 testVpsLocator :: Locator
 testVpsLocator = Locator{locatorFetcher = "custom", locatorProject = "42/testProjectName", locatorRevision = Nothing}

--- a/test/App/Fossa/API/BuildWaitSpec.hs
+++ b/test/App/Fossa/API/BuildWaitSpec.hs
@@ -1,6 +1,6 @@
 module App.Fossa.API.BuildWaitSpec (spec) where
 
-import App.Fossa.API.BuildWait (waitForBuild, waitForIssues, waitForScanCompletion)
+import App.Fossa.API.BuildWait (waitForBuild, waitForIssues, waitForReport, waitForScanCompletion)
 import Control.Algebra (Has)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
 import Control.Effect.Lift (Lift)
@@ -12,6 +12,8 @@ import Fossa.API.Types (
   BuildStatus (StatusCreated, StatusFailed, StatusRunning, StatusSucceeded),
   BuildTask (..),
   Project (projectIsMonorepo),
+  RevisionDependencyCache (RevisionDependencyCache),
+  RevisionDependencyCacheStatus (Ready, Waiting),
   ScanResponse (responseScanStatus),
  )
 import Srclib.Types (Locator (..))
@@ -135,6 +137,34 @@ spec =
         expectFatal' . runWithTimeout $
           waitForBuild Fixtures.projectRevision
 
+    describe "waitForReport" $ do
+      it' "should return when the dependency cache are ready" $ do
+        expectGetApiOpts
+        expectGetOrganization
+        expectIssuesAvailable
+        expectGetRevisionCache Ready
+        runWithTimeout $
+          waitForReport Fixtures.projectRevision
+
+      it' "should retry periodically if the revision's dependency cache is in waiting state" $ do
+        expectGetApiOpts
+        expectGetOrganization
+        expectIssuesAvailable
+        expectGetRevisionCache Waiting
+        expectGetRevisionCache Waiting
+        expectGetRevisionCache Waiting
+        expectGetRevisionCache Ready
+        runWithTimeout $
+          waitForReport Fixtures.projectRevision
+
+      it' "should cancel when the timeout expires" $ do
+        expectGetApiOpts
+        expectGetOrganization
+        expectIssuesAvailable
+        expectRevisionDependencyCacheAlwaysWaiting
+        expectFatal' . runWithTimeout $
+          waitForReport Fixtures.projectRevision
+
 testVpsLocator :: Locator
 testVpsLocator = Locator{locatorFetcher = "custom", locatorProject = "42/testProjectName", locatorRevision = Nothing}
 
@@ -155,6 +185,11 @@ expectGetLatestBuild :: Has MockApi sig m => BuildStatus -> m ()
 expectGetLatestBuild status =
   (GetLatestBuild Fixtures.projectRevision)
     `returnsOnce` Fixtures.build{buildTask = BuildTask{buildTaskStatus = status}}
+
+expectGetRevisionCache :: Has MockApi sig m => RevisionDependencyCacheStatus -> m ()
+expectGetRevisionCache status =
+  (GetRevisionDependencyCacheStatus Fixtures.projectRevision)
+    `returnsOnce` (RevisionDependencyCache status)
 
 expectGetLatestScan :: Has MockApi sig m => m ()
 expectGetLatestScan =
@@ -190,6 +225,11 @@ expectBuildAlwaysRunning :: Has MockApi sig m => m ()
 expectBuildAlwaysRunning =
   (GetLatestBuild Fixtures.projectRevision)
     `alwaysReturns` Fixtures.build{buildTask = BuildTask{buildTaskStatus = StatusRunning}}
+
+expectRevisionDependencyCacheAlwaysWaiting :: Has MockApi sig m => m ()
+expectRevisionDependencyCacheAlwaysWaiting =
+  (GetRevisionDependencyCacheStatus Fixtures.projectRevision)
+    `alwaysReturns` RevisionDependencyCache Waiting
 
 expectIssuesAlwaysWaiting :: Has MockApi sig m => m ()
 expectIssuesAlwaysWaiting =

--- a/test/App/Fossa/ReportSpec.hs
+++ b/test/App/Fossa/ReportSpec.hs
@@ -5,11 +5,11 @@ import App.Fossa.Report (fetchReport)
 import Control.Algebra (Has)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
 import Control.Timeout (Duration (MilliSeconds))
+import Fossa.API.Types (RevisionDependencyCache (RevisionDependencyCache), RevisionDependencyCacheStatus (Ready))
 import Test.Effect (expectFatal', it')
 import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec, describe, runIO)
 import Test.MockApi (MockApi, alwaysReturns, fails, returnsOnce)
-import Fossa.API.Types (RevisionDependencyCache(RevisionDependencyCache), RevisionDependencyCacheStatus (Ready))
 
 reportConfig :: IO ReportConfig
 reportConfig = do

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -71,7 +71,7 @@ apiOpts =
     }
 
 organization :: API.Organization
-organization = API.Organization (API.OrgId 42) True True True CLILicenseScan True True
+organization = API.Organization (API.OrgId 42) True True True CLILicenseScan True True True
 
 project :: API.Project
 project =

--- a/test/Test/MockApi.hs
+++ b/test/Test/MockApi.hs
@@ -216,6 +216,7 @@ matchExpectation a@(GetLatestScan{}) (ApiExpectation _ requestExpectation b@(Get
 matchExpectation a@(GetOrganization{}) (ApiExpectation _ requestExpectation b@(GetOrganization{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetEndpointVersion{}) (ApiExpectation _ requestExpectation b@(GetEndpointVersion{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetProject{}) (ApiExpectation _ requestExpectation b@(GetProject{}) resp) = checkResult requestExpectation a b resp
+matchExpectation a@(GetRevisionDependencyCacheStatus{}) (ApiExpectation _ requestExpectation b@(GetRevisionDependencyCacheStatus{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetScan{}) (ApiExpectation _ requestExpectation b@(GetScan{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetSignedLicenseScanUrl{}) (ApiExpectation _ requestExpectation b@(GetSignedLicenseScanUrl{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetSignedUploadUrl{}) (ApiExpectation _ requestExpectation b@(GetSignedUploadUrl{}) resp) = checkResult requestExpectation a b resp


### PR DESCRIPTION
# Overview

This PR modified the `report` command such that, 
- If the endpoint server supports polling for revision's dependency cache status, we poll until `READY` status is received
- If the endpoint server does not support polling for revision's dependency cache status, we wait for the issues scan (this is current behaviour)

## Acceptance criteria

- If the endpoint server supports polling for revision's dependency cache status, we poll until the `READY` status is received
- If the endpoint server does not support polling for revision's dependency cache status, we wait for the issues scan (this is current behaviour)

## Testing plan
Sibing PR: https://github.com/fossas/FOSSA/pull/8522.

0) Perform `git checkout master && git pull origin && git checkout feat/adds-report-polling && make install-local`
1) Ensure your LOCAL endpoint is at: https://github.com/fossas/FOSSA/pull/8522.
2) Perform until Step 3 from the sibling PR testing plan.
3) Perform
```bash
./fossa report attribution --format json --project ane380 --revision 0 --endpoint http://localhost:9578 --fossa-api-key <API-KEY>
```
4) Perform Step 4 from the sibling PR testing plan.
4) CLI should successfully produce the report.

## Risks

N/A

## References

[ANE-380](https://fossa.atlassian.net/browse/ANE-380)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
