### PR TITLE
Update contrib days

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.5.1
+
+- Contributor counting: update the contributor count range from 90 days to 365 days. ([#1083](https://github.com/fossas/fossa-cli/pull/1083))
+
 ## v3.5.0
 
 - Container Scanning: Uses native container scanner, deprecates old container scanner ([#1078](https://github.com/fossas/fossa-cli/pull/1078)), ([#1079](https://github.com/fossas/fossa-cli/pull/1079)), ([#1080](https://github.com/fossas/fossa-cli/pull/1080)), ([1082](https://github.com/fossas/fossa-cli/pull/1082)).

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ install-dev: build
 
 check: check-fmt lint
 
-fast-check: check-fmt fast-lint
+fast-check: check-fmt-haskell fast-lint
 
 # Run any build scripts required for test data to be generated.
 build-test-data:
@@ -72,10 +72,12 @@ clean-test-data:
 
 # Format everything (if this fails, update FMT_OPTS or use your IDE to format)
 # `@command` does not echo the command before running
-fmt: fmt-cargo
+fmt: fmt-haskell fmt-cargo
+
+fmt-haskell:
 	@echo "Running fourmolu"
-	./fourmolu --version
-	./fourmolu --mode inplace ${FMT_OPTS} $(shell find ${FIND_OPTS})
+	@fourmolu --version
+	@fourmolu --mode inplace ${FMT_OPTS} $(shell find ${FIND_OPTS})
 	@echo "Running cabal-fmt"
 	@cabal-fmt spectrometer.cabal --inplace
 
@@ -85,7 +87,9 @@ fmt-cargo:
 	@cargo fmt
 
 # Confirm everything is formatted without changing anything
-check-fmt: check-fmt-cargo
+check-fmt: check-fmt-haskell check-fmt-cargo
+
+check-fmt-haskell:
 	@echo "Running fourmolu"
 	@fourmolu --version
 	@fourmolu --mode check ${FMT_OPTS} $(shell find ${FIND_OPTS})
@@ -99,7 +103,9 @@ check-fmt-cargo:
 	@cargo fmt --check
 
 # Lint everything (If this fails, update .hlint.yaml or report the failure)
-lint: lint-cargo
+lint: lint-haskell lint-cargo
+
+lint-haskell:
 	@echo "Running hlint"
 	@hlint --version
 	@hlint src test integration-test --cross --timing -vj
@@ -117,7 +123,7 @@ lint-cargo:
 # The two git commands are for staged (cached) and unstaged files.
 # We also succeed if there are no changed filers to lint.  We grep the list of files for non-whitespace,
 # and if we find any non-whitespace characters, then the git search found at least one file.
-fast-lint:
+fast-lint-haskell:
 	@test "${current_dir}" = "/fossa-cli/" && \
 		git config --global --add safe.directory /fossa-cli && \
 		echo "Running in docker, added temp safe.directory entry to git config"
@@ -143,18 +149,18 @@ check-links:
 # Run the formatter from within a docker image, with the project mounted as a volume
 fmt-ci:
 	docker pull ${DEV_TOOLS}
-	docker run ${MOUNTED_DEV_TOOLS} make fmt
+	docker run ${MOUNTED_DEV_TOOLS} make fmt-haskell
 
 # Run the fast-lint target with the CI docker container
 fast-lint-ci:
 	docker pull ${DEV_TOOLS}
-	docker run ${MOUNTED_DEV_TOOLS} make fast-lint
+	docker run ${MOUNTED_DEV_TOOLS} make fast-lint-haskell
 
 # Docker doesn't always check for new versions during build, so pulling ensures
 # that we always have the latest.
 check-ci:
 	docker pull ${DEV_TOOLS}
-	docker run ${MOUNTED_DEV_TOOLS} make check
+	docker run ${MOUNTED_DEV_TOOLS} make check-haskell
 
 # Run the fast-check target with the CI docker container
 fast-check-ci:

--- a/src/Control/Carrier/Git.hs
+++ b/src/Control/Carrier/Git.hs
@@ -25,6 +25,9 @@ import Path (Abs, Dir, Path)
 
 type GitC = SimpleC GitF
 
+gitContributorDays :: NominalDiffTime
+gitContributorDays = 365
+
 runGit :: (Has (Lift IO) sig m, Has Exec sig m, Has Diag.Diagnostics sig m) => GitC m a -> m a
 runGit = interpret $ \case
   FetchGitContributors baseDir -> fetchGitContributors baseDir
@@ -38,7 +41,7 @@ gitLogCmd now =
     }
   where
     sinceArg = toText . iso8601Show $ utctDay wayBack
-    delta = nominalDay * (-90)
+    delta = nominalDay * (- gitContributorDays)
     wayBack = addUTCTime delta now
 
 fetchGitContributors ::

--- a/src/Control/Carrier/Git.hs
+++ b/src/Control/Carrier/Git.hs
@@ -5,9 +5,12 @@ module Control.Carrier.Git (
   runGit,
 ) where
 
-import Control.Carrier.Diagnostics (errCtx)
-import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Simple (SimpleC, interpret)
+import Control.Effect.Diagnostics (
+  ToDiagnostic (renderDiagnostic),
+  errCtx,
+ )
+import Control.Effect.Diagnostics qualified as Diag
 import Control.Effect.Git (GitF (..))
 import Control.Effect.Lift (Lift, sendIO)
 import Data.Map qualified as Map
@@ -16,10 +19,24 @@ import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Extra (splitOnceOn)
-import Data.Time
+import Data.Time (
+  Day,
+  NominalDiffTime,
+  UTCTime (utctDay),
+  addUTCTime,
+  defaultTimeLocale,
+  getCurrentTime,
+  nominalDay,
+  parseTimeM,
+ )
 import Data.Time.Format.ISO8601 (iso8601Show)
-import Diag.Diagnostic (ToDiagnostic)
-import Effect.Exec
+import Effect.Exec (
+  AllowErr (Never),
+  Command (..),
+  Exec,
+  Has,
+  execThrow,
+ )
 import Fossa.API.Types (Contributors (..))
 import Path (Abs, Dir, Path)
 
@@ -41,7 +58,7 @@ gitLogCmd now =
     }
   where
     sinceArg = toText . iso8601Show $ utctDay wayBack
-    delta = nominalDay * (- gitContributorDays)
+    delta = nominalDay * (-gitContributorDays)
     wayBack = addUTCTime delta now
 
 fetchGitContributors ::


### PR DESCRIPTION
# Overview

Updates the contrib count day limit from 90 days to 365.  Also fixes the broken `*-ci` targets in the makefile

## Acceptance criteria

Contrib counts are uploaded with the latest contribution dates for the last 365 days.

## Testing plan

Jumping into the repl and testing the internal command output.

```
$ cabal repl
> :l Control.Carrier.Git
> cmdArgs . gitLogCmd <$> getCurrentTime
```

Date (the arg after `--since`) should be current date 1 year ago (except on leap day, or perhaps after leap day on a leap year).

## References

ANE-657

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
