### PR TITLE
[ANE-591] deprecates `--json` to favor `--format json` for `fossa test` and `fossa container test`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,10 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## v3.6.5
 
-- Added breadcrumb to main help output indicating that subcommands have additional options. ([#1106](https://github.com/fossas/fossa-cli/pull/1106))
+- `fossa test`: deprecates `--json` flag in favor of `--format json` option. ([]())
+- `fossa container test`: deprecates `--json` flag in favor of `--format json` option. ([]())
+- UX: Added breadcrumb to main help output indicating that subcommands have additional options. ([#1106](https://github.com/fossas/fossa-cli/pull/1106))
 
 ## v3.6.4
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,8 @@
 
 ## v3.6.5
 
-- `fossa test`: deprecates `--json` flag in favor of `--format json` option. ([]())
-- `fossa container test`: deprecates `--json` flag in favor of `--format json` option. ([]())
+- `fossa test`: deprecates `--json` flag in favor of `--format json` option. ([#1109](https://github.com/fossas/fossa-cli/pull/1109))
+- `fossa container test`: deprecates `--json` flag in favor of `--format json` option. ([#1109](https://github.com/fossas/fossa-cli/pull/1109))
 - UX: Added breadcrumb to main help output indicating that subcommands have additional options. ([#1106](https://github.com/fossas/fossa-cli/pull/1106))
 
 ## v3.6.4

--- a/docs/references/subcommands/container.md
+++ b/docs/references/subcommands/container.md
@@ -56,6 +56,12 @@ For example:
 fossa container test redis:alpine
 ```
 
+To render results in JSON format: 
+
+```bash
+fossa container test redis:alpine --format json
+```
+
 ## Printing results without uploading to FOSSA
 
 The `--output` flag outputs dependency graph information to the terminal rather than uploading to FOSSA.

--- a/docs/references/subcommands/test.md
+++ b/docs/references/subcommands/test.md
@@ -23,7 +23,7 @@ Where `60` is the maximum number of seconds to wait for issue scan results.
 By default, `fossa test` displays issues in a human-readable format. To instead print issues as JSON, use:
 
 ```sh
-fossa test --json
+fossa test --format json
 ```
 
 ### Test for new issues compared to another revision

--- a/src/App/Fossa/Config/Container.hs
+++ b/src/App/Fossa/Config/Container.hs
@@ -1,7 +1,7 @@
 module App.Fossa.Config.Container (
   mkSubCommand,
   ImageText (..),
-  OutputFormat (..),
+  TestOutputFormat (..),
   ContainerCommand,
   ContainerScanConfig (..),
   ContainerAnalyzeConfig (..),
@@ -20,7 +20,7 @@ import App.Fossa.Config.Container.Analyze qualified as Analyze
 import App.Fossa.Config.Container.Common (ImageText (..))
 import App.Fossa.Config.Container.ListTargets (ContainerListTargetsConfig, ContainerListTargetsOptions)
 import App.Fossa.Config.Container.ListTargets qualified as ListTargets
-import App.Fossa.Config.Container.Test (ContainerTestConfig, ContainerTestOptions (..), OutputFormat (..))
+import App.Fossa.Config.Container.Test (ContainerTestConfig, ContainerTestOptions (..), TestOutputFormat (..))
 import App.Fossa.Config.Container.Test qualified as Test
 import App.Fossa.Config.EnvironmentVars (EnvVars)
 import App.Fossa.Subcommand (EffStack, GetCommonOpts (getCommonOpts), GetSeverity (getSeverity), SubCommand (SubCommand))
@@ -45,6 +45,7 @@ mkSubCommand = SubCommand "container" containerCmdInfo parser loadConfig mergeOp
 
 mergeOpts ::
   ( Has Diagnostics sig m
+  , Has Logger sig m
   ) =>
   Maybe ConfigFile ->
   EnvVars ->

--- a/src/App/Fossa/Config/Container/Test.hs
+++ b/src/App/Fossa/Config/Container/Test.hs
@@ -109,7 +109,7 @@ mergeOpts cfgfile envvars ContainerTestOptions{..} = do
     logWarn $
       vsep
         [ "DEPRECATION NOTICE"
-        , "=================="
+        , "========================"
         , "--json flag is now deprecated for `fossa container test` command."
         , ""
         , "Please use: "

--- a/src/App/Fossa/Config/Test.hs
+++ b/src/App/Fossa/Config/Test.hs
@@ -189,7 +189,7 @@ mergeOpts maybeConfig envvars TestCliOpts{..} = do
     logWarn $
       vsep
         [ "DEPRECATION NOTICE"
-        , "=================="
+        , "========================"
         , "--json flag is now deprecated for `fossa test` command."
         , ""
         , "Please use: "

--- a/src/App/Fossa/Config/Test.hs
+++ b/src/App/Fossa/Config/Test.hs
@@ -5,10 +5,14 @@ module App.Fossa.Config.Test (
   TestCliOpts,
   TestConfig (..),
   DiffRevision (..),
-  OutputFormat (..),
+  TestOutputFormat (..),
   mkSubCommand,
   parser,
   loadConfig,
+  validateOutputFormat,
+  testOutputFormatList,
+  defaultOutputFmt,
+  parseFossaTestOutputFormat,
 ) where
 
 import App.Fossa.Config.Common (
@@ -28,14 +32,19 @@ import App.Types (BaseDir, OverrideProject (OverrideProject), ProjectRevision)
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
+  ToDiagnostic,
+  fromMaybe,
  )
 import Control.Effect.Lift (Lift)
+import Control.Monad (when)
 import Control.Timeout (Duration (..))
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
+import Data.List (intercalate)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
+import Diag.Diagnostic (ToDiagnostic (renderDiagnostic))
 import Effect.Exec (Exec)
-import Effect.Logger (Logger, Severity (SevDebug, SevInfo))
+import Effect.Logger (Logger, Pretty (pretty), Severity (SevDebug, SevInfo), logWarn, vsep)
 import Effect.ReadFS (ReadFS, getCurrentDir, resolveDir)
 import Fossa.API.Types (ApiOpts)
 import GHC.Generics (Generic)
@@ -45,6 +54,7 @@ import Options.Applicative (
   auto,
   flag,
   help,
+  internal,
   long,
   option,
   optional,
@@ -52,12 +62,43 @@ import Options.Applicative (
   strOption,
  )
 
-data OutputFormat
+data TestOutputFormat
   = TestOutputPretty
   | TestOutputJson
-  deriving (Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Generic, Enum, Bounded)
 
-instance ToJSON OutputFormat where
+instance Show TestOutputFormat where
+  show TestOutputJson = "json"
+  show TestOutputPretty = "text-pretty"
+
+defaultOutputFmt :: TestOutputFormat
+defaultOutputFmt = TestOutputPretty
+
+testOutputFormatList :: String
+testOutputFormatList = intercalate ", " $ map show allFormats
+  where
+    allFormats :: [TestOutputFormat]
+    allFormats = enumFromTo minBound maxBound
+
+newtype InvalidReportFormat = InvalidReportFormat String
+instance ToDiagnostic InvalidReportFormat where
+  renderDiagnostic (InvalidReportFormat fmt) =
+    pretty $
+      "Fossa test format "
+        <> toText fmt
+        <> " is not supported. Supported formats: "
+        <> (toText testOutputFormatList)
+
+validateOutputFormat :: Has Diagnostics sig m => Bool -> Maybe String -> m TestOutputFormat
+validateOutputFormat True _ = pure TestOutputJson
+validateOutputFormat False Nothing = pure defaultOutputFmt
+validateOutputFormat False (Just format) = fromMaybe (InvalidReportFormat format) $ parseFossaTestOutputFormat format
+
+parseFossaTestOutputFormat :: String -> Maybe TestOutputFormat
+parseFossaTestOutputFormat "json" = Just TestOutputJson
+parseFossaTestOutputFormat _ = Nothing
+
+instance ToJSON TestOutputFormat where
   toEncoding = genericToEncoding defaultOptions
 
 newtype DiffRevision = DiffRevision Text deriving (Show, Eq, Ord, Generic)
@@ -68,7 +109,8 @@ instance ToJSON DiffRevision where
 data TestCliOpts = TestCliOpts
   { commons :: CommonOpts
   , testTimeout :: Maybe Int
-  , testOutputType :: OutputFormat
+  , testDeprecatedOutputType :: TestOutputFormat
+  , testOutputFmt :: Maybe String
   , testBaseDir :: FilePath
   , testDiffRevision :: Maybe Text
   }
@@ -84,7 +126,7 @@ data TestConfig = TestConfig
   { baseDir :: BaseDir
   , apiOpts :: ApiOpts
   , timeout :: Duration
-  , outputFormat :: OutputFormat
+  , outputFormat :: TestOutputFormat
   , projectRevision :: ProjectRevision
   , diffRevision :: Maybe DiffRevision
   }
@@ -104,7 +146,8 @@ parser =
   TestCliOpts
     <$> commonOpts
     <*> optional (option auto (long "timeout" <> help "Duration to wait for build completion in seconds (Defaults to 1 hour)"))
-    <*> flag TestOutputPretty TestOutputJson (long "json" <> help "Output issues as json")
+    <*> flag defaultOutputFmt TestOutputJson (long "json" <> help "Output issues as json" <> internal)
+    <*> optional (strOption (long "format" <> help ("Output the report in the specified format. Currently available formats: (" <> testOutputFormatList <> ")")))
     <*> baseDirArg
     <*> optional (strOption (long "diff" <> help "Checks for new issues of the revision, that does not exist in provided diff revision."))
 
@@ -126,6 +169,7 @@ mergeOpts ::
   , Has Diagnostics sig m
   , Has ReadFS sig m
   , Has Exec sig m
+  , Has Logger sig m
   ) =>
   Maybe ConfigFile ->
   EnvVars ->
@@ -140,10 +184,29 @@ mergeOpts maybeConfig envvars TestCliOpts{..} = do
           OverrideProject (optProjectName commons) (optProjectRevision commons) Nothing
       diffRevision = DiffRevision <$> testDiffRevision
 
+  -- if the non-default value is present for flag, user is using deprecatedJsonFlag
+  when (testDeprecatedOutputType /= defaultOutputFmt) $ do
+    logWarn $
+      vsep
+        [ "DEPRECATION NOTICE"
+        , "=================="
+        , "--json flag is now deprecated for `fossa test` command."
+        , ""
+        , "Please use: "
+        , "   `--format json` instead."
+        , ""
+        , "In future, usage of --json may result in fatal error."
+        ]
+
+  testOutputFormat <-
+    validateOutputFormat
+      (testDeprecatedOutputType == TestOutputJson)
+      testOutputFmt
+
   TestConfig
     <$> baseDir
     <*> apiOpts
     <*> pure timeout
-    <*> pure testOutputType
+    <*> pure testOutputFormat
     <*> revision
     <*> pure diffRevision

--- a/src/App/Fossa/Container/Test.hs
+++ b/src/App/Fossa/Container/Test.hs
@@ -11,7 +11,7 @@ import App.Fossa.API.BuildWait (
  )
 import App.Fossa.Config.Container (
   ContainerTestConfig (ContainerTestConfig, timeoutDuration),
-  OutputFormat (TestOutputJson, TestOutputPretty),
+  TestOutputFormat (TestOutputJson, TestOutputPretty),
  )
 import App.Fossa.Config.Container qualified as Config
 import App.Fossa.Container.Scan (scanImageNoAnalysis)

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -10,9 +10,9 @@ import App.Fossa.API.BuildWait (
  )
 import App.Fossa.Config.Test (
   DiffRevision (..),
-  OutputFormat (TestOutputJson, TestOutputPretty),
   TestCliOpts,
   TestConfig (diffRevision),
+  TestOutputFormat (TestOutputJson, TestOutputPretty),
  )
 import App.Fossa.Config.Test qualified as Config
 import App.Fossa.Subcommand (SubCommand)


### PR DESCRIPTION
# Overview

This PR;
- deprecates `--json` to favor `--format json` for `fossa test` and `fossa container test`

## Acceptance criteria

Don't break existing users, but display warnings:
- when user uses `fossa test --json` a warning is displayed AND JSON output if rendered
- when user uses `fossa container test --json` a warning is displayed AND JSON output if rendered

New method works:
- when user uses `fossa test --format json`, JSON output if rendered.
- when user uses `fossa container test --format json`, JSON output if rendered.

## Testing plan

### `fossa test`
```bash
# Setup
git checkout feat/deprecate-fossa-test-json
make install-local
mkdir sandbox && echo 'black' > sandbox/reqs.txt
./fossa analyze sandbox --project  ane591 --revision 0

# Act

## No regression
./fossa test --project  ane591 --revision 0

## new fmt works
./fossa test --project  ane591 --revision 0 --format json

## warning is rendered
## same output as `fossa test --project  ane591 --revision 0 --format json`
./fossa test --project  ane591 --revision 0 --json
```

### `fossa container test`
```bash
# Setup
git checkout feat/deprecate-fossa-test-json
make install-local
./fossa container analyze redis:alpine --project  ane591container --revision 0

# Act

## No regression
./fossa container test --project  ane591container --revision 0

## new fmt works
./fossa container test --project  ane591container --revision 0 --format json

## warning is rendered
## same output as `fossa test --project  ane591container --revision 0 --format json`
./fossa container test --project  ane591container --revision 0 --json
```


## Risks
Low risk

## References
https://fossa.atlassian.net/browse/ANE-591

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
