### PR TITLE
[ANE-707] CLILicenseScan path filters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## v3.6.10
 
 - Vendored Dependencies: Allow path filtering when doing cli-side license scans ([#1128](https://github.com/fossas/fossa-cli/pull/1128))
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Allow path filtering when doing cli-side license scans ([#1128](https://github.com/fossas/fossa-cli/pull/1128))
+- Vendored Dependencies: Allow path filtering when doing cli-side license scans ([#1128](https://github.com/fossas/fossa-cli/pull/1128))
 
 ## v3.6.9
 - Yarn: Fix a bug where tarball URLs were recognized as git urls. ([#1126](https://github.com/fossas/fossa-cli/pull/1126))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Allow path filtering when doing cli-side license scans ([#1128](https://github.com/fossas/fossa-cli/pull/1128))
+
 ## v3.6.9
 - Yarn: Fix a bug where tarball URLs were recognized as git urls. ([#1126](https://github.com/fossas/fossa-cli/pull/1126))
 

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -198,3 +198,18 @@ The following table shows which files will be matched by a glob for this directo
 
 - If you also want to scan all files directly in that directory, add a second entry with the directory followed by `/*`. E.g. `path/to/scan/*`.
 
+### Debugging your path filters
+
+If you want to see what files we are scanning with your current `.fossa.yml` file, you can use the `fossa license-scan fossa-deps` command:
+
+```
+fossa license-scan fossa-deps
+```
+
+That will output the results of the license-scan. If you have `jq` installed, you can filter the output to just show the paths that were scanned:
+
+```
+fossa license-scan fossa-deps | jq '.uploadUnits[].LicenseUnits[].Files'
+```
+
+This will include all of the files scanned, even those with no licenses found in them.

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -157,7 +157,7 @@ So in the example above, we will license scan files named "LICENSE" and files th
 
 There are a few things to note here. First, the `**`, known as a globstar, is a non-standard extension to globs. It means "one or more directories".
 
-So if you have a directory structure like this:
+The following table shows which files will be matched by a glob for this directory structure.
 
 ```
 .
@@ -173,30 +173,36 @@ So if you have a directory structure like this:
     └── runit_test.rb
 ```
 
-Then we have the following results
-
-| Glob        | Meaning                                             | Files matched                                                                                   |
-| ----------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| src/*.rb    | All .rb files directly in the root src directory    | `src/runit.rb`, `src/runit_external.rb`                                                         |
-| **/src/*.rb | All .rb files directly in any directory named `src` | `src/runit.rb`, `src/runit_external.rb`                                                         |
-| **/*.rb     | All .rb files                                       | `foo.rb`, `src/runit.rb`, `src/runit_external.rb`,  `src/subdir/again.rb`, `test/runit_test.rb` |
-| **/src/**   | All files under the src directory                   | `src/subdir/again.rb`                                                                           |
+| Glob          | Meaning                                             | Files matched                                                                                   |
+| ------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `src/*.rb`    | All .rb files directly in the root src directory    | `src/runit.rb`, `src/runit_external.rb`                                                         |
+| `**/src/*.rb` | All .rb files directly in any directory named `src` | `src/runit.rb`, `src/runit_external.rb`                                                         |
+| `**/*.rb`     | All .rb files                                       | `foo.rb`, `src/runit.rb`, `src/runit_external.rb`,  `src/subdir/again.rb`, `test/runit_test.rb` |
+| `**/src/**`   | All files under the src directory                   | `src/subdir/again.rb`                                                                           |
 
 > Note: Some implementations of globstar treat it as "zero or more directories". Since different implementations differ in their globstar functionality, we have decided to treat globstars as matching "one or more directories". We did this as it is simpler to include the additional glob for the base directory case when desired than to exclude the base directory case when it is not desired.
 
-To filter out all files with a given extension, add an entry like `**/*.extension` to the `exclude` object. E.g. `**/*.ts`.
+To filter out all files with a given extension
+: add an entry like `**/*.extension` to the `exclude` object. E.g. `**/*.ts`.
 
-To filter out all files with a given name, add an entry like `**/filename` to the `exclude` object. E.g `**/LICENSE` or `**/LICENSE.*`.
+To filter out all files with a given name
+: add an entry like `**/filename` to the `exclude` object. E.g `**/LICENSE` or `**/LICENSE.*`.
 
-To include only files with a given extension, add an entry like `**/*.extension` to the `only` object. If you want to include files with multiple extensions, you can add multiple entries to the `only` object. E.g. `**/*.ts`.
+To include only files with a given extension
+: add an entry like `**/*.extension` to the `only` object. If you want to include files with multiple extensions, you can add multiple entries to the `only` object. E.g. `**/*.ts`.
 
-To include all files with a given name, add an entry like `**/filename` to the `only` object. E.g `**/LICENSE` or `**/LICENSE.*`.
+To include all files with a given name
+: add an entry like `**/filename` to the `only` object. E.g `**/LICENSE` or `**/LICENSE.*`.
 
-To exclude all files in subdirectories of a given directory, add that directory followed by `/**` to the exclude object. E.g. `path/to/exclude/**`.
+To exclude all files in subdirectories of a given directory
+: add that directory followed by `/**` to the exclude object. E.g. `path/to/exclude/**`.
 
-If you also want to exclude files directly in that directory, add a second entry with the directory followed by `/*`. E.g. `path/to/exclude/*`.
+If you also want to exclude files directly in that directory
+: add a second entry with the directory followed by `/*`. E.g. `path/to/exclude/*`.
 
-To scan only files in a subdirectory of a given directory, add that directory followed by `/**` to the exclude object.  E.g. `path/to/scan/**`.
+To scan only files in a subdirectory of a given directory
+: add that directory followed by `/**` to the exclude object.  E.g. `path/to/scan/**`.
 
-If you also want to scan all files directly in that directory, add a second entry with the directory followed by `/*`. E.g. `path/to/scan/*`.
+If you also want to scan all files directly in that directory
+: add a second entry with the directory followed by `/*`. E.g. `path/to/scan/*`.
 

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -149,13 +149,15 @@ vendoredDependencies:
       - "**/spec/*"
 ```
 
-As you can see, the filters are set in the `vendoredDependencies.licenseScanPathFilters` section of the file. You can provide an `only` object and an `exclude` object. Both of these objects consist of a list of file globs.
+Filters are set in the `vendoredDependencies.licenseScanPathFilters` section of the file. You can provide an `only` object and an `exclude` object. Both of these objects consist of a list of file globs. You can provide both `only` and `exclude` objects or just `only` or just `exclude`.
 
-The `only` object will filter to only paths that match at least one of the entries in the `only` object. The `exclude` object will exclude paths that match any of the entries in the `exclude` object.
+The `only` object will scan paths that match at least one of the entries in the `only` object. The `exclude` object will exclude paths that match any of the entries in the `exclude` object.
 
 So in the example above, we will license scan files named "LICENSE" and files that have an extension of `.rb`. We will also filter out any files in directories named `test` or `spec`, even if they match the `only` filters.
 
-There are a few things to note here. First, the `**`, known as a globstar, is a non-standard extension to globs. It means "one or more directories".
+The `**`, known as a globstar, is a non-standard extension to globs. It matches one or more directories.
+
+> Note: Some implementations of globstar treat it as matching "zero or more directories". Since different implementations differ in their globstar functionality, we have decided to treat globstars as matching "one or more directories". We did this as it is simpler to include the additional glob for the base directory case when desired than to exclude the base directory case when it is not desired.
 
 The following table shows which files will be matched by a glob for this directory structure.
 
@@ -179,8 +181,6 @@ The following table shows which files will be matched by a glob for this directo
 | `**/src/*.rb` | All .rb files directly in any directory named `src` | `src/runit.rb`, `src/runit_external.rb`                                                         |
 | `**/*.rb`     | All .rb files                                       | `foo.rb`, `src/runit.rb`, `src/runit_external.rb`,  `src/subdir/again.rb`, `test/runit_test.rb` |
 | `**/src/**`   | All files under the src directory                   | `src/subdir/again.rb`                                                                           |
-
-> Note: Some implementations of globstar treat it as "zero or more directories". Since different implementations differ in their globstar functionality, we have decided to treat globstars as matching "one or more directories". We did this as it is simpler to include the additional glob for the base directory case when desired than to exclude the base directory case when it is not desired.
 
 - To filter out all files with a given extension, add an entry like `**/*.extension` to the `exclude` object. E.g. `**/*.ts`.
 

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -200,6 +200,10 @@ The following table shows which files will be matched by a glob for this directo
 
 - If you also want to scan all files directly in that directory, add a second entry with the directory followed by `/*`. E.g. `path/to/scan/*`.
 
+### Path filtering and Windows
+
+You must always use `/` as a path separator in your path filters. The CLI will convert these to `\` when you run in a Windows environment.
+
 ### Debugging your path filters
 
 If you want to see what files we are scanning with your current `.fossa.yml` file, you can use the `fossa license-scan fossa-deps` command:

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -158,6 +158,8 @@ So in the example above, we will license scan files named "LICENSE" and files th
 The `**`, known as a globstar, is a non-standard extension to globs. It matches one or more directories.
 
 > Note: Some implementations of globstar treat it as matching "zero or more directories". Since different implementations differ in their globstar functionality, we have decided to treat globstars as matching "one or more directories". We did this as it is simpler to include the additional glob for the base directory case when desired than to exclude the base directory case when it is not desired.
+>
+> There is one exception to this. A glob like `**/*.rb` will also include `*.rb` files in the root directory. This was done so that you would only need one line in order to exclude all files with a given extension. If you had `**/*.rb` in the `only` object but wanted to exclude `*.rb` files in the root directory, you would need to add an entry of `*.rb` to the `exclude` object.
 
 The following table shows which files will be matched by a glob for this directory structure.
 

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -182,27 +182,19 @@ The following table shows which files will be matched by a glob for this directo
 
 > Note: Some implementations of globstar treat it as "zero or more directories". Since different implementations differ in their globstar functionality, we have decided to treat globstars as matching "one or more directories". We did this as it is simpler to include the additional glob for the base directory case when desired than to exclude the base directory case when it is not desired.
 
-To filter out all files with a given extension
-: add an entry like `**/*.extension` to the `exclude` object. E.g. `**/*.ts`.
+- To filter out all files with a given extension, add an entry like `**/*.extension` to the `exclude` object. E.g. `**/*.ts`.
 
-To filter out all files with a given name
-: add an entry like `**/filename` to the `exclude` object. E.g `**/LICENSE` or `**/LICENSE.*`.
+- To filter out all files with a given name, add an entry like `**/filename` to the `exclude` object. E.g `**/LICENSE` or `**/LICENSE.*`.
 
-To include only files with a given extension
-: add an entry like `**/*.extension` to the `only` object. If you want to include files with multiple extensions, you can add multiple entries to the `only` object. E.g. `**/*.ts`.
+- To include only files with a given extension, add an entry like `**/*.extension` to the `only` object. If you want to include files with multiple extensions, you can add multiple entries to the `only` object. E.g. `**/*.ts`.
 
-To include all files with a given name
-: add an entry like `**/filename` to the `only` object. E.g `**/LICENSE` or `**/LICENSE.*`.
+- To include all files with a given name, add an entry like `**/filename` to the `only` object. E.g `**/LICENSE` or `**/LICENSE.*`.
 
-To exclude all files in subdirectories of a given directory
-: add that directory followed by `/**` to the exclude object. E.g. `path/to/exclude/**`.
+- To exclude all files in subdirectories of a given directory, add that directory followed by `/**` to the exclude object. E.g. `path/to/exclude/**`.
 
-If you also want to exclude files directly in that directory
-: add a second entry with the directory followed by `/*`. E.g. `path/to/exclude/*`.
+- If you also want to exclude files directly in that directory, add a second entry with the directory followed by `/*`. E.g. `path/to/exclude/*`.
 
-To scan only files in a subdirectory of a given directory
-: add that directory followed by `/**` to the exclude object.  E.g. `path/to/scan/**`.
+- To scan only files in a subdirectory of a given directory, add that directory followed by `/**` to the exclude object.  E.g. `path/to/scan/**`.
 
-If you also want to scan all files directly in that directory
-: add a second entry with the directory followed by `/*`. E.g. `path/to/scan/*`.
+- If you also want to scan all files directly in that directory, add a second entry with the directory followed by `/*`. E.g. `path/to/scan/*`.
 

--- a/docs/features/vendored-dependencies.md
+++ b/docs/features/vendored-dependencies.md
@@ -131,7 +131,7 @@ In the event caching is causing problems, FOSSA can be made to rescan this kind 
 
 ## Path Filtering
 
-Note: This section does not apply to archive uploads. Path filtering is only available when doing a CLI License Scan. See [here](#how-vendored-dependencies-are-scanned) for more info on the difference between these two methods.
+> Note: This section does not apply to archive uploads. Path filtering is only available when doing a CLI License Scan. See [here](#how-vendored-dependencies-are-scanned) for more info on the difference between these two methods.
 
 Path filtering can be used to omit some files or directories from license scanning. Path filtering is set up in the `.fossa.yml` file. Here is an example:
 
@@ -149,7 +149,7 @@ vendoredDependencies:
       - "**/spec/*"
 ```
 
-As you can see, the filters are set in the `vendoredDependencies.licenseScanPathFilters` section of the file. You can provide an `only` object and an `exclude` object. Both of these objects is a list of file globs.
+As you can see, the filters are set in the `vendoredDependencies.licenseScanPathFilters` section of the file. You can provide an `only` object and an `exclude` object. Both of these objects consist of a list of file globs.
 
 The `only` object will filter to only paths that match at least one of the entries in the `only` object. The `exclude` object will exclude paths that match any of the entries in the `exclude` object.
 
@@ -183,3 +183,20 @@ Then we have the following results
 | **/src/**   | All files under the src directory                   | `src/subdir/again.rb`                                                                           |
 
 > Note: Some implementations of globstar treat it as "zero or more directories". Since different implementations differ in their globstar functionality, we have decided to treat globstars as matching "one or more directories". We did this as it is simpler to include the additional glob for the base directory case when desired than to exclude the base directory case when it is not desired.
+
+To filter out all files with a given extension, add an entry like `**/*.extension` to the `exclude` object. E.g. `**/*.ts`.
+
+To filter out all files with a given name, add an entry like `**/filename` to the `exclude` object. E.g `**/LICENSE` or `**/LICENSE.*`.
+
+To include only files with a given extension, add an entry like `**/*.extension` to the `only` object. If you want to include files with multiple extensions, you can add multiple entries to the `only` object. E.g. `**/*.ts`.
+
+To include all files with a given name, add an entry like `**/filename` to the `only` object. E.g `**/LICENSE` or `**/LICENSE.*`.
+
+To exclude all files in subdirectories of a given directory, add that directory followed by `/**` to the exclude object. E.g. `path/to/exclude/**`.
+
+If you also want to exclude files directly in that directory, add a second entry with the directory followed by `/*`. E.g. `path/to/exclude/*`.
+
+To scan only files in a subdirectory of a given directory, add that directory followed by `/**` to the exclude object.  E.g. `path/to/scan/**`.
+
+If you also want to scan all files directly in that directory, add a second entry with the directory followed by `/*`. E.g. `path/to/scan/*`.
+

--- a/docs/references/files/fossa-yml.md
+++ b/docs/references/files/fossa-yml.md
@@ -30,6 +30,12 @@ revision:
 vendoredDependencies:
   forceRescans: false
   scanMethod: CLILicenseScan
+  licenseScanPathFilters:
+    only:
+      - "**/*.rb"
+    exclude:
+      - ".git/**"
+      - "test/**/*.rb"
 
 targets:
   only:

--- a/docs/references/files/fossa-yml.v3.schema.json
+++ b/docs/references/files/fossa-yml.v3.schema.json
@@ -293,6 +293,26 @@
                             "description": "Vendored dependencies are scanned by the \"CLI-side license scan\" method, as described in https://github.com/fossas/fossa-cli/blob/master/docs/features/vendored-dependencies.md"
                         }
                     ]
+                },
+                "licenseScanPathFilters": {
+                    "type": "object",
+                    "description": "licenseScanPathFilters allows you to filter which files are scanned when doing a CLILicenseScan. This setting does not apply if you use the ArchiveUpload method of scanning vendoredDependencies.",
+                    "properties": {
+                      "only": {
+                          "type": "array",
+                          "description": "A list of globs that will be used to filter paths. If there are any entries in the `only` list, then only paths that match one or more of the globs in the `only` list will be scanned for licenses.",
+                          "items": {
+                              "$ref": "#/$defs/targetFilter"
+                          }
+                      },
+                      "exclude": {
+                          "type": "array",
+                          "description": "A list of globs that will be used to filter paths. If there are any entries in the `exclude` list, then paths that match any of the `exclude` entries will not be scanned for licenses.",
+                          "items": {
+                              "$ref": "#/$defs/targetFilter"
+                          }
+                      }
+                    }
                 }
             }
         }

--- a/docs/references/files/fossa-yml.v3.schema.json
+++ b/docs/references/files/fossa-yml.v3.schema.json
@@ -302,14 +302,14 @@
                           "type": "array",
                           "description": "A list of globs that will be used to filter paths. If there are any entries in the `only` list, then only paths that match one or more of the globs in the `only` list will be scanned for licenses.",
                           "items": {
-                              "$ref": "#/$defs/targetFilter"
+                              "type": "string"
                           }
                       },
                       "exclude": {
                           "type": "array",
                           "description": "A list of globs that will be used to filter paths. If there are any entries in the `exclude` list, then paths that match any of the `exclude` entries will not be scanned for licenses.",
                           "items": {
-                              "$ref": "#/$defs/targetFilter"
+                              "type": "string"
                           }
                       }
                     }

--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -25,8 +25,8 @@ import Srclib.Types (
   LicenseUnit (licenseUnitFiles, licenseUnitName),
   emptyLicenseUnit,
  )
-import Types (LicenseScanPathFilters (..), GlobFilter (GlobFilter))
 import Test.Hspec (Spec, describe, it, shouldBe)
+import Types (GlobFilter (GlobFilter), LicenseScanPathFilters (..))
 
 recursiveArchive :: FixtureArtifact
 recursiveArchive =

--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -65,7 +65,7 @@ spec = do
     it "should find licenses in nested archives" $ do
       extractedDir <- getArtifact recursiveArchive
       let scanDir = extractedDir </> [reldir|cli-license-scan-integration-test-fixtures-main/recursive-archive|]
-      units <- runStack . runDiagnostics . ignoreStickyLogger . runExecIO . runReadFSIO . fmap licenseSourceUnitLicenseUnits $ scanVendoredDep scanDir vendoredDep
+      units <- runStack . runDiagnostics . ignoreStickyLogger . runExecIO . runReadFSIO . fmap licenseSourceUnitLicenseUnits $ scanVendoredDep scanDir Nothing vendoredDep
       PIO.removeDirRecur extractedDir
       case units of
         Failure ws eg -> fail (show (renderFailure ws eg "An issue occurred"))

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -505,6 +505,7 @@ test-suite unit-tests
     App.Fossa.Report.AttributionSpec
     App.Fossa.Report.Log4jReportSpec
     App.Fossa.ReportSpec
+    App.Fossa.RunThemisSpec
     App.Fossa.VendoredDependencySpec
     App.Fossa.VSI.DynLinked.Internal.BinarySpec
     App.Fossa.VSI.DynLinked.Internal.Lookup.DEBSpec

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -105,7 +105,7 @@ import Options.Applicative (
  )
 import Path (Abs, Dir, File, Path, Rel)
 import System.Info qualified as SysInfo
-import Types (ArchiveUploadType (..), TargetFilter, LicenseScanPathFilters (..))
+import Types (ArchiveUploadType (..), LicenseScanPathFilters (..), TargetFilter)
 
 -- CLI flags, for use with 'Data.Flag'
 data DeprecatedAllowNativeLicenseScan = DeprecatedAllowNativeLicenseScan deriving (Generic)

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -46,9 +46,10 @@ import App.Fossa.Config.ConfigFile (
   ConfigTelemetryScope (NoTelemetry),
   ExperimentalConfigs (..),
   ExperimentalGradleConfigs (..),
+  LicenseScanPathFilters,
   VendoredDependencyConfigs (..),
   mergeFileCmdMetadata,
-  resolveConfigFile, LicenseScanPathFilters,
+  resolveConfigFile,
  )
 import App.Fossa.Config.EnvironmentVars (EnvVars)
 import App.Fossa.Subcommand (EffStack, GetCommonOpts (getCommonOpts), GetSeverity (getSeverity), SubCommand (SubCommand))

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -46,7 +46,6 @@ import App.Fossa.Config.ConfigFile (
   ConfigTelemetryScope (NoTelemetry),
   ExperimentalConfigs (..),
   ExperimentalGradleConfigs (..),
-  LicenseScanPathFilters,
   VendoredDependencyConfigs (..),
   mergeFileCmdMetadata,
   resolveConfigFile,
@@ -106,7 +105,7 @@ import Options.Applicative (
  )
 import Path (Abs, Dir, File, Path, Rel)
 import System.Info qualified as SysInfo
-import Types (ArchiveUploadType (..), TargetFilter)
+import Types (ArchiveUploadType (..), TargetFilter, LicenseScanPathFilters (..))
 
 -- CLI flags, for use with 'Data.Flag'
 data DeprecatedAllowNativeLicenseScan = DeprecatedAllowNativeLicenseScan deriving (Generic)

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -39,6 +39,10 @@ import Data.Aeson (
   (.!=),
   (.:),
   (.:?),
+  ToJSON (toJSON),
+  FromJSON,
+  KeyValue ((.=)),
+  object,
  )
 import Data.Foldable (asum)
 import Data.Functor (($>))
@@ -324,4 +328,9 @@ instance FromJSON LicenseScanPathFilters where
       <$> (obj .:? "only" .!= [])
       <*> (obj .:? "exclude" .!= [])
 
-
+instance ToJSON LicenseScanPathFilters where
+  toJSON LicenseScanPathFilters{..} =
+    object
+      [ "only" .= configLicenseScanPathFiltersOnly
+      , "exclude" .= configLicenseScanPathFiltersExclude
+      ]

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -71,7 +71,7 @@ import Path (
   parseSomeFile,
   (</>),
  )
-import Types (ArchiveUploadType, GlobFilter, TargetFilter)
+import Types (ArchiveUploadType, GlobFilter, TargetFilter, LicenseScanPathFilters)
 
 defaultConfigFileNames :: [Path Rel File]
 defaultConfigFileNames =
@@ -315,21 +315,3 @@ instance FromJSON VendoredDependencyConfigs where
       <*> (obj .:? "scanMethod")
       <*> (obj .:? "licenseScanPathFilters")
 
-data LicenseScanPathFilters = LicenseScanPathFilters
-  { configLicenseScanPathFiltersOnly :: [GlobFilter]
-  , configLicenseScanPathFiltersExclude :: [GlobFilter]
-  }
-  deriving (Eq, Ord, Show)
-
-instance FromJSON LicenseScanPathFilters where
-  parseJSON = withObject "LicenseScanPathFilters" $ \obj ->
-    LicenseScanPathFilters
-      <$> (obj .:? "only" .!= [])
-      <*> (obj .:? "exclude" .!= [])
-
-instance ToJSON LicenseScanPathFilters where
-  toJSON LicenseScanPathFilters{..} =
-    object
-      [ "only" .= configLicenseScanPathFiltersOnly
-      , "exclude" .= configLicenseScanPathFiltersExclude
-      ]

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -34,15 +34,14 @@ import Control.Effect.Diagnostics (
 import Control.Effect.Lift (Lift)
 import Data.Aeson (
   FromJSON (parseJSON),
+  KeyValue ((.=)),
+  ToJSON (toJSON),
+  object,
   withObject,
   withText,
   (.!=),
   (.:),
   (.:?),
-  ToJSON (toJSON),
-  FromJSON,
-  KeyValue ((.=)),
-  object,
  )
 import Data.Foldable (asum)
 import Data.Functor (($>))
@@ -72,7 +71,7 @@ import Path (
   parseSomeFile,
   (</>),
  )
-import Types (ArchiveUploadType, TargetFilter, GlobFilter)
+import Types (ArchiveUploadType, GlobFilter, TargetFilter)
 
 defaultConfigFileNames :: [Path Rel File]
 defaultConfigFileNames =

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -14,6 +14,7 @@ module App.Fossa.Config.ConfigFile (
   ExperimentalConfigs (..),
   ExperimentalGradleConfigs (..),
   VendoredDependencyConfigs (..),
+  LicenseScanPathFilters (..),
   mergeFileCmdMetadata,
   empty,
   resolveLocalConfigFile,

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -14,7 +14,6 @@ module App.Fossa.Config.ConfigFile (
   ExperimentalConfigs (..),
   ExperimentalGradleConfigs (..),
   VendoredDependencyConfigs (..),
-  LicenseScanPathFilters (..),
   mergeFileCmdMetadata,
   empty,
   resolveLocalConfigFile,
@@ -34,9 +33,6 @@ import Control.Effect.Diagnostics (
 import Control.Effect.Lift (Lift)
 import Data.Aeson (
   FromJSON (parseJSON),
-  KeyValue ((.=)),
-  ToJSON (toJSON),
-  object,
   withObject,
   withText,
   (.!=),
@@ -71,7 +67,7 @@ import Path (
   parseSomeFile,
   (</>),
  )
-import Types (ArchiveUploadType, GlobFilter, TargetFilter, LicenseScanPathFilters)
+import Types (ArchiveUploadType, TargetFilter, LicenseScanPathFilters)
 
 defaultConfigFileNames :: [Path Rel File]
 defaultConfigFileNames =

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -67,7 +67,7 @@ import Path (
   parseSomeFile,
   (</>),
  )
-import Types (ArchiveUploadType, TargetFilter, LicenseScanPathFilters)
+import Types (ArchiveUploadType, LicenseScanPathFilters, TargetFilter)
 
 defaultConfigFileNames :: [Path Rel File]
 defaultConfigFileNames =
@@ -310,4 +310,3 @@ instance FromJSON VendoredDependencyConfigs where
       <$> (obj .:? "forceRescans" .!= False)
       <*> (obj .:? "scanMethod")
       <*> (obj .:? "licenseScanPathFilters")
-

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -67,7 +67,7 @@ import Path (
   parseSomeFile,
   (</>),
  )
-import Types (ArchiveUploadType, TargetFilter)
+import Types (ArchiveUploadType, TargetFilter, GlobFilter)
 
 defaultConfigFileNames :: [Path Rel File]
 defaultConfigFileNames =
@@ -300,6 +300,7 @@ instance FromJSON ConfigTelemetryScope where
 data VendoredDependencyConfigs = VendoredDependencyConfigs
   { configForceRescans :: Bool
   , configLicenseScanMethod :: Maybe ArchiveUploadType
+  , configLicenseScanPathFilters :: Maybe LicenseScanPathFilters
   }
   deriving (Eq, Ord, Show)
 
@@ -308,3 +309,18 @@ instance FromJSON VendoredDependencyConfigs where
     VendoredDependencyConfigs
       <$> (obj .:? "forceRescans" .!= False)
       <*> (obj .:? "scanMethod")
+      <*> (obj .:? "licenseScanPathFilters")
+
+data LicenseScanPathFilters = LicenseScanPathFilters
+  { configLicenseScanPathFiltersOnly :: [GlobFilter]
+  , configLicenseScanPathFiltersExclude :: [GlobFilter]
+  }
+  deriving (Eq, Ord, Show)
+
+instance FromJSON LicenseScanPathFilters where
+  parseJSON = withObject "LicenseScanPathFilters" $ \obj ->
+    LicenseScanPathFilters
+      <$> (obj .:? "only" .!= [])
+      <*> (obj .:? "exclude" .!= [])
+
+

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -2,6 +2,7 @@ module App.Fossa.LicenseScan (
   licenseScanSubCommand,
 ) where
 
+import App.Fossa.Config.ConfigFile (ConfigFile (configVendoredDependencies), VendoredDependencyConfigs (configLicenseScanPathFilters), resolveConfigFile)
 import App.Fossa.Config.LicenseScan (
   LicenseScanCommand,
   LicenseScanConfig (..),
@@ -40,7 +41,6 @@ import Effect.ReadFS (ReadFS)
 import Path (Abs, Dir, Path)
 import Prettyprinter (vsep)
 import Srclib.Types (LicenseSourceUnit)
-import App.Fossa.Config.ConfigFile (resolveConfigFile, VendoredDependencyConfigs (configLicenseScanPathFilters), ConfigFile (configVendoredDependencies))
 import Types (LicenseScanPathFilters)
 
 data MissingFossaDepsFile = MissingFossaDepsFile

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -40,7 +40,8 @@ import Effect.ReadFS (ReadFS)
 import Path (Abs, Dir, Path)
 import Prettyprinter (vsep)
 import Srclib.Types (LicenseSourceUnit)
-import App.Fossa.Config.ConfigFile (resolveConfigFile, VendoredDependencyConfigs (configLicenseScanPathFilters), ConfigFile (configVendoredDependencies), LicenseScanPathFilters)
+import App.Fossa.Config.ConfigFile (resolveConfigFile, VendoredDependencyConfigs (configLicenseScanPathFilters), ConfigFile (configVendoredDependencies))
+import Types (LicenseScanPathFilters)
 
 data MissingFossaDepsFile = MissingFossaDepsFile
 data NoVendoredDeps = NoVendoredDeps

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -101,4 +101,4 @@ runLicenseScan ::
   Path Abs Dir ->
   NonEmpty VendoredDependency ->
   m (NonEmpty LicenseSourceUnit)
-runLicenseScan basedir vdeps = dedupVendoredDeps vdeps >>= traverse (scanVendoredDep basedir)
+runLicenseScan basedir vdeps = dedupVendoredDeps vdeps >>= traverse (scanVendoredDep basedir Nothing)

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -7,7 +7,6 @@ module App.Fossa.LicenseScanner (
   scanVendoredDep,
 ) where
 
-import App.Fossa.Config.ConfigFile (LicenseScanPathFilters (..))
 import App.Fossa.EmbeddedBinary (ThemisBins, withThemisAndIndex)
 import App.Fossa.RunThemis (
   execThemis,
@@ -73,7 +72,7 @@ import Srclib.Types (
   LicenseUnit (..),
   Locator (..),
  )
-import Types (GlobFilter (unGlobFilter))
+import Types (GlobFilter (unGlobFilter), LicenseScanPathFilters (..))
 
 data LicenseScanErr
   = NoSuccessfulScans

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -10,6 +10,7 @@ module App.Fossa.LicenseScanner (
 import App.Fossa.EmbeddedBinary (ThemisBins, withThemisAndIndex)
 import App.Fossa.RunThemis (
   execThemis,
+  themisFlags,
  )
 import App.Fossa.VendoredDependency (
   NeedScanningDeps (..),
@@ -72,7 +73,7 @@ import Srclib.Types (
   LicenseUnit (..),
   Locator (..),
  )
-import Types (GlobFilter (unGlobFilter), LicenseScanPathFilters (..))
+import Types (LicenseScanPathFilters)
 
 data LicenseScanErr
   = NoSuccessfulScans
@@ -169,14 +170,6 @@ themisRunner pathPrefix licenseScanPathFilters scanDir themisBins = runThemis th
 runThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Maybe LicenseScanPathFilters -> Path Abs Dir -> m [LicenseUnit]
 runThemis themisBins pathPrefix licenseScanPathFilters scanDir = do
   context "Running license scan binary" $ execThemis themisBins pathPrefix scanDir $ themisFlags licenseScanPathFilters
-
-themisFlags :: Maybe LicenseScanPathFilters -> [Text]
-themisFlags Nothing = ["--srclib-with-matches"]
-themisFlags (Just filters) =
-  let defaultFilter = ["--srclib-with-matches"]
-      onlyFilters = concatMap (\only -> ["--only-paths", unGlobFilter only]) $ licenseScanPathFiltersOnly filters
-      exceptFilters = concatMap (\exclude -> ["--exclude-paths", unGlobFilter exclude]) $ licenseScanPathFiltersExclude filters
-   in defaultFilter ++ onlyFilters ++ exceptFilters
 
 calculateVendoredHash :: Path Abs Dir -> Text -> Path Abs Dir -> IO Text
 calculateVendoredHash baseDir vendoredPath tmpDir = do

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -177,8 +177,8 @@ themisFlags (Just filters) =
   let defaultFilter = ["--srclib-with_matches"]
       onlyFilters = concatMap (\only -> ["--only-paths", unGlobFilter only]) $ configLicenseScanPathFiltersOnly filters
       exceptFilters = concatMap (\exclude -> ["--exclude-paths", unGlobFilter exclude]) $ configLicenseScanPathFiltersExclude filters
-  in
-    defaultFilter ++ onlyFilters ++ exceptFilters
+   in
+      defaultFilter ++ onlyFilters ++ exceptFilters
 
 calculateVendoredHash :: Path Abs Dir -> Text -> Path Abs Dir -> IO Text
 calculateVendoredHash baseDir vendoredPath tmpDir = do
@@ -340,7 +340,7 @@ licenseScanSourceUnit ::
   Path Abs Dir ->
   NonEmpty VendoredDependency ->
   m (NonEmpty Locator)
-licenseScanSourceUnit vendoredDependencyScanMode licenseScanPathFilters baseDir vendoredDeps  = do
+licenseScanSourceUnit vendoredDependencyScanMode licenseScanPathFilters baseDir vendoredDeps = do
   uniqDeps <- dedupVendoredDeps vendoredDeps
 
   -- The organizationID is needed to prefix each locator name. The FOSSA API automatically prefixes the locator when queuing the build

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -72,6 +72,8 @@ import Srclib.Types (
   LicenseUnit (..),
   Locator (..),
  )
+import App.Fossa.Config.ConfigFile (LicenseScanPathFilters (..))
+import Types (GlobFilter(unGlobFilter))
 
 data LicenseScanErr
   = NoSuccessfulScans
@@ -98,13 +100,14 @@ runLicenseScanOnDir ::
   , Has ReadFS sig m
   ) =>
   Text ->
+  Maybe LicenseScanPathFilters ->
   Path Abs Dir ->
   m [LicenseUnit]
-runLicenseScanOnDir pathPrefix scanDir = do
+runLicenseScanOnDir pathPrefix licenseScanPathFilters scanDir = do
   -- license scan the root directory
-  rootDirUnits <- withThemisAndIndex $ themisRunner pathPrefix scanDir
+  rootDirUnits <- withThemisAndIndex $ themisRunner pathPrefix licenseScanPathFilters scanDir
   -- recursively unpack archives and license scan them too
-  otherArchiveUnits <- runFinally $ recursivelyScanArchives pathPrefix scanDir
+  otherArchiveUnits <- runFinally $ recursivelyScanArchives pathPrefix licenseScanPathFilters scanDir
   -- when we scan multiple archives, we need to combine the results
   pure $ combineLicenseUnits (rootDirUnits <> otherArchiveUnits)
 
@@ -116,14 +119,15 @@ recursivelyScanArchives ::
   , Has Exec sig m
   ) =>
   Text ->
+  Maybe LicenseScanPathFilters ->
   Path Abs Dir ->
   m [LicenseUnit]
-recursivelyScanArchives pathPrefix dir = flip walk' dir $
+recursivelyScanArchives pathPrefix licenseScanPathFilters dir = flip walk' dir $
   \_ _ files -> do
     let process file unpackedDir = do
           let updatedPathPrefix = pathPrefix <> getPathPrefix dir (parent file)
-          currentDirResults <- withThemisAndIndex $ themisRunner updatedPathPrefix unpackedDir
-          recursiveResults <- recursivelyScanArchives updatedPathPrefix unpackedDir
+          currentDirResults <- withThemisAndIndex $ themisRunner updatedPathPrefix licenseScanPathFilters unpackedDir
+          recursiveResults <- recursivelyScanArchives updatedPathPrefix licenseScanPathFilters unpackedDir
           pure $ currentDirResults <> recursiveResults
     -- withArchive' emits Nothing when archive type is not supported.
     archives <- traverse (\file -> withArchive' file (process file)) files
@@ -157,14 +161,24 @@ themisRunner ::
   , Has Exec sig m
   ) =>
   Text ->
+  Maybe LicenseScanPathFilters ->
   Path Abs Dir ->
   ThemisBins ->
   m [LicenseUnit]
-themisRunner pathPrefix scanDir themisBins = runThemis themisBins pathPrefix scanDir
+themisRunner pathPrefix licenseScanPathFilters scanDir themisBins = runThemis themisBins pathPrefix licenseScanPathFilters scanDir
 
-runThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Path Abs Dir -> m [LicenseUnit]
-runThemis themisBins pathPrefix scanDir = do
-  context "Running license scan binary" $ execThemis themisBins pathPrefix scanDir ["--srclib-with-matches"]
+runThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Maybe LicenseScanPathFilters -> Path Abs Dir -> m [LicenseUnit]
+runThemis themisBins pathPrefix licenseScanPathFilters scanDir = do
+  context "Running license scan binary" $ execThemis themisBins pathPrefix scanDir $ themisFlags licenseScanPathFilters
+
+themisFlags :: Maybe LicenseScanPathFilters -> [Text]
+themisFlags Nothing = ["--srclib-with_matches"]
+themisFlags (Just filters) =
+  let defaultFilter = ["--srclib-with_matches"]
+      onlyFilters = concatMap (\only -> ["--only-paths", unGlobFilter only]) $ configLicenseScanPathFiltersOnly filters
+      exceptFilters = concatMap (\exclude -> ["--exclude-paths", unGlobFilter exclude]) $ configLicenseScanPathFiltersExclude filters
+  in
+    defaultFilter ++ onlyFilters ++ exceptFilters
 
 calculateVendoredHash :: Path Abs Dir -> Text -> Path Abs Dir -> IO Text
 calculateVendoredHash baseDir vendoredPath tmpDir = do
@@ -180,10 +194,11 @@ scanAndUploadVendoredDep ::
   , Has FossaApiClient sig m
   ) =>
   Path Abs Dir ->
+  Maybe LicenseScanPathFilters ->
   VendoredDependency ->
   m (Maybe Archive)
-scanAndUploadVendoredDep baseDir vdep = context "Processing vendored dependency" $ do
-  maybeLicenseUnits <- recover $ scanVendoredDep baseDir vdep
+scanAndUploadVendoredDep baseDir licenseScanPathFilters vdep = context "Processing vendored dependency" $ do
+  maybeLicenseUnits <- recover $ scanVendoredDep baseDir licenseScanPathFilters vdep
   case maybeLicenseUnits of
     Nothing -> pure Nothing
     Just licenseUnits -> uploadVendoredDep baseDir vdep licenseUnits
@@ -196,16 +211,17 @@ scanVendoredDep ::
   , Has ReadFS sig m
   ) =>
   Path Abs Dir ->
+  Maybe LicenseScanPathFilters ->
   VendoredDependency ->
   m LicenseSourceUnit
-scanVendoredDep baseDir VendoredDependency{..} = context "Scanning vendored deps for license data" $ do
+scanVendoredDep baseDir licenseScanPathFilters VendoredDependency{..} = context "Scanning vendored deps for license data" $ do
   logSticky $ "License Scanning '" <> vendoredName <> "' at '" <> vendoredPath <> "'"
   scanPath <- resolvePath' baseDir $ toString vendoredPath
   licenseUnits <- case scanPath of
-    SomeFile (Abs path) -> scanArchive baseDir $ ScannableArchive path
-    SomeFile (Rel path) -> scanArchive baseDir . ScannableArchive $ baseDir </> path
-    SomeDir (Abs path) -> scanDirectory Nothing (getPathPrefix baseDir path) path
-    SomeDir (Rel path) -> scanDirectory Nothing (toText path) (baseDir </> path)
+    SomeFile (Abs path) -> scanArchive baseDir licenseScanPathFilters $ ScannableArchive path
+    SomeFile (Rel path) -> scanArchive baseDir licenseScanPathFilters . ScannableArchive $ baseDir </> path
+    SomeDir (Abs path) -> scanDirectory Nothing (getPathPrefix baseDir path) licenseScanPathFilters path
+    SomeDir (Rel path) -> scanDirectory Nothing (toText path) licenseScanPathFilters (baseDir </> path)
   pure $ LicenseSourceUnit vendoredPath CliLicenseScanned licenseUnits
 
 getPathPrefix :: Path Abs Dir -> Path Abs t -> Text
@@ -222,12 +238,13 @@ scanArchive ::
   , Has StickyLogger sig m
   ) =>
   Path Abs Dir ->
+  Maybe LicenseScanPathFilters ->
   ScannableArchive ->
   m (NonEmpty LicenseUnit)
-scanArchive baseDir file = runFinally $ do
+scanArchive baseDir licenseScanPathFilters file = runFinally $ do
   -- withArchive' emits Nothing when archive type is not supported.
   logSticky $ "scanning archive at " <> toText (scanFile file)
-  result <- withArchive' (scanFile file) (scanDirectory (Just file) pathPrefix)
+  result <- withArchive' (scanFile file) (scanDirectory (Just file) pathPrefix licenseScanPathFilters)
   case result of
     Nothing -> fatal . UnsupportedArchive $ scanFile file
     Just units -> pure units
@@ -243,12 +260,13 @@ scanDirectory ::
   ) =>
   Maybe ScannableArchive ->
   Text ->
+  Maybe LicenseScanPathFilters ->
   Path Abs Dir ->
   m (NonEmpty LicenseUnit)
-scanDirectory origin pathPrefix path = do
+scanDirectory origin pathPrefix licenseScanPathFilters path = do
   hasFiles <- hasAnyFiles path
   if hasFiles
-    then scanNonEmptyDirectory pathPrefix path
+    then scanNonEmptyDirectory pathPrefix licenseScanPathFilters path
     else maybe (fatal $ EmptyDirectory path) (fatal . EmptyArchive . scanFile) origin
 
 hasAnyFiles ::
@@ -275,10 +293,11 @@ scanNonEmptyDirectory ::
   , Has ReadFS sig m
   ) =>
   Text ->
+  Maybe LicenseScanPathFilters ->
   Path Abs Dir ->
   m (NonEmpty LicenseUnit)
-scanNonEmptyDirectory pathPrefix cliScanDir = do
-  themisScanResult <- runLicenseScanOnDir pathPrefix cliScanDir
+scanNonEmptyDirectory pathPrefix licenseScanPathFilters cliScanDir = do
+  themisScanResult <- runLicenseScanOnDir pathPrefix licenseScanPathFilters cliScanDir
   case NE.nonEmpty themisScanResult of
     Nothing -> fatal $ NoLicenseResults cliScanDir
     Just results -> pure results
@@ -317,10 +336,11 @@ licenseScanSourceUnit ::
   , Has FossaApiClient sig m
   ) =>
   VendoredDependencyScanMode ->
+  Maybe LicenseScanPathFilters ->
   Path Abs Dir ->
   NonEmpty VendoredDependency ->
   m (NonEmpty Locator)
-licenseScanSourceUnit vendoredDependencyScanMode baseDir vendoredDeps = do
+licenseScanSourceUnit vendoredDependencyScanMode licenseScanPathFilters baseDir vendoredDeps  = do
   uniqDeps <- dedupVendoredDeps vendoredDeps
 
   -- The organizationID is needed to prefix each locator name. The FOSSA API automatically prefixes the locator when queuing the build
@@ -339,7 +359,7 @@ licenseScanSourceUnit vendoredDependencyScanMode baseDir vendoredDeps = do
 
   -- At this point, we have a good list of deps, so go for it.
   -- If none of the dependencies need scanning we still need to do `finalizeLicenseScan`, so keep going
-  maybeScannedArchives <- traverse (scanAndUploadVendoredDep baseDir) (needScanningDeps needScanning)
+  maybeScannedArchives <- traverse (scanAndUploadVendoredDep baseDir licenseScanPathFilters) (needScanningDeps needScanning)
 
   -- We need to include both scanned and skipped archives in this list so that they all get included in the build in FOSSA
   let skippedArchives = map forceVendoredToArchive $ skippableDeps skippable

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -172,9 +172,9 @@ runThemis themisBins pathPrefix licenseScanPathFilters scanDir = do
   context "Running license scan binary" $ execThemis themisBins pathPrefix scanDir $ themisFlags licenseScanPathFilters
 
 themisFlags :: Maybe LicenseScanPathFilters -> [Text]
-themisFlags Nothing = ["--srclib-with_matches"]
+themisFlags Nothing = ["--srclib-with-matches"]
 themisFlags (Just filters) =
-  let defaultFilter = ["--srclib-with_matches"]
+  let defaultFilter = ["--srclib-with-matches"]
       onlyFilters = concatMap (\only -> ["--only-paths", unGlobFilter only]) $ configLicenseScanPathFiltersOnly filters
       exceptFilters = concatMap (\exclude -> ["--exclude-paths", unGlobFilter exclude]) $ configLicenseScanPathFiltersExclude filters
    in defaultFilter ++ onlyFilters ++ exceptFilters

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -175,8 +175,8 @@ themisFlags :: Maybe LicenseScanPathFilters -> [Text]
 themisFlags Nothing = ["--srclib-with-matches"]
 themisFlags (Just filters) =
   let defaultFilter = ["--srclib-with-matches"]
-      onlyFilters = concatMap (\only -> ["--only-paths", unGlobFilter only]) $ configLicenseScanPathFiltersOnly filters
-      exceptFilters = concatMap (\exclude -> ["--exclude-paths", unGlobFilter exclude]) $ configLicenseScanPathFiltersExclude filters
+      onlyFilters = concatMap (\only -> ["--only-paths", unGlobFilter only]) $ licenseScanPathFiltersOnly filters
+      exceptFilters = concatMap (\exclude -> ["--exclude-paths", unGlobFilter exclude]) $ licenseScanPathFiltersExclude filters
    in defaultFilter ++ onlyFilters ++ exceptFilters
 
 calculateVendoredHash :: Path Abs Dir -> Text -> Path Abs Dir -> IO Text

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -7,6 +7,7 @@ module App.Fossa.LicenseScanner (
   scanVendoredDep,
 ) where
 
+import App.Fossa.Config.ConfigFile (LicenseScanPathFilters (..))
 import App.Fossa.EmbeddedBinary (ThemisBins, withThemisAndIndex)
 import App.Fossa.RunThemis (
   execThemis,
@@ -72,8 +73,7 @@ import Srclib.Types (
   LicenseUnit (..),
   Locator (..),
  )
-import App.Fossa.Config.ConfigFile (LicenseScanPathFilters (..))
-import Types (GlobFilter(unGlobFilter))
+import Types (GlobFilter (unGlobFilter))
 
 data LicenseScanErr
   = NoSuccessfulScans
@@ -177,8 +177,7 @@ themisFlags (Just filters) =
   let defaultFilter = ["--srclib-with_matches"]
       onlyFilters = concatMap (\only -> ["--only-paths", unGlobFilter only]) $ configLicenseScanPathFiltersOnly filters
       exceptFilters = concatMap (\exclude -> ["--exclude-paths", unGlobFilter exclude]) $ configLicenseScanPathFiltersExclude filters
-   in
-      defaultFilter ++ onlyFilters ++ exceptFilters
+   in defaultFilter ++ onlyFilters ++ exceptFilters
 
 calculateVendoredHash :: Path Abs Dir -> Text -> Path Abs Dir -> IO Text
 calculateVendoredHash baseDir vendoredPath tmpDir = do

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -169,7 +169,7 @@ scanAndUpload root vdeps vendoredDepsOptions = do
   (archiveOrCLI, vendoredDependencyScanMode) <- getScanCfg org vendoredDepsOptions
   let scanner = case archiveOrCLI of
         ArchiveUpload -> archiveUploadSourceUnit
-        CLILicenseScan -> licenseScanSourceUnit vendoredDependencyScanMode
+        CLILicenseScan -> licenseScanSourceUnit vendoredDependencyScanMode $ licenseScanPathFilters vendoredDepsOptions
   scanner root vdeps
 
 getScanCfg :: (Has Diagnostics sig m) => Organization -> VendoredDependencyOptions -> m (ArchiveUploadType, VendoredDependencyScanMode)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -228,8 +228,6 @@ newtype BuildTarget = BuildTarget {unBuildTarget :: Text}
 newtype GlobFilter = GlobFilter { unGlobFilter :: Text }
   deriving (Eq, Ord, Show, ToJSON, FromJSON)
 
-
-
 data TargetFilter
   = TypeTarget Text
   | TypeDirTarget Text (Path Rel Dir)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -12,6 +12,7 @@ module Types (
   LicenseType (..),
   module DepTypes,
   TargetFilter (..),
+  GlobFilter (..),
   DiscoveredProjectType (..),
   projectTypeToText,
 ) where
@@ -223,6 +224,12 @@ newtype BuildTarget = BuildTarget {unBuildTarget :: Text}
   However, many Gradle targets consist of a strategy type, a directory,
   and an exact gradle target.
 -}
+
+newtype GlobFilter = GlobFilter { unGlobFilter :: Text }
+  deriving (Eq, Ord, Show, ToJSON, FromJSON)
+
+
+
 data TargetFilter
   = TypeTarget Text
   | TypeDirTarget Text (Path Rel Dir)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -27,9 +27,9 @@ import Data.Aeson (
   object,
   withObject,
   withText,
+  (.!=),
   (.:),
   (.:?),
-  (.!=),
  )
 import Data.Aeson.Types (Parser)
 import Data.Set.NonEmpty (NonEmptySet)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -225,7 +225,7 @@ newtype BuildTarget = BuildTarget {unBuildTarget :: Text}
   and an exact gradle target.
 -}
 
-newtype GlobFilter = GlobFilter { unGlobFilter :: Text }
+newtype GlobFilter = GlobFilter {unGlobFilter :: Text}
   deriving (Eq, Ord, Show, ToJSON, FromJSON)
 
 data TargetFilter

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -14,6 +14,7 @@ module Types (
   TargetFilter (..),
   GlobFilter (..),
   DiscoveredProjectType (..),
+  LicenseScanPathFilters (..),
   projectTypeToText,
 ) where
 
@@ -28,6 +29,7 @@ import Data.Aeson (
   withText,
   (.:),
   (.:?),
+  (.!=),
  )
 import Data.Aeson.Types (Parser)
 import Data.Set.NonEmpty (NonEmptySet)
@@ -308,3 +310,22 @@ instance FromJSON ArchiveUploadType where
 
 instance ToJSON ArchiveUploadType where
   toJSON = toJSON . show
+
+data LicenseScanPathFilters = LicenseScanPathFilters
+  { licenseScanPathFiltersOnly :: [GlobFilter]
+  , licenseScanPathFiltersExclude :: [GlobFilter]
+  }
+  deriving (Eq, Ord, Show)
+
+instance FromJSON LicenseScanPathFilters where
+  parseJSON = withObject "LicenseScanPathFilters" $ \obj ->
+    LicenseScanPathFilters
+      <$> (obj .:? "only" .!= [])
+      <*> (obj .:? "exclude" .!= [])
+
+instance ToJSON LicenseScanPathFilters where
+  toJSON LicenseScanPathFilters{..} =
+    object
+      [ "only" .= licenseScanPathFiltersOnly
+      , "exclude" .= licenseScanPathFiltersExclude
+      ]

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -12,6 +12,7 @@ import App.Fossa.Config.ConfigFile (
   ExperimentalConfigs (..),
   ExperimentalGradleConfigs (ExperimentalGradleConfigs),
   VendoredDependencyConfigs (..),
+  LicenseScanPathFilters (..),
   resolveConfigFile,
  )
 import App.Types (ReleaseGroupMetadata (..))
@@ -26,7 +27,7 @@ import Path.IO (getCurrentDir)
 import ResultUtil (assertOnSuccess, expectFailure)
 import Test.Hspec qualified as T
 import Test.Hspec.Core.Spec (SpecM)
-import Types (ArchiveUploadType (..), BuildTarget (..), TargetFilter (..))
+import Types (ArchiveUploadType (..), BuildTarget (..), TargetFilter (..), GlobFilter (GlobFilter))
 
 expectedConfigFile :: ConfigFile
 expectedConfigFile =
@@ -88,7 +89,15 @@ expectedVendoredDependencies =
   VendoredDependencyConfigs
     { configForceRescans = True
     , configLicenseScanMethod = Just ArchiveUpload
+    , configLicenseScanPathFilters = Just expectedVendoredDependencyFilters
     }
+
+expectedVendoredDependencyFilters :: LicenseScanPathFilters
+expectedVendoredDependencyFilters =
+  LicenseScanPathFilters
+  { configLicenseScanPathFiltersOnly = [GlobFilter "**/*.rb"]
+  , configLicenseScanPathFiltersExclude =  [GlobFilter ".git/**", GlobFilter "test/**/*.rb"]
+  }
 
 simpleTarget :: TargetFilter
 simpleTarget = TypeTarget "pip"

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -11,8 +11,8 @@ import App.Fossa.Config.ConfigFile (
   ConfigTargets (..),
   ExperimentalConfigs (..),
   ExperimentalGradleConfigs (ExperimentalGradleConfigs),
-  VendoredDependencyConfigs (..),
   LicenseScanPathFilters (..),
+  VendoredDependencyConfigs (..),
   resolveConfigFile,
  )
 import App.Types (ReleaseGroupMetadata (..))
@@ -27,7 +27,7 @@ import Path.IO (getCurrentDir)
 import ResultUtil (assertOnSuccess, expectFailure)
 import Test.Hspec qualified as T
 import Test.Hspec.Core.Spec (SpecM)
-import Types (ArchiveUploadType (..), BuildTarget (..), TargetFilter (..), GlobFilter (GlobFilter))
+import Types (ArchiveUploadType (..), BuildTarget (..), GlobFilter (GlobFilter), TargetFilter (..))
 
 expectedConfigFile :: ConfigFile
 expectedConfigFile =
@@ -95,9 +95,9 @@ expectedVendoredDependencies =
 expectedVendoredDependencyFilters :: LicenseScanPathFilters
 expectedVendoredDependencyFilters =
   LicenseScanPathFilters
-  { configLicenseScanPathFiltersOnly = [GlobFilter "**/*.rb"]
-  , configLicenseScanPathFiltersExclude =  [GlobFilter ".git/**", GlobFilter "test/**/*.rb"]
-  }
+    { configLicenseScanPathFiltersOnly = [GlobFilter "**/*.rb"]
+    , configLicenseScanPathFiltersExclude = [GlobFilter ".git/**", GlobFilter "test/**/*.rb"]
+    }
 
 simpleTarget :: TargetFilter
 simpleTarget = TypeTarget "pip"

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -26,7 +26,7 @@ import Path.IO (getCurrentDir)
 import ResultUtil (assertOnSuccess, expectFailure)
 import Test.Hspec qualified as T
 import Test.Hspec.Core.Spec (SpecM)
-import Types (ArchiveUploadType (..), BuildTarget (..), GlobFilter (GlobFilter), TargetFilter (..), LicenseScanPathFilters (..))
+import Types (ArchiveUploadType (..), BuildTarget (..), GlobFilter (GlobFilter), LicenseScanPathFilters (..), TargetFilter (..))
 
 expectedConfigFile :: ConfigFile
 expectedConfigFile =

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -95,8 +95,8 @@ expectedVendoredDependencies =
 expectedVendoredDependencyFilters :: LicenseScanPathFilters
 expectedVendoredDependencyFilters =
   LicenseScanPathFilters
-    { configLicenseScanPathFiltersOnly = [GlobFilter "**/*.rb"]
-    , configLicenseScanPathFiltersExclude = [GlobFilter ".git/**", GlobFilter "test/**/*.rb"]
+    { licenseScanPathFiltersOnly = [GlobFilter "**/*.rb"]
+    , licenseScanPathFiltersExclude = [GlobFilter ".git/**", GlobFilter "test/**/*.rb"]
     }
 
 simpleTarget :: TargetFilter

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -11,7 +11,6 @@ import App.Fossa.Config.ConfigFile (
   ConfigTargets (..),
   ExperimentalConfigs (..),
   ExperimentalGradleConfigs (ExperimentalGradleConfigs),
-  LicenseScanPathFilters (..),
   VendoredDependencyConfigs (..),
   resolveConfigFile,
  )
@@ -27,7 +26,7 @@ import Path.IO (getCurrentDir)
 import ResultUtil (assertOnSuccess, expectFailure)
 import Test.Hspec qualified as T
 import Test.Hspec.Core.Spec (SpecM)
-import Types (ArchiveUploadType (..), BuildTarget (..), GlobFilter (GlobFilter), TargetFilter (..))
+import Types (ArchiveUploadType (..), BuildTarget (..), GlobFilter (GlobFilter), TargetFilter (..), LicenseScanPathFilters (..))
 
 expectedConfigFile :: ConfigFile
 expectedConfigFile =

--- a/test/App/Fossa/Configuration/testdata/valid-default-yaml/.fossa.yaml
+++ b/test/App/Fossa/Configuration/testdata/valid-default-yaml/.fossa.yaml
@@ -37,3 +37,9 @@ experimental:
 vendoredDependencies:
   forceRescans: true
   scanMethod: ArchiveUpload
+  licenseScanPathFilters:
+    only:
+      - "**/*.rb"
+    exclude:
+      - ".git/**"
+      - "test/**/*.rb"

--- a/test/App/Fossa/Configuration/testdata/valid-default/.fossa.yml
+++ b/test/App/Fossa/Configuration/testdata/valid-default/.fossa.yml
@@ -37,3 +37,9 @@ experimental:
 vendoredDependencies:
   forceRescans: true
   scanMethod: ArchiveUpload
+  licenseScanPathFilters:
+    only:
+      - "**/*.rb"
+    exclude:
+      - ".git/**"
+      - "test/**/*.rb"

--- a/test/App/Fossa/LicenseScannerSpec.hs
+++ b/test/App/Fossa/LicenseScannerSpec.hs
@@ -96,7 +96,7 @@ spec = do
       expectGetOrganization
       expectEverythingScannedAlready
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should scan all if Core does not know about the revisions" $ do
@@ -108,7 +108,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should scan all if the revisions are still being scanned" $ do
@@ -120,7 +120,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should scan one if one revision is still being scanned" $ do
@@ -130,7 +130,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "first-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.firstLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should always scan all if vendor dependency skipping is not supported" $ do
@@ -141,7 +141,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkippingNotSupported scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkippingNotSupported Nothing scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should always scan all if the --force-vendor-dependency-rescans flag is used" $ do
@@ -152,7 +152,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScanWithForceRebuild Fixtures.archives
-      locators <- licenseScanSourceUnit SkippingDisabledViaFlag scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkippingDisabledViaFlag Nothing scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
 expectGetApiOpts :: Has MockApi sig m => m ()

--- a/test/App/Fossa/ManualDepsSpec.hs
+++ b/test/App/Fossa/ManualDepsSpec.hs
@@ -88,39 +88,39 @@ spec = do
 
   describe "getScanCfg" $ do
     it' "should fail if you try to force a license scan but the FOSSA server does not support it" $ do
-      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Just CLILicenseScan}
+      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Just CLILicenseScan, licenseScanPathFilters = Nothing}
           org = Fixtures.organization{orgCoreSupportsLocalLicenseScan = False}
       expectFatal' $ getScanCfg org opts
 
     it' "should do a license scan if requested and FOSSA supports it" $ do
-      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Just CLILicenseScan}
+      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Just CLILicenseScan, licenseScanPathFilters = Nothing}
       (uploadType, scanMode) <- getScanCfg Fixtures.organization opts
       (uploadType, scanMode) `shouldBe'` (CLILicenseScan, SkipPreviouslyScanned)
 
     it' "should do a license scan if they are the default and no flags are passed" $ do
-      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Nothing}
+      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Nothing, licenseScanPathFilters = Nothing}
       (uploadType, scanMode) <- getScanCfg Fixtures.organization opts
       (uploadType, scanMode) `shouldBe'` (CLILicenseScan, SkipPreviouslyScanned)
 
     it' "should force a license scan rebuild if forceRescans is True" $ do
-      let opts = VendoredDependencyOptions{forceRescans = True, licenseScanMethod = Nothing}
+      let opts = VendoredDependencyOptions{forceRescans = True, licenseScanMethod = Nothing, licenseScanPathFilters = Nothing}
       (uploadType, scanMode) <- getScanCfg Fixtures.organization opts
       (uploadType, scanMode) `shouldBe'` (CLILicenseScan, SkippingDisabledViaFlag)
 
     it' "should not skip if the server does not support the analyzed revisions query" $ do
-      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Nothing}
+      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Nothing, licenseScanPathFilters = Nothing}
           org = Fixtures.organization{orgSupportsAnalyzedRevisionsQuery = False}
       (uploadType, scanMode) <- getScanCfg org opts
       (uploadType, scanMode) `shouldBe'` (CLILicenseScan, SkippingNotSupported)
 
     it' "should do an archive upload if they are the default and no flags are passed" $ do
-      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Nothing}
+      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Nothing, licenseScanPathFilters = Nothing}
           org = Fixtures.organization{orgDefaultVendoredDependencyScanType = ArchiveUpload}
       (uploadType, scanMode) <- getScanCfg org opts
       (uploadType, scanMode) `shouldBe'` (ArchiveUpload, SkipPreviouslyScanned)
 
     it' "should do an archive upload if requested and CLI license scan is the default" $ do
-      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Just ArchiveUpload}
+      let opts = VendoredDependencyOptions{forceRescans = False, licenseScanMethod = Just ArchiveUpload, licenseScanPathFilters = Nothing}
           org = Fixtures.organization{orgDefaultVendoredDependencyScanType = ArchiveUpload}
       (uploadType, scanMode) <- getScanCfg org opts
       (uploadType, scanMode) `shouldBe'` (ArchiveUpload, SkipPreviouslyScanned)

--- a/test/App/Fossa/RunThemisSpec.hs
+++ b/test/App/Fossa/RunThemisSpec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module App.Fossa.RunThemisSpec (spec) where
 
 import App.Fossa.RunThemis (themisFlags)

--- a/test/App/Fossa/RunThemisSpec.hs
+++ b/test/App/Fossa/RunThemisSpec.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.Fossa.RunThemisSpec (spec) where
+
+import App.Fossa.RunThemis (themisFlags)
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Types (GlobFilter (GlobFilter), LicenseScanPathFilters (..))
+
+spec :: Spec
+spec = do
+  describe "themisFlags" $ do
+    it "should return the default flag if LicenseScanPathFilters is Nothing" $
+      themisFlags Nothing `shouldBe` ["--srclib-with-matches"]
+
+    it "should add multiple only flags if provided" $
+      let licenseScanPathFilters =
+            Just
+              LicenseScanPathFilters
+                { licenseScanPathFiltersOnly = [GlobFilter "**.rb", GlobFilter "**.html"]
+                , licenseScanPathFiltersExclude = []
+                }
+       in themisFlags licenseScanPathFilters `shouldBe` ["--srclib-with-matches", "--only-paths", "**.rb", "--only-paths", "**.html"]
+
+    it "should add only and exclude flags if provided" $
+      let licenseScanPathFilters =
+            Just
+              LicenseScanPathFilters
+                { licenseScanPathFiltersOnly = [GlobFilter "**.rb", GlobFilter "**.html"]
+                , licenseScanPathFiltersExclude = [GlobFilter "**.jsx"]
+                }
+       in themisFlags licenseScanPathFilters `shouldBe` ["--srclib-with-matches", "--only-paths", "**.rb", "--only-paths", "**.html", "--exclude-paths", "**.jsx"]

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -79,7 +79,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2022-10-11-40ed95c"
+THEMIS_TAG="2023-01-05-d5a3fe2-1672962253"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

Delivers the fossa-cli side of [ANE-707](https://fossa.atlassian.net/browse/ANE-707) 

The Themis side is being done in https://github.com/fossas/basis/pull/1774

## Acceptance criteria

- Customers should be able to filter the files being scanned using globs added to their `.fossa.yml` file
- The same files should be scanned regardless of your operating system without having to make any changes to the `.fossa.yml` file
- A customer should be able to debug which files are being scanned using `fossa license-scan fossa-deps`. This should be described in the documentation.
- The filters should work for nested archives
- The documentation should give enough examples that customers can figure this out without having to ask for help.

- [ ] TODO: update the themis tag in `vendor_download.sh` once https://github.com/fossas/basis/pull/1774 has been merged and released.

## Testing plan

I tested by building Themis locally with the `themis-path-filters` path checked out, putting that in `vendor-bins` and then rebuilding:

```
cd ~/fossa/basis
git checkout themis-path-filters
CGO_ENABLED=0 go run ./tooling/internal/cmd/basis build -production -o release -targets darwin-amd64 themis cli
cp ~/fossa/basis/release/themis-cli-darwin-amd64 vendor-bins/themis-cli
```

```
cd ~/fossa/fossa-cli
cabal clean
cabal build
rm -f `which fossa-dev`; make install-dev
```

Then I tested in a few sample directory structures.

### Test with recursive archives

https://github.com/fossas/example-projects/tree/main/recursive-archive-generator

Follow the directions there to generate a recursive archive in /Users/scott/fossa/license-scan-dirs/recursive-archive-3

Test with no filters. It should find all of the files listed in the README for `recursive-archive-generator`.

```
fossa-dev license-scan fossa-deps | jq '.uploadUnits[].LicenseUnits[].Files'
```

Create a `.fossa-deps.yml` that looks like this:

```yaml
version: 3
vendoredDependencies:
  licenseScanPathFilters:
    only:
      - "./vendor/foo/bar/**/*_LICENSE"
```

You should only see `*_LICENSE` files:

```
fossa-dev license-scan fossa-deps | jq '.uploadUnits[].LicenseUnits[].Files'

[
  "vendor/foo/bar/baz/SOMETHING_LICENSE",
  "vendor/foo/bar/baz/quux/QUUX_LICENSE"
]
```

Run `fossa analyze` and check that the same files show up in the UI (You will have to either bump the version number in `fossa-deps.yml` or add the `--force-vendored-dependency-rescans` flag to force a rescan).

### Test with the test directory structure in themis

```
cp -r ~/fossa/basis/themis/internal/lib/licensing/testdata/filter_test_dirs .
cd filter_test_dirs
```

Put this in fossa-deps.yml:

```yaml
vendored-dependencies:
  - name: runit
    path: .
    version: 2.0.15
```

Here is the directory structure:

```
 tree runit
runit
├── LICENSE
├── root.rb
├── src
│   ├── runit.rb
│   ├── runit_external.rb
│   └── subdir
│       └── again.rb
└── test
    ├── runit_test.erb
    └── runit_test.rb
```

Run with no filtering:

```
fossa-dev license-scan fossa-deps | jq '.uploadUnits[].LicenseUnits[].Files'

[
  "fossa-deps.yml",
  "runit/root.rb",
  "runit/src/runit.rb",
  "runit/src/subdir/again.rb",
  "runit/test/runit_test.erb",
  "runit/test/runit_test.rb"
]
[
  "runit/src/runit_external.rb"
]
[
  "runit/LICENSE"
]
```

Play around with some filters.

Put this in `.fossa.yml`:

```yaml
version: 3
vendoredDependencies:
  licenseScanPathFilters:
    only:
      - "**/*.rb"
      - "**/LICENSE"
    exclude:
      - "**/*_external.rb"
```

Scan again. You should only see `*.rb` and `LICENSE` files, and `runit_external.rb` should be excluded.

```
fossa-dev license-scan fossa-deps | jq '.uploadUnits[].LicenseUnits[].Files'

[
  "runit/root.rb",
  "runit/src/runit.rb",
  "runit/src/subdir/again.rb",
  "runit/test/runit_test.rb"
]
[
  "runit/LICENSE"
]
```

Run `fossa analyze` and check that the same files show up in the UI (You will have to either bump the version number in `fossa-deps.yml` or add the `--force-vendored-dependency-rescans` flag to force a rescan).

Test that we fail with an explanatory message when you do an archive upload and there are path filters in `.fossa.yml`:

```
fossa-dev analyze --force-vendored-dependency-scan-method ArchiveUpload
```

```
[ERROR] ----------
  An issue occurred

  >>> Relevant errors

    Error

      You have provided path filters in the vendoredDependencies.licenseScanPathFilters section of your .fossa.yml file. Path filters are not allowed when doing archive uploads.

      Traceback:
        - Converting fossa-deps to partial API payload
        - fossa-deps
        - fossa-analyze
```

Remove the `licenseScanPathFilters` section from `.fossa.yml`, re-run with ArchiveUpload forced on, and verify that it worked.

## Risks

This will only affect customers who add the new stanza to their `.fossa.yml`, so it should be low risk.

## References

https://fossa.atlassian.net/browse/ANE-707

## Checklist

- [X] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [X] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [X] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-707]: https://fossa.atlassian.net/browse/ANE-707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ