### PR TITLE
[Docs only] Prefer transitive label over deep label

### DIFF
--- a/docs/references/experimental/msb/README.md
+++ b/docs/references/experimental/msb/README.md
@@ -16,7 +16,7 @@ Such binary can be a library purchased from a vendor, or a prebuilt open source 
 If the team building the internal binary links the binary to its project, multi-stage build support can identify such binaries vendored into the directory structure of another project.
 Linking will preserve all of the metadata known about the artifact during the linking.
 
-The upstream library project will be shown as a direct dependency of the project that is vendoring the binary artifact, and upstream project’s dependencies are shown as deep dependencies of the vendoring project.
+The upstream library project will be shown as a direct dependency of the project that is vendoring the binary artifact, and upstream project’s dependencies are shown as transitive dependencies of the vendoring project.
 
 #### Build a binary used downstream
 
@@ -26,7 +26,7 @@ This allows you to configure the CI pipeline for your project to always keep the
 ### Link a binary’s fingerprint to a user project
 
 When the source of a library is available, FOSSA can scan that library for its dependencies and associate one or more binaries with the project.
-Then, when scanning a downstream project that uses one of those binaries, all the dependency information from the library will appear as deep dependency information for the downstream project.
+Then, when scanning a downstream project that uses one of those binaries, all the dependency information from the library will appear as transitive dependency information for the downstream project.
 
 To link one or more binaries to a project, use `--experimental-link-project-binary`.
 

--- a/docs/references/experimental/vsi/README.md
+++ b/docs/references/experimental/vsi/README.md
@@ -45,7 +45,7 @@ This process has undergone a lot of optimization to improve its performance (and
 > _For more information on multi-stage builds see the [multi stage builds overview](../msb/README.md)._
 
 Let's say we have two C projects: `LibProject` and `CliProject`.
-`LibProject` is a library that is used inside `CliProject`, and we want to report that relationship in FOSSA, such that dependencies of `LibProject` appear as deep dependencies of `CliProject`.
+`LibProject` is a library that is used inside `CliProject`, and we want to report that relationship in FOSSA, such that dependencies of `LibProject` appear as transitive dependencies of `CliProject`.
 
 Let's go further and say our CI pipeline for `LibProject` looks like this, where we compile its output binary (`libproject.o`) into the directory `out/`:
 
@@ -66,7 +66,7 @@ Later, when we scan `CliProject`, so long as it contains a copy of `libproject.o
 
 1. The CLI will determine that `LibProject` is a dependency of `CliProject`, because it sees that copy of `libproject.o` inside the `CliProject` directory tree.
 2. The CLI will then ask the FOSSA server for the list of `LibProject`'s dependencies.
-3. The CLI will then report to the FOSSA server that `LibProject` is a dependency of `CliProject`, and include `LibProject`'s dependencies as deep dependencies.
+3. The CLI will then report to the FOSSA server that `LibProject` is a dependency of `CliProject`, and include `LibProject`'s dependencies as transitive dependencies.
 
 The trouble is, what happens if the user scanning `CliProject` doesn't have access to view the dependencies of `LibProject`?
 
@@ -80,7 +80,7 @@ You may not have access to the projects, or they may not exist (see the warnings
 If desired you can use --experimental-skip-vsi-graph to skip resolving the dependencies of these projects.
 ```
 
-This is the CLI telling us "I know `LibProject` is a dependency of `CliProject`, but I can't view `LibProject` in the FOSSA server, so I don't know its dependencies and therefore I can't report its dependencies as deep dependencies of `CliProject`".
+This is the CLI telling us "I know `LibProject` is a dependency of `CliProject`, but I can't view `LibProject` in the FOSSA server, so I don't know its dependencies and therefore I can't report its dependencies as transitive dependencies of `CliProject`".
 
 The best way to handle this is to ensure that anyone using `LibProject` as a dependency has access to view it in FOSSA, so that they can get an accurate dependency graph.
-However, as a workaround, the user may also use `--experimental-skip-vsi-graph custom+1/libproject$1635972409`, which tells the CLI "that's OK, I know you can't see it, and I'm OK with not getting the deep dependencies from that project".
+However, as a workaround, the user may also use `--experimental-skip-vsi-graph custom+1/libproject$1635972409`, which tells the CLI "that's OK, I know you can't see it, and I'm OK with not getting the transitive dependencies from that project".

--- a/docs/references/strategies/languages/clojure/clojure.md
+++ b/docs/references/strategies/languages/clojure/clojure.md
@@ -3,7 +3,7 @@
 When developing in Clojure, [leiningen](https://leiningen.org/) is the most common package manager. Dependencies are specified in a manifest file by users which is used by the `lein` tool to build a dependency graph and download the correct dependencies.
 
 
-| Strategy    | Direct Deps        | Deep Deps          | Edges              | Container Scanning (Experimental) |
+| Strategy    | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (Experimental) |
 | ----------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
 | `lein deps` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
 

--- a/docs/references/strategies/languages/dart/dart.md
+++ b/docs/references/strategies/languages/dart/dart.md
@@ -10,7 +10,7 @@ Find file named `pubspec.yaml`.
 
 We attempt to perform all of the strategies below, we select the result of succeeded strategies which has the highest preference. 
 
-| Preference | Strategy                                                                                               | Direct Deps        | Deep Deps          | Edges              | Container Scanning (Experimental) |
+| Preference | Strategy                                                                                               | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (Experimental) |
 | ---------- | ------------------------------------------------------------------------------------------------------ | ------------------ | ------------------ | ------------------ | --------------------------------- |
 | Highest    | 1. `pubspec.yaml` and `pubspec.lock` are discovered, and `flutter pub deps -s compact` can be executed | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
 |            | 2. `pubspec.yaml` and `pubspec.lock` are discovered, and `dart pub deps -s compact` can be executed    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
@@ -23,7 +23,7 @@ Where,
 * :heavy_check_mark: - Supported in all projects
 * :x: - Not Supported
 
-It is recommended that, `pub deps get` is executed prior to analyzing dart project. This ensures dependencies are retrieved, so `pub deps -s compact` command can produce edges between direct, and deep dependencies.
+It is recommended that, `pub deps get` is executed prior to analyzing dart project. This ensures dependencies are retrieved, so `pub deps -s compact` command can produce edges between direct, and transitive dependencies.
 
 ### Limitations
 
@@ -248,7 +248,7 @@ When pub deps command is successfully executed, and lockfile id discovered (stra
 
 ![With lock file and deps command](dart-resolved-graph-with-lock-cmd.svg)
 
-Note: Dependencies in yellow boxes are direct dependencies, rest are deep dependencies. All descendent dependencies of sdk dependencies are promoted to their ancestor - e.g. characters, collection, meta, typed_data, and vector_math.
+Note: Dependencies in yellow boxes are direct dependencies, rest are transitive dependencies. All descendent dependencies of sdk dependencies are promoted to their ancestor - e.g. characters, collection, meta, typed_data, and vector_math.
 
 If pub deps command is not successfully executed:
 

--- a/docs/references/strategies/languages/dotnet/README.md
+++ b/docs/references/strategies/languages/dotnet/README.md
@@ -2,7 +2,7 @@
 
 There are several different methods of .NET analysis, that use both the `NuGet` (`nuspec`, `PackageReference`, `packages.config`, `project.json`, `project.assets.json`) and `Paket` package managers.
 
-| Strategy                                 | Direct Deps | Deep Deps | Edges |
+| Strategy                                 | Direct Deps | Transitive Deps | Edges |
 | ---------------------------------------- | ----------- | --------- | ----- |
 | [nuspec](nuspec.md)                         | ✅          | ❌        | ❌    |
 | [PackageReference](packagereference.md)     | ✅          | ❌        | ❌    |

--- a/docs/references/strategies/languages/elixir/elixir.md
+++ b/docs/references/strategies/languages/elixir/elixir.md
@@ -2,7 +2,7 @@
 
 When developing in Elixir, [Mix](https://hexdocs.pm/mix/Mix.html) and [Hex](https://hex.pm/) are most commonly used to manage dependencies. 
 
-| Strategy | Direct Deps        | Deep Deps          | Edges              | Container Scanning (experimental) |
+| Strategy | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
 | -------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
 | mix deps | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
 

--- a/docs/references/strategies/languages/erlang/erlang.md
+++ b/docs/references/strategies/languages/erlang/erlang.md
@@ -3,7 +3,7 @@
 When developing in Erlang, [Rebar](https://www.rebar3.org/) is the most common package manager. Dependencies are specified in a manifest file by users which is used by the `rebar3` tool to build a dependency graph and download the correct dependencies.
 
 
-| Strategy | Direct Deps        | Deep Deps          | Edges              | Container Scanning (experimental) |
+| Strategy | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
 | -------- | ------------------ | ------------------ | ------------------ |
 | rebar3   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
 

--- a/docs/references/strategies/languages/fortran/fortran.md
+++ b/docs/references/strategies/languages/fortran/fortran.md
@@ -2,7 +2,7 @@
 
 Currently, we only support analysis of fortran project which are using [fortran package manager](https://github.com/fortran-lang/fpm).
 
-| Strategy | Direct Deps        | Deep Deps | Edges | Classifies Dev & Test Deps | Container Scanning (experimental) |
+| Strategy | Direct Deps        | Transitive Deps | Edges | Classifies Dev & Test Deps | Container Scanning (experimental) |
 | -------- | ------------------ | --------- | ----- | -------------------------- | --------------------------------- |
 | fpm      | :white_check_mark: | :x:       | :x:   | :white_check_mark:         | :white_check_mark:                |
 

--- a/docs/references/strategies/languages/golang/golang.md
+++ b/docs/references/strategies/languages/golang/golang.md
@@ -12,7 +12,7 @@ into maintenance mode, with the notable exception of dep. As such, Go
 analysis in fossa-cli primarily targets Go 1.11+ modules and dep. Support
 for Glide is also included, because it's still commonly used.
 
-| Strategy               | Direct Deps        | Deep Deps          | Edges     | Container Scanning (Experimental) |
+| Strategy               | Direct Deps        | Transitive Deps          | Edges     | Container Scanning (Experimental) |
 | ---------------------- | ------------------ | ------------------ | --------- | --------------------------------- |
 | [golist](gomodules.md) | :white_check_mark: | :white_check_mark: | :warning: | :x:                               |
 | [gomod](gomodules.md)  | :white_check_mark: | :x:                | :warning: | :x:                               |
@@ -20,7 +20,7 @@ for Glide is also included, because it's still commonly used.
 | [gopkgtoml](godep.md)  | :white_check_mark: | :warning:          | :warning: | :x:                               |
 | [glide](glide.md)      | :white_check_mark: | :white_check_mark: | :X:       | :white_check_mark:                |
 
-## 🔶 Edges and deep dependencies
+## 🔶 Edges and transitive dependencies
 
 Most strategies (except for gomod, where it would be redundant -- golist
 supersedes gomod) use `go list -json all` to hydrate edges and transitive

--- a/docs/references/strategies/languages/haskell/README.md
+++ b/docs/references/strategies/languages/haskell/README.md
@@ -2,7 +2,7 @@
 
 The haskell buildtool ecosystem consists of two major toolchains: the `cabal`-the-tool and `stack`
 
-| Strategy          | Direct Deps        | Deep Deps          | Edges              | Container Scanning (experimental) |
+| Strategy          | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
 | ----------------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
 | [cabal](cabal.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
 | [stack](stack.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |

--- a/docs/references/strategies/languages/maven/maven.md
+++ b/docs/references/strategies/languages/maven/maven.md
@@ -2,7 +2,7 @@
 
 For maven projects, we offer a more-accurate strategy (mavenplugin), and a strategy with zero requirements (pomxml).
 
-| Strategy                      | Direct Deps        | Deep Deps          | Edges              | Container Scanning (experimental) |
+| Strategy                      | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
 |-------------------------------|--------------------|--------------------|--------------------|-----------------------------------|
 | [mavenplugin](mavenplugin.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
 | [treecmd](treecmd.md)         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |

--- a/docs/references/strategies/languages/maven/mavenplugin.md
+++ b/docs/references/strategies/languages/maven/mavenplugin.md
@@ -1,6 +1,6 @@
 # Maven plugin
 
-| Strategy           | Direct Deps | Deep Deps | Edges | Tags       |
+| Strategy           | Direct Deps | Transitive Deps | Edges | Tags       |
 | ---                | ---         | ---       | ---   | ---        |
 | depgraph plugin    | ✅          | ✅        | ✅   | Optional   |
 
@@ -44,7 +44,7 @@ org:submodule1:1.0.0:compile
 ```
 
 If `submodule1` and `submodule2` are both submodules of the project we would
-report `pkg3` and `pkg1` as direct dependencies. `pkg2` is reported as a deep
+report `pkg3` and `pkg1` as direct dependencies. `pkg2` is reported as a transitive
 dependency. `submodule1` and `submodule2` won't be included at all. `fossa-cli`'s
 graph would look like this:
 

--- a/docs/references/strategies/languages/nim/nimble.md
+++ b/docs/references/strategies/languages/nim/nimble.md
@@ -2,7 +2,7 @@
 
 When developing in [nim](https://nim-lang.org/), nimble is used to manage dependencies.
 
-| Strategy                      | Direct Deps        | Deep Deps          | Edges              | Classifies Dev Dependencies | Container Scanning (experimental) |
+| Strategy                      | Direct Deps        | Transitive Deps          | Edges              | Classifies Dev Dependencies | Container Scanning (experimental) |
 | ----------------------------- | ------------------ | ------------------ | ------------------ | --------------------------- | --------------------------------- |
 | nimble.lock and `nimble dump` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                         | :x:                               |
 | nimble.lock                   | :warning:          | :white_check_mark: | :white_check_mark: | :x:                         | :white_check_mark:                |

--- a/docs/references/strategies/languages/nodejs/nodejs.md
+++ b/docs/references/strategies/languages/nodejs/nodejs.md
@@ -2,7 +2,7 @@
 
 The nodejs buildtool ecosystem consists of three major toolchains: the `npm` cli, `pnpm` and `yarn`.
 
-| Strategy                      | Direct Deps        | Deep Deps          | Edges              | Container Scanning (experimental) |
+| Strategy                      | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
 | ----------------------------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
 | [yarnlock](yarn.md)           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:                |
 | [npmlock](npm-lockfile.md)    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:                |

--- a/docs/references/strategies/languages/nodejs/pnpm.md
+++ b/docs/references/strategies/languages/nodejs/pnpm.md
@@ -21,7 +21,7 @@ in `pnpm-lock.yaml` to analyze the dependency graph.
 - `packages`
   - `[packagesKey]`
     - `resolution`: infer git URL, git commit, or package source URL.  
-    - `dependencies`: list of deep dependencies 
+    - `dependencies`: list of transitive dependencies 
     - `peerDependencies`: list of peer dependencies (will be treated like any other dependency)
     - `dev`: to infer if this is used dependency or not. If the value is `true` by default CLI will not include this in the final analysis.
 
@@ -118,7 +118,7 @@ FOSSA will use provided URL address to download and analyze this dependency.
 ```
 
 * If the dependency was resolved using the local directory (`resolution` will have the `type: directory` attribute),
-FOSSA will not analyze this dependency. Local dependency's deep dependencies will be analyzed, 
+FOSSA will not analyze this dependency. Local dependency's transitive dependencies will be analyzed, 
 and they will be promoted in place of local dependency. 
 
 ```yaml

--- a/docs/references/strategies/languages/perl/perl.md
+++ b/docs/references/strategies/languages/perl/perl.md
@@ -1,6 +1,6 @@
 # Perl Analysis
 
-| Strategy           | Direct Deps        | Deep Deps          | Edges | Classifies Dev Dependencies | Container Scanning (experimental) |
+| Strategy           | Direct Deps        | Transitive Deps          | Edges | Classifies Dev Dependencies | Container Scanning (experimental) |
 | ------------------ | ------------------ | ------------------ | ----- | --------------------------- | --------------------------------- |
 | `*META.{yml, json} | :white_check_mark: | :white_check_mark: | :x:   | :white_check_mark:          | :white_check_mark:                |
 

--- a/docs/references/strategies/languages/php/composer.md
+++ b/docs/references/strategies/languages/php/composer.md
@@ -2,7 +2,7 @@
 
 When developing in PHP, [composer](https://getcomposer.org/) is commonly used to manage dependencies.
 
-| Strategy      | Direct Deps        | Deep Deps          | Edges              | Classifies Dev Dependencies | Container Scanning (experimental) |
+| Strategy      | Direct Deps        | Transitive Deps          | Edges              | Classifies Dev Dependencies | Container Scanning (experimental) |
 | ------------- | ------------------ | ------------------ | ------------------ | --------------------------- | --------------------------------- |
 | composer.lock | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:          | :white_check_mark:                |
 
@@ -12,7 +12,7 @@ Find a file named `composer.lock`.
 
 ## Analysis
 
-1. Parse `composer.lock` to identify direct and deep dependencies.
+1. Parse `composer.lock` to identify direct and transitive dependencies.
 
 ## Example 
 

--- a/docs/references/strategies/languages/python/piplist.md
+++ b/docs/references/strategies/languages/python/piplist.md
@@ -12,7 +12,7 @@ Find directories containing `setup.py` or `requirements.txt`
 
 We run `pip list --format=json` and parse the output -- in the worst case, this
 only provides global dependencies; in the best case, the global dependencies
-will include our project's direct and deep dependencies.
+will include our project's direct and transitive dependencies.
 
 ## Example
 

--- a/docs/references/strategies/languages/python/poetry.md
+++ b/docs/references/strategies/languages/python/poetry.md
@@ -22,7 +22,7 @@ If `poetry.lock` file is discovered, following will be analyzed from lockfile to
 
 If `poetry.lock` file is not discovered, we fallback to reporting only direct dependencies parsed from `pyproject.toml`.
 
-| Strategy                                          | Direct Deps        | Deep Deps          | Edges              |
+| Strategy                                          | Direct Deps        | Transitive Deps          | Edges              |
 | ------------------------------------------------- | ------------------ | ------------------ | ------------------ |
 | `pyproject.toml` and `poetry.lock` are discovered | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Only `pyproject.toml` is discovered               | :heavy_check_mark: | :x:                | :x:                |
@@ -172,14 +172,14 @@ content-hash = "31cb32d5165d1cc95e45e9d3e839af556f548df74dda74e25a02b79ba5aa5948
 We will produce the following dependency graph, from our analyses if both `poetry.lock` and `pyproject.toml` are discovered.
 
 ![With poetry.lock file](poetry-with-lock.svg)
-_Dependencies highlighted in yellow boxes are direct dependencies, rest are deep dependencies._
+_Dependencies highlighted in yellow boxes are direct dependencies, rest are transitive dependencies._
 
 If only, `pyproject.toml` is discovered, following dependency graph will be produced.
 
 ![Without poetry.lock file](poetry-without-lock.svg)
-_Dependencies highlighted in yellow boxes are direct dependencies, rest are deep dependencies._
+_Dependencies highlighted in yellow boxes are direct dependencies, rest are transitive dependencies._
 
-Without `poetry.lock` we are not able to identify any deep dependencies. We are also unable to locally resolve dependency when version ranges are provided, like `loguru = "^0.5"`.
+Without `poetry.lock` we are not able to identify any transitive dependencies. We are also unable to locally resolve dependency when version ranges are provided, like `loguru = "^0.5"`.
 
 ### References
 

--- a/docs/references/strategies/languages/python/python.md
+++ b/docs/references/strategies/languages/python/python.md
@@ -3,7 +3,7 @@
 The python buildtool ecosystem consists of three major toolchains: setuptools
 (requirements.txt, setup.py), pipenv, and conda.
 
-| Strategy                                       | Direct Deps        | Deep Deps          | Edges              | Container Scanning (experimental) |
+| Strategy                                       | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
 | ---------------------------------------------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
 | [pipenv](pipenv.md)                            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:                               |
 | [pipfile](pipenv.md)                           | :heavy_check_mark: | :heavy_check_mark: | :x:                | :x:                               |

--- a/docs/references/strategies/languages/ruby/ruby.md
+++ b/docs/references/strategies/languages/ruby/ruby.md
@@ -3,7 +3,7 @@
 Ruby projects use a buildtool called `bundler` to manage their dependencies. We
 parse a lockfile or run the `bundle` cli to determine dependencies.
 
-| Strategy    | Direct Deps                    | Deep Deps                      | Edges              | Tags | Container Scanning (experimental) |
+| Strategy    | Direct Deps                    | Transitive Deps                      | Edges              | Tags | Container Scanning (experimental) |
 | ----------- | ------------------------------ | ------------------------------ | ------------------ | ---- | --------------------------------- |
 | gemfilelock | :white_check_mark:             | :white_check_mark:             | :white_check_mark: |      | :white_check_mark:                |
 | bundleshow  | :white_check_mark: (unlabeled) | :white_check_mark: (unlabeled) | :x:                |      | :x:                               |
@@ -76,7 +76,7 @@ BUNDLED WITH
 
 Running `bundle show` displays information about all dependencies used by a
 project, and their pinned versions. It doesn't label which dependencies are
-direct or deep, and doesn't tell us edges between dependencies
+direct or transitive, and doesn't tell us edges between dependencies
 
 Example output:
 

--- a/docs/references/strategies/languages/rust/rust.md
+++ b/docs/references/strategies/languages/rust/rust.md
@@ -5,7 +5,7 @@ that ships with rust distributions. There are rare, but known cases of generic
 buildtools being used, like `make`, `cmake`, and `ninja`.  These cases are not
 handled here.
 
-| Strategy | Direct Deps        | Deep Deps          | Edges              | Tags        | Container Scanning |
+| Strategy | Direct Deps        | Transitive Deps          | Edges              | Tags        | Container Scanning |
 | -------- | ------------------ | ------------------ | ------------------ | ----------- | ------------------ |
 | cargo    | :white_check_mark: | :white_check_mark: | :white_check_mark: | Environment | :x:                |
 
@@ -60,7 +60,7 @@ been generated, it will try to update the package index.  This usually takes abo
 2-10 seconds, which is potentially wasteful, but far less so than the 10 minutes
 that it would take to download entire crates.
 
-We can interrogate the JSON output for direct and deep dependency info, but it is
+We can interrogate the JSON output for direct and transitive dependency info, but it is
 non-trivial to do so.  For more info, see the metadata schema found
 [here](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html)
 

--- a/docs/references/strategies/languages/scala/sbt.md
+++ b/docs/references/strategies/languages/scala/sbt.md
@@ -2,7 +2,7 @@
 
 While the other analysis strategies for `gradle` and `maven` offer some scala project coverage, scala projects overwhelmingly use the build tool `sbt`.
 
-| Strategy           | Direct Deps        | Deep Deps          | Edges              | Container Scanning (experimental) |
+| Strategy           | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
 | ------------------ | ------------------ | ------------------ | ------------------ | --------------------------------- |
 | sbt dependencyTree | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
 | pom                | :white_check_mark: | :x:                | :x:                | :x:                               |

--- a/docs/references/strategies/platforms/ios/ios.md
+++ b/docs/references/strategies/platforms/ios/ios.md
@@ -2,7 +2,7 @@
 
 The iOS buildtool ecosystem consists of two major toolchains: `Carthage` and `Cocoapods`
 
-| Strategy                     | Direct Deps        | Deep Deps          | Edges              | Container Scanning (experimental) |
+| Strategy                     | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
 | ---------------------------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
 | [Carthage](carthage.md)      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:                |
 | [Podfile.lock](cocoapods.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |

--- a/docs/references/strategies/platforms/ios/swift.md
+++ b/docs/references/strategies/platforms/ios/swift.md
@@ -7,7 +7,7 @@ We will not scan `.build` directory if the `Package.swift` or Xcode project file
 
 # Swift Analysis
 
-| Strategy                                                                 | Direct Deps        | Deep Deps          | Edges | Classifies Test Dependencies | Container Scanning (experimental) |
+| Strategy                                                                 | Direct Deps        | Transitive Deps          | Edges | Classifies Test Dependencies | Container Scanning (experimental) |
 | ------------------------------------------------------------------------ | ------------------ | ------------------ | ----- | ---------------------------- | --------------------------------- |
 | Parse dependencies from `Package.swift`                                  | :white_check_mark: | :x:                | :x:   | :x:                          | :white_check_mark:                |
 | Parse dependencies from `Package.swift` and `Package.resolved`           | :white_check_mark: | :white_check_mark: | :x:   | :x:                          | :white_check_mark:                |
@@ -80,7 +80,7 @@ When the analysis is performed (e.g. `fossa analyze -o`), we will identify the f
 
 - https://github.com/grpc/grpc-swift.git with version 1.3.0
 
-If `Package.resolved` is discovered, the following deep dependencies will be identified, however, we will not identify the edges in the dependency graph:
+If `Package.resolved` is discovered, the following transitive dependencies will be identified, however, we will not identify the edges in the dependency graph:
 
 - https://github.com/apple/swift-log.git with version 1.4.2
 
@@ -118,7 +118,7 @@ Excerpt from example `project.pbxproj`:
 } 
 ```
 
-If the `Package.resolved` is discovered, deep dependencies will be identified. If not, only direct dependencies listed in xcode project file will be identified. In either case, no edges among dependencies will be reported.
+If the `Package.resolved` is discovered, transitive dependencies will be identified. If not, only direct dependencies listed in xcode project file will be identified. In either case, no edges among dependencies will be reported.
 
 ## F.A.Q
 

--- a/docs/references/strategies/system/rpm/rpm.md
+++ b/docs/references/strategies/system/rpm/rpm.md
@@ -4,7 +4,7 @@ RPM packages managed by system package managers like `dnf` and `yum` are built
 using SPEC files.  We are able to analyze these files to determine runtime
 dependencies.
 
-| Strategy | Direct Deps        | Deep Deps | Edges | Tags        | Container Scanning |
+| Strategy | Direct Deps        | Transitive Deps | Edges | Tags        | Container Scanning |
 | -------- | ------------------ | --------- | ----- | ----------- | ------------------ |
 | rpm-spec | :white_check_mark: | :x:       | :x:   | Environment | :white_check_mark: |
 

--- a/docs/walkthroughs/aosp.md
+++ b/docs/walkthroughs/aosp.md
@@ -120,7 +120,7 @@ If you need to analyze a different set of directories, you should modify this fi
 
 `version` is actually an optional field when defining vendored dependencies in `fossa-deps.yml`.
 However, omitting this field causes the FOSSA CLI to compress each vendored directory to calculate a hash to use as a placeholder version.
-AOSP directory trees are too deep for zip files, so we manually define a dummy version to avoid having to compress each subdirectory.
+AOSP directory trees are too transitive for zip files, so we manually define a dummy version to avoid having to compress each subdirectory.
 
 Running `fossa analyze` without any other flags or configuration files causes all [analysis strategies](../references/strategies/README.md) to be executed, which requires significantly more resources. This is likely to fail or take an excessive amount of time due to the size and number of subprojects discovered in the AOSP source tree.
 

--- a/docs/walkthroughs/custom-integrating-with-bower-example.md
+++ b/docs/walkthroughs/custom-integrating-with-bower-example.md
@@ -76,5 +76,5 @@ To programmatically add these dependencies, you can write a script in your langu
 
 Please note that with the fossa-deps file, we can report dependencies, but we cannot:
 
-- differentiate between direct and deep dependencies
+- differentiate between direct and transitive dependencies
 - report edge information between dependencies


### PR DESCRIPTION
# Overview

This PR, 

- relabels "deep" to "transitive", as web app now refers to [deep dependencies as transitive dependencies ](https://fossa.atlassian.net/browse/CORE-1183)

I used the editor to do the replacements,

from `deep -> transitive`
from `Deep -> Transitive`

<img width="379" alt="CleanShot 2022-10-11 at 12 03 48@2x" src="https://user-images.githubusercontent.com/86321858/195166316-c34f60b7-f506-4de8-a4c9-262fc706b49e.png">

## Acceptance criteria

- Docs do not refer to "deep" dependencies
- Docs use the transitive labels for what was previously referred to as "deep"
- You agree with this change

## Testing plan

N/A

## Risks

N/A

## References

This is the result of: 
- https://fossa.atlassian.net/browse/CORE-1183

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
