### PR TITLE
Minor conda docs fix

### DIFF
--- a/docs/references/strategies/languages/python/python.md
+++ b/docs/references/strategies/languages/python/python.md
@@ -10,7 +10,7 @@ The python buildtool ecosystem consists of three major toolchains: setuptools
 | [requirements.txt & setuptools](setuptools.md) | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark:                |
 | [setup.py & setuptools](setuptools.md)         | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark:                |
 | [piplist](piplist.md)                          | :white_check_mark: | :white_check_mark: | :x:                | :heavy_check_mark:                |
-| [conda](conda.md)                              | :heavy_check_mark: | :heavy_check_mark: | :x:                | :x:                               |
+| [conda](conda.md)                              | :heavy_check_mark: | :white_check_mark: | :x:                | :x:                               |
 | [poetry](poetry.md)                            | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_check_mark:                |
 
 * :heavy_check_mark: - Supported in all projects


### PR DESCRIPTION
Per https://github.com/fossas/fossa-cli/blob/642aa4252c4bf1f23687588d333702065b16713f/docs/references/strategies/languages/python/conda.md, transitive dependencies are not available if `conda` fails and we fall back to parsing environment.yml.