### PR TITLE
[ANE-328] Fixes issues with node's edge when multiple version of dependencies exist at sibling level (in node_modules)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## v3.4.11
 - Npm (Lockfile v3) - Fixes a defect where, _sometimes_ wrong version of the dependency was reported if multiple version of the same dependency existed in the lock file. ([#1075](https://github.com/fossas/fossa-cli/pull/1075))
+- Npm (Lockfile v2) - Fixes a defect where, _sometimes_ wrong version of the dependency was reported if multiple version of the same dependency existed in the lock file. ([#1075](https://github.com/fossas/fossa-cli/pull/1075))
 
 ## v3.4.10
 - Scala: Supports analysis of multi-project sbt builds with `sbt-dependency-graph` plugin. ([#1074](https://github.com/fossas/fossa-cli/pull/1074)).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.4.11
+- Npm (Lockfile v3) - Fixes a defect where, _sometimes_ wrong version of the dependency was reported if multiple version of the same dependency existed in the lock file. ([#1075](https://github.com/fossas/fossa-cli/pull/1075))
+
 ## v3.4.10
 - Scala: Supports analysis of multi-project sbt builds with `sbt-dependency-graph` plugin. ([#1074](https://github.com/fossas/fossa-cli/pull/1074)).
 

--- a/docs/references/strategies/languages/nodejs/npm-lockfile.md
+++ b/docs/references/strategies/languages/nodejs/npm-lockfile.md
@@ -102,6 +102,9 @@ With this approach, for aforementioned example, we will generate following depen
 
 We use `dev` field to infer if the dependency is development dependency or not.
 
+We analyze `optional` dependencies. If you would like to ignore them, you can do
+so from [FOSSA UI](https://docs.fossa.com/docs/generating-reports#modifying-report-information).
+
 ## Analysis (for lockFile version 1)
 
 Opening a `package-lock.json` file reveals the project's dependency tree. This

--- a/src/Strategy/Node/Npm/PackageLockV3.hs
+++ b/src/Strategy/Node/Npm/PackageLockV3.hs
@@ -140,6 +140,7 @@ data PackageLockV3Package = PackageLockV3Package
   , plV3PkgResolved :: NpmLockV3Resolved
   , plV3PkgDependencies :: Map PackageName Text
   , plV3PkgDevDependencies :: Map PackageName Text
+  , plV3PkgOptionalDependencies :: Map PackageName Text
   , plV3PkgPeerDependencies :: Map PackageName Text
   , plV3PkgDev :: Bool
   }
@@ -152,6 +153,7 @@ instance FromJSON PackageLockV3Package where
       <*> obj .:? "resolved" .!= (NpmLockV3Resolved Nothing)
       <*> obj .:? "dependencies" .!= mempty
       <*> obj .:? "devDependencies" .!= mempty
+      <*> obj .:? "optionalDependencies" .!= mempty
       <*> obj .:? "peerDependencies" .!= mempty
       <*> obj .:? "dev" .!= False -- if 'dev' key is not included, it is presumed to be prod dependency
 
@@ -256,6 +258,7 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
                   [ plV3PkgDependencies pkgMetadata
                   , plV3PkgDevDependencies pkgMetadata
                   , plV3PkgPeerDependencies pkgMetadata
+                  , plV3PkgOptionalDependencies pkgMetadata
                   ]
 
         let resolvedDeps :: [Dependency]
@@ -294,6 +297,7 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
                   [ plV3PkgDependencies pkgMetadata
                   , plV3PkgDevDependencies pkgMetadata
                   , plV3PkgPeerDependencies pkgMetadata
+                  , plV3PkgOptionalDependencies pkgMetadata
                   ]
 
         let resolvedDeps :: [Dependency]
@@ -337,6 +341,7 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
                   Map.keys
                   [ plV3PkgDependencies pkgMetadata
                   , plV3PkgPeerDependencies pkgMetadata
+                  , plV3PkgOptionalDependencies pkgMetadata
                   ]
 
         let resolvedDeepDeps :: [Dependency]

--- a/src/Strategy/Node/Npm/PackageLockV3.hs
+++ b/src/Strategy/Node/Npm/PackageLockV3.hs
@@ -357,13 +357,12 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
     --  1) {prefix}/node_modules/{pkgName}
     --  2) {root of prefix}/node_modules/{pkgName} (handles workspace root projects)
     --  3) {parent root of prefix}/node_modules/{pkgName}
-    --  4) ....
-    --  5) node_modules/{pkgName}
+    --  4) node_modules/{pkgName}
     --
     -- Example, for prefix of "workspace-a/node_modules/a/" for 'PackageName b' we will attempt,
     --  1) workspace-a/node_modules/a/node_modules/b/
     --  2) workspace-a/node_modules/b/
-    --  3) node_modules/b/
+    --  3) node_modules/b/ (same as step 5 from above)
     vendoredPathElseTopLevelPath :: Text -> PackageName -> PackagePath
     vendoredPathElseTopLevelPath prefix pkgName =
       case find (`Map.member` allDependencyPackages) $ possiblePkgPaths prefix pkgName of

--- a/test/Node/PackageLockSpec.hs
+++ b/test/Node/PackageLockSpec.hs
@@ -394,6 +394,56 @@ underscore =
     , dependencyTags = mempty
     }
 
+expressSession :: Dependency
+expressSession =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "express-session"
+    , dependencyVersion = Just $ CEq "1.17.3"
+    , dependencyLocations = ["https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz"]
+    , dependencyEnvironments = Set.singleton EnvProduction
+    , dependencyTags = mempty
+    }
+
+debug :: Dependency
+debug =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "debug"
+    , dependencyVersion = Just $ CEq "2.6.9"
+    , dependencyLocations = ["https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"]
+    , dependencyEnvironments = Set.singleton EnvProduction
+    , dependencyTags = mempty
+    }
+
+ms :: Dependency
+ms =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "ms"
+    , dependencyVersion = Just $ CEq "2.0.0"
+    , dependencyLocations = ["https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"]
+    , dependencyEnvironments = Set.singleton EnvProduction
+    , dependencyTags = mempty
+    }
+
+log4js :: Dependency
+log4js =
+  Dependency
+    { dependencyType = NodeJSType
+    , dependencyName = "log4js"
+    , dependencyVersion = Just $ CEq "6.7.0"
+    , dependencyLocations = ["https://registry.npmjs.org/log4js/-/log4js-6.7.0.tgz"]
+    , dependencyEnvironments = Set.singleton EnvProduction
+    , dependencyTags = mempty
+    }
+
+debug' :: Dependency
+debug' = debug{dependencyVersion = Just $ CEq "4.3.4", dependencyLocations = ["https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"]}
+
+ms' :: Dependency
+ms' = ms{dependencyVersion = Just $ CEq "2.1.2", dependencyLocations = ["https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"]}
+
 mockLockWithWorkspacePkgs :: PkgLockJson
 mockLockWithWorkspacePkgs =
   PkgLockJson
@@ -445,6 +495,19 @@ buildGraphSpec testDir =
       expectEdges'
         [ (jsyaml, argparseDeep)
         , (argparseDirect, sprintf)
+        ]
+        graph
+
+    it' "should process nested sibling dependencies" $ do
+      parsed <- readContentsJson (testDir </> $(mkRelFile "sibling-nested-deps.json"))
+      let graph = buildGraph' parsed (Set.fromList ["express-session", "log4js"])
+      expectDeps' [expressSession, log4js, debug, ms, debug', ms'] graph
+      expectDirect' [expressSession, log4js] graph
+      expectEdges'
+        [ (expressSession, debug)
+        , (debug, ms)
+        , (log4js, debug')
+        , (debug', ms')
         ]
         graph
 

--- a/test/Node/testdata/lockfileV3/graphing/multi-level-vendor-package-lock.json
+++ b/test/Node/testdata/lockfileV3/graphing/multi-level-vendor-package-lock.json
@@ -1,0 +1,68 @@
+{
+    "name": "multi-level-pkg",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "multi-level-pkg",
+            "version": "1.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "express-session": "^1.17.2",
+                "log4js": "^6.4.1"
+            }
+        },
+        "node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "node_modules/express-session": {
+            "version": "1.17.3",
+            "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
+            "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
+            "dependencies": {
+                "debug": "2.6.9"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/log4js": {
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.0.tgz",
+            "integrity": "sha512-KA0W9ffgNBLDj6fZCq/lRbgR6ABAodRIDHrZnS48vOtfKa4PzWImb0Md1lmGCdO3n3sbCm/n1/WmrNlZ8kCI3Q==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/log4js/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            }
+        },
+        "node_modules/log4js/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+    }
+}

--- a/test/Node/testdata/sibling-nested-deps.json
+++ b/test/Node/testdata/sibling-nested-deps.json
@@ -1,0 +1,114 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+        "name": "foo",
+        "version": "1.0.0",
+        "license": "ISC",
+        "dependencies": {
+            "express-session": "^1.17.2",
+            "log4js": "^6.4.1"
+        }
+    },
+    "node_modules/debug": {
+        "version": "2.6.9",
+        "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+        "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "dependencies": {
+            "ms": "2.0.0"
+        }
+    },
+    "node_modules/ms": {
+        "version": "2.0.0",
+        "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+        "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/express-session": {
+        "version": "1.17.3",
+        "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
+        "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
+        "dependencies": {
+            "debug": "2.6.9"
+        },
+        "engines": {
+            "node": ">= 0.8.0"
+        }
+    },
+    "node_modules/log4js": {
+        "version": "6.7.0",
+        "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.0.tgz",
+        "integrity": "sha512-KA0W9ffgNBLDj6fZCq/lRbgR6ABAodRIDHrZnS48vOtfKa4PzWImb0Md1lmGCdO3n3sbCm/n1/WmrNlZ8kCI3Q==",
+        "dependencies": {
+            "debug": "^4.3.4"
+        },
+        "engines": {
+            "node": ">=8.0"
+        }
+    },
+    "node_modules/log4js/node_modules/debug": {
+        "version": "4.3.4",
+        "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+        "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+        "dependencies": {
+            "ms": "2.1.2"
+        },
+        "engines": {
+            "node": ">=6.0"
+        }
+    },
+    "node_modules/log4js/node_modules/ms": {
+        "version": "2.1.2",
+        "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+        "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    }
+  },
+  "dependencies": {
+    "express-session": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
+      "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
+      "requires": {
+        "debug": "2.6.9"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "log4js": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.0.tgz",
+      "integrity": "sha512-KA0W9ffgNBLDj6fZCq/lRbgR6ABAodRIDHrZnS48vOtfKa4PzWImb0Md1lmGCdO3n3sbCm/n1/WmrNlZ8kCI3Q==",
+      "requires": {
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Overview

This PR, 

- Fixes an issue where sometimes FOSSA CLI was _sometimes_ reporting an incorrect version of the dependency (with npm), if multiple versions of the dependency existed/

## Acceptance criteria

- npm Lockfile v2 is correctly analyzed, such that correct versions are identified for dependencies that have multiple versions in the dependency graph.
- npm Lockfile v3 is correctly analyzed, such that correct versions are identified for dependencies that have multiple versions in the dependency graph.
- npm Lockfile v3 includes optional dependencies

## Testing plan


1. `git checkout fix/node-edge-ane-328`
2. `make install-dev`
3. `mkdir npm2 && cd npm2 && touch package.json && npm i`
```json
{
    "name": "pr1075",
    "version": "1.0.0",
    "description": "",
    "main": "index.js",
    "scripts": {
      "test": "echo \"Error: no test specified\" && exit 1"
    },
    "keywords": [],
    "author": "",
    "license": "ISC",
    "dependencies": {
      "express-session": "^1.17.2",
      "log4js": "^6.4.1"
    }
  } 
```
4. `fossa analyze -o | rendergraph` should match `npm list --all`
5. `cd .. && mkdir npm3 && cd npm3 && touch package.json && npm i --lockfile-version 3`
```json
{
    "name": "pr1075",
    "version": "1.0.0",
    "description": "",
    "main": "index.js",
    "scripts": {
      "test": "echo \"Error: no test specified\" && exit 1"
    },
    "keywords": [],
    "author": "",
    "license": "ISC",
    "dependencies": {
      "express-session": "^1.17.2",
      "log4js": "^6.4.1"
    }
  } 
```
6. `fossa analyze -o | rendergraph` should match `npm list --all`

## Risks

This is one of the most used strategy - blast zone is likely _high_.

## References

https://fossa.atlassian.net/browse/ANE-328

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
