### PR TITLE
emit a warning if --experimental-native-license-scan flag is used

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Emit a warning if the `--experimental-native-license-scan` flag is used
+
 ## v3.6.6
 
 - Conda: Change dynamic strategy to simulate building an environment from `environment.yml` instead of reading from the currently active environment. ([#1099](https://github.com/fossas/fossa-cli/pull/1099))
@@ -52,16 +56,16 @@ Gradle: Considers dependencies from `debugUnitTest*` configurations to be unused
 
 _Notice:_
 
-- Now, container scanning analyzes projects for applications (`npm`, `pip`, etc) dependencies. 
+- Now, container scanning analyzes projects for applications (`npm`, `pip`, etc) dependencies.
 - Now, container scanning can filter specific targets via target exclusions using [fossa configuration file](./docs/references/files/fossa-yml.md).
 - Now, `fossa-cli`'s windows binary can perform container scanning.
 - Now, container scanned projects will show origin path in FOSSA web UI.
 - Now, container scanned projects can target specific architecture via digest.
 
-You can use `--only-system-deps` flag to only scan for dependencies from `apk`, `dpkg`, `dpm`. 
+You can use `--only-system-deps` flag to only scan for dependencies from `apk`, `dpkg`, `dpm`.
 This will mimic behavior of older FOSSA CLI's container scanning (older than v3.5.0).
 
-Learn more: 
+Learn more:
 - [container scanner](./docs/references/subcommands/container/scanner.md)
 - [fossa container analyze](./docs/references/subcommands/container.md)
 

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.Config.Analyze (
-  AllowNativeLicenseScan (..),
   AnalyzeCliOpts (..),
   AnalyzeConfig (..),
   BinaryDiscovery (..),
@@ -109,7 +108,7 @@ import System.Info qualified as SysInfo
 import Types (ArchiveUploadType (..), TargetFilter)
 
 -- CLI flags, for use with 'Data.Flag'
-data AllowNativeLicenseScan = AllowNativeLicenseScan deriving (Generic)
+data DeprecatedAllowNativeLicenseScan = DeprecatedAllowNativeLicenseScan deriving (Generic)
 data ForceVendoredDependencyRescans = ForceVendoredDependencyRescans deriving (Generic)
 
 data BinaryDiscovery = BinaryDiscovery deriving (Generic)
@@ -174,7 +173,7 @@ data AnalyzeCliOpts = AnalyzeCliOpts
   , analyzeJsonOutput :: Flag JsonOutput
   , analyzeIncludeAllDeps :: Flag IncludeAll
   , analyzeNoDiscoveryExclusion :: Flag NoDiscoveryExclusion
-  , analyzeAllowNativeLicenseScan :: Flag AllowNativeLicenseScan
+  , analyzeDeprecatedAllowNativeLicenseScan :: Flag DeprecatedAllowNativeLicenseScan
   , analyzeForceVendoredDependencyMode :: Maybe ArchiveUploadType
   , analyzeForceVendoredDependencyRescans :: Flag ForceVendoredDependencyRescans
   , analyzeBranch :: Maybe Text
@@ -267,7 +266,7 @@ cliParser =
     <*> flagOpt IncludeAll (long "include-unused-deps" <> help "Include all deps found, instead of filtering non-production deps.  Ignored by VSI.")
     <*> flagOpt NoDiscoveryExclusion (long "debug-no-discovery-exclusion" <> help "Ignore filters during discovery phase.  This is for debugging only and may be removed without warning." <> hidden)
     -- AllowNativeLicenseScan is no longer used. We started emitting a warning if it was used in https://github.com/fossas/fossa-cli/pull/1113
-    <*> flagOpt AllowNativeLicenseScan (long "experimental-native-license-scan" <> hidden)
+    <*> flagOpt DeprecatedAllowNativeLicenseScan (long "experimental-native-license-scan" <> hidden)
     <*> optional vendoredDependencyModeOpt
     <*> flagOpt ForceVendoredDependencyRescans (long "force-vendored-dependency-rescans" <> help "Force vendored dependencies to be rescanned even if the revision has been previously analyzed by FOSSA. This currently only works for CLI-side license scans.")
     <*> optional (strOption (long "branch" <> short 'b' <> help "this repository's current branch (default: current VCS branch)"))
@@ -350,7 +349,7 @@ mergeOpts ::
   AnalyzeCliOpts ->
   m AnalyzeConfig
 mergeOpts cfg env cliOpts = do
-  let experimentalNativeLicenseScanFlagUsed = fromFlag AllowNativeLicenseScan $ analyzeAllowNativeLicenseScan cliOpts
+  let experimentalNativeLicenseScanFlagUsed = fromFlag DeprecatedAllowNativeLicenseScan $ analyzeDeprecatedAllowNativeLicenseScan cliOpts
   when experimentalNativeLicenseScanFlagUsed $ do
     logWarn $
       vsep

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -267,7 +267,7 @@ cliParser =
     <*> flagOpt IncludeAll (long "include-unused-deps" <> help "Include all deps found, instead of filtering non-production deps.  Ignored by VSI.")
     <*> flagOpt NoDiscoveryExclusion (long "debug-no-discovery-exclusion" <> help "Ignore filters during discovery phase.  This is for debugging only and may be removed without warning." <> hidden)
     -- AllowNativeLicenseScan is no longer used. We started emitting a warning if it was used in https://github.com/fossas/fossa-cli/pull/1113
-     <*> flagOpt AllowNativeLicenseScan (long "experimental-native-license-scan" <> hidden)
+    <*> flagOpt AllowNativeLicenseScan (long "experimental-native-license-scan" <> hidden)
     <*> optional vendoredDependencyModeOpt
     <*> flagOpt ForceVendoredDependencyRescans (long "force-vendored-dependency-rescans" <> help "Force vendored dependencies to be rescanned even if the revision has been previously analyzed by FOSSA. This currently only works for CLI-side license scans.")
     <*> optional (strOption (long "branch" <> short 'b' <> help "this repository's current branch (default: current VCS branch)"))

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -360,10 +360,6 @@ mergeOpts cfg env cliOpts = do
         , ""
         , "The functionality enabled by the flag, CLI-license-scans, is now the default method for scanning vendored-dependencies."
         , ""
-        , "In rare cases, your organization may have made Archive Uploads the default method for scanning vendored-dependencies."
-        , ""
-        , "If you need to force CLI-license-scans on, you can use `--force-vendored-dependency-scan-method CLILicenseScan`."
-        , ""
         , "In the future, usage of the --experimental-native-license-scan flag may result in fatal error."
         ]
 

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -266,7 +266,8 @@ cliParser =
     <*> flagOpt JsonOutput (long "json" <> help "Output project metadata as json to the console. Useful for communicating with the FOSSA API")
     <*> flagOpt IncludeAll (long "include-unused-deps" <> help "Include all deps found, instead of filtering non-production deps.  Ignored by VSI.")
     <*> flagOpt NoDiscoveryExclusion (long "debug-no-discovery-exclusion" <> help "Ignore filters during discovery phase.  This is for debugging only and may be removed without warning." <> hidden)
-    <*> flagOpt AllowNativeLicenseScan (long "experimental-native-license-scan" <> hidden)
+    -- AllowNativeLicenseScan is no longer used. We started emitting a warning if it was used in https://github.com/fossas/fossa-cli/pull/1113
+     <*> flagOpt AllowNativeLicenseScan (long "experimental-native-license-scan" <> hidden)
     <*> optional vendoredDependencyModeOpt
     <*> flagOpt ForceVendoredDependencyRescans (long "force-vendored-dependency-rescans" <> help "Force vendored dependencies to be rescanned even if the revision has been previously analyzed by FOSSA. This currently only works for CLI-side license scans.")
     <*> optional (strOption (long "branch" <> short 'b' <> help "this repository's current branch (default: current VCS branch)"))


### PR DESCRIPTION
# Overview

Emit a warning if the `--experimental-native-license-scan` flag is used.

This warning will turn into an error in the future.

```
fossa-dev analyze --experimental-native-license-scan
[ WARN] DEPRECATION NOTICE
  ========================
  The --experimental-native-license-scan flag is deprecated.

  The functionality enabled by the flag, CLI-license-scans, is now the default method for scanning vendored-dependencies.

  In the future, usage of the --experimental-native-license-scan flag may result in fatal error.

...rest of output from analyze
```

## Acceptance criteria

- We should emit a warning, but still run successfully, if the `--experimental-native-license-scan` flag is used

## Testing plan

```
make install-dev
cd <directory with fossa-deps.yml in it>

fossa-dev analyze
<should work normally>

fossa-dev analyze --experimental-native-license-scan
<should emit a warning and work normally>
```

## Risks

None

## References

None

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
