### PR TITLE
refactor: Match strings only appear in some Themis formats

### DIFF
--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -150,7 +150,7 @@ instance FromJSON LicenseUnitData where
       <*> obj .:? "Copyrights"
 
 data LicenseUnitMatchData = LicenseUnitMatchData
-  { licenseUnitMatchDataMatchString :: Text
+  { licenseUnitMatchDataMatchString :: Maybe Text
   , licenseUnitMatchDataLocation :: Integer
   , licenseUnitMatchDataLength :: Integer
   , licenseUnitMatchDataIndex :: Integer


### PR DESCRIPTION
This PR fixes the typing for `LicenseUnitMatchData` so that `fromJSON` no longer crashes when `match_string` is missing (e.g. when running Themis in `--srclib` mode).

Surprisingly, no other code changes are required for this, since we never actually examine the field (we merely deserialize and emit it).