### PR TITLE
refactor: Update path-io

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -54,7 +54,7 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
-index-state: hackage.haskell.org 2022-08-15T18:24:28Z
+index-state: hackage.haskell.org 2023-01-11T00:56:49Z
 
 package *
   extra-include-dirs: /opt/homebrew/include

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -61,4 +61,4 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
-index-state: hackage.haskell.org 2022-08-15T18:24:28Z
+index-state: hackage.haskell.org 2023-01-11T00:56:49Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -59,4 +59,4 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
-index-state: hackage.haskell.org 2022-08-15T18:24:28Z
+index-state: hackage.haskell.org 2023-01-11T00:56:49Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -61,4 +61,4 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
-index-state: hackage.haskell.org 2022-08-15T18:24:28Z
+index-state: hackage.haskell.org 2023-01-11T00:56:49Z

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -104,7 +104,7 @@ common deps
     , optparse-applicative         ^>=0.17.0.0
     , parser-combinators           ^>=1.3
     , path                         ^>=0.9.0
-    , path-io                      ^>=1.7.0
+    , path-io                      ^>=1.8.0
     , pretty-simple                ^>=4.1.1.0
     , prettyprinter                >=1.6      && <1.8
     , prettyprinter-ansi-terminal  ^>=1.1.1


### PR DESCRIPTION
# Overview

This PR upgrades `path-io` to `1.8.0`, unblocking https://github.com/fossas/hubble/pull/157.

The changelog suggests that this is a safe change that only adds some typeclass instances: https://hackage.haskell.org/package/path-io-1.8.0/changelog

## Acceptance criteria

No behavior changes.

## Testing plan

I'm relying on CI for this since it seems safe.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
