### PR TITLE
Change packet to paket

### DIFF
--- a/docs/references/subcommands/container/scanner.md
+++ b/docs/references/subcommands/container/scanner.md
@@ -214,7 +214,7 @@ The following package managers are supported in container scanning:
 | Python (setuptools, poetry, etc.)    | :white_check_mark: | [Python Docs](./../../strategies/languages/python/python.md)     |
 | Javascript (npm, yarn, pnpm, etc.)   | :white_check_mark: | [Javascript Docs](./../../strategies/languages/nodejs/nodejs.md) |
 | Ruby (bundler)                       | :white_check_mark: | [Ruby](./../../strategies/languages/ruby/ruby.md)                |
-| .Net (packet, projectjson, etc.)     | :white_check_mark: | [.Net](./../../strategies/languages/dotnet/README.md)            |
+| .Net (paket, projectjson, etc.)     | :white_check_mark: | [.Net](./../../strategies/languages/dotnet/README.md)            |
 | Perl                                 | :white_check_mark: | [Perl](./../../strategies/languages/perl/perl.md)                |
 | Swift (xcode, swift package manager) | :white_check_mark: | [Swift](./../../strategies/platforms/ios/swift.md)               |
 | Carthage                             | :white_check_mark: | [Carthage](./../../strategies/platforms/ios/carthage.md)         |

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -134,7 +134,7 @@ projectTypeToText = \case
   NuspecProjectType -> "nuspec"
   PackageReferenceProjectType -> "packagereference"
   PackagesConfigProjectType -> "packagesconfig"
-  PaketProjectType -> "packet"
+  PaketProjectType -> "paket"
   PerlProjectType -> "perl"
   PipenvProjectType -> "pipenv"
   PnpmProjectType -> "pnpm"


### PR DESCRIPTION
# Overview

Rename "packet" to the correctly named "packet.

https://fsprojects.github.io/Paket/

Closes #1115 

## Acceptance criteria

- Packet is no longer used to refer to the Paket package manager.

## Risks

The only risk is that someone is relying on the "packet" type that has been used to declare paket projects. This field is only used for debugging as far as I'm aware which makes this a safe change. In the future, this field may be used for metrics which makes me believe it is better to change now rather than later.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
