### PR TITLE
Fix `--detect-vendored` on Windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## v3.6.4
 
-- Fixes `--detect-vendored` on Windows. ([#1096](https://github.com/fossas/fossa-cli/pull/1096))
+- C/C++: Fixes `--detect-vendored` on Windows. ([#1096](https://github.com/fossas/fossa-cli/pull/1096))
 - Uses an ISO timestamp for the revision if no better revision can be inferred ([#1091](https://github.com/fossas/fossa-cli/pull/1091)).
 
 ## v3.6.3

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## v3.6.4
 
+- Fixes `--detect-vendored` on Windows. ([#1096](https://github.com/fossas/fossa-cli/pull/1096))
 - Uses an ISO timestamp for the revision if no better revision can be inferred ([#1091](https://github.com/fossas/fossa-cli/pull/1091)).
 
 ## v3.6.3

--- a/docs/references/strategies/README.md
+++ b/docs/references/strategies/README.md
@@ -19,6 +19,14 @@
 
 - [leiningen](languages/clojure/leiningen.md)
 
+### C/C++
+
+- [C](languages/c-cpp/c-cpp.md)
+- [C++](languages/c-cpp/c-cpp.md)
+
+In order to use these strategies special options must be provided to the CLI.
+See the linked documentation above for details.
+
 ### dart
 
 - [pub](languages/dart/pub.md)
@@ -118,31 +126,33 @@ It is important to note that neither type of strategy has an inherent benefit wh
 
 > If the FOSSA CLI is forced to utilize a fallback strategy, meaning it did not detect ideal results, a warning is emitted in the scan summary after running `fossa analyze`.
 
-| Language/Package Manager                                                                                                                        | Dynamic | Static | Primary Strategy |
-| ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------ | ---------------- |
-| [C#](https://github.com/fossas/fossa-cli/tree/master/docs/references/strategies/languages/dotnet)                                               | ✅       | ✅      | Dynamic          |
-| [Clojure (leiningen)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/clojure/clojure.md)                  | ✅       | ❌      | Dynamic          |
-| [Dart (pub)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/dart/dart.md)                                 | ✅       | ✅      | Dynamic          |
-| [Elixer (mix)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/elixir/elixir.md)                           | ✅       | ❌      | Dynamic          |
-| [Erlang (rebar3)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/erlang/erlang.md)                        | ✅       | ❌      | Dynamic          |
-| [Fortran](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/fortran/fortran.md)                              | ❌       | ✅      | Static           |
-| [Go (dep)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/godep.md)                                | ❌       | ✅      | Static           |
-| [Go (glide)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/glide.md)                              | ❌       | ✅      | Static           |
-| [Go (gomodules)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/gomodules.md)                      | ✅       | ✅      | Dynamic          |
-| [Gradle](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/gradle/gradle.md)                                 | ✅       | ❌      | Dynamic          |
-| [Haskell (cabal)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/haskell/cabal.md)                        | ✅       | ❌      | Dynamic          |
-| [Haskell (stack)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/haskell/stack.md)                        | ✅       | ❌      | Dynamic          |
-| [iOS (carthage)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/platforms/ios/carthage.md)                          | ❌       | ✅      | Static           |
-| [iOS (cocoapods)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/platforms/ios/cocoapods.md)                        | ❌       | ✅      | Static           |
-| [Maven](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/maven/maven.md)                                    | ✅       | ✅      | Dynamic          |
-| [NodeJS (NPM/Yarn/pnpm)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/nodejs/nodejs.md)                 | ❌       | ✅      | Static           |
-| [Perl](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/perl/perl.md)                                       | ❌       | ✅      | Static           |
-| [PHP (Composer)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/php/composer.md)                          | ❌       | ✅      | Static           |
-| [Python (Conda)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/conda.md)                          | ✅       | ✅      | Dynamic          |
-| [Python (Pipenv)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/pipenv.md)                        | ✅       | ✅      | Dynamic          |
-| [Python (Poetry)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/poetry.md)                        | ❌       | ✅      | Static           |
-| [Python (setup.py/requirements.txt)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/setuptools.md) | ❌       | ✅      | Static           |
-| [R (renv)](./languages/r/renv.md)                                                                                                               | ❌       | ✅      | Static           |
-| [Ruby (bundler)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/ruby/ruby.md)                             | ✅       | ✅      | Static           |
-| [Rust (cargo)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/rust/rust.md)                               | ✅       | ❌      | Dynamic          |
-| [Scala (sbt)](https://github.com/fossas/fossa-cli/tree/master/docs/references/strategies/languages/scala)                                       | ✅       | ✅      | Dynamic          |
+| Language/Package Manager                                                                                                                        | Dynamic | Static | Detect Vendored Code | Primary Strategy |
+|-------------------------------------------------------------------------------------------------------------------------------------------------|---------|--------|----------------------|------------------|
+| [C#](https://github.com/fossas/fossa-cli/tree/master/docs/references/strategies/languages/dotnet)                                               | ✅       | ✅      | ❌                    | Dynamic          |
+| [C](https://github.com/fossas/fossa-cli/tree/master/docs/references/strategies/languages/c-cpp/c-cpp.md)                                        | ✅       | ✅      | ✅                    | None             |
+| [C++](https://github.com/fossas/fossa-cli/tree/master/docs/references/strategies/languages/c-cpp/c-cpp.md)                                      | ✅       | ✅      | ✅                    | None             |
+| [Clojure (leiningen)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/clojure/clojure.md)                  | ✅       | ❌      | ❌                    | Dynamic          |
+| [Dart (pub)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/dart/dart.md)                                 | ✅       | ✅      | ❌                    | Dynamic          |
+| [Elixer (mix)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/elixir/elixir.md)                           | ✅       | ❌      | ❌                    | Dynamic          |
+| [Erlang (rebar3)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/erlang/erlang.md)                        | ✅       | ❌      | ❌                    | Dynamic          |
+| [Fortran](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/fortran/fortran.md)                              | ❌       | ✅      | ❌                    | Static           |
+| [Go (dep)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/godep.md)                                | ❌       | ✅      | ❌                    | Static           |
+| [Go (glide)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/glide.md)                              | ❌       | ✅      | ❌                    | Static           |
+| [Go (gomodules)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/golang/gomodules.md)                      | ✅       | ✅      | ❌                    | Dynamic          |
+| [Gradle](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/gradle/gradle.md)                                 | ✅       | ❌      | ❌                    | Dynamic          |
+| [Haskell (cabal)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/haskell/cabal.md)                        | ✅       | ❌      | ❌                    | Dynamic          |
+| [Haskell (stack)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/haskell/stack.md)                        | ✅       | ❌      | ❌                    | Dynamic          |
+| [iOS (carthage)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/platforms/ios/carthage.md)                          | ❌       | ✅      | ❌                    | Static           |
+| [iOS (cocoapods)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/platforms/ios/cocoapods.md)                        | ❌       | ✅      | ❌                    | Static           |
+| [Maven](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/maven/maven.md)                                    | ✅       | ✅      | ❌                    | Dynamic          |
+| [NodeJS (NPM/Yarn/pnpm)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/nodejs/nodejs.md)                 | ❌       | ✅      | ❌                    | Static           |
+| [Perl](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/perl/perl.md)                                       | ❌       | ✅      | ❌                    | Static           |
+| [PHP (Composer)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/php/composer.md)                          | ❌       | ✅      | ❌                    | Static           |
+| [Python (Conda)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/conda.md)                          | ✅       | ✅      | ❌                    | Dynamic          |
+| [Python (Pipenv)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/pipenv.md)                        | ✅       | ✅      | ❌                    | Dynamic          |
+| [Python (Poetry)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/poetry.md)                        | ❌       | ✅      | ❌                    | Static           |
+| [Python (setup.py/requirements.txt)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/python/setuptools.md) | ❌       | ✅      | ❌                    | Static           |
+| [R (renv)](./languages/r/renv.md)                                                                                                               | ❌       | ✅      | ❌                    | Static           |
+| [Ruby (bundler)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/ruby/ruby.md)                             | ✅       | ✅      | ❌                    | Static           |
+| [Rust (cargo)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/rust/rust.md)                               | ✅       | ❌      | ❌                    | Dynamic          |
+| [Scala (sbt)](https://github.com/fossas/fossa-cli/tree/master/docs/references/strategies/languages/scala)                                       | ✅       | ✅      | ❌                    | Dynamic          |

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -151,8 +151,7 @@ import Network.HTTP.Req (
 import Network.HTTP.Req.Extra (httpConfigRetryTimeouts)
 import Network.HTTP.Types qualified as HTTP
 import Parse.XML (FromXML (..), child, parseXML, xmlErrorPretty)
-import Path (File, Path, Rel)
-import Path qualified
+import Path (File, Path, Rel, toFilePath)
 import Srclib.Types (
   LicenseSourceUnit,
   Locator (..),
@@ -1166,8 +1165,8 @@ vsiAddFilesToScan apiOpts scanID files = fossaReq $ do
     normalizeFile (path, fp) = (normalizePath path, fp)
 
     normalizePath :: Path Rel File -> FilePath
-    normalizePath input | pathSeparator == '/' = Path.toFilePath input
-    normalizePath input = toString . Text.intercalate "/" $ toText <$> splitDirectories (Path.toFilePath input)
+    normalizePath input | pathSeparator == '/' = toFilePath input
+    normalizePath input = toString . Text.intercalate "/" $ toText <$> splitDirectories (toFilePath input)
 
 -- | The 'vsiCompleteScanFilePath' is an absolute path denoting what portion of the scan should be considered complete.
 -- In this path structure, '/' means "the root of the scan".

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -1159,7 +1159,7 @@ vsiAddFilesToScan apiOpts scanID files = fossaReq $ do
   pure ()
   where
     normalizeFiles :: [(Path Rel File, Fingerprint.Combined)] -> [(FilePath, Fingerprint.Combined)]
-    normalizeFiles = fmap normalizeFile
+    normalizeFiles = map normalizeFile
 
     normalizeFile :: (Path Rel File, Fingerprint.Combined) -> (FilePath, Fingerprint.Combined)
     normalizeFile (path, fp) = (normalizePath path, fp)


### PR DESCRIPTION
# Overview

Fixes VSI scans for windows

## Acceptance criteria

VSI scans work when running on windows.
We don't currently have a great story for integration testing this - I plan to test this with my personal windows PC and list the results before and after here to prove this works.

Longer term integration testing is handled more cleanly with the `foundation-libs` powered VSI client, but this is intended to be a quicker fix than integrating that. Since integration testing is handled more cleanly on that repo I plan to focus my efforts on integrating that instead of implementing integration testing in this repo.

## Testing plan

First, I validated that the results still work on non-windows:
```
; cabal run fossa -- analyze --detect-vendored -p pre-windows-test ~/projects/cpp-vsi-demo
```
<img width="1280" alt="Screenshot 2022-11-09 at 4 52 25 PM" src="https://user-images.githubusercontent.com/55713231/200973649-ce5fecfc-fa73-4450-9b9b-1f6eea720076.png">
(Note: the `libssh2` is because of my local working state; that's not in the standard `cpp-vsi-demo`)

I tested the artifact built for this PR in Windows, which led to a successful scan:
<img width="1280" alt="Screenshot 2022-11-10 at 3 30 40 PM" src="https://user-images.githubusercontent.com/55713231/201227661-45caa0ce-29c1-4a65-9443-3cf2674c2b17.png">
([Scan link in org jessoteric](https://app.fossa.com/projects/custom%2B24357%2Ffrom-windows-vsi-1096/refs/branch/master/1668122842/browse/dependencies))

I validated with the currently published version of the CLI (v3.6.3) that the scan failed on my Windows machine.

## Risks

Not really risky.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
