### PR TITLE
[No Ticket] Support raw authentication from config.json for Docker

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.5.2
+
+- Container Scanning: Fixes an issue with base64 encoded raw authentications [#1085](https://github.com/fossas/fossa-cli/pull/1085).
+
 ## v3.5.1
 
 - Contributor counting: update the contributor count range from 90 days to 365 days. ([#1083](https://github.com/fossas/fossa-cli/pull/1083))

--- a/src/Container/Docker/Credentials.hs
+++ b/src/Container/Docker/Credentials.hs
@@ -5,18 +5,23 @@ module Container.Docker.Credentials (
 
   -- * For Testing
   DockerConfig (..),
+  DockerConfigRawAuth (..),
   DockerCredentialHelperGetResponse (..),
+  getRawCred,
 ) where
 
 import Container.Docker.SourceParser (RegistryImageSource (RegistryImageSource))
 import Control.Algebra (Has)
-import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Diagnostics (Diagnostics, fatalText)
 import Control.Effect.Lift (Lift, sendIO)
 import Data.Aeson (FromJSON (parseJSON), withObject, (.!=), (.:), (.:?))
+import Data.ByteString.Base64 (decode)
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Data.String.Conversion (ConvertUtf8 (decodeUtf8, encodeUtf8), toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Text.Extra (breakOnEndAndRemove)
 import Effect.Exec (
   AllowErr (Never),
   Command (Command, cmdAllowErr, cmdArgs, cmdName),
@@ -28,7 +33,8 @@ import Path (Abs, File, Path, mkRelFile, (</>))
 import Path.IO qualified as PIO
 
 data DockerConfig = DockerConfig
-  { credStore :: Text
+  { credStore :: Maybe Text
+  , auths :: Map Text DockerConfigRawAuth
   , -- With Docker 1.13.0 or greater, Docker lets you configure different credential helpers
     -- for different registries. These are stored in Credential Helpers.
     -- Refer to: https://docs.docker.com/engine/reference/commandline/login/#credential-helpers
@@ -39,12 +45,24 @@ data DockerConfig = DockerConfig
 instance FromJSON DockerConfig where
   parseJSON = withObject "DockerConfig" $ \o ->
     DockerConfig
-      <$> o .: "credsStore"
+      <$> o .:? "credsStore"
+      <*> (o .:? "auths" .!= mempty)
       <*> o .:? "credHelpers" .!= mempty
 
-getCredentialStore :: Text -> DockerConfig -> Text
-getCredentialStore host (DockerConfig defaultStore hostToCred) =
-  Map.findWithDefault defaultStore host withoutUriScheme
+newtype DockerConfigRawAuth = DockerConfigRawAuth
+  { -- auth is base64(user:pass) value
+    auth :: Maybe Text
+  }
+  deriving (Show, Eq, Ord)
+
+instance FromJSON DockerConfigRawAuth where
+  parseJSON = withObject "DockerConfigRawAuth" $ \o ->
+    DockerConfigRawAuth <$> o .:? "auth"
+
+getCredentialStore :: Text -> DockerConfig -> Maybe Text
+getCredentialStore _ (DockerConfig Nothing _ _) = Nothing
+getCredentialStore host (DockerConfig (Just defaultStore) _ hostToCred) =
+  Just $ Map.findWithDefault defaultStore host withoutUriScheme
   where
     -- Docker Config considers quay.io and https://quay.io to be equivalent
     -- for credentials. Remove URI scheme to ensure compatibility
@@ -57,14 +75,35 @@ getCredentialStore host (DockerConfig defaultStore hostToCred) =
     withoutHttps :: Text -> Text
     withoutHttps = Text.replace "https://" ""
 
+getRawCred :: Text -> DockerConfig -> Maybe (Text, Text)
+getRawCred host (DockerConfig _ auths _) = case auth <$> (Map.lookup host authsWithoutUriScheme) of
+  Just (Just auth') -> case decode . encodeUtf8 $ auth' of
+    Right bs -> case breakOnEndAndRemove ":" $ decodeUtf8 bs of
+      Just (user, pass) -> pure (user, pass)
+      _ -> Nothing -- could not break by ':'
+    _ -> Nothing -- could not base64 decode!
+  _ -> Nothing -- does not have raw auth!
+  where
+    -- Docker Config considers quay.io and https://quay.io to be equivalent
+    -- for credentials. Remove URI scheme to ensure compatibility
+    authsWithoutUriScheme :: Map Text DockerConfigRawAuth
+    authsWithoutUriScheme = Map.mapKeys (withoutHttp . withoutHttps) auths
+
+    withoutHttp :: Text -> Text
+    withoutHttp = Text.replace "http://" ""
+
+    withoutHttps :: Text -> Text
+    withoutHttps = Text.replace "https://" ""
+
+
 -- | Uses Credentials from Credential Helpers and Config File.
 --
 -- Retrieves Docker Config File From:
 --  - Linux & macOs: $HOME/.docker/config.json
 --  - Windows: %USERPROFILE%/.docker/config.json
 --
--- Identifies credential store, and uses credential store, to
--- retrieve server's credentials.
+-- Identifies credential store, and uses credential store, or raw base64 encoded
+-- auth values for server's credentials.
 useCredentialFromConfig ::
   ( Has ReadFS sig m
   , Has Exec sig m
@@ -82,7 +121,12 @@ useCredentialFromConfig (RegistryImageSource host scheme _ repo repoRef arch) = 
   dockerConfig <- readContentsJson configFile
 
   let credStore = getCredentialStore host dockerConfig
-  (user, pass) <- getCredential host credStore
+  let rawCred = getRawCred host dockerConfig
+
+  (user, pass) <- case (rawCred, credStore) of
+    (_, Just credStore') -> getCredential host credStore'
+    (Just (user', pass'), _) -> pure (user', pass')
+    (Nothing, Nothing) -> fatalText ("could not retrieve credential from" <> toText configFile)
 
   pure $
     RegistryImageSource

--- a/test/Container/Docker/CredentialsSpec.hs
+++ b/test/Container/Docker/CredentialsSpec.hs
@@ -70,7 +70,7 @@ spec = do
         Just config -> config `shouldBe` expectedDockerConfigRawAuth
 
     it "should should decode raw authentication values" $ do
-      getRawCred "gcr.io" expectedDockerConfigRawAuth `shouldBe` Just ("someUser", "somePass")
+      getRawCred "gcr.io" expectedDockerConfigRawAuth `shouldBe` Right ("someUser", "somePass")
 
     it "should parse docker credential helper's response" $ do
       case decodeStrict dockerCredHelperResponse of

--- a/test/Container/Docker/CredentialsSpec.hs
+++ b/test/Container/Docker/CredentialsSpec.hs
@@ -4,10 +4,13 @@ module Container.Docker.CredentialsSpec (spec) where
 
 import Container.Docker.Credentials (
   DockerConfig (..),
+  DockerConfigRawAuth (..),
   DockerCredentialHelperGetResponse (..),
+  getRawCred,
  )
 import Data.Aeson (decodeStrict)
 import Data.ByteString (ByteString)
+import Data.Map qualified as Map
 import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe)
 import Text.RawString.QQ (r)
 
@@ -22,16 +25,52 @@ dockerConfig =
   }
 }|]
 
+dockerConfigRawAuth :: ByteString
+dockerConfigRawAuth =
+  [r|{
+  "auths": {
+    "gcr.io": {
+      "auth": "c29tZVVzZXI6c29tZVBhc3M="
+    }
+  }
+}|]
+
+expectedDockerConfigRawAuth :: DockerConfig
+expectedDockerConfigRawAuth =
+  DockerConfig
+    Nothing
+    ( Map.fromList
+        [ ("gcr.io", DockerConfigRawAuth (Just "c29tZVVzZXI6c29tZVBhc3M="))
+        ]
+    )
+    mempty
+
 dockerCredHelperResponse :: ByteString
 dockerCredHelperResponse = [r|{"ServerURL":"index.docker.io","Username":"user","Secret":"ohno!"}|]
 
 spec :: Spec
 spec = do
   describe "Docker Credentials" $ do
-    it "should parse docker config file" $
+    it "should parse docker config file" $ do
       case decodeStrict dockerConfig of
         Nothing -> expectationFailure "Failed to parse docker config"
-        Just config -> config `shouldBe` DockerConfig "desktop" mempty
+        Just config ->
+          config
+            `shouldBe` DockerConfig
+              (Just "desktop")
+              ( Map.fromList
+                  [ ("quay.io", DockerConfigRawAuth Nothing)
+                  , ("https://index.docker.io/v1/", DockerConfigRawAuth Nothing)
+                  ]
+              )
+              mempty
+
+      case decodeStrict dockerConfigRawAuth of
+        Nothing -> expectationFailure "Failed to parse docker config"
+        Just config -> config `shouldBe` expectedDockerConfigRawAuth
+
+    it "should should decode raw authentication values" $ do
+      getRawCred "gcr.io" expectedDockerConfigRawAuth `shouldBe` Just ("someUser", "somePass")
 
     it "should parse docker credential helper's response" $ do
       case decodeStrict dockerCredHelperResponse of


### PR DESCRIPTION
# Overview

This PR supports raw authentication value from Docker's Config file 

## Acceptance criteria

- fossa container analyze works when, docker config with raw authentication is provided

## Testing plan

I added automated test.

I followed the steps from https://cloud.google.com/container-registry/docs/advanced-authentication#json-key

```bash
docker tag redis:alpine gcr.io/plated-observer-366802/redis:tag1
docker push gcr.io/plated-observer-366802/redis:tag1
fossa-dev container analyze gcr.io/plated-observer-366802/redis:tag1 -o
```

Please message me, I can provide you with my Docker config file to replicate this test.

```json
"auths": {
		"gcr.io": {
			"auth": "...."
		},
		"https://index.docker.io/v1/": {},
		"quay.io": {}
	},
	"currentContext": "default"
}                               
```

## Risks

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
