### PR TITLE
rename experimental-license-scan command to license-scan

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Rename `--experimental-license-scan` to `--license-scan` (https://github.com/fossas/fossa-cli/pull/1110)
+
 ## v3.6.6
 
 - Conda: Change dynamic strategy to simulate building an environment from `environment.yml` instead of reading from the currently active environment. ([#1099](https://github.com/fossas/fossa-cli/pull/1099))
@@ -52,16 +56,16 @@ Gradle: Considers dependencies from `debugUnitTest*` configurations to be unused
 
 _Notice:_
 
-- Now, container scanning analyzes projects for applications (`npm`, `pip`, etc) dependencies. 
+- Now, container scanning analyzes projects for applications (`npm`, `pip`, etc) dependencies.
 - Now, container scanning can filter specific targets via target exclusions using [fossa configuration file](./docs/references/files/fossa-yml.md).
 - Now, `fossa-cli`'s windows binary can perform container scanning.
 - Now, container scanned projects will show origin path in FOSSA web UI.
 - Now, container scanned projects can target specific architecture via digest.
 
-You can use `--only-system-deps` flag to only scan for dependencies from `apk`, `dpkg`, `dpm`. 
+You can use `--only-system-deps` flag to only scan for dependencies from `apk`, `dpkg`, `dpm`.
 This will mimic behavior of older FOSSA CLI's container scanning (older than v3.5.0).
 
-Learn more: 
+Learn more:
 - [container scanner](./docs/references/subcommands/container/scanner.md)
 - [fossa container analyze](./docs/references/subcommands/container.md)
 

--- a/src/App/Fossa/Config/LicenseScan.hs
+++ b/src/App/Fossa/Config/LicenseScan.hs
@@ -25,10 +25,10 @@ import Options.Applicative (
  )
 
 licenseScanInfo :: InfoMod a
-licenseScanInfo = progDesc "Experimental utilities for native license-scanning"
+licenseScanInfo = progDesc "Utilities for native license-scanning"
 
 mkSubCommand :: (LicenseScanConfig -> EffStack ()) -> SubCommand LicenseScanCommand LicenseScanConfig
-mkSubCommand = SubCommand "experimental-license-scan" licenseScanInfo cliParser noLoadConfig mergeOpts
+mkSubCommand = SubCommand "license-scan" licenseScanInfo cliParser noLoadConfig mergeOpts
   where
     noLoadConfig = const $ pure Nothing
 

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -47,7 +47,7 @@ data NoVendoredDeps = NoVendoredDeps
 instance ToDiagnostic MissingFossaDepsFile where
   renderDiagnostic _ =
     vsep
-      [ "'fossa experimental-license-scan fossa-deps' requires pointing to a directory with a fossa-deps file."
+      [ "'fossa license-scan fossa-deps' requires pointing to a directory with a fossa-deps file."
       , "The file can have one of the extensions: .yaml .yml .json"
       ]
 

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -72,6 +72,7 @@ subcommands = public <|> private
         mconcat
           [ internal
           , initCommand
+          , experimentalLicenseScanCommand
           , decodeSubCommand Dump.dumpSubCommand
           , decodeSubCommand Log4j.log4jSubCommand
           , decodeSubCommand LicenseScan.licenseScanSubCommand
@@ -92,6 +93,12 @@ initCommand = command "init" (info runInit $ progDesc "Deprecated, no longer has
   where
     runInit :: Parser (IO ())
     runInit = pure $ putStrLn "The 'init' command has been deprecated and no longer has any effect.  You may safely remove this command."
+
+experimentalLicenseScanCommand :: Mod CommandFields (IO ())
+experimentalLicenseScanCommand = command "experimental-license-scan" (info runInit $ progDesc "The 'experimental-license-scan' command has been deprecated and renamed to 'license-scan'")
+  where
+    runInit :: Parser (IO ())
+    runInit = pure $ putStrLn "The 'experimental-license-scan' has been deprecated and renamed to 'license-scan'. Please use the 'license-scan' command instead."
 
 decodeSubCommand :: (GetSeverity a, GetCommonOpts a, Show b, ToJSON b) => SubCommand a b -> Mod CommandFields (IO ())
 decodeSubCommand cmd@SubCommand{..} = command commandName $ info (runSubCommand cmd) commandInfo


### PR DESCRIPTION
# Overview

Renames the `experimental-license-scan` comment to `license-scan`

## Acceptance criteria

- `fossa license-scan` should do what `fossa experimental-license-scan` used to do.
- `fossa experimental-license-scan` should fail and tell you that it was renamed.

## Testing plan

```
make install-dev
cd <directory with fossa-deps.yml in it>

fossa-dev license-scan fossa-deps 
<should scan using fossa-deps.yml>

fosas-dev license-scan direct
<should run Themis on the directory>

fossa-dev experimental-license-scan fossa-deps
<should tell you it has been renamed>

fossa-dev experimental-license-scan direct
<should tell you it has been renamed>
```


## Risks

None

## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [X] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
