### PR TITLE
[Oncall] Gradle: Ignore dependencies from `debugUnitTest*` configurations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.6.3
+
+Gradle: Considers dependencies from `debugUnitTest*` configurations to be unused. ([#1097](https://github.com/fossas/fossa-cli/pull/1097))
+
 ## v3.6.2
 
 - Container Scanning: Fixes a bug where tar entry were not normalized within nested layer tar. [#1095](https://github.com/fossas/fossa-cli/pull/1095)

--- a/docs/references/strategies/languages/gradle/gradle.md
+++ b/docs/references/strategies/languages/gradle/gradle.md
@@ -225,16 +225,12 @@ Any dependencies with following prefixes:
 - androidTest
 - debugAndroidTest
 - releaseUnitTest
+- debugUnitTest
 
 And any configuration named:
 - androidJacocoAnt
 - testApiDependenciesMetadata
 - testCompileOnlyDependenciesMetadata
-- debugUnitTestApiDependenciesMetadata
-- debugUnitTestCompileOnlyDependenciesMetadata
-- debugUnitTestImplementationDependenciesMetadata
-- debugUnitTestIntransitiveDependenciesMetadata
-- debugUnitTestRuntimeOnlyDependenciesMetadata
 - testDebugApiDependenciesMetadata
 - testDebugCompileOnlyDependenciesMetadata
 - testDebugImplementationDependenciesMetadata
@@ -248,8 +244,6 @@ And any configuration named:
 - testReleaseIntransitiveDependenciesMetadata
 - testReleaseRuntimeOnlyDependenciesMetadata
 - testRuntimeOnlyDependenciesMetadata
-- debugUnitTestAnnotationProcessorClasspath
-
 ```
 
 We classify following configurations, and dependencies originating from it as a development (or debug) environment dependency:

--- a/src/Strategy/Android/Util.hs
+++ b/src/Strategy/Android/Util.hs
@@ -71,7 +71,7 @@ isDefaultAndroidDevConfig config = config `elem` androidDefaultConfigs
 
 isDefaultAndroidTestConfig :: Text -> Bool
 isDefaultAndroidTestConfig config =
-  any (config `isPrefixedBy`) ["androidTest", "debugAndroidTest", "releaseUnitTest"]
+  any (config `isPrefixedBy`) ["androidTest", "debugAndroidTest", "releaseUnitTest", "debugUnitTest"]
     || (config `elem` androidDefaultConfigs)
   where
     isPrefixedBy :: Text -> Text -> Bool
@@ -83,11 +83,6 @@ isDefaultAndroidTestConfig config =
       , -- Metadata for test dependencies
         "testApiDependenciesMetadata"
       , "testCompileOnlyDependenciesMetadata"
-      , "debugUnitTestApiDependenciesMetadata"
-      , "debugUnitTestCompileOnlyDependenciesMetadata"
-      , "debugUnitTestImplementationDependenciesMetadata"
-      , "debugUnitTestIntransitiveDependenciesMetadata"
-      , "debugUnitTestRuntimeOnlyDependenciesMetadata"
       , -- For 'testDebug' sources
         "testDebugApiDependenciesMetadata"
       , "testDebugCompileOnlyDependenciesMetadata"
@@ -104,6 +99,4 @@ isDefaultAndroidTestConfig config =
       , "testReleaseIntransitiveDependenciesMetadata"
       , "testReleaseRuntimeOnlyDependenciesMetadata"
       , "testRuntimeOnlyDependenciesMetadata"
-      , -- Misc
-        "debugUnitTestAnnotationProcessorClasspath"
       ]

--- a/test/Android/UtilSpec.hs
+++ b/test/Android/UtilSpec.hs
@@ -22,6 +22,9 @@ defaultAndroidTestConfigs =
   , "androidTestApiDependenciesMetadata"
   , "debugAndroidTestImplementationDependenciesMetadata"
   , "releaseUnitTestImplementationDependenciesMetadata"
+  , "debugUnitTestAnnotationProcessorClasspath"
+  , "debugUnitTestCompileClasspath"
+  , "debugUnitTestRuntimeClasspath"
   ]
 
 defaultNonDevAndTestConfigs :: [Text]


### PR DESCRIPTION
# Overview

This PR:
- ignores dependencies from `debugUnitTest*` configuration

## Acceptance criteria

- CLI by default ignores dependencies from `debugUnitTest*` configuration

## Testing plan

Create a new test Android project. I did this using Android Studio. 

Add following dependencies in `app/build.groovy`
```groovy
    implementation 'androidx.appcompat:appcompat:1.5.1'
    implementation 'com.google.android.material:material:1.6.1'
    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
    implementation 'androidx.navigation:navigation-fragment:2.5.2'
    implementation 'androidx.navigation:navigation-ui:2.5.2'
    testImplementation 'junit:junit:4.13.2'
    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
```

Perform `fossa analyze -o | jq`, and confirm that `junit` dependency is not included as direct.

## Risks

N/A

## References

Slack: https://teamfossa.slack.com/archives/CJBPV3Z0E/p1668093515200229

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
