### PR TITLE
update THEMIS_TAG to latest basis release

### DIFF
--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -79,7 +79,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2022-08-22-263a164"
+THEMIS_TAG="2022-10-11-40ed95c"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

Update THEMIS_TAG in `vendor_download.sh` to use the latest release of Themis.

## Acceptance criteria

- Running `vendor_download.sh` should download Themis from the 2022-10-11-40ed95c release of Basis
- This version of Themis should work

## Testing plan

Run `vendor_download.sh`:

```
GITHUB_TOKEN=<A valid Github token> ./vendor_download.sh
```

Unzip the downloaded `index.gob` and validate that the downloaded version of Themis works:

```
 xz -d vendor-bins/index.gob.xz 
./vendor-bins/themis-cli --version
./vendor-bins/themis-cli --license-data-dir ./vendor-bins --only-files-with-findings .
```

The output of `themis-cli --version` should have a version of `40ed95c618c8192f36f604d3281eace47172600a`.

The output of `themis-cli` without the `--version` flag should successfully load the index and scan the directory

## Risks

## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
