### PR TITLE
[ANE-282] Make native scanner default scanner, and deprecate syft [1/3]

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -45,7 +45,7 @@
 ## v3.4.0
 
 - Container scanning: New experimental scanner. ([#1001](https://github.com/fossas/fossa-cli/pull/1001), [#1002](https://github.com/fossas/fossa-cli/pull/1002), [#1003](https://github.com/fossas/fossa-cli/pull/1003), [#1004](https://github.com/fossas/fossa-cli/pull/1004), [#1005](https://github.com/fossas/fossa-cli/pull/1005), [#1006](https://github.com/fossas/fossa-cli/pull/1006), [#1010](https://github.com/fossas/fossa-cli/pull/1010), [#1011](https://github.com/fossas/fossa-cli/pull/1011), [#1012](https://github.com/fossas/fossa-cli/pull/1012), [#1014](https://github.com/fossas/fossa-cli/pull/1014), [#1016](https://github.com/fossas/fossa-cli/pull/1016), [#1017](https://github.com/fossas/fossa-cli/pull/1017), [#1021](https://github.com/fossas/fossa-cli/pull/1021), [#1025](https://github.com/fossas/fossa-cli/pull/1025), [#1026](https://github.com/fossas/fossa-cli/pull/1026), [#1029](https://github.com/fossas/fossa-cli/pull/1029), [#1031](https://github.com/fossas/fossa-cli/pull/1031), [#1032](https://github.com/fossas/fossa-cli/pull/1032), [#1034](https://github.com/fossas/fossa-cli/pull/1034))<br>
-  For more information, see the [experimental container scanning documentation](./docs/references/experimental/container/experimental-scanner.md).
+  For more information, see the [experimental container scanning documentation](./docs/references/subcommands/container/scanner.md).
 - Filters: Add `dist-newstyle` to the list of automatically filtered directories. ([#1030](https://github.com/fossas/fossa-cli/pull/1035))
 - `fossa-deps`: Fix a bug in `fossa-deps.schema.json`, it is now valid JSON. ([#1030](https://github.com/fossas/fossa-cli/pull/1030))
 

--- a/docs/references/strategies/languages/clojure/clojure.md
+++ b/docs/references/strategies/languages/clojure/clojure.md
@@ -3,9 +3,9 @@
 When developing in Clojure, [leiningen](https://leiningen.org/) is the most common package manager. Dependencies are specified in a manifest file by users which is used by the `lein` tool to build a dependency graph and download the correct dependencies.
 
 
-| Strategy    | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (Experimental) |
-| ----------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
-| `lein deps` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
+| Strategy    | Direct Deps        | Transitive Deps    | Edges              | Container Scanning |
+| ----------- | ------------------ | ------------------ | ------------------ | ------------------ |
+| `lein deps` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 
 ## Project Discovery
 

--- a/docs/references/strategies/languages/dart/dart.md
+++ b/docs/references/strategies/languages/dart/dart.md
@@ -10,13 +10,13 @@ Find file named `pubspec.yaml`.
 
 We attempt to perform all of the strategies below, we select the result of succeeded strategies which has the highest preference. 
 
-| Preference | Strategy                                                                                               | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (Experimental) |
-| ---------- | ------------------------------------------------------------------------------------------------------ | ------------------ | ------------------ | ------------------ | --------------------------------- |
-| Highest    | 1. `pubspec.yaml` and `pubspec.lock` are discovered, and `flutter pub deps -s compact` can be executed | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
-|            | 2. `pubspec.yaml` and `pubspec.lock` are discovered, and `dart pub deps -s compact` can be executed    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
-|            | 3. `pubspec.yaml` and `pubspec.lock` are discovered, and `pub deps -s compact` can be executed         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
-|            | 4. `pubspec.yaml` and `pubspec.lock` are discovered                                                    | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark:                |
-| Lowest     | 5. Only `pubspec.yaml` is discovered                                                                   | :white_check_mark: | :x:                | :x:                | :white_check_mark:                |
+| Preference | Strategy                                                                                               | Direct Deps        | Transitive Deps    | Edges              | Container Scanning |
+| ---------- | ------------------------------------------------------------------------------------------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| Highest    | 1. `pubspec.yaml` and `pubspec.lock` are discovered, and `flutter pub deps -s compact` can be executed | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+|            | 2. `pubspec.yaml` and `pubspec.lock` are discovered, and `dart pub deps -s compact` can be executed    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+|            | 3. `pubspec.yaml` and `pubspec.lock` are discovered, and `pub deps -s compact` can be executed         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+|            | 4. `pubspec.yaml` and `pubspec.lock` are discovered                                                    | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| Lowest     | 5. Only `pubspec.yaml` is discovered                                                                   | :white_check_mark: | :x:                | :x:                | :white_check_mark: |
 
 Where, 
 

--- a/docs/references/strategies/languages/elixir/elixir.md
+++ b/docs/references/strategies/languages/elixir/elixir.md
@@ -2,9 +2,9 @@
 
 When developing in Elixir, [Mix](https://hexdocs.pm/mix/Mix.html) and [Hex](https://hex.pm/) are most commonly used to manage dependencies. 
 
-| Strategy | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
-| -------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
-| mix deps | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
+| Strategy | Direct Deps        | Transitive Deps    | Edges              | Container Scanning |
+| -------- | ------------------ | ------------------ | ------------------ | ------------------ |
+| mix deps | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 
 ## Project Discovery
 

--- a/docs/references/strategies/languages/erlang/erlang.md
+++ b/docs/references/strategies/languages/erlang/erlang.md
@@ -3,9 +3,9 @@
 When developing in Erlang, [Rebar](https://www.rebar3.org/) is the most common package manager. Dependencies are specified in a manifest file by users which is used by the `rebar3` tool to build a dependency graph and download the correct dependencies.
 
 
-| Strategy | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
-| -------- | ------------------ | ------------------ | ------------------ |
-| rebar3   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
+| Strategy | Direct Deps        | Transitive Deps    | Edges              | Container Scanning |
+| -------- | ------------------ | ------------------ | ------------------ | ------------------ |
+| rebar3   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 
 ## Project Discovery
 

--- a/docs/references/strategies/languages/fortran/fortran.md
+++ b/docs/references/strategies/languages/fortran/fortran.md
@@ -2,9 +2,9 @@
 
 Currently, we only support analysis of fortran project which are using [fortran package manager](https://github.com/fortran-lang/fpm).
 
-| Strategy | Direct Deps        | Transitive Deps | Edges | Classifies Dev & Test Deps | Container Scanning (experimental) |
-| -------- | ------------------ | --------- | ----- | -------------------------- | --------------------------------- |
-| fpm      | :white_check_mark: | :x:       | :x:   | :white_check_mark:         | :white_check_mark:                |
+| Strategy | Direct Deps        | Transitive Deps | Edges | Classifies Dev & Test Deps | Container Scanning |
+| -------- | ------------------ | --------------- | ----- | -------------------------- | ------------------ |
+| fpm      | :white_check_mark: | :x:             | :x:   | :white_check_mark:         | :white_check_mark: |
 
 ## Project Discovery
 

--- a/docs/references/strategies/languages/golang/golang.md
+++ b/docs/references/strategies/languages/golang/golang.md
@@ -12,13 +12,13 @@ into maintenance mode, with the notable exception of dep. As such, Go
 analysis in fossa-cli primarily targets Go 1.11+ modules and dep. Support
 for Glide is also included, because it's still commonly used.
 
-| Strategy               | Direct Deps        | Transitive Deps          | Edges     | Container Scanning (Experimental) |
-| ---------------------- | ------------------ | ------------------ | --------- | --------------------------------- |
-| [golist](gomodules.md) | :white_check_mark: | :white_check_mark: | :warning: | :x:                               |
-| [gomod](gomodules.md)  | :white_check_mark: | :x:                | :warning: | :x:                               |
-| [gopkglock](godep.md)  | :white_check_mark: | :white_check_mark: | :warning: | :x:                               |
-| [gopkgtoml](godep.md)  | :white_check_mark: | :warning:          | :warning: | :x:                               |
-| [glide](glide.md)      | :white_check_mark: | :white_check_mark: | :X:       | :white_check_mark:                |
+| Strategy               | Direct Deps        | Transitive Deps    | Edges     | Container Scanning |
+| ---------------------- | ------------------ | ------------------ | --------- | ------------------ |
+| [golist](gomodules.md) | :white_check_mark: | :white_check_mark: | :warning: | :x:                |
+| [gomod](gomodules.md)  | :white_check_mark: | :x:                | :warning: | :x:                |
+| [gopkglock](godep.md)  | :white_check_mark: | :white_check_mark: | :warning: | :x:                |
+| [gopkgtoml](godep.md)  | :white_check_mark: | :warning:          | :warning: | :x:                |
+| [glide](glide.md)      | :white_check_mark: | :white_check_mark: | :X:       | :white_check_mark: |
 
 ## 🔶 Edges and transitive dependencies
 

--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -123,7 +123,7 @@ This init script is implemented [here](https://github.com/fossas/fossa-cli/blob/
 
 The script works by iterating through configurations, getting resolution result for the configuration, and then serializing those dependencies into JSON. Please note that we currently only support analysis for builds using gradle v3.3 or greater.
 
-> Gradle analysis is not supported in Container Scanning (experimental).
+> Gradle analysis is not supported in Container Scanning.
 
 ### Parsing `gradle :dependencies`
 

--- a/docs/references/strategies/languages/haskell/README.md
+++ b/docs/references/strategies/languages/haskell/README.md
@@ -2,7 +2,7 @@
 
 The haskell buildtool ecosystem consists of two major toolchains: the `cabal`-the-tool and `stack`
 
-| Strategy          | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
-| ----------------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
-| [cabal](cabal.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
-| [stack](stack.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
+| Strategy          | Direct Deps        | Transitive Deps    | Edges              | Container Scanning |
+| ----------------- | ------------------ | ------------------ | ------------------ | ------------------ |
+| [cabal](cabal.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| [stack](stack.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |

--- a/docs/references/strategies/languages/maven/maven.md
+++ b/docs/references/strategies/languages/maven/maven.md
@@ -2,11 +2,11 @@
 
 For maven projects, we offer a more-accurate strategy (mavenplugin), and a strategy with zero requirements (pomxml).
 
-| Strategy                      | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
-|-------------------------------|--------------------|--------------------|--------------------|-----------------------------------|
-| [mavenplugin](mavenplugin.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
-| [treecmd](treecmd.md)         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
-| [pomxml](pomxml.md)           | :white_check_mark: | :x:                | :x:                | :white_check_mark:                |
+| Strategy                      | Direct Deps        | Transitive Deps    | Edges              | Container Scanning |
+| ----------------------------- | ------------------ | ------------------ | ------------------ | ------------------ |
+| [mavenplugin](mavenplugin.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| [treecmd](treecmd.md)         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| [pomxml](pomxml.md)           | :white_check_mark: | :x:                | :x:                | :white_check_mark: |
 
 Maven analysis attempts these analysis methods in order:
 1. Run the maven plugin command version 4.0.1.

--- a/docs/references/strategies/languages/nim/nimble.md
+++ b/docs/references/strategies/languages/nim/nimble.md
@@ -2,10 +2,10 @@
 
 When developing in [nim](https://nim-lang.org/), nimble is used to manage dependencies.
 
-| Strategy                      | Direct Deps        | Transitive Deps          | Edges              | Classifies Dev Dependencies | Container Scanning (experimental) |
-| ----------------------------- | ------------------ | ------------------ | ------------------ | --------------------------- | --------------------------------- |
-| nimble.lock and `nimble dump` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                         | :x:                               |
-| nimble.lock                   | :warning:          | :white_check_mark: | :white_check_mark: | :x:                         | :white_check_mark:                |
+| Strategy                      | Direct Deps        | Transitive Deps    | Edges              | Classifies Dev Dependencies | Container Scanning |
+| ----------------------------- | ------------------ | ------------------ | ------------------ | --------------------------- | ------------------ |
+| nimble.lock and `nimble dump` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                         | :x:                |
+| nimble.lock                   | :warning:          | :white_check_mark: | :white_check_mark: | :x:                         | :white_check_mark: |
 
 ## Project Discovery
 

--- a/docs/references/strategies/languages/nodejs/nodejs.md
+++ b/docs/references/strategies/languages/nodejs/nodejs.md
@@ -2,9 +2,9 @@
 
 The nodejs buildtool ecosystem consists of three major toolchains: the `npm` cli, `pnpm` and `yarn`.
 
-| Strategy                      | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
-| ----------------------------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
-| [yarnlock](yarn.md)           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:                |
-| [npmlock](npm-lockfile.md)    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:                |
-| [pnpmlock](pnpm.md)           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:                |
-| [packagejson](packagejson.md) | :white_check_mark: | :x:                | :x:                | :white_check_mark:                |
+| Strategy                      | Direct Deps        | Transitive Deps    | Edges              | Container Scanning |
+| ----------------------------- | ------------------ | ------------------ | ------------------ | ------------------ |
+| [yarnlock](yarn.md)           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [npmlock](npm-lockfile.md)    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [pnpmlock](pnpm.md)           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [packagejson](packagejson.md) | :white_check_mark: | :x:                | :x:                | :white_check_mark: |

--- a/docs/references/strategies/languages/perl/perl.md
+++ b/docs/references/strategies/languages/perl/perl.md
@@ -1,8 +1,8 @@
 # Perl Analysis
 
-| Strategy           | Direct Deps        | Transitive Deps          | Edges | Classifies Dev Dependencies | Container Scanning (experimental) |
-| ------------------ | ------------------ | ------------------ | ----- | --------------------------- | --------------------------------- |
-| `*META.{yml, json} | :white_check_mark: | :white_check_mark: | :x:   | :white_check_mark:          | :white_check_mark:                |
+| Strategy           | Direct Deps        | Transitive Deps    | Edges | Classifies Dev Dependencies | Container Scanning |
+| ------------------ | ------------------ | ------------------ | ----- | --------------------------- | ------------------ |
+| `*META.{yml, json} | :white_check_mark: | :white_check_mark: | :x:   | :white_check_mark:          | :white_check_mark: |
 
 ## Project Discovery
 

--- a/docs/references/strategies/languages/php/composer.md
+++ b/docs/references/strategies/languages/php/composer.md
@@ -2,7 +2,7 @@
 
 When developing in PHP, [composer](https://getcomposer.org/) is commonly used to manage dependencies.
 
-| Strategy      | Direct Deps        | Transitive Deps          | Edges              | Classifies Dev Dependencies | Container Scanning (experimental) |
+| Strategy      | Direct Deps        | Transitive Deps          | Edges              | Classifies Dev Dependencies | Container Scanning |
 | ------------- | ------------------ | ------------------ | ------------------ | --------------------------- | --------------------------------- |
 | composer.lock | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:          | :white_check_mark:                |
 

--- a/docs/references/strategies/languages/python/python.md
+++ b/docs/references/strategies/languages/python/python.md
@@ -3,14 +3,14 @@
 The python buildtool ecosystem consists of three major toolchains: setuptools
 (requirements.txt, setup.py), pipenv, and conda.
 
-| Strategy                                       | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
-| ---------------------------------------------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
-| [pipenv](pipenv.md)                            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:                               |
-| [pipfile](pipenv.md)                           | :heavy_check_mark: | :heavy_check_mark: | :x:                | :x:                               |
-| [requirements.txt & setuptools](setuptools.md) | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark:                |
-| [setup.py & setuptools](setuptools.md)         | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark:                |
-| [conda](conda.md)                              | :heavy_check_mark: | :white_check_mark: | :x:                | :x:                               |
-| [poetry](poetry.md)                            | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_check_mark:                |
+| Strategy                                       | Direct Deps        | Transitive Deps    | Edges              | Container Scanning |
+| ---------------------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ |
+| [pipenv](pipenv.md)                            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:                |
+| [pipfile](pipenv.md)                           | :heavy_check_mark: | :heavy_check_mark: | :x:                | :x:                |
+| [requirements.txt & setuptools](setuptools.md) | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark: |
+| [setup.py & setuptools](setuptools.md)         | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark: |
+| [conda](conda.md)                              | :heavy_check_mark: | :white_check_mark: | :x:                | :x:                |
+| [poetry](poetry.md)                            | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_check_mark: |
 
 * :heavy_check_mark: - Supported in all projects
 * :white_check_mark: - Supported only when relevant data is available (e.g. lockfiles are present)

--- a/docs/references/strategies/languages/r/renv.md
+++ b/docs/references/strategies/languages/r/renv.md
@@ -2,10 +2,10 @@
 
 Currently, we only support analysis of r project which are using [renv package manager](https://rstudio.github.io/renv/index.html).
 
-| Files                       | Direct Deps                             | Deep Deps          | Edges              | Classifies Dev & Test Deps | Container Scanning (experimental) |
-| --------------------------- | --------------------------------------- | ------------------ | ------------------ | -------------------------- | --------------------------------- |
-| `renv.lock`                 | (included but not classified as direct) | :white_check_mark: | :white_check_mark: | :x:                        | :white_check_mark:                |
-| `DESCRIPTION` & `renv.lock` | :white_check_mark:                      | :white_check_mark: | :white_check_mark: | :x:                        | :white_check_mark:                |
+| Files                       | Direct Deps                             | Deep Deps          | Edges              | Classifies Dev & Test Deps | Container Scanning |
+| --------------------------- | --------------------------------------- | ------------------ | ------------------ | -------------------------- | ------------------ |
+| `renv.lock`                 | (included but not classified as direct) | :white_check_mark: | :white_check_mark: | :x:                        | :white_check_mark: |
+| `DESCRIPTION` & `renv.lock` | :white_check_mark:                      | :white_check_mark: | :white_check_mark: | :x:                        | :white_check_mark: |
 
 
 ## Project Discovery

--- a/docs/references/strategies/languages/ruby/ruby.md
+++ b/docs/references/strategies/languages/ruby/ruby.md
@@ -3,10 +3,10 @@
 Ruby projects use a buildtool called `bundler` to manage their dependencies. We
 parse a lockfile or run the `bundle` cli to determine dependencies.
 
-| Strategy    | Direct Deps                    | Transitive Deps                      | Edges              | Tags | Container Scanning (experimental) |
-| ----------- | ------------------------------ | ------------------------------ | ------------------ | ---- | --------------------------------- |
-| gemfilelock | :white_check_mark:             | :white_check_mark:             | :white_check_mark: |      | :white_check_mark:                |
-| bundleshow  | :white_check_mark: (unlabeled) | :white_check_mark: (unlabeled) | :x:                |      | :x:                               |
+| Strategy    | Direct Deps                    | Transitive Deps                | Edges              | Tags | Container Scanning |
+| ----------- | ------------------------------ | ------------------------------ | ------------------ | ---- | ------------------ |
+| gemfilelock | :white_check_mark:             | :white_check_mark:             | :white_check_mark: |      | :white_check_mark: |
+| bundleshow  | :white_check_mark: (unlabeled) | :white_check_mark: (unlabeled) | :x:                |      | :x:                |
 
 ## Project Discovery
 

--- a/docs/references/strategies/languages/scala/sbt.md
+++ b/docs/references/strategies/languages/scala/sbt.md
@@ -2,11 +2,11 @@
 
 While the other analysis strategies for `gradle` and `maven` offer some scala project coverage, scala projects overwhelmingly use the build tool `sbt`.
 
-| Tactics                        | Direct Deps        | Transitive Deps    | Edges              | Container Scanning (experimental) |
-| ------------------------------ | ------------------ | ------------------ | ------------------ | --------------------------------- |
-| `sbt dependencyBrowseTreeHTML` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
-| `sbt dependencyTree`           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
-| `sbt makePom`                  | :white_check_mark: | :x:                | :x:                | :x:                               |
+| Tactics                        | Direct Deps        | Transitive Deps    | Edges              | Container Scanning |
+| ------------------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| `sbt dependencyBrowseTreeHTML` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| `sbt dependencyTree`           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| `sbt makePom`                  | :white_check_mark: | :x:                | :x:                | :x:                |
  
 # Requirements
 

--- a/docs/references/strategies/platforms/ios/ios.md
+++ b/docs/references/strategies/platforms/ios/ios.md
@@ -2,8 +2,8 @@
 
 The iOS buildtool ecosystem consists of two major toolchains: `Carthage` and `Cocoapods`
 
-| Strategy                     | Direct Deps        | Transitive Deps          | Edges              | Container Scanning (experimental) |
-| ---------------------------- | ------------------ | ------------------ | ------------------ | --------------------------------- |
-| [Carthage](carthage.md)      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:                |
-| [Podfile.lock](cocoapods.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                               |
-| [Podfile](cocoapods.md)      | :white_check_mark: | :x:                | :x:                | :white_check_mark:                |
+| Strategy                     | Direct Deps        | Transitive Deps    | Edges              | Container Scanning |
+| ---------------------------- | ------------------ | ------------------ | ------------------ | ------------------ |
+| [Carthage](carthage.md)      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [Podfile.lock](cocoapods.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| [Podfile](cocoapods.md)      | :white_check_mark: | :x:                | :x:                | :white_check_mark: |

--- a/docs/references/strategies/platforms/ios/swift.md
+++ b/docs/references/strategies/platforms/ios/swift.md
@@ -7,12 +7,12 @@ We will not scan `.build` directory if the `Package.swift` or Xcode project file
 
 # Swift Analysis
 
-| Strategy                                                                 | Direct Deps        | Transitive Deps          | Edges | Classifies Test Dependencies | Container Scanning (experimental) |
-| ------------------------------------------------------------------------ | ------------------ | ------------------ | ----- | ---------------------------- | --------------------------------- |
-| Parse dependencies from `Package.swift`                                  | :white_check_mark: | :x:                | :x:   | :x:                          | :white_check_mark:                |
-| Parse dependencies from `Package.swift` and `Package.resolved`           | :white_check_mark: | :white_check_mark: | :x:   | :x:                          | :white_check_mark:                |
-| Parse dependencies from Xcode's `project.pbxproj`                        | :white_check_mark: | :x:                | :x:   | :x:                          | :white_check_mark:                |
-| Parse dependencies from Xcode's `project.pbxproj` and `Package.resolved` | :white_check_mark: | :white_check_mark: | :x:   | :x:                          | :white_check_mark:                |
+| Strategy                                                                 | Direct Deps        | Transitive Deps    | Edges | Classifies Test Dependencies | Container Scanning |
+| ------------------------------------------------------------------------ | ------------------ | ------------------ | ----- | ---------------------------- | ------------------ |
+| Parse dependencies from `Package.swift`                                  | :white_check_mark: | :x:                | :x:   | :x:                          | :white_check_mark: |
+| Parse dependencies from `Package.swift` and `Package.resolved`           | :white_check_mark: | :white_check_mark: | :x:   | :x:                          | :white_check_mark: |
+| Parse dependencies from Xcode's `project.pbxproj`                        | :white_check_mark: | :x:                | :x:   | :x:                          | :white_check_mark: |
+| Parse dependencies from Xcode's `project.pbxproj` and `Package.resolved` | :white_check_mark: | :white_check_mark: | :x:   | :x:                          | :white_check_mark: |
 
 - Manifest file: `Package.swift`, must begin with `// swift-tools-version:` string, followed by version number specifier. 
 - We follow swift package manager's convention and presume properties of the package are defined in a single nested initializer statement and are not modified after initialization.

--- a/docs/references/subcommands/container.md
+++ b/docs/references/subcommands/container.md
@@ -39,8 +39,8 @@ You can provide, `--only-system-deps` to only analyze dependencies originating f
 - rpm
 - alpine
 
-> Performing `fossa container analyze <IMAGE> --only-system-deps` will match scanner behaviour that of
-> previous FOSSA container scanner (same as all CLI prior to v3.5.0)
+> Performing `fossa container analyze <IMAGE> --only-system-deps` will match the behavior of
+> the previous FOSSA CLI container scanner (same as all CLI prior to v3.5.0)
 
 You can refer to [scanner](./container/scanner.md) documentation, to learn
 more about how FOSSA CLI performs scan on a container image.

--- a/docs/references/subcommands/container.md
+++ b/docs/references/subcommands/container.md
@@ -33,6 +33,17 @@ fossa container analyze debian
 # Explicit remote image via docker.your-org.com
 fossa container analyze docker.your-org.com/project/image
 ```
+You can provide, `--only-system-deps` to only analyze dependencies originating from following package managers:
+
+- dpkg
+- rpm
+- alpine
+
+> Performing `fossa container analyze <IMAGE> --only-system-deps` will match scanner behaviour that of
+> previous FOSSA container scanner (same as all CLI prior to v3.5.0)
+
+You can refer to [scanner](./container/scanner.md) documentation, to learn
+more about how FOSSA CLI performs scan on a container image.
 
 ## `fossa container test <ARG>`
 
@@ -52,11 +63,3 @@ The `--output` flag outputs dependency graph information to the terminal rather 
 ```sh
 fossa container analyze redis:alpine --output
 ```
-
-## Experimental Options
-
-_Important: For support and other general information, refer to the [experimental options overview](../experimental/README.md) before using experimental options._
-
-| Name                     | Description                                                                                                       |
-|--------------------------|-------------------------------------------------------------------------------------------------------------------|
-| `--experimental-scanner` | Provides many enhancements to container scanning ([reference](../experimental/container/experimental-scanner.md)). |

--- a/docs/references/subcommands/container/podman.md
+++ b/docs/references/subcommands/container/podman.md
@@ -43,7 +43,7 @@ Machine "podman-machine-default" started successfully
 Now we can specify `DOCKER_HOST` when running `fossa-cli`. 
 
 ```bash
-DOCKER_HOST='unix:///Users/fossa/.local/share/containers/podman/machine/podman-machine-default/podman.sock' fossa container analyze --experimental-scanner
+DOCKER_HOST='unix:///Users/fossa/.local/share/containers/podman/machine/podman-machine-default/podman.sock' fossa container analyze
 ```
 
 Likewise, if you are using `podman-remote`, you should be able to use generate unix socket, and use it with `fossa-cli`. Refer to documentation below for more details.
@@ -80,7 +80,7 @@ with `fossa-cli`.
 podman build . -t someImg:1.0.0
 podman save --format docker-archive -o image.tar
 
-fossa container analyze image.tar --experimental-scanner
+fossa container analyze image.tar
 
 # Cleanup
 rm image.tar

--- a/docs/references/subcommands/container/scanner.md
+++ b/docs/references/subcommands/container/scanner.md
@@ -29,7 +29,7 @@ FOSSA's new container scanner brings support for standard FOSSA CLI features int
 
 Finally, FOSSA's new container scanner improves the user experience and reports more information to FOSSA servers,
 improving both the information available to users and the ability for FOSSA to debug questions or issues.
-For example images scanned with the container scanner show the origin path for each dependency discovered inside the image, just like analysis of a local project.
+For example, images scanned with the container scanner show the origin path for each dependency discovered inside the image, just like analysis of a local project.
 
 Like the legacy container scanner, the container scanner fully supports the detection of OS dependencies (`apk`, `deb`, etc).
 

--- a/docs/references/subcommands/container/scanner.md
+++ b/docs/references/subcommands/container/scanner.md
@@ -2,7 +2,6 @@
 
 - [FOSSA's new container scanner](#fossas-new-container-scanner)
   - [What's new in this scanner?](#whats-new-in-this-scanner)
-  - [Integration](#integration)
 - [Documentation](#documentation)
   - [Container image source](#container-image-source)
     - [1) Exported docker archive](#1-exported-docker-archive)
@@ -30,32 +29,9 @@ FOSSA's new container scanner brings support for standard FOSSA CLI features int
 
 Finally, FOSSA's new container scanner improves the user experience and reports more information to FOSSA servers,
 improving both the information available to users and the ability for FOSSA to debug questions or issues.
-For example images scanned with the experimental scanner show the origin path for each dependency discovered inside the image, just like analysis of a local project.
+For example images scanned with the container scanner show the origin path for each dependency discovered inside the image, just like analysis of a local project.
 
-Like the legacy container scanner, the experimental scanner fully supports the detection of OS dependencies (`apk`, `deb`, etc).
-
-## Integration
-
-To use the new fossa container scanner, use the `--experimental-scanner` flag 
-with the container analyze command like the following:
-
-```bash
-fossa container analyze <ARG> --experimental-scanner
-fossa container test <ARG> # no changes to container test command  
-```
-
-For example:
-
-```bash
-fossa container analyze redis:alpine --experimental-scanner
-fossa container analyze ghcr.io/fossas/haskell-dev-tools:9.0.2 --experimental-scanner
-
-# via docker archive
-fossa container analyze image.tar --experimental-scanner
-
-# only analyze system dependencies (alpine, dpkg, rpm)
-fossa container analyze redis:alpine --experimental-scanner --only-system-deps
-```
+Like the legacy container scanner, the container scanner fully supports the detection of OS dependencies (`apk`, `deb`, etc).
 
 Refer to following guides for integrating container scanning in your CI,
 
@@ -69,19 +45,19 @@ Scans report compliance and security issues for operating system dependencies an
 To scan a container image with `fossa-cli`, use the `container analyze` command:
 
 ```bash
-# Analyze the container image `<IMAGE>` with experimental scanner and upload scan results to FOSSA.
+# Analyze the container image `<IMAGE>` with container scanner and upload scan results to FOSSA.
 # This command only reports dependency metadata, no source code or actual file is sent to FOSSA.
 #
 # This command uses the repository name as project name, and image digest as the revision.
 # Like standard FOSSA analysis, the project name is customizable via `--project` and revision via `--revision`:
 #
-#   >> fossa container analyze <IMAGE> --project <PROJECT-NAME> --revision <REVISION-VALUE> --experimental-scanner 
+#   >> fossa container analyze <IMAGE> --project <PROJECT-NAME> --revision <REVISION-VALUE> 
 #
-fossa container analyze <IMAGE> --experimental-scanner 
+fossa container analyze <IMAGE> 
 
 # Similar to the above, but instead of uploading the results they are instead written to the terminal in JSON format.
 #
-fossa container analyze <IMAGE> --experimental-scanner -o
+fossa container analyze <IMAGE> -o
 ```
 
 Once the container image has been scanned and the results uploaded to FOSSA,
@@ -95,7 +71,7 @@ security and compliance issues are reported via the `fossa container test` comma
 # Policies are also able to surface or suppress issues based on the layer in which the issue was detected.
 # Refer to FOSSA's product documentation for more information: https://docs.fossa.com
 #
-# This does not need the `--experimental-scanner` flag.
+# This does not need the `` flag.
 fossa container test <IMAGE>
 ```
 
@@ -114,13 +90,13 @@ By default `fossa-cli` attempts to identify `<IMAGE>` source in the following or
 
 ```bash
 docker save redis:alpine > redis_alpine.tar
-fossa container analyze redis_alpine.tar --experimental-scanner
+fossa container analyze redis_alpine.tar 
 ```
 
 ### 2) From Docker Engine
 
 ```bash
-fossa container analyze redis:alpine --experimental-scanner
+fossa container analyze redis:alpine 
 ```
 
 For this image source to work, `fossa-cli` requires docker to be running and accessible.
@@ -143,7 +119,7 @@ curl --unix-socket /var/run/docker.sock -X GET "http://localhost/v1.28/images/re
 ### 3) From registries
 
 ```bash
-fossa container analyze ghcr.io/fossas/haskell-dev-tools:9.0.2 --experimental-scanner
+fossa container analyze ghcr.io/fossas/haskell-dev-tools:9.0.2 
 ```
 
 This step works even if you do not have docker installed or have docker engine accessible.
@@ -173,7 +149,7 @@ Analyzing the container image for a platform other than the one currently runnin
 For example, the following command analyzes the `arm64` platform image of `ghcr.io/graalvm/graalvm-ce@sha256` regardless of the platform running `fossa container analyze`:
 
 ```bash
-fossa container analyze ghcr.io/graalvm/graalvm-ce@sha256:bdcba07acb11053fea0026b807ecf94550ace7df27b10596ca4c765165243cef --experimental-scanner
+fossa container analyze ghcr.io/graalvm/graalvm-ce@sha256:bdcba07acb11053fea0026b807ecf94550ace7df27b10596ca4c765165243cef 
 ```
 
 **Private registries**
@@ -202,7 +178,7 @@ To explicitly provide a username and password, use HTTP-style authentication in 
 For this to work the host value must be present in the image URL:
 
 ```bash
-fossa container analyze user:secret@quay.io/org/image:tag --experimental-scanner
+fossa container analyze user:secret@quay.io/org/image:tag 
 ```
 
 **Retrieving image from registry**
@@ -224,7 +200,7 @@ All `GET` request from step 2 to step 5, will make `HEAD` call prior to confirm 
 
 ## Container image analysis
 
-The new experimental scanner scans in two steps:
+The new container scanner scans in two steps:
 1. The base layer.
 2. The rest of the layers, squashed. 
 
@@ -264,10 +240,10 @@ Where:
 
 ### View detected projects
 
-To view the list of projects detected within the container by the above strategies run `fossa container list-targets <ARG> --experimental-scanner`.
-`ARG` must be the same value as provided to `fossa container analyze <ARG> --experimental-scanner` or `fossa container test <ARG>`.
+To view the list of projects detected within the container by the above strategies run `fossa container list-targets <ARG> `.
+`ARG` must be the same value as provided to `fossa container analyze <ARG> ` or `fossa container test <ARG>`.
 
-This output can be useful to understand what is going to be analyzed via `fossa container analyze <ARG> --experimental-scanner`,
+This output can be useful to understand what is going to be analyzed via `fossa container analyze <ARG> `,
 and if desired can inform [analysis target configuration](../../files/fossa-yml.md#analysis-target-configuration).
 
 #### Command output
@@ -280,7 +256,7 @@ Example output:
 [ INFO] Exporting docker image to temp file: /private/var/folders/hb/pg5d0r196kq1qdswr6_79hzh0000gn/T/fossa-docker-engine-tmp-f7af2b5d1ec5173d/image.tar! This may take a while!
 [ INFO] Listing targets exported docker archive: /private/var/folders/hb/pg5d0r196kq1qdswr6_79hzh0000gn/T/fossa-docker-engine-tmp-f7af2b5d1ec5173d/image.tar
 [ WARN] fossa container list-targets does not apply any filtering, you may see projects which are not present in the final analysis.
-[ WARN] fossa container list-targets only lists targets for experimental-scanner (when analyzed with --experimental-scanner flag).
+[ WARN] fossa container list-targets only lists targets for experimental-scanner (when analyzed with flag).
 [ INFO] Found project: apkdb@lib/apk/db/ (Base Layer)
 [ INFO] Found target: apkdb@lib/apk/db/ (Base Layer)
 [ INFO] Found project: setuptools@usr/local/lib/node_modules/npm/node_modules/node-gyp/gyp/ (Other Layers)
@@ -295,7 +271,7 @@ Example output:
 
 ### Utilize analysis target configuration
 
-The new experimental scanner supports configuring analysis targets via `.fossa.yml`, as with a standard `fossa analyze` command.
+The new container scanner supports configuring analysis targets via `.fossa.yml`, as with a standard `fossa analyze` command.
 For more information on configuring analysis targets, see [analysis target configuration](../../files/fossa-yml.md#analysis-target-configuration).
 
 For example, the following `fossa.yml` excludes all `setuptools` targets:
@@ -306,10 +282,10 @@ exclude:
 
 ### Debugging
 
-`fossa-cli` supports the `--debug` flag and debug bundle generation with the experimental scanner. 
+`fossa-cli` supports the `--debug` flag and debug bundle generation with the container scanner. 
 
 ```bash
-fossa container analyze redis:alpine --experimental-scanner --debug
+fossa container analyze redis:alpine --debug
 
 # Generates debug logs in the terminal.
 # Writes the FOSSA debug bundle in the current working directory with the filename "fossa.container.debug.json.gz".
@@ -325,7 +301,7 @@ Images can be exported to archives using Docker:
 docker pull <IMAGE>:<TAG> # or docker pull <IMAGE>@<DIGEST>
 docker save <IMAGE>:<TAG> > image.tar
 
-fossa container analyze image.tar --experimental scanner 
+fossa container analyze image.tar --container scanner 
 
 rm image.tar
 ```
@@ -338,7 +314,7 @@ By default when `fossa-cli` is analyzing multi-platform image it prefers using t
 If a specific platform is desired, use the digest for that platform:
 
 ```bash
-fossa container analyze ghcr.io/graalvm/graalvm-ce@sha256:bdcba07acb11053fea0026b807ecf94550ace7df27b10596ca4c765165243cef --experimental-scanner
+fossa container analyze ghcr.io/graalvm/graalvm-ce@sha256:bdcba07acb11053fea0026b807ecf94550ace7df27b10596ca4c765165243cef 
 ```
 
 ### How can I only scan for system dependencies (alpine, dpkg, rpm)?
@@ -346,7 +322,7 @@ fossa container analyze ghcr.io/graalvm/graalvm-ce@sha256:bdcba07acb11053fea0026
 Use the `--only-system-deps` option:
 
 ```bash
-fossa container analyze <IMAGE> --experimental-scanner --only-system-deps
+fossa container analyze <IMAGE> --only-system-deps
 ```
 
 ### How do I exclude specific projects from container scanning?
@@ -367,12 +343,12 @@ targets:
 ```
 
 ```bash
-fossa container analyze <IMAGE> --experimental-scanner -c .fossa.config.yaml --output
+fossa container analyze <IMAGE> -c .fossa.config.yaml --output
 ```
 
 ## Limitations & Workarounds
 
-`fossa-cli` using the experimental scanner does not support [v1 docker manifest format](https://docs.docker.com/registry/spec/manifest-v2-1/).
+`fossa-cli` using the container scanner does not support [v1 docker manifest format](https://docs.docker.com/registry/spec/manifest-v2-1/).
 This manifest format is officially deprecated, but is still found in some registries.
 
 The recommended workaround is to export the image to an archive, then analyze that:
@@ -381,7 +357,7 @@ The recommended workaround is to export the image to an archive, then analyze th
 docker pull quay.io/org/image:tag
 docker save quay.io/org/image:tag > img.tar
 
-fossa container analyze img.tar --experimental-scanner
+fossa container analyze img.tar 
 rm img.tar
 ```
 

--- a/src/Container/Docker/SourceParser.hs
+++ b/src/Container/Docker/SourceParser.hs
@@ -150,7 +150,7 @@ suggestDockerExport (RegistryImageSource host _ _ repo ref _) =
     saveCmd = pretty $ "docker save " <> imgIdentifier <> " > image-exported.tar"
 
     fossaAnalyzeCmd :: Doc AnsiStyle
-    fossaAnalyzeCmd = "fossa container analyze image-exported.tar --experimental-scanner"
+    fossaAnalyzeCmd = "fossa container analyze image-exported.tar"
 
 showReferenceWithSep :: RepoReference -> Text
 showReferenceWithSep (RepoReferenceTag (RepoTag tag)) = ":" <> tag

--- a/src/Container/Errors.hs
+++ b/src/Container/Errors.hs
@@ -47,7 +47,7 @@ instance ToDiagnostic EndpointDoesNotSupportNativeContainerScan where
       [ "Provided endpoint does not support native container scans."
       , ""
       , "Container scanning with new scanner is not supported for your FOSSA endpoint."
-      , "" 
+      , ""
       , "Upgrade your FOSSA instance to v4.0.37 or downgrade your FOSSA CLI to 3.4.x"
       , ""
       , "Please contact FOSSA support for more assistance."

--- a/src/Container/Errors.hs
+++ b/src/Container/Errors.hs
@@ -46,9 +46,9 @@ instance ToDiagnostic EndpointDoesNotSupportNativeContainerScan where
     vsep
       [ "Provided endpoint does not support native container scans."
       , ""
-      , "If you are using, --experimental-scanner option, it is not supported for your"
-      , "FOSSA instance. Try without using --experimental-scanner."
+      , "Container scanning with new scanner is not supported for your FOSSA endpoint."
+      , "" 
+      , "Upgrade your FOSSA instance to v4.0.37 or downgrade your FOSSA CLI to 3.4.x"
       , ""
-      , "If your instance of FOSSA is on-premise, it likely needs to be updated to latest version."
       , "Please contact FOSSA support for more assistance."
       ]


### PR DESCRIPTION
# Overview

This PR, 
- updates container scanning docs to remove experimental docs, and associated prefixes.


This PR is part of PR chain:
- https://github.com/fossas/fossa-cli/pull/1078

## Acceptance criteria

- experimental scanner docs are converted to container scanner docs

## Testing plan

N/A

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-282

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
