### PR TITLE
Don't automatically promote deep deps to being direct

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.6.2
+
+- Don't promote transitive dependencies  [#1092](https://github.com/fossas/fossa-cli/pull/1092).
+
 ## v3.6.1
 
 - Container Scanning: Fixes a bug where image source parser ignored '-' in host. Also fixes an issue regarding to redirect headers when communicating with registry. [#1089](https://github.com/fossas/fossa-cli/pull/1089) 

--- a/docs/references/strategies/languages/maven/maven.md
+++ b/docs/references/strategies/languages/maven/maven.md
@@ -14,6 +14,17 @@ Maven analysis attempts these analysis methods in order:
 3. Run the maven plugin command version 3.3.0.
 4. Scan `pom.xml` files located in the file tree.
 
+## FAQ
+### One of my transitive dependencies does not have path information
+The mavenplugin and treecmd tactic can result in transitive dependencies which do not display paths to parents. This example graph shows how that can happen:
+```
++- com.amazonaws:aws-java-sdk-kms:1.11.415:compile
+|  +- com.amazonaws:aws-java-sdk-core:1.11.415:compile
+\- com.jayway.restassured:rest-assured:2.9.0:test
+   +- org.apache.httpcomponents:httpclient:4.5.1:compile   👈
+```
+`httpclient` will appear as a transitive dependency in the FOSSA UI, but it will not have any paths. There are a few things that contribute to this happening. `httpclient`'s only listed parent is `restassured` which is a `test` dependency, however, `httpclient` is a `compile`. This tells us that `httpclient` has another parent in the graph, but we are unable to determine where.
+
 <!--
 
 TODO: write docs, like Gradle's.

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -139,8 +139,7 @@ shrink f = Graphing . AME.shrink f' . unGraphing
     f' Root = True
     f' (Node a) = f a
 
--- | Unlike @shrink@ when root vertices are deleted, their successor are not promoted as direct
--- if they have any predecessors.
+-- | Unlike @shrink@ when root vertices are deleted, their successor are not promoted as direct.
 --
 --  Example:
 --

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -163,9 +163,9 @@ shrinkWithoutPromotionToDirect f gr = foldl' withoutEdgeToRoot shrunkGraph jumpe
     jumpedDirects :: [a]
     jumpedDirects =
       Set.toList $
-          Set.difference
-            (Set.fromList . directList $ shrunkGraph)
-            (Set.fromList . directList $ gr)
+        Set.difference
+          (Set.fromList . directList $ shrunkGraph)
+          (Set.fromList . directList $ gr)
 
     withoutEdgeToRoot :: Graphing a -> a -> Graphing a
     withoutEdgeToRoot g n = Graphing . AM.removeEdge Root (Node n) $ unGraphing g

--- a/src/Graphing.hs
+++ b/src/Graphing.hs
@@ -151,27 +151,26 @@ shrink f = Graphing . AME.shrink f' . unGraphing
 --    \
 --     8
 --
---  When node (3) is shrinked, 8 will be promoted to direct, and 4 will be not be promoted as direct.
+--  When node (3) is shrunk, neither 4 or 8 will be not be promoted as direct.
 shrinkWithoutPromotionToDirect :: forall a. Ord a => (a -> Bool) -> Graphing a -> Graphing a
-shrinkWithoutPromotionToDirect f gr = foldl' withoutEdgeToRoot shrinkedGraph jumpedDirects
+shrinkWithoutPromotionToDirect f gr = foldl' withoutEdgeToRoot shrunkGraph jumpedDirects
   where
-    shrinkedGraph :: Graphing a
-    shrinkedGraph = shrink f gr
+    shrunkGraph :: Graphing a
+    shrunkGraph = shrink f gr
 
     -- Identify direct nodes after shrinking the graph on predicate,
     -- that were not part of direct nodes previously and have predecessors.
     jumpedDirects :: [a]
     jumpedDirects =
       Set.toList $
-        Set.filter (hasPredecessors shrinkedGraph) $
           Set.difference
-            (Set.fromList . directList $ shrinkedGraph)
+            (Set.fromList . directList $ shrunkGraph)
             (Set.fromList . directList $ gr)
 
     withoutEdgeToRoot :: Graphing a -> a -> Graphing a
     withoutEdgeToRoot g n = Graphing . AM.removeEdge Root (Node n) $ unGraphing g
 
--- | Delete a vertex in a Grahing, preserving the overall structure by rewiring edges through the delted vertex.
+-- | Delete a vertex in a Graphing, preserving the overall structure by rewiring edges through the deleted vertex.
 --
 -- For example, given the graph @1 -> 2 -> 3 -> 4@ and applying @shrinkSingle 3@, we return the graph
 -- @1 -> 2 -> 4@

--- a/test/GraphingSpec.hs
+++ b/test/GraphingSpec.hs
@@ -202,7 +202,7 @@ shrinkingSpec = context "Shrinking" $ do
       expectDeps [1, 2, 4, 6, 7] graph'
       expectEdges [(1, 2), (2, 4), (2, 6), (2, 7)] graph'
 
-    it "should promote to direct, if and only if no predecessors exist" $ do
+    it "should not promote any deps to direct" $ do
       --   1 -> 2 -> 5 -> 6
       --        \       \
       --         \       7
@@ -216,7 +216,7 @@ shrinkingSpec = context "Shrinking" $ do
           graph' :: Graphing Int
           graph' = Graphing.shrinkWithoutPromotionToDirect (\x -> x /= 3 && x /= 5) graph
 
-      expectDirect [1, 8] graph'
+      expectDirect [1] graph'
       expectDeps [1, 2, 4, 6, 7, 8] graph'
       expectEdges [(1, 2), (2, 4), (2, 6), (2, 7)] graph'
 


### PR DESCRIPTION
# Overview

This PR is similar to this #8578 on FOSSA core. Currently, the following dependency graph is impossible. `itsdangerous` would be automatically promoted to being a direct dependency.
```
      "Imports": ["pip+pipenv$2018.11.26"],
      "Dependencies": [
        { "locator": "pip+itsdangerous$1.1.0" },
        { "locator": "pip+enum34$1.1.6" },
        { "locator": "pip+pipenv$2018.11.26", "imports": ["pip+enum34$1.1.6"] }
```

This can happen when a direct dependency is pruned from the graph for being out of scope (i.e. a test dep) and its immediate transitive dependencies are promoted to direct dependencies themselves. This PR removes that behavior and keeps the dependencies as transitive dependencies.

## Acceptance criteria

- Transitive dependencies are no longer promoted to direct if their parent is pruned.
- All existing strategies behave how we previously expected.

## Testing plan

1. Manually test this using an example pom file that demonstrates the behavior. Running `fossa analyze` in a directory with only the pom file below will test this logic. We should see that `httpclient` is **not** listed in the `Imports` array.
```
<?xml version="1.0" encoding="UTF-8"?>
<project
	xmlns="http://maven.apache.org/POM/4.0.0"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
	<modelVersion>4.0.0</modelVersion>
	<groupId>com.example</groupId>
	<artifactId>example</artifactId>
	<version>0.0.1-SNAPSHOT</version>
	<dependencies>
		<dependency>
			<groupId>com.amazonaws</groupId>
			<artifactId>aws-java-sdk-kms</artifactId>
			<version>1.11.415</version>
		</dependency>
		<dependency>
			<groupId>com.jayway.restassured</groupId>
			<artifactId>rest-assured</artifactId>
			<version>2.9.0</version>
			<scope>test</scope>
		</dependency>
	</dependencies>
</project>
```
2. Ensuring all of the integration tests pass, and the ones that do fail are failing for a good reason.

## Risks

We could break existing strategies that rely on this behavior for unknown and untested reasons. I think this is a fair trade-off if they are unknown and untested. I also don't believe that any analyzer's results should be reliant on generic pre-upload pruning to deliver correct results, this logic should live with that analyzer's graph building logic.

## References

[ANE-659](https://fossa.atlassian.net/browse/ANE-659)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`. - I need to add docs for Maven specifically
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
