### PR TITLE
Add documentation about how manual deps are cached

### DIFF
--- a/docs/features/manual-dependencies.md
+++ b/docs/features/manual-dependencies.md
@@ -156,15 +156,15 @@ remote-dependencies:
 
 ## Performance
 
-The FOSSA service caches the results of dependency analysis by different keys depending on the type of remote dependency specified (explained below).
-Due to this caching setup, it is normal for the first analysis to take some time, especially for larger projects, but future analysis of dependencies with the cache keys unchanged should be fast.
+The FOSSA service caches the results of dependency analysis depending on the type of remote dependency specified (explained below).
+Due to this caching setup, it is normal for the first analysis to take some time, especially for larger projects, but future analysis of dependencies with the same information should be fast.
 
 ### Referenced dependencies
 
-Most `referenced-dependencies` are cached by their `(type, name, version)` tuple.
+Most `referenced-dependencies` are cached by the combination of their `(type, name, version)` fields.
 If `version` is not provided, the system assumes the version is "latest", and caching is usually not applied.
 
-For dependency types that require `arch`, `os`, and `osVersion` attributes, these fields additionally form part of the cache tuple.
+For dependency types that require `arch`, `os`, and `osVersion` attributes, these fields are additionally considered for the cache.
 
 In the event caching is causing problems, FOSSA can be made to rebuild this kind of dependency: 
 Click the dependency in the UI and then click "Reanalyze".
@@ -176,7 +176,7 @@ This button enqueues a background job to rebuild the dependency, which should re
 
 ### Remote dependencies
 
-`remote-dependencies` are cached by their `(name, url, version)` tuple, which are all required fields.
+`remote-dependencies` are cached by their `(name, url, version)` fields, which are all required.
 
 In the event caching is causing problems, FOSSA can be made to rebuild this kind of dependency: 
 Click the dependency in the UI and then click "Reanalyze".

--- a/docs/features/manual-dependencies.md
+++ b/docs/features/manual-dependencies.md
@@ -153,3 +153,23 @@ remote-dependencies:
     description: Provides foo and a helpful interface around foo-like tasks.
     homepage: https://www.foowrapper-home.com
 ```
+
+## Performance
+
+The FOSSA service caches the results of dependency analysis by different keys depending on the type of remote dependency specified (explained below).
+Due to this caching setup, it is normal for the first analysis to take some time, especially for larger projects, but future analysis of dependencies with the cache keys unchanged should be fast.
+
+### Referenced dependencies
+
+Most `referenced-dependencies` are cached by their `(type, name, version)` tuple.
+If `version` is not provided, the system assumes the version is "latest", and caching is usually not applied.
+
+For dependency types that require `arch`, `os`, and `osVersion` attributes, these fields additionally form part of the cache tuple.
+
+### Custom dependencies
+
+`custom-dependencies` do not require analysis by the FOSSA backend and are therefore not cached.
+
+### Remote dependencies
+
+`remote-dependencies` are cached by their `(name, url, version)` tuple, which are all required fields.

--- a/docs/features/manual-dependencies.md
+++ b/docs/features/manual-dependencies.md
@@ -166,6 +166,10 @@ If `version` is not provided, the system assumes the version is "latest", and ca
 
 For dependency types that require `arch`, `os`, and `osVersion` attributes, these fields additionally form part of the cache tuple.
 
+In the event caching is causing problems, FOSSA can be made to rebuild this kind of dependency: 
+Click the dependency in the UI and then click "Reanalyze".
+This button enqueues a background job to rebuild the dependency, which should resolve after a few minutes.
+
 ### Custom dependencies
 
 `custom-dependencies` do not require analysis by the FOSSA backend and are therefore not cached.
@@ -173,3 +177,7 @@ For dependency types that require `arch`, `os`, and `osVersion` attributes, thes
 ### Remote dependencies
 
 `remote-dependencies` are cached by their `(name, url, version)` tuple, which are all required fields.
+
+In the event caching is causing problems, FOSSA can be made to rebuild this kind of dependency: 
+Click the dependency in the UI and then click "Reanalyze".
+This button enqueues a background job to rebuild the dependency, which should resolve after a few minutes.

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -118,13 +118,13 @@ A "CLI license scan" inspects your code for licensing on the local system within
 
 You can change the scan method by using the `--force-vendored-dependency-scan-method` flag when invoking the CLI, or by setting the `vendoredDependencies.scanMethod` field in your `.fossa.yml` file. See the [.fossa.yml documentation](https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md) for details.
 
-## Forcing rescans
+## Performance
 
-If you are scanning a revision that has already been scanned by FOSSA, then by default we will not rescan that dependency. A revision has been scanned by FOSSA if you or someone else from your organization has previously analyzed a dependency with the same name and version in the `vendored-dependencies` field in a `fossa-deps.yml` file.
+The FOSSA service caches the results of a vendored dependency by the combination of its `(name, version)` fields.
+Due to this caching setup, it is normal for the first analysis to take some time, especially for larger projects, but future analysis of dependencies with the same information should be fast.
 
-Avoiding rescans speeds up your CI scans and avoids unnecessary work.
+If `version` is not specified, FOSSA computes a version based on the contents specified by `path`; this means that if the contents have not changed then the results are reused.
 
-However, if you have made a change to your code and do not want to change the version provided, you can force a rescan by using the `--force-vendored-dependency-rescans` flag or setting the `vendoredDependencies.forceRescans` field to true in your `.fossa.yml` file.
-
-If you do not provide a version for the vendored dependency, then we generate a version by calculating an MD5 hash of the contents of the vendored dependency. Any changes to your code will be picked up as a new version and there is typically no need to force a rescan.
-
+In the event caching is causing problems, FOSSA can be made to rescan this kind of dependency: 
+- Run `fossa analyze` with the `--force-vendored-dependency-rescans` flag, or
+- Set `vendoredDependencies.forceRescans` to `true` in `.fossa.yml` at the root of the project.


### PR DESCRIPTION
# Overview

Include documentation about how manual dependencies are cached and on which config keys.

## Acceptance criteria

This is a docs only change. I believe these docs are accurate but would love a double check.

## Risks

If these docs are inaccurate users may be confused by the actual behavior we exhibit. Overall low risk.

## References

In response to ZD 4559.

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
