### PR TITLE
fixes where ./ filepaths are provided for docker archive

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,12 @@
 # FOSSA CLI Changelog
 
+## v3.6.2
+
+- Container Scanning: Fixes a bug where tar entry were not normalized within nested layer tar. [#1095](https://github.com/fossas/fossa-cli/pull/1095)
+
 ## v3.6.1
 
-- Container Scanning: Fixes a bug where image source parser ignored '-' in host. Also fixes an issue regarding to redirect headers when communicating with registry. [#1089](https://github.com/fossas/fossa-cli/pull/1089) 
+- Container Scanning: Fixes a bug where image source parser ignored '-' in host. Also fixes an issue regarding to redirect headers when communicating with registry. [#1089](https://github.com/fossas/fossa-cli/pull/1089)
 
 ## v3.6.0
 

--- a/src/Container/Tarball.hs
+++ b/src/Container/Tarball.hs
@@ -43,6 +43,7 @@ import Data.Sequence qualified as Seq
 import Data.String.Conversion (ToText (toText), toString)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import System.FilePath.Posix (normalise)
 
 -- | Container of list of tar entries with their offset for random content read.
 data TarEntries = TarEntries
@@ -238,7 +239,7 @@ fileNameOf path = snd $ Text.breakOnEnd "/" path
 
 -- | Retrieves filepath from tar path.
 filePathOf :: TarPath -> FilePath
-filePathOf = fromTarPathToPosixPath
+filePathOf = normalise . fromTarPathToPosixPath
 
 -- | Removes whiteout prefix from the filepath. If no whiteout prefix is detected returns Nothing.
 --


### PR DESCRIPTION
# Overview

This PR, fixes an issue when a docker image with a non-normalized path is provided. For instance, within layer tarball, if the tar path of `./etc/os-release` was provided, previously this entry was not normalized.


## Acceptance criteria

- We can scan distroless images.

## Testing plan

AC Test:
```
fossa container analyze gcr.io/distroless/nodejs:16 -o 
```

Regression Test:
```
fossa container analyze redis:latest -o
```

## Risks

N/A

## References

https://github.com/fossas/fossa-cli/issues/1093

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
