### PR TITLE
Yarn: See if the tar resolver will work before trying git.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.6.9
+- Yarn: Fix a bug where tarball URLs were recognized as git urls. ([#1126](https://github.com/fossas/fossa-cli/pull/1126))
+
 ## v3.6.8
 - Go: Allow quotes module names in static analysis ([#1118](https://github.com/fossas/fossa-cli/pull/1118))
 - `fossa test`: Includes revision summary and target information, when accessible ([#1119](https://github.com/fossas/fossa-cli/pull/1119))

--- a/src/Strategy/Node/YarnV2/Resolvers.hs
+++ b/src/Strategy/Node/YarnV2/Resolvers.hs
@@ -75,8 +75,13 @@ allResolvers :: [Resolver]
 allResolvers =
   [ workspaceResolver
   , npmResolver
+  , -- Ensure that tarResolver appears before gitResolver in this list.
+    -- Currently there are some package locators that the git resolver matches that are actually tarballs.
+    -- To get around this, the tarResolver gets to examine a locator first.
+    -- Ideally the git resolver's 'resolverSupportsLocator' function would be more specific.
+    -- ANE-720 captures that work.
+    tarResolver
   , gitResolver
-  , tarResolver
   , fileResolver
   , linkResolver
   , execResolver

--- a/test/Yarn/V2/ResolversSpec.hs
+++ b/test/Yarn/V2/ResolversSpec.hs
@@ -20,9 +20,11 @@ import Strategy.Node.YarnV2.Resolvers (
   npmResolver,
   patchResolver,
   portalResolver,
+  resolveLocatorToPackage,
   tarResolver,
   workspaceResolver,
  )
+import Test.Effect (it', shouldBe')
 import Test.Hspec (Spec, describe, it, shouldBe)
 
 spec :: Spec
@@ -66,6 +68,18 @@ spec = do
   testUnsupportedResolver portalResolver "portal:" PortalPackage
   testUnsupportedResolver execResolver "exec:" ExecPackage
   testUnsupportedResolver patchResolver "patch:" PatchPackage
+
+  testResolveLocatorToPackage
+
+gitPkgLocator :: Text
+gitPkgLocator = "https://gitpkg.now.sh/api/pkg.tgz?url=colorjs%2fcolor-name&commit=0f12d6e6ad4ab04e5cbc26360b759b446b0c6a4e"
+
+testResolveLocatorToPackage :: Spec
+testResolveLocatorToPackage =
+  describe "resolveLocatorToPackage" $
+    it' "Should prefer the tarball to the git resolver in case of conflict" $ do
+      pkg <- resolveLocatorToPackage (Locator Nothing "unused" gitPkgLocator)
+      pkg `shouldBe'` (TarPackage gitPkgLocator)
 
 testResolver ::
   Resolver ->

--- a/test/Yarn/V2/ResolversSpec.hs
+++ b/test/Yarn/V2/ResolversSpec.hs
@@ -77,7 +77,7 @@ gitPkgLocator = "https://gitpkg.now.sh/api/pkg.tgz?url=colorjs%2fcolor-name&comm
 testResolveLocatorToPackage :: Spec
 testResolveLocatorToPackage =
   describe "resolveLocatorToPackage" $
-    it' "Should prefer the tarball to the git resolver in case of conflict" $ do
+    it' "Should prefer the tarball to the git resolver in cases where a locator would match both" $ do
       pkg <- resolveLocatorToPackage (Locator Nothing "unused" gitPkgLocator)
       pkg `shouldBe'` (TarPackage gitPkgLocator)
 


### PR DESCRIPTION
# Overview

The git resolver for yarn will sometimes look at a tarball url and think that it's a git url. This PR swaps the ordering of the git and tar resolvers to give the tar resolver a first chance at resolving a locator.

## Acceptance criteria

Following the testing plan should not result in an error.

## Testing plan

1. Create an empty directory
2. Inside the directory, run `yarn init`
3. Run `yarn add "colorjs-test@https://gitpkg.now.sh/api/pkg.tgz?url=colorjs%2fcolor-name&commit=0f12d6e6ad4ab04e5cbc26360b759b446b0c6a4e"`
4. Run `fossa analyze`

On master, running `fossa analyze` will exit with a GitResolver error saying that the URL was invalid. On this branch `fossa analyze` should exist successfully.

## Risks

This solution relies on the internal ordering of a list. A more robust but time-consuming solution would be to make the GitResolver not match a tarball URL like the one in the test.

## References

ZD-5281

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
