### PR TITLE
[No Ticket] image with multiple symlinked layer can be analyzed

### DIFF
--- a/src/Container/Tarball.hs
+++ b/src/Container/Tarball.hs
@@ -35,7 +35,7 @@ import Container.Types (
  )
 import Data.ByteString.Lazy qualified as ByteStringLazy
 import Data.Either (lefts, rights)
-import Data.FileTree.IndexFileTree (SomeFileTree, empty, insert, remove, toSomePath)
+import Data.FileTree.IndexFileTree (SomeFileTree, empty, insert, remove, resolveSymLinkRef, toSomePath)
 import Data.Foldable (foldl')
 import Data.List.NonEmpty qualified as NLE
 import Data.Sequence (Seq, ViewL (EmptyL, (:<)), viewl, (|>))
@@ -130,8 +130,8 @@ mkImage manifest imgJson entries layerTarballPaths =
     layers = zipWith (curry $ mkLayer entries) (getLayerIds imgJson) (NLE.toList layerTarballPaths)
 
 mkLayer :: TarEntries -> (Text, FilePath) -> Either ContainerImgParsingError ContainerLayer
-mkLayer (TarEntries entries _) (layerId, layerTarball) =
-  case viewl $ Seq.filter (\(t, _) -> (filePathOf . entryTarPath) t == layerTarball && isFile t) entries of
+mkLayer (TarEntries entries tarOffset) (layerId, layerTarball) =
+  case viewl $ Seq.filter (\(t, _) -> (filePathOf . entryTarPath) t == layerTarball && (isFile t || isSymLink t)) entries of
     EmptyL -> Left $ TarMissingLayerTar layerTarball
     (layerTarballEntry :< _) -> case entryContent $ fst layerTarballEntry of
       (NormalFile c _) -> do
@@ -140,8 +140,19 @@ mkLayer (TarEntries entries _) (layerId, layerTarball) =
           Left err -> Left err
           Right layer -> Right layer
 
-      -- Layer tarball must be a file, they cannot be a directory
-      -- or symlink to some other file.
+      -- Sometimes layer tar is alias to existing tarball file
+      -- This occurs when same layer is used multiple times in container image.
+      (SymbolicLink target) -> do
+        mkLayer
+          (TarEntries entries tarOffset)
+          ( layerId
+          , toString $
+              resolveSymLinkRef
+                (toText layerTarball)
+                (toText $ TarEntry.fromLinkTarget target)
+          )
+
+      -- Layer tarball must be a file, or symbolic link to existing tar file.
       _ -> Left $ TarLayerNotAFile layerTarball
 
 mkLayerFromOffset ::

--- a/src/Container/Tarball.hs
+++ b/src/Container/Tarball.hs
@@ -149,7 +149,7 @@ mkLayer (TarEntries entries tarOffset) (layerId, layerTarball) =
           , toString $
               resolveSymLinkRef
                 (toText layerTarball)
-                (toText $ TarEntry.fromLinkTarget target)
+                (toText $ TarEntry.fromLinkTargetToPosixPath target)
           )
 
       -- Layer tarball must be a file, or symbolic link to existing tar file.

--- a/test/Container/TarballSpec.hs
+++ b/test/Container/TarballSpec.hs
@@ -190,7 +190,6 @@ mkImageSpec = do
   let tarFile = Tar.read tarFileBs
 
   tarFileBsSymEntries <- runIO $ ByteStringLazy.readFile exampleImgSymLinkEntries
-  let tarFileSymEntries = Tar.read tarFileBsSymEntries
 
   describe "parse" $ do
     it "should parse image with all layers and correct layer Ids" $ do
@@ -216,9 +215,8 @@ mkImageSpec = do
     it "should parse image with all layers and correct layer Ids when some layers are symlinked" $ do
       case parse tarFileBsSymEntries of
         Left errs -> expectationFailure (show errs)
-        Right (ContainerImageRaw neLayers imgManifest) -> do
+        Right (ContainerImageRaw neLayers _) -> do
           let l = NLE.toList neLayers
-          let otherLayers = NLE.fromList . NLE.tail $ neLayers
 
           layerDigest (head l) `shouldBe` "sha256:0b16ab2571f4b3e0d5a96b66a00e5016ddc0d268e8bc45dc612948c4c95b94cd"
           layerDigest (l !! 1) `shouldBe` "sha256:79561e664b2eb736c17d5019036e2bcafe26c760859e65d34f2e006b1c0beb9a"

--- a/test/Container/TarballSpec.hs
+++ b/test/Container/TarballSpec.hs
@@ -50,6 +50,9 @@ removeWhiteOutSpec =
 exampleImg :: FilePath
 exampleImg = "test/Container/testdata/changeset_example.tar"
 
+exampleImgSymLinkEntries :: FilePath
+exampleImgSymLinkEntries = "test/Container/testdata/changesets_symlinked_entries.tar"
+
 exampleImgLayers :: NLE.NonEmpty FilePath
 exampleImgLayers =
   NLE.fromList
@@ -186,7 +189,10 @@ mkImageSpec = do
   tarFileBs <- runIO $ ByteStringLazy.readFile exampleImg
   let tarFile = Tar.read tarFileBs
 
-  describe "parse" $
+  tarFileBsSymEntries <- runIO $ ByteStringLazy.readFile exampleImgSymLinkEntries
+  let tarFileSymEntries = Tar.read tarFileBsSymEntries
+
+  describe "parse" $ do
     it "should parse image with all layers and correct layer Ids" $ do
       case parse tarFileBs of
         Left errs -> expectationFailure (show errs)
@@ -206,6 +212,21 @@ mkImageSpec = do
 
           toChangeSets (ContainerImageRaw otherLayers imgManifest)
             `shouldBe` expectedLayerChangeSets
+
+    it "should parse image with all layers and correct layer Ids when some layers are symlinked" $ do
+      case parse tarFileBsSymEntries of
+        Left errs -> expectationFailure (show errs)
+        Right (ContainerImageRaw neLayers imgManifest) -> do
+          let l = NLE.toList neLayers
+          let otherLayers = NLE.fromList . NLE.tail $ neLayers
+
+          layerDigest (head l) `shouldBe` "sha256:0b16ab2571f4b3e0d5a96b66a00e5016ddc0d268e8bc45dc612948c4c95b94cd"
+          layerDigest (l !! 1) `shouldBe` "sha256:79561e664b2eb736c17d5019036e2bcafe26c760859e65d34f2e006b1c0beb9a"
+          layerDigest (l !! 2) `shouldBe` "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+          layerDigest (l !! 3) `shouldBe` "sha256:ac0192bbb75bcafb054a0b4bc0915771c12f46b1e3ac2ae284ac7852fa0a55df"
+          layerDigest (l !! 4) `shouldBe` "sha256:b0ffa65701492545ff15c114e01fa3b3e88876830e3176524f9c2ad6bbd68337"
+          layerDigest (l !! 5) `shouldBe` "sha256:202fcf6ef76ae496d03f4466be0b56de0c88fac0d4a6ca529496c60f67eb0e2d"
+          layerDigest (l !! 6) `shouldBe` "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
 
   describe "mkImage" $
     it "should build image with layers with all change sets" $

--- a/test/Container/testdata/Dockerfile.sample2
+++ b/test/Container/testdata/Dockerfile.sample2
@@ -1,0 +1,20 @@
+# Testcase: changesets_symlinked_entries.tar
+#
+# To Build:
+#   docker build -f Dockerfile.sample2 . -t changesets_symlinked_entries:latest
+#
+# To Export:
+#   docker save changesets_symlinked_entries:latest > changesets_symlinked_entries.tar
+#   
+# To Run:
+#   docker run -it changesets_symlinked_entries:latest /bin/sh
+FROM busybox
+
+RUN echo 'a' > filea.txt
+WORKDIR /tmp
+
+RUN echo 'b' > fileb.txt
+WORKDIR /app
+
+RUN echo 'c' > filec.txt
+WORKDIR /tmp

--- a/test/Container/testdata/changesets_symlinked_entries.tar
+++ b/test/Container/testdata/changesets_symlinked_entries.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a55c19186d2e959a3e02633ca0b13f55ef6ed8351f8d393957c96027dd02f9b
+size 1501184


### PR DESCRIPTION
# Overview

This PR fixes a defect with new scanner, when container image contains duplicate layers (in docker-archive layers are symlinked)

## Acceptance criteria

- `fossa container analyze` works for container image with symlinked layers.

## Testing plan

I have added an automated test.

```bash
git checkout fix/multiple-symlinked-empty-tar-entries
make install-local
./fossa container analyze test/Container/testdata/changesets_symlinked_entries.tar --experimental-scanner -o # this should not fail!
```

## Risks

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
