### PR TITLE
Use ISO timestamp for revision fallback

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Uses an ISO timestamp for the revision if no better revision can be inferred [#1091](https://github.com/fossas/fossa-cli/pull/1091).
+
 ## v3.6.0
 
 - Promote C/C++ features to general availability [#1087](https://github.com/fossas/fossa-cli/pull/1087).

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,21 +2,21 @@
 
 ## Unreleased
 
-- Uses an ISO timestamp for the revision if no better revision can be inferred [#1091](https://github.com/fossas/fossa-cli/pull/1091).
+- Uses an ISO timestamp for the revision if no better revision can be inferred ([#1091](https://github.com/fossas/fossa-cli/pull/1091)).
 
 ## v3.6.0
 
-- Promote C/C++ features to general availability [#1087](https://github.com/fossas/fossa-cli/pull/1087).
+- Promote C/C++ features to general availability ([#1087](https://github.com/fossas/fossa-cli/pull/1087)).
   - `--experimental-enable-vsi` is now `--detect-vendored`.
   - `--experimental-analyze-dynamic-deps` is now `--detect-dynamic`.
 
 ## v3.5.3
 
-- Manual Dependencies: Linux Dependencies (`rpm-generic`, `apk`, `deb`) can be provided as reference dependency in fossa-deps file [#1086](https://github.com/fossas/fossa-cli/pull/1086).
+- Manual Dependencies: Linux Dependencies (`rpm-generic`, `apk`, `deb`) can be provided as reference dependency in fossa-deps file ([#1086](https://github.com/fossas/fossa-cli/pull/1086)).
 
 ## v3.5.2
 
-- Container Scanning: Fixes an issue with base64 encoded raw authentications [#1085](https://github.com/fossas/fossa-cli/pull/1085).
+- Container Scanning: Fixes an issue with base64 encoded raw authentications ([#1085](https://github.com/fossas/fossa-cli/pull/1085)).
 
 ## v3.5.1
 

--- a/docs/features/manual-dependencies.md
+++ b/docs/features/manual-dependencies.md
@@ -31,7 +31,7 @@ Supported dependency types:
 - `carthage` - Dependencies as specified by the [Carthage](https://github.com/Carthage/Carthage) package manager.
 - `composer` - Dependencies specified by the PHP package manager [Composer](https://getcomposer.org/), which are located on [Packagist](https://packagist.org/).
 - `cpan` - Dependencies located on the [CPAN package manager](https://www.cpan.org/).
-- `cran` - Dependencies located on the [CRAN](https://www.cran.org/) like repository.
+- `cran` - Dependencies located on the [CRAN](https://cran.r-project.org/) like repository.
 - `gem` - Dependencies which can be found at [RubyGems.org](https://rubygems.org/).
 - `git` - Github projects (which appear as dependencies in many package managers). Specified as the full github repository `https://github.com/fossas/fossa-cli`.
 - `go` - Go specific dependency. Many Go dependencies are located on Github, but there are some which look like the following `go.mongodb.org/mongo-driver` that have custom Go URLs.

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -70,7 +70,7 @@ inferProjectDefault dir = context "Inferring project from directory name / times
   time <- iso8601Show <$> getCurrentTime
 
   let stamp = Text.takeWhile (/= '.') $ toText time -- trim milliseconds off, format is yyyy-mm-ddThh:mm:ss[.sss]
-  pure (InferredProject (toText name) stamp Nothing)
+  pure (InferredProject (toText name) (stamp <> "Z") Nothing)
 
 svnCommand :: Command
 svnCommand =

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -29,7 +29,8 @@ import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.IO qualified as TIO
-import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Time.Clock.POSIX (getCurrentTime)
+import Data.Time.Format.ISO8601 (iso8601Show)
 import Effect.Exec
 import Effect.Logger
 import Effect.ReadFS
@@ -66,9 +67,8 @@ inferProjectCached dir = do
 inferProjectDefault :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path b Dir -> m InferredProject
 inferProjectDefault dir = context "Inferring project from directory name / timestamp" . sendIO $ do
   let name = FP.dropTrailingPathSeparator (fromRelDir (dirname dir))
-  time <- floor <$> getPOSIXTime :: IO Int
-
-  pure (InferredProject (toText name) (toText (show time)) Nothing)
+  time <- iso8601Show <$> getCurrentTime
+  pure (InferredProject (toText name) (toText time) Nothing)
 
 svnCommand :: Command
 svnCommand =

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -68,7 +68,9 @@ inferProjectDefault :: (Has (Lift IO) sig m, Has Diagnostics sig m) => Path b Di
 inferProjectDefault dir = context "Inferring project from directory name / timestamp" . sendIO $ do
   let name = FP.dropTrailingPathSeparator (fromRelDir (dirname dir))
   time <- iso8601Show <$> getCurrentTime
-  pure (InferredProject (toText name) (toText time) Nothing)
+
+  let stamp = Text.takeWhile (/= '.') $ toText time -- trim milliseconds off, format is yyyy-mm-ddThh:mm:ss[.sss]
+  pure (InferredProject (toText name) stamp Nothing)
 
 svnCommand :: Command
 svnCommand =


### PR DESCRIPTION
# Overview

We generate the revision for a project automatically, eventually falling back to the current timestamp.
Currently that timestamp is just a unix string. @rolodato suggested that this should be an ISO timestamp instead to make it more clear to users.

I thought this was super simple and a good idea so I just threw it in, but if anyone has a major issue with it happy to just close the PR.

This change isn't tested because I think we don't really have tests for this and adding it into tests would be more time investment than I think this change warrants. If you disagree though, let me know!

## Acceptance criteria

The final fallback for `--revision` is an ISO8601 timestamp instead of a unix epoch timestamp.

## Testing plan

I created a project with no `.git`:
```shell
; pwd
/Users/jessica/projects/scratch/tiny
; ls -al
total 24
drwxr-xr-x   7 jessica  staff   224 Nov  4 16:56 .
drwxr-xr-x  48 jessica  staff  1536 Oct 31 15:47 ..
-rw-r--r--   1 jessica  staff     8 Mar 16  2022 .gitignore
-rw-r--r--   1 jessica  staff   378 Mar 16  2022 Cargo.lock
-rw-r--r--   1 jessica  staff   195 Mar 16  2022 Cargo.toml
drwxr-xr-x   3 jessica  staff    96 Mar 16  2022 src
drwxr-xr-x@  5 jessica  staff   160 Aug 22 13:29 target
```

I then ran the scan:
```shell
; cabal run fossa -- analyze ~/projects/scratch/tiny
# ...
[ INFO] ------------
[ INFO]
[ INFO] Using project name: `tiny`
[ INFO] Using revision: `2022-11-04T23:57:26.932386Z`
[ INFO] Using branch: `No branch (detached HEAD)`
# ...
```

And checked the UI:
<img width="1840" alt="Screenshot 2022-11-04 at 5 02 58 PM" src="https://user-images.githubusercontent.com/55713231/200091182-7423e107-9347-449a-b23b-8108e598a6fc.png">

## Risks

Does not seem risky.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
