### PR TITLE
Disable link check for security, license, and fossa downloads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 # FOSSA CLI
 
 [![Build](https://github.com/fossas/fossa-cli/actions/workflows/build-all.yml/badge.svg)](https://github.com/fossas/fossa-cli/actions/workflows/build.yml)
-[![Dependency scan](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml/badge.svg)](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml) <!-- markdown-link-check-disable-next-line -->
-[![FOSSA License Status](https://app.fossa.com/api/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli.svg?type=shield)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield) <!-- markdown-link-check-disable-next-line -->
-[![FOSSA Security Status](https://app.fossa.com/api/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli.svg?type=shield&issueType=security)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield) <!-- markdown-link-check-disable-next-line -->
+[![Dependency scan](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml/badge.svg)](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml) 
+<!-- markdown-link-check-disable-next-line -->
+[![FOSSA License Status](https://app.fossa.com/api/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli.svg?type=shield)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield) 
+<!-- markdown-link-check-disable-next-line -->
+[![FOSSA Security Status](https://app.fossa.com/api/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli.svg?type=shield&issueType=security)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield) 
+<!-- markdown-link-check-disable-next-line -->
 [![FOSSA Downloads](https://img.shields.io/github/downloads/fossas/fossa-cli/total.svg)](https://github.com/fossas/fossa-cli/releases)
 
 


### PR DESCRIPTION
# Overview

This disables link checking for the security badge in our readme. 

## Acceptance criteria

We should not check links for the security badge in our readme

## Testing plan

1. Ensure `markdown-link-check` is installed using homebrew
2. Run `markdown-link-check README.md -c .markdown-link-check.json` on master, notice that it includes the link for the security badge in the outputted list of checked links. 
3. Run `markdown-link-check README.md -c .markdown-link-check.json` on this branch and notice that the security badge link is not included in the list of checked links.

## Risks

None besides the link-check step of our builds being broken.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
