### PR TITLE
Skip UPX on macOS

### DIFF
--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -34,10 +34,12 @@ mkdir -p vendor-bins
 ASSET_POSTFIX=""
 BASIS_ASSET_POSTFIX=""
 OS_WINDOWS=false
+OS_DARWIN=false
 case "$(uname -s)" in
   Darwin)
     ASSET_POSTFIX="darwin"
     BASIS_ASSET_POSTFIX="darwin-amd64"
+    OS_DARWIN=true
     ;;
 
   Linux)
@@ -119,7 +121,11 @@ chmod +x vendor-bins/*
 
 echo "Compressing binaries"
 xz vendor-bins/index.gob
+if [[ $OS_DARWIN ]]; then
+echo "Skipping UPX on macOS as it leads to segfaults on some versions of macOS when used"
+else
 find vendor-bins -type f -not -name '*.xz' | xargs upx || echo "WARN: 'upx' command not found, binaries will not be compressed"
+fi
 
 echo "Vendored binaries are ready for use"
 ls -lh vendor-bins/


### PR DESCRIPTION
# Overview

No longer compresses vendored binary plugins with UPX on macOS.
I ran into this issue on macOS Ventura, and we've previously seen this in other projects when running inside Docker containers on macOS.

It turns out that on macOS, UPX strips linking info:
```
; diff <(otool -L ./vendor-bins/themis-cli) <(otool -L ./themis-cli-upx)
1,4c1
< ./vendor-bins/themis-cli:
< 	/usr/lib/libSystem.B.dylib (compatibility version 0.0.0, current version 0.0.0)
< 	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 0.0.0, current version 0.0.0)
< 	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 0.0.0, current version 0.0.0)
---
> ./themis-cli-upx:
```

## Acceptance criteria

The built artifact from CI executes plugins correctly when running in macOS Ventura.

## Testing plan

I ran `vendor_bins.sh` on both `master` and this branch, and tested by running `./vendor-bins/themis-cli -h`.
On `master`, this fails with a segfault. On this branch, this works.

I will do the same after this branch builds in CI, but will extract `themis-cli` from `fossa` and test that directly.

## Risks

This increases the size of the binary for macOS builds.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
