### PR TITLE
Fossa test enhancements ane 588

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.6.14
+- Fossa Test: Improved reporting from `fossa test`. ([#1135](https://github.com/fossas/fossa-cli/pull/1135))
+
 ## v3.6.13
 
 - Vendored Dependencies: Add the unity companion license (https://unity.com/legal/licenses/unity-companion-license) and unity package distribution license (https://unity.com/legal/licenses/unity-package-distribution-license) to license scanning ([#1136](https://github.com/fossas/fossa-cli/pull/1136))

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -217,8 +217,6 @@ instance Ord IssueSummaryTarget where
       then comparing istTargetPaths lhs rhs
       else comparing istTargetType lhs rhs
 
--- This is not yet used, but may need to be in the future.
--- Reevaluate before making PR.
 data IssueCategory
   = Security
   | Compliance

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -163,12 +163,9 @@ newtype BuildTask = BuildTask
 instance FromJSON Build where
   parseJSON = withObject "Build" $ \obj ->
     Build
-      <$> obj
-        .: "id"
-      <*> obj
-        .:? "error"
-      <*> obj
-        .: "task"
+      <$> obj .: "id"
+      <*> obj .:? "error"
+      <*> obj .: "task"
 
 instance FromJSON BuildTask where
   parseJSON = withObject "BuildTask" $ \obj ->
@@ -319,10 +316,8 @@ instance ToJSON Issues where
 instance FromJSON IssuesSummary where
   parseJSON = withObject "IssuesSummary" $ \obj ->
     IssuesSummary
-      <$> obj
-        .: "revision"
-      <*> obj
-        .: "targets"
+      <$> obj .: "revision"
+      <*> obj .: "targets"
 
 instance ToJSON IssuesSummary where
   toJSON IssuesSummary{..} =
@@ -334,12 +329,9 @@ instance ToJSON IssuesSummary where
 instance FromJSON IssueSummaryRevision where
   parseJSON = withObject "IssueSummaryRevision" $ \obj ->
     IssueSummaryRevision
-      <$> obj
-        .: "projectTitle"
-      <*> obj
-        .: "projectRevision"
-      <*> obj
-        .:? "isPublic"
+      <$> obj .: "projectTitle"
+      <*> obj .: "projectRevision"
+      <*> obj .:? "isPublic"
 
 instance ToJSON IssueSummaryRevision where
   toJSON IssueSummaryRevision{..} =
@@ -352,10 +344,8 @@ instance ToJSON IssueSummaryRevision where
 instance FromJSON IssueSummaryTarget where
   parseJSON = withObject "IssueSummaryTarget" $ \obj ->
     IssueSummaryTarget
-      <$> obj
-        .: "type"
-      <*> obj
-        .: "originPaths"
+      <$> obj .: "type"
+      <*> obj .: "originPaths"
 
 instance ToJSON IssueSummaryTarget where
   toJSON IssueSummaryTarget{..} =

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -672,7 +672,7 @@ renderedIssues issues = rendered
         issuePolicyConflictMessage :: Text
         issuePolicyConflictMessage =
           "Denied by policy "
-            <> fromMaybe ("(unknown policy, issueId: " <> intToText issueId <> ")") issueLicense
+            <> fromMaybe ("(unknown policy, issueId: " <> intToText issueId <> ") ") issueLicense
             <> "on"
             <> nameRevision
 

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -47,7 +47,7 @@ import Data.Aeson (
   (.:?),
  )
 import Data.Coerce (coerce)
-import Data.List (intersperse, sort)
+import Data.List (sort)
 import Data.List.Extra ((!?))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map

--- a/test/Fossa/API/TypesSpec.hs
+++ b/test/Fossa/API/TypesSpec.hs
@@ -53,6 +53,7 @@ genIssue =
     <*> arbitraryText
     <*> genIssueType
     <*> Gen.maybe genIssueRule
+    <*> Gen.maybe arbitraryText
 
 genIssueType :: Gen IssueType
 genIssueType =
@@ -67,9 +68,7 @@ genIssueType =
 
 genIssueRule :: Gen IssueRule
 genIssueRule =
-  IssueRule
-    <$> Gen.maybe (Gen.int (Range.linear 0 100))
-    <*> Gen.maybe arbitraryText
+  IssueRule <$> Gen.maybe (Gen.int (Range.linear 0 100))
 
 arbitraryText :: Gen Text
 arbitraryText = Gen.text (Range.linear 0 100) Gen.unicodeAll

--- a/test/Fossa/API/TypesSpec.hs
+++ b/test/Fossa/API/TypesSpec.hs
@@ -66,7 +66,10 @@ genIssueType =
     ]
 
 genIssueRule :: Gen IssueRule
-genIssueRule = IssueRule <$> Gen.maybe arbitraryText
+genIssueRule =
+  IssueRule
+    <$> Gen.maybe (Gen.int (Range.linear 0 100))
+    <*> Gen.maybe arbitraryText
 
 arbitraryText :: Gen Text
 arbitraryText = Gen.text (Range.linear 0 100) Gen.unicodeAll

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -225,6 +225,7 @@ issuesAvailable =
           , API.issueRevisionId = "IssueRevisionId" <> showT issueId
           , API.issueType = issueType
           , API.issueRule = Nothing
+          , API.issueLicense = Nothing
           }
       issueList = zipWith makeIssue [1 ..] issueTypes
    in API.Issues
@@ -253,6 +254,7 @@ issuesDiffAvailable =
           , API.issueRevisionId = "IssueRevisionId" <> showT issueId
           , API.issueType = issueType
           , API.issueRule = Nothing
+          , API.issueLicense = Nothing
           }
       issueList = zipWith makeIssue [1 ..] issueTypes
    in API.Issues


### PR DESCRIPTION
# Overview

This PR implements a new format for `fossa test`.

## Acceptance criteria

* The output of the fossa test, shows issues in the same format as prescribed in the Details section.
* The output of the fossa test shows issue by issue type, in which all issues of the same types are shown together.
* The output of the fossa test shows issues by the total count of issues for a specific type.
* The output of the fossa test list issues in a deterministic order (ordered by product offering, issue type, dependency name ASC)
* The new CLI should work for existing FOSSA core versions (no regression for on-prem customers)

The ticket includes on AC around a bug with how we display package names for user dependencies. I did some investigation of it and have decided to split it into another ticket.

This functionality won't be fully available until a core PR gets merged but ideally will look something like this:
![image](https://user-images.githubusercontent.com/190980/213505628-a15420a7-1cb9-4f49-ac60-47af549a4217.png)

For most issues that don't rely on any new data, the new descriptions are available without that PR going out:
![image](https://user-images.githubusercontent.com/190980/213507981-cbae3993-b15f-42c6-b855-4c05bf43ae24.png)

If someone does use this version of the CLI against an old version of the server, it still tries its best:
![image](https://user-images.githubusercontent.com/190980/213508516-ad012be1-0294-43a7-b524-b4de8262872b.png)

The issue ids in that output are primarily for our use in case we receive a ticket about it.

## Testing plan

Testing for this was primarily manual because the bulk of the work is human readable text output. I have updated the round-trip tests for the new `license` field. 

To test, you can run `fossa test` against any project. Until the core changes get merged and deployed you won't see any new license information, but it will display issue counts and descriptions in the new format. 

## Risks

## References

[ANE-588](https://fossa.atlassian.net/browse/ANE-588)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-588]: https://fossa.atlassian.net/browse/ANE-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ