### PR TITLE
Adds Docs for Production Path Filtering, Improves Scan Summary

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Scan Summary: Identifies project skipped due to production path filtering, or exclusion filtering. ([]())
+
 ## v3.4.8
 - Report: Fixes a defect, where `report` command was failing due to invalid dependencies cache from endpoint ([#1068](https://github.com/fossas/fossa-cli/pull/1068)).
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Scan Summary: Identifies project skipped due to production path filtering, or exclusion filtering. ([]())
+- Scan Summary: Identifies project skipped due to production path filtering, or exclusion filtering. ([#1071](https://github.com/fossas/fossa-cli/pull/1071))
 
 ## v3.4.8
 - Report: Fixes a defect, where `report` command was failing due to invalid dependencies cache from endpoint ([#1068](https://github.com/fossas/fossa-cli/pull/1068)).

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -85,3 +85,44 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 | `--experimental-skip-vsi-graph 'custom+1/some$locator'` | Skip resolving the dependencies of the given project that was previously linked via `--experimental-link-project-binary`.                                           |
 | `--experimental-enable-monorepo 'monorepo-type'`        | Scan the project in monorepo mode. For more information, see the [monorepo overview](../experimental/monorepo/README.md).                                           |
 | `--experimental-analyze-dynamic-deps './some-binary`    | Analyze the binary at the provided path for dynamically linked dependencies. For more information, see [dynamic link detection](../experimental/dynlink/README.md)  |
+
+### F.A.Q.
+
+1. Why is `fossa-cli` is skipping my project?
+
+`fossa-cli` may sometime report a project of interest was skipped from the analysis. For example,
+
+```text
+[ INFO] Scan Summary
+[ INFO] ------------
+[ INFO] 3 projects scanned;  2 skipped,  1 succeeded,  0 failed,  1 analysis warning
+[ INFO] 
+[ INFO] * setuptools project in "sandbox/": succeeded with 1 warning
+[ INFO] * setuptools project in "sandbox/example/": skipped (production path filtering)
+[ INFO] * setuptools project in "sandbox/external/": skipped (exclusion filters)
+```
+
+`fossa-cli` skips analysis, if and only if 
+
+- (a) Target is excluded via fossa configuration file (this filtering is referred to as "exclusion filters")
+- (b) Target is skipped because its `fossa-cli` considers target to be not part of production (this filtering is referred to as "production path filtering")
+
+`fossa-cli` skips any target per (b), if the target is found within the following directories:
+
+- `dist-newstyle`
+- `doc/`
+- `docs/`
+- `test/`
+- `example/`
+- `examples/`
+- `vendor/`
+- `node_modules/`
+- `.srclib-cache/`
+- `spec/`
+- `Godeps/`
+- `.git/`
+- `bower_components/`
+- `third_party/`
+- `third-party/`
+- `Carthage/`
+- `Checkouts/` 

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -88,9 +88,9 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 
 ### F.A.Q.
 
-1. Why is `fossa-cli` is skipping my project?
+1. Why is the `fossa-cli` skipping my project?
 
-`fossa-cli` may sometime report a project of interest was skipped from the analysis. For example,
+`fossa-cli` may sometimes report a project of interest was skipped from the analysis. For example,
 
 ```text
 [ INFO] Scan Summary
@@ -104,8 +104,8 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 
 `fossa-cli` skips analysis, if and only if 
 
-- (a) Target is excluded via fossa configuration file (this filtering is referred to as "exclusion filters")
-- (b) Target is skipped because its `fossa-cli` considers target to be not part of production (this filtering is referred to as "production path filtering")
+- (a) Target is excluded via fossa configuration file (this filtering is referred to as "exclusion filters").
+- (b) Target is skipped because the `fossa-cli` does not consider the target to be a production target (this filtering is referred to as "production path filtering").
 
 `fossa-cli` skips any target per (b), if the target is found within the following directories:
 
@@ -126,3 +126,8 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 - `third-party/`
 - `Carthage/`
 - `Checkouts/` 
+
+As `fossa-cli` relies on manifest and lock files provided in the project's directory, we 
+intentionally skip `node_modules/` and such directories. If `fossa-cli` discovers and
+analyzes project found in `node_modules/`: `fossa-cli` will not be able to infer
+the dependency's scope (development or production) and may double count dependencies.

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -104,7 +104,7 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 
 `fossa-cli` skips analysis, if and only if 
 
-- (a) Target is excluded via fossa configuration file (this filtering is referred to as "exclusion filters").
+- (a) Target is excluded via [fossa configuration file](https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md#analysis-target-configuration) (this filtering is referred to as "exclusion filters").
 - (b) Target is skipped because the `fossa-cli` does not consider the target to be a production target (this filtering is referred to as "production path filtering").
 
 `fossa-cli` skips any target per (b), if the target is found within the following directories:

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -245,8 +245,8 @@ summarizeSrcUnit _ _ _ = []
 summarizeProjectScan :: DiscoveredProjectScan -> Doc AnsiStyle
 summarizeProjectScan (Scanned dpi (Failure _ _)) = failColorCoded $ renderDiscoveredProjectIdentifier dpi <> renderFailed
 summarizeProjectScan (Scanned _ (Success wg pr)) = successColorCoded wg $ renderProjectResult pr <> renderSucceeded wg
-summarizeProjectScan (SkippedDueToProvidedFilter dpi) = renderDiscoveredProjectIdentifier dpi <> renderSkipped
-summarizeProjectScan (SkippedDueToDefaultProductionFilter dpi) = renderDiscoveredProjectIdentifier dpi <> renderSkipped
+summarizeProjectScan (SkippedDueToProvidedFilter dpi) = renderDiscoveredProjectIdentifier dpi <> skippedDueFilter
+summarizeProjectScan (SkippedDueToDefaultProductionFilter dpi) = renderDiscoveredProjectIdentifier dpi <> skippedDueProductionPathFiltering
 
 ---------- Rendering Helpers
 
@@ -274,8 +274,11 @@ successColorCoded ew =
 failColorCoded :: Doc AnsiStyle -> Doc AnsiStyle
 failColorCoded = annotate $ color Red
 
-renderSkipped :: Doc AnsiStyle
-renderSkipped = ": skipped"
+skippedDueFilter :: Doc AnsiStyle
+skippedDueFilter = ": skipped (exclusion filters)"
+
+skippedDueProductionPathFiltering :: Doc AnsiStyle
+skippedDueProductionPathFiltering = ": skipped (production path filtering)"
 
 renderSucceeded :: [EmittedWarn] -> Doc AnsiStyle
 renderSucceeded ew =


### PR DESCRIPTION
# Overview

This PR improves the scan summary by specifying why the project was skipped. It also adds relevant docs.

New Format Looks like this now:
```
[ INFO] Scan Summary
[ INFO] ------------
[ INFO] fossa-cli branch docs-only/adds-path-filtering-details (revision b2d6a6737753 (dirty) compiled with ghc-9.0)
[ INFO] fossa endpoint server version: N/A
[ INFO] 
[ INFO] 3 projects scanned;  2 skipped,  1 succeeded,  0 failed,  1 analysis warning
[ INFO] 
[ INFO] * setuptools project in "/Users/dev/Work/upstream/fossa-cli/sandbox/": succeeded with 1 warning
[ INFO] * setuptools project in "/Users/dev/Work/upstream/fossa-cli/sandbox/example/": skipped (production path filtering)
[ INFO] * setuptools project in "/Users/dev/Work/upstream/fossa-cli/sandbox/external/": skipped (exclusion filters)
```

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
