### PR TITLE
refactor: Allow callers to customize Themis flags

### DIFF
--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -72,7 +72,7 @@ licenseScanMain ::
   LicenseScanConfig ->
   m ()
 licenseScanMain = \case
-  RawPathScan (BaseDir dir) -> logStdout . decodeUtf8 =<< withThemisAndIndex (`execRawThemis` dir)
+  RawPathScan (BaseDir dir) -> logStdout . decodeUtf8 =<< withThemisAndIndex (\bins -> execRawThemis bins dir ["--srclib-with-matches"])
   VendoredDepsOutput basedir -> outputVendoredDeps basedir
 
 outputVendoredDeps ::

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -164,7 +164,7 @@ themisRunner pathPrefix scanDir themisBins = runThemis themisBins pathPrefix sca
 
 runThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Path Abs Dir -> m [LicenseUnit]
 runThemis themisBins pathPrefix scanDir = do
-  context "Running license scan binary" $ execThemis themisBins pathPrefix scanDir
+  context "Running license scan binary" $ execThemis themisBins pathPrefix scanDir ["--srclib-with-matches"]
 
 calculateVendoredHash :: Path Abs Dir -> Text -> Path Abs Dir -> IO Text
 calculateVendoredHash baseDir vendoredPath tmpDir = do

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -26,28 +26,28 @@ import Effect.Exec (
 import Path (Abs, Dir, Path, parent)
 import Srclib.Types (LicenseUnit)
 
-execRawThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> m BL.ByteString
-execRawThemis themisBins scanDir = execThrow scanDir $ themisCommand themisBins ""
+execRawThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> [Text] -> m BL.ByteString
+execRawThemis themisBins scanDir flags = execThrow scanDir $ themisCommand themisBins "" flags
 
 -- TODO: We should log the themis version and index version
-execThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Path Abs Dir -> m [LicenseUnit]
-execThemis themisBins pathPrefix scanDir = do
-  execJson @[LicenseUnit] scanDir $ themisCommand themisBins pathPrefix
+execThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Path Abs Dir -> [Text] -> m [LicenseUnit]
+execThemis themisBins pathPrefix scanDir flags = do
+  execJson @[LicenseUnit] scanDir $ themisCommand themisBins pathPrefix flags
 
-themisCommand :: ThemisBins -> Text -> Command
-themisCommand ThemisBins{..} pathPrefix = do
+themisCommand :: ThemisBins -> Text -> [Text] -> Command
+themisCommand ThemisBins{..} pathPrefix flags = do
   Command
     { cmdName = toText . toPath $ unTag themisBinaryPaths
-    , cmdArgs = generateThemisArgs indexBinaryPaths pathPrefix
+    , cmdArgs = generateThemisArgs indexBinaryPaths pathPrefix flags
     , cmdAllowErr = Never
     }
 
-generateThemisArgs :: Tagged ThemisIndex BinaryPaths -> Text -> [Text]
-generateThemisArgs taggedThemisIndex pathPrefix =
+generateThemisArgs :: Tagged ThemisIndex BinaryPaths -> Text -> [Text] -> [Text]
+generateThemisArgs taggedThemisIndex pathPrefix flags =
   [ "--license-data-dir"
   , toText . parent . toPath $ unTag taggedThemisIndex
   , "--path-prefix"
   , pathPrefix
-  , "--srclib-with-matches"
-  , "."
   ]
+    <> flags
+    <> ["."]


### PR DESCRIPTION
This PR refactors `generateThemisArgs` so that library consumers can pass different flags to it. I'm relying on the automated tests for this one - seems like a safe PR.