### PR TITLE
[No Ticket] Adds env variables of intereset in debug bundle

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## Unreleased
-- Go: Collects environment variables in debug bundle. ([#]())
+- Go: Collects environment variables in debug bundle. ([#1132](https://github.com/fossas/fossa-cli/pull/1132))
 
 ## v3.6.9
 - Yarn: Fix a bug where tarball URLs were recognized as git urls. ([#1126](https://github.com/fossas/fossa-cli/pull/1126))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- Go: Collects environment variables in debug bundle. ([#]())
+
 ## v3.6.9
 - Yarn: Fix a bug where tarball URLs were recognized as git urls. ([#1126](https://github.com/fossas/fossa-cli/pull/1126))
 

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -142,12 +142,9 @@ the dependency's scope (development or production) and may double count dependen
 
 2. How do I ensure `fossa analyze` does not exit fatally when no targets are discovered?
 
-In some scenarios, you may want to configure `fossa analyze` and `fossa test` CI workflow on
-empty repository. Unfortunately there is no configuration on CLI which will 
-allow for analysis when 0 targets are discovered as of yet.
+In some scenarios, you may want to configure the `fossa analyze` and `fossa test` CI workflow on an empty repository or directory with 0 targets. Unfortunately, `fossa-cli` does not have a configuration yet, which will allow for successful analysis (exit code of 0) when 0 targets are discovered.
 
-For workaround, create empty `reqs.txt` file prior to running `fossa analyze`, which will
-force `fossa-cli` to presume empty pip project (with 0 dependencies).
+For a workaround, create an empty `reqs.txt` file before running `fossa analyze,` which will force `fossa-cli` to presume an empty pip project (with 0 dependencies).
 
 ```bash
 touch reqs.txt && fossa analyze && rm reqs.txt && fossa test

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -139,3 +139,16 @@ As `fossa-cli` relies on manifest and lock files provided in the project's direc
 intentionally skip `node_modules/` and such directories. If `fossa-cli` discovers and
 analyzes project found in `node_modules/`: `fossa-cli` will not be able to infer
 the dependency's scope (development or production) and may double count dependencies.
+
+2. How do I ensure `fossa analyze` does not exit fatally when no targets are discovered?
+
+In some scenarios, you may want to configure `fossa analyze` and `fossa test` CI workflow on
+empty repository. Unfortunately there is no configuration on CLI which will 
+allow for analysis when 0 targets are discovered as of yet.
+
+For workaround, create empty `reqs.txt` file prior to running `fossa analyze`, which will
+force `fossa-cli` to presume empty pip project (with 0 dependencies).
+
+```bash
+touch reqs.txt && fossa analyze && rm reqs.txt && fossa test
+```


### PR DESCRIPTION
# Overview

This PR 
- Adds golang's configuration environment variables in debug bundle.
- Adds entry on how to workaround for successful `fossa analyze` when 0 targets are discovered

## Acceptance criteria

- `GCCGO` environment variable is recorded in debug bundle if present.
- `GO111MODULE` environment variable is recorded in debug bundle if present.
- `GOARCH` environment variable is recorded in debug bundle if present.
- `GOBIN` environment variable is recorded in debug bundle if present.
- `GOCACHE` environment variable is recorded in debug bundle if present.
- `GODEBUG` environment variable is recorded in debug bundle if present.
- `GOENV` environment variable is recorded in debug bundle if present.
- `GOFLAGS` environment variable is recorded in debug bundle if present.
- `GOINSECURE` environment variable is recorded in debug bundle if present.
- `GOMODCACHE` environment variable is recorded in debug bundle if present.
- `GONOPROXY ` environment variable is recorded in debug bundle if present.
- `GONOSUMDB` environment variable is recorded in debug bundle if present.
- `GOOS` environment variable is recorded in debug bundle if present.
- `GOPATH` environment variable is recorded in debug bundle if present.
- `GOPRIVATE` environment variable is recorded in debug bundle if present.
- `GOPROXY` environment variable is recorded in debug bundle if present.
- `GOROOT` environment variable is recorded in debug bundle if present.
- `GOSUMDB` environment variable is recorded in debug bundle if present.
- `GOTMPDIR` environment variable is recorded in debug bundle if present.
- `GOVCS` environment variable is recorded in debug bundle if present.
- `GOWORK` environment variable is recorded in debug bundle if present.

## Testing plan

```bash
git checkout feat/include-go-env-vars-in-debug-bundle
make install-local

mkdir sandbox

###############
## regression case
###############
printenv # print environment variables

./fossa analyze sandbox --debug 
gunzip fossa.debug.json.gz
cat fossa.debug.json | jq '.bundleEnvVariables' # should include only 
rm fossa.debug.json # remove debug bundle for next test case

##########
## test case
##########
export GOPROXY=1 
printenv # print environment variables, confirm GOPROXY=1 

./fossa analyze sandbox --debug 
gunzip fossa.debug.json.gz
cat fossa.debug.json | jq '.bundleEnvVariables' # should include GOPROXY=1
```

## Risks

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
