### PR TITLE
Generate conda locators with channel/platform where possible.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- Conda: Output more detailed locators for channel/platform specific analysis. ([#1084])(https://github.com/fossas/fossa-cli/pull/1084)
+
 ## v3.5.1
 
 - Contributor counting: update the contributor count range from 90 days to 365 days. ([#1083](https://github.com/fossas/fossa-cli/pull/1083))

--- a/docs/references/strategies/languages/python/conda.md
+++ b/docs/references/strategies/languages/python/conda.md
@@ -9,7 +9,11 @@ Find the first file named `environment.yml`
 ## Analysis: conda list
 
 We run `conda list --json` in order to get a complete list of all installed conda packages in the conda environment.
+This tactic tries to determine which channel/platform a package was installed for to get the most accurate results.
+If it can't determine a channel/environment it will use just the name to get best-effort results for that package.
 
 ## Analysis: environment.yml
 
 If the `conda list --json` operation does not succeed, we fall back to parsing the `environment.yml`, and getting the list of dependencies from the `dependencies` section of this file.
+`environment.yml` does not include data about which channel a package was installed from.
+Instead, FOSSA will try to make a best effort to retrieve package data based on the name.

--- a/test/Conda/CondaListSpec.hs
+++ b/test/Conda/CondaListSpec.hs
@@ -18,7 +18,7 @@ expected = run . evalGrapher $ do
   direct $
     Dependency
       { dependencyType = CondaType
-      , dependencyName = "biopython"
+      , dependencyName = "'pkgs/main':osx-64:biopython"
       , dependencyVersion = Just (CEq "1.78")
       , dependencyLocations = []
       , dependencyEnvironments = mempty
@@ -27,7 +27,7 @@ expected = run . evalGrapher $ do
   direct $
     Dependency
       { dependencyType = CondaType
-      , dependencyName = "blas"
+      , dependencyName = "'pkgs/main':osx-64:blas"
       , dependencyVersion = Just (CEq "1.0")
       , dependencyLocations = []
       , dependencyEnvironments = mempty
@@ -36,8 +36,28 @@ expected = run . evalGrapher $ do
   direct $
     Dependency
       { dependencyType = CondaType
-      , dependencyName = "ca-certificates"
+      , dependencyName = "'pkgs/main':osx-64:ca-certificates"
       , dependencyVersion = Just (CEq "2021.1.19")
+      , dependencyLocations = []
+      , dependencyEnvironments = mempty
+      , dependencyTags = Map.empty
+      }
+  -- Missing platform, should default to the v1 package spec format
+  direct $
+    Dependency
+      { dependencyType = CondaType
+      , dependencyName = "absl-py"
+      , dependencyVersion = Just (CEq "1.3.0")
+      , dependencyLocations = []
+      , dependencyEnvironments = mempty
+      , dependencyTags = Map.empty
+      }
+  -- Missing channel field, should default to v1 package spec format
+  direct $
+    Dependency
+      { dependencyType = CondaType
+      , dependencyName = "aenum"
+      , dependencyVersion = Just (CEq "3.1.5")
       , dependencyLocations = []
       , dependencyEnvironments = mempty
       , dependencyTags = Map.empty

--- a/test/Conda/testdata/conda-list-output.txt
+++ b/test/Conda/testdata/conda-list-output.txt
@@ -28,5 +28,25 @@
     "name": "ca-certificates",
     "platform": "osx-64",
     "version": "2021.1.19"
+  },
+  {
+    "base_url": "https://repo.anaconda.com/pkgs/main",
+    "build_number": 0,
+    "build_string": "py310hecd8cb5_0",
+    "channel": "pkgs/main",
+    "dist_name": "absl-py-1.3.0-py310hecd8cb5_0",
+    "name": "absl-py",
+    "platform": null,
+    "version": "1.3.0"
+  } ,
+  {
+    "base_url": "https://repo.anaconda.com/pkgs/main",
+    "build_number": 0,
+    "build_string": "py310hecd8cb5_0",
+    "channel": null,
+    "dist_name": "aenum-3.1.5-py310hecd8cb5_0",
+    "name": "aenum",
+    "platform": "osx-64",
+    "version": "3.1.5"
   }
 ]


### PR DESCRIPTION
# Overview

Basis PR [1768](https://github.com/fossas/basis/pull/1768) adds support to the fetchers API service to accept channel and platform in order to return more accurate results. This PR adds support to the CLI to produce those new locators, where possible. The format is: `conda+{org/}?'{channel}':{platform}:{name}${version}`

## Risks

I've put the channel value in quotes in the package spec because if we were to support an optional `org/` at the beginning of the locator it makes it impossible to know whether the package spec has no org and a channel with a slash or an org with a channel. For example `org/conda-forge` could be interpreted as an `org = 'org'` and `channel = 'conda-forge'` or as having no org and `channel = 'org/conda-forge'`. Slashes must be allowed in channels because the `conda` tool reports channels such as `pkgs/main`. 

This format with quotes satisfies the [regex](https://github.com/fossas/FOSSA/blob//shared/Locator.ts#L63) in fossa core, but is there any reason not to do it this way?

## References

- [ANE-571](https://fossa.atlassian.net/browse/ANE-571)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
