### PR TITLE
Expands instances of Simple and Finally

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -85,7 +85,7 @@ common deps
     , file-embed                   ^>=0.0.11
     , filepath                     ^>=1.4.2.1
     , filepattern                  ^>=0.1.2
-    , fused-effects                ^>=1.1.0.0
+    , fused-effects                ^>=1.1.2.0
     , fused-effects-exceptions     ^>=1.1.0.0
     , git-config                   ^>=0.1.2
     , githash                      ^>=0.1.4.0
@@ -124,6 +124,7 @@ common deps
     , transformers
     , typed-process                ^>=0.2.6
     , unix-compat                  ^>=0.6
+    , unliftio-core                ^>=0.2.0.1
     , unordered-containers         ^>=0.2.10
     , uuid                         ^>=1.3.15
     , vector                       ^>=0.13.0.0

--- a/src/Control/Carrier/Finally.hs
+++ b/src/Control/Carrier/Finally.hs
@@ -15,14 +15,13 @@ import Control.Carrier.Reader
 import Control.Effect.Exception (finally)
 import Control.Effect.Finally as X
 import Control.Effect.Lift
+import Control.Monad.Except (MonadError (..))
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Control.Monad.Trans (MonadTrans (..))
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.IORef
-import Prelude
-import Control.Monad.IO.Unlift (MonadUnliftIO)
-import Control.Monad.Except (MonadError (..))
 
 newtype FinallyC m a = FinallyC {runFinallyC :: ReaderC (IORef [FinallyC m ()]) m a}
   deriving (Functor, Applicative, Monad, MonadIO, MonadUnliftIO)

--- a/src/Control/Carrier/Finally.hs
+++ b/src/Control/Carrier/Finally.hs
@@ -20,9 +20,10 @@ import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.IORef
 import Prelude
+import Control.Monad.IO.Unlift (MonadUnliftIO)
 
 newtype FinallyC m a = FinallyC {runFinallyC :: ReaderC (IORef [FinallyC m ()]) m a}
-  deriving (Functor, Applicative, Monad, MonadIO)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadUnliftIO)
 
 runFinally :: Has (Lift IO) sig m => FinallyC m a -> m a
 runFinally (FinallyC go) = do

--- a/src/Control/Carrier/Finally.hs
+++ b/src/Control/Carrier/Finally.hs
@@ -16,14 +16,25 @@ import Control.Effect.Exception (finally)
 import Control.Effect.Finally as X
 import Control.Effect.Lift
 import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.IORef
 import Prelude
 import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Control.Monad.Except (MonadError (..))
 
 newtype FinallyC m a = FinallyC {runFinallyC :: ReaderC (IORef [FinallyC m ()]) m a}
   deriving (Functor, Applicative, Monad, MonadIO, MonadUnliftIO)
+
+instance MonadTrans (FinallyC) where
+  lift = FinallyC . lift
+
+instance MonadError e m => MonadError e (FinallyC m) where
+  throwError = lift . throwError
+  catchError action handler =
+    FinallyC . ReaderC $ \ref ->
+      catchError (runReader ref . runFinallyC $ action) (runReader ref . runFinallyC . handler)
 
 runFinally :: Has (Lift IO) sig m => FinallyC m a -> m a
 runFinally (FinallyC go) = do

--- a/src/Control/Carrier/Simple.hs
+++ b/src/Control/Carrier/Simple.hs
@@ -125,9 +125,9 @@ import Control.Algebra as X
 import Control.Applicative
 import Control.Carrier.Reader
 import Control.Carrier.State.Strict
-import Control.Monad.Trans
 import Control.Monad.Except (MonadError (..))
-import Conduit (MonadUnliftIO)
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Control.Monad.Trans
 
 ---------- The Simple effect
 
@@ -170,7 +170,7 @@ import Conduit (MonadUnliftIO)
 data Simple e m a where
   Simple :: e a -> Simple e m a
 
--- | Invoke an effect constructor
+-- | Invoke an effect constructor. Can be composed with constructors of one argument.
 sendSimple :: Has (Simple eff) sig m => eff a -> m a
 sendSimple = send . Simple
 

--- a/src/Control/Carrier/Simple.hs
+++ b/src/Control/Carrier/Simple.hs
@@ -174,11 +174,11 @@ data Simple e m a where
 sendSimple :: Has (Simple eff) sig m => eff a -> m a
 sendSimple = send . Simple
 
--- | Invoke an effect constructor
+-- | Invoke an effect constructor of two arguments
 sendSimple2 :: Has (Simple eff) sig m => (a -> b -> eff c) -> a -> b -> m c
 sendSimple2 constructor arg = send . Simple . constructor arg
 
--- | Invoke an effect constructor
+-- | Invoke an effect constructor of three arguments
 sendSimple3 :: Has (Simple eff) sig m => (a -> b -> c -> eff d) -> a -> b -> c -> m d
 sendSimple3 constructor arg1 arg2 = send . Simple . constructor arg1 arg2
 

--- a/src/Control/Carrier/Simple.hs
+++ b/src/Control/Carrier/Simple.hs
@@ -111,9 +111,11 @@
 -- @
 module Control.Carrier.Simple (
   Simple (..),
-  sendSimple,
   SimpleC (..),
   SimpleStateC,
+  sendSimple,
+  sendSimple2,
+  sendSimple3,
   interpret,
   interpretState,
   module X,
@@ -171,6 +173,14 @@ data Simple e m a where
 -- | Invoke an effect constructor
 sendSimple :: Has (Simple eff) sig m => eff a -> m a
 sendSimple = send . Simple
+
+-- | Invoke an effect constructor
+sendSimple2 :: Has (Simple eff) sig m => (a -> b -> eff c) -> a -> b -> m c
+sendSimple2 constructor arg = send . Simple . constructor arg
+
+-- | Invoke an effect constructor
+sendSimple3 :: Has (Simple eff) sig m => (a -> b -> c -> eff d) -> a -> b -> c -> m d
+sendSimple3 constructor arg1 arg2 = send . Simple . constructor arg1 arg2
 
 ---------- Direct interpretation
 


### PR DESCRIPTION
# Overview

We are moving Hubble over to use Fused Effects.  We needed to update `SimpleC` and `FinallyC` a little to accommodate this.  Those are the two general carriers we plan to utilize.

First, we need a few more instances.  Servant, our HTTP server framework, requires instances of `MonadError`.  Blammo/aeson-logger, our logging framework, needs instances of `MonadUnliftIO`.  These are simple enough to derive as they can both percolate up from a base monad.

Second, I added some small helpers to `Simple` to make writing `sendX` functions easier.  `sendSimple2` takes a constructor of two args. `sendSimple3` takes a constructor of three arguments.  They convert the constructor into a function within the context of the algebra instance monad.

I bumped the version of `fused-effects` because `MonadUnliftIO` instances were added to the stock effects in 1.1.2.0

## Acceptance criteria

`Simple` and `Finally` derive the needed instances without impacting the CLI in any negative way.

## Testing plan

These changes _should_ be simply additive.  I already have changes in Hubble that depend on these by pointing cabal at the specific commit.  All other spectrometer tests should continue to pass.

The instances themselves have very small and mechanical implementations.

## Risks

This is low risk as it should not change any existing code-paths.

## References

- [PLAT-438](https://fossa.atlassian.net/browse/PLAT-438): Make updates to the CLI carriers 

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
