### PR TITLE
Output footer with indication of more info

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,13 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Added breadcrumb to main help output indicating that subcommands have additional options. ([#1106](https://github.com/fossas/fossa-cli/pull/1106))
+
 ## v3.6.4
 
 - C/C++: Fixes `--detect-vendored` on Windows. ([#1096](https://github.com/fossas/fossa-cli/pull/1096))
-- Uses an ISO timestamp for the revision if no better revision can be inferred ([#1091](https://github.com/fossas/fossa-cli/pull/1091)).
+- Uses an ISO timestamp for the revision if no better revision can be inferred. ([#1091](https://github.com/fossas/fossa-cli/pull/1091))
 
 ## v3.6.3
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -25,6 +25,7 @@ import Options.Applicative (
   ParserPrefs,
   command,
   customExecParser,
+  footer,
   fullDesc,
   header,
   help,
@@ -58,7 +59,10 @@ versionOpt =
       [long "version", short 'V', help "show version information and exit"]
 
 progData :: InfoMod (IO ())
-progData = fullDesc <> header "fossa-cli - Flexible, performant dependency analysis"
+progData =
+  fullDesc
+    <> header "fossa-cli - Flexible, performant dependency analysis"
+    <> footer "Subcommands have additional options, run 'fossa COMMAND -h' for more details"
 
 subcommands :: Parser (IO ())
 subcommands = public <|> private


### PR DESCRIPTION
# Overview

Adds a breadcrumb in the footer of output for `fossa -h` indicating that each subcommand has additional options.

## Acceptance criteria

I ran `cabal run fossa -- -h` and observed that the footer is displayed.
I ran `cabal run fossa -- report -h` and observed the footer is not displayed.

## Testing plan

Same as AC.

## References

https://teamfossa.slack.com/archives/C0155DTGWB1/p1668616037650739

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
