### PR TITLE
fix: Parser should actually be optional on match strings

### DIFF
--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -173,7 +173,7 @@ instance ToJSON LicenseUnitMatchData where
 instance FromJSON LicenseUnitMatchData where
   parseJSON = withObject "LicenseUnitMatchData" $ \obj ->
     LicenseUnitMatchData
-      <$> obj .: "match_string"
+      <$> obj .:? "match_string"
       <*> obj .: "location"
       <*> obj .: "length"
       <*> obj .: "index"


### PR DESCRIPTION
This PR is a follow-up to #1125, because I'm an idiot.