### PR TITLE
Support custom lib yarn protocol

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.6.11
+
+- Lib yarn protocol: When we encounter Yarn lib deps we should warn but not fail the scan ([#1134](https://github.com/fossas/fossa-cli/pull/1134))
+
 ## v3.6.10
 
 - Vendored Dependencies: Allow path filtering when doing cli-side license scans ([#1128](https://github.com/fossas/fossa-cli/pull/1128))

--- a/docs/references/strategies/languages/nodejs/yarn.md
+++ b/docs/references/strategies/languages/nodejs/yarn.md
@@ -38,3 +38,12 @@ As of _v2.19.x_, we also support yarn workspaces.  In practice, this means that
 the `package.json` files used to build the `yarn.lock` file are also checked,
 and the knowledge of both is combined to form a (usually) complete picture of
 the full graph of dependencies.
+
+
+## FAQ
+
+### What Yarn Protocols are supported
+
+There are many default [Yarn protocols](https://yarnpkg.com/features/protocols) that Yarn allows users to fetch dependencies. The FOSSA CLI currently supports the `npm` and `git` protocols.
+
+<!-- We also support a tar protocol resolver, but this must be related to npm or a custom protocol because I can't find an example. -->

--- a/src/Strategy/Node/YarnV2/Resolvers.hs
+++ b/src/Strategy/Node/YarnV2/Resolvers.hs
@@ -56,7 +56,6 @@ data Package
   | TarPackage Text -- url
   | FilePackage Text
   | -- LibPackages are a custom protocol supported by a user.
-    -- TODO: Support all custom protocols out of the box.
     LibPackage Text
   | LinkPackage Text
   | PortalPackage Text

--- a/src/Strategy/Node/YarnV2/Resolvers.hs
+++ b/src/Strategy/Node/YarnV2/Resolvers.hs
@@ -40,12 +40,12 @@ import Strategy.Node.YarnV2.Lockfile
 import Text.Megaparsec
 
 data Resolver = Resolver
-  { resolverName :: Text
-  -- ^ Used for error messages
-  , resolverSupportsLocator :: Locator -> Bool
-  -- ^ Does this resolver support the locator?
-  , resolverLocatorToPackage :: Locator -> Either Text Package
-  -- ^ Convert this locator to a yarn package
+  { -- | Used for error messages
+    resolverName :: Text
+  , -- | Does this resolver support the locator?
+    resolverSupportsLocator :: Locator -> Bool
+  , -- | Convert this locator to a yarn package
+    resolverLocatorToPackage :: Locator -> Either Text Package
   }
 
 -- Default Yarn Protocols can be found at https://yarnpkg.com/features/protocols.
@@ -55,9 +55,9 @@ data Package
   | GitPackage Text Text -- url, commit
   | TarPackage Text -- url
   | FilePackage Text
-  -- LibPackages are a custom protocol supported by a user.
-  -- TODO: Support all custom protocols out of the box.
-  | LibPackage Text
+  | -- LibPackages are a custom protocol supported by a user.
+    -- TODO: Support all custom protocols out of the box.
+    LibPackage Text
   | LinkPackage Text
   | PortalPackage Text
   | ExecPackage Text
@@ -80,12 +80,12 @@ allResolvers :: [Resolver]
 allResolvers =
   [ workspaceResolver
   , npmResolver
-    -- Ensure that tarResolver appears before gitResolver in this list.
+  , -- Ensure that tarResolver appears before gitResolver in this list.
     -- Currently there are some package locators that the git resolver matches that are actually tarballs.
     -- To get around this, the tarResolver gets to examine a locator first.
     -- Ideally the git resolver's 'resolverSupportsLocator' function would be more specific.
     -- ANE-720 captures that work.
-  , tarResolver
+    tarResolver
   , gitResolver
   , fileResolver
   , libResolver
@@ -249,7 +249,6 @@ tarResolver =
 ---------- Unsupported (by fossa) resolvers
 
 -- | The file resolver supports local "file:" references on disk
---
 fileResolver :: Resolver
 fileResolver = unsupportedResolver "FileResolver" "file:" FilePackage
 

--- a/src/Strategy/Node/YarnV2/Resolvers.hs
+++ b/src/Strategy/Node/YarnV2/Resolvers.hs
@@ -21,6 +21,7 @@ module Strategy.Node.YarnV2.Resolvers (
   gitResolver,
   tarResolver,
   fileResolver,
+  libResolver,
   linkResolver,
   execResolver,
   portalResolver,
@@ -47,12 +48,16 @@ data Resolver = Resolver
   -- ^ Convert this locator to a yarn package
   }
 
+-- Default Yarn Protocols can be found at https://yarnpkg.com/features/protocols.
 data Package
   = WorkspacePackage Text -- relative reference to a directory. not quite a Path Rel Dir because it may contain '..'
   | NpmPackage (Maybe Text) Text Text -- scope, package, version
   | GitPackage Text Text -- url, commit
   | TarPackage Text -- url
   | FilePackage Text
+  -- LibPackages are a custom protocol supported by a user.
+  -- TODO: Support all custom protocols out of the box.
+  | LibPackage Text
   | LinkPackage Text
   | PortalPackage Text
   | ExecPackage Text
@@ -75,14 +80,15 @@ allResolvers :: [Resolver]
 allResolvers =
   [ workspaceResolver
   , npmResolver
-  , -- Ensure that tarResolver appears before gitResolver in this list.
+    -- Ensure that tarResolver appears before gitResolver in this list.
     -- Currently there are some package locators that the git resolver matches that are actually tarballs.
     -- To get around this, the tarResolver gets to examine a locator first.
     -- Ideally the git resolver's 'resolverSupportsLocator' function would be more specific.
     -- ANE-720 captures that work.
-    tarResolver
+  , tarResolver
   , gitResolver
   , fileResolver
+  , libResolver
   , linkResolver
   , execResolver
   , portalResolver
@@ -270,6 +276,9 @@ portalResolver = unsupportedResolver "PortalResolver" "portal:" PortalPackage
 -- resolution field
 execResolver :: Resolver
 execResolver = unsupportedResolver "ExecResolver" "exec:" ExecPackage
+
+libResolver :: Resolver
+libResolver = unsupportedResolver "LibResolver" "lib:" LibPackage
 
 -- | The patch resolver allows you to modify another package with patch files.
 -- The packages appear elsewhere in the lockfile, so we don't do any further

--- a/src/Strategy/Node/YarnV2/Resolvers.hs
+++ b/src/Strategy/Node/YarnV2/Resolvers.hs
@@ -40,12 +40,12 @@ import Strategy.Node.YarnV2.Lockfile
 import Text.Megaparsec
 
 data Resolver = Resolver
-  { -- | Used for error messages
-    resolverName :: Text
-  , -- | Does this resolver support the locator?
-    resolverSupportsLocator :: Locator -> Bool
-  , -- | Convert this locator to a yarn package
-    resolverLocatorToPackage :: Locator -> Either Text Package
+  { resolverName :: Text
+  -- ^ Used for error messages
+  , resolverSupportsLocator :: Locator -> Bool
+  -- ^ Does this resolver support the locator?
+  , resolverLocatorToPackage :: Locator -> Either Text Package
+  -- ^ Convert this locator to a yarn package
   }
 
 -- Default Yarn Protocols can be found at https://yarnpkg.com/features/protocols.
@@ -55,9 +55,9 @@ data Package
   | GitPackage Text Text -- url, commit
   | TarPackage Text -- url
   | FilePackage Text
-  | -- LibPackages are a custom protocol supported by a user.
-    -- TODO: Support all custom protocols out of the box.
-    LibPackage Text
+  -- LibPackages are a custom protocol supported by a user.
+  -- TODO: Support all custom protocols out of the box.
+  | LibPackage Text
   | LinkPackage Text
   | PortalPackage Text
   | ExecPackage Text

--- a/src/Strategy/Node/YarnV2/Resolvers.hs
+++ b/src/Strategy/Node/YarnV2/Resolvers.hs
@@ -55,9 +55,9 @@ data Package
   | GitPackage Text Text -- url, commit
   | TarPackage Text -- url
   | FilePackage Text
-  -- LibPackages are a custom protocol supported by a user.
-  -- TODO: Support all custom protocols out of the box.
-  | LibPackage Text
+  | -- LibPackages are a custom protocol supported by a user.
+    -- TODO: Support all custom protocols out of the box.
+    LibPackage Text
   | LinkPackage Text
   | PortalPackage Text
   | ExecPackage Text

--- a/src/Strategy/Node/YarnV2/Resolvers.hs
+++ b/src/Strategy/Node/YarnV2/Resolvers.hs
@@ -250,8 +250,6 @@ tarResolver =
 
 -- | The file resolver supports local "file:" references on disk
 --
--- FOSSA cannot handle these, so we don't do any further parsing of the
--- resolution field
 fileResolver :: Resolver
 fileResolver = unsupportedResolver "FileResolver" "file:" FilePackage
 
@@ -277,6 +275,10 @@ portalResolver = unsupportedResolver "PortalResolver" "portal:" PortalPackage
 execResolver :: Resolver
 execResolver = unsupportedResolver "ExecResolver" "exec:" ExecPackage
 
+-- | The lib resolver is a custom implementation of the portal protocol
+--
+-- FOSSA cannot handle these, so we don't do any further parsing of the
+-- resolution field
 libResolver :: Resolver
 libResolver = unsupportedResolver "LibResolver" "lib:" LibPackage
 

--- a/src/Strategy/Node/YarnV2/YarnLock.hs
+++ b/src/Strategy/Node/YarnV2/YarnLock.hs
@@ -206,6 +206,7 @@ buildGraph gr FlatPackages{..} = hydrateDepEnvs convertedGraphing
 packageToDependency :: Package -> Maybe Dependency
 packageToDependency WorkspacePackage{} = Nothing
 packageToDependency FilePackage{} = Nothing
+packageToDependency LibPackage{} = Nothing
 packageToDependency LinkPackage{} = Nothing
 packageToDependency PortalPackage{} = Nothing
 packageToDependency ExecPackage{} = Nothing

--- a/test/Yarn/V2/ResolversSpec.hs
+++ b/test/Yarn/V2/ResolversSpec.hs
@@ -16,6 +16,7 @@ import Strategy.Node.YarnV2.Resolvers (
   execResolver,
   fileResolver,
   gitResolver,
+  libResolver,
   linkResolver,
   npmResolver,
   patchResolver,
@@ -64,6 +65,7 @@ spec = do
     ]
 
   testUnsupportedResolver fileResolver "file:" FilePackage
+  testUnsupportedResolver libResolver "lib:" LibPackage
   testUnsupportedResolver linkResolver "link:" LinkPackage
   testUnsupportedResolver portalResolver "portal:" PortalPackage
   testUnsupportedResolver execResolver "exec:" ExecPackage


### PR DESCRIPTION
# Overview

By default, we support Yarn's [default protocols](https://yarnpkg.com/features/protocols). One user brought up an issue to us where they use a custom protocol named `lib` that causes their scans to fail. `lib` is a custom implementation of the `portal` protocol that essentially supports vendored dependencies.

This PR adds support for treating `lib` deps the same way we treat `portal` deps which makes sure we don't fail if we see a `lib` dep.

An example of a lib dep in a `yarn.lock` file can be found in this [thread](https://teamfossa.slack.com/archives/C02A1ERTXDZ/p1673561528991159).

## Acceptance criteria

`lib` type deps do not cause the CLI to fail.

## Testing plan
I tested this using a `yarn.lock` file found in this [thread](https://teamfossa.slack.com/archives/C02A1ERTXDZ/p1673561528991159).

I also added a test for the `libResolver` in the `ResolverSpec`

## Risks

I honestly can't think of 1 risk associated with this change.

## References

https://teamfossa.slack.com/archives/C02A1ERTXDZ/p1673561528991159

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
