### PR TITLE
Support quotes in go module directives

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+
+## Unreleased
+- Go: Allow quotes module names in static analysis ([#1118](https://github.com/fossas/fossa-cli/pull/1118))
+
 ## v3.6.7
 
 - Rename `--experimental-license-scan` to `--license-scan` (https://github.com/fossas/fossa-cli/pull/1110)

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ install-dev: build
 
 check: check-fmt lint
 
+check-haskell: check-fmt-haskell lint-haskell
+
 fast-check: check-fmt-haskell fast-lint
 
 # Run any build scripts required for test data to be generated.

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -287,6 +287,7 @@ gomodParser = do
     packageName :: Parser PackageName
     packageName = toText <$> lexeme (some (alphaNumChar <|> char '.' <|> char '/' <|> char '-' <|> char '_'))
 
+    modulePath :: Parser Text
     modulePath =
       packageName
         <|> between (char '"') (char '"') packageName

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -199,7 +199,7 @@ gomodParser :: Parser Gomod
 gomodParser = do
   _ <- scn
   _ <- lexeme (chunk "module")
-  name <- packageName
+  name <- modulePath
   _ <- scn
   statements <- many (statement <* scn)
   eof
@@ -286,6 +286,10 @@ gomodParser = do
     -- package name, e.g., golang.org/x/text
     packageName :: Parser PackageName
     packageName = toText <$> lexeme (some (alphaNumChar <|> char '.' <|> char '/' <|> char '-' <|> char '_'))
+
+    modulePath =
+      packageName
+        <|> between (char '"') (char '"') packageName
 
     -- goVersion, e.g.:
     --   v0.0.0-20190101000000-abcdefabcdef

--- a/test/Go/testdata/go.mod.trivial
+++ b/test/Go/testdata/go.mod.trivial
@@ -1,4 +1,4 @@
-module github.com/my/package
+module "github.com/my/package"
 
 require (
     github.com/pkg/one v1.0.0


### PR DESCRIPTION
# Overview

During static analysis of a go mod file the CLI would fail with an error like

```
[ERROR] ----------
  An issue occurred

  >>> Relevant errors

    Error

      Error parsing file: /foo/go.mod.

          /foo/go.mod:1:8:
            |
          1 | module "github.com/<organization>/modulename"
            |        ^
          unexpected '"'
          expecting '-', '.', '/', '_', or alphanumeric character
```

Quotes in a module path are valid, as shown in this real world example: https://github.com/go-yaml/yaml/blob/v3/go.mod

This PR also adds a missing target to our Makefile.

## Acceptance criteria

The CLI should correctly parse a quoted module 
## Testing plan

When using static analysis on a go.mod file with a quoted module path the CLI should succeed.

## Testing

Disable dynamic analysis on [master](https://github.com/fossas/fossa-cli/blob/master/src/Strategy/Gomodules.hs#L69) then analyze the above repo. Change to this branch, disabling dynamic analysis and analyze the same repo. It should succeed. 

## Risks

None.

## References

None.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
