### PR TITLE
Add Unity Licenses

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # FOSSA CLI Changelog
 
+## v3.6.12
+
+- Vendored Dependencies: Add the unity companion license (https://unity.com/legal/licenses/unity-companion-license) and unity package distribution license (https://unity.com/legal/licenses/unity-package-distribution-license) ([#1136](https://github.com/fossas/fossa-cli/pull/1136)) to license scanning
+
+
 ## v3.6.11
 
 - Lib yarn protocol: When we encounter Yarn lib deps we should warn but not fail the scan ([#1134](https://github.com/fossas/fossa-cli/pull/1134))

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## v3.6.12
 
-- Vendored Dependencies: Add the unity companion license (https://unity.com/legal/licenses/unity-companion-license) and unity package distribution license (https://unity.com/legal/licenses/unity-package-distribution-license) ([#1136](https://github.com/fossas/fossa-cli/pull/1136)) to license scanning
+- Vendored Dependencies: Add the unity companion license (https://unity.com/legal/licenses/unity-companion-license) and unity package distribution license (https://unity.com/legal/licenses/unity-package-distribution-license) to license scanning ([#1136](https://github.com/fossas/fossa-cli/pull/1136))
 
 
 ## v3.6.11

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -79,7 +79,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2023-01-05-d5a3fe2-1672962253"
+THEMIS_TAG="2023-01-13-330c1a9-1673649513"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

This is the fourth PR in a chain to add the unity licenses to FOSSA.

It updates the basis tag to the current release, https://github.com/fossas/basis/releases/tag/2023-01-13-330c1a9-1673649513

- https://github.com/fossas/themis-license-data/pull/35
- https://github.com/fossas/basis/pull/1782
- https://github.com/fossas/srclib-themis/pull/32
- https://github.com/fossas/fossa-cli/pull/1136

Fixes [ANE-754](https://fossa.atlassian.net/browse/ANE-754)

## Testing

## Acceptance criteria

The version of Themis and its index downloaded by `vendor_download.sh` should find the unity license

## Testing plan

Download  the unity companion license (https://unity.com/legal/licenses/unity-companion-license) and unity package distribution license (https://unity.com/legal/licenses/unity-package-distribution-license). I put them in `~/tmp/unity-licenses`.

Run `vendor_download.sh`, unzip the `index.gob.xz` file that is downloaded and test that it finds the unity license.

```bash
./vendor_download.sh 
xz -d vendor-bins/index.gob.xz
./vendor-bins/themis-cli --license-data-dir ./vendor-bins ~/tmp/unity-licenses
```

## Risks

None that I can think of

## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-754]: https://fossa.atlassian.net/browse/ANE-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ