### PR TITLE
Maven: Parse all scopes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## v3.6.12
 
-- Maven: If a package is both `"test"` and `"compile"`, it is no longer filtered.
+- Maven: If a package is both `"test"` and `"compile"`, it is no longer filtered ([#1138](https://github.com/fossas/fossa-cli/pull/1138)).
 
 ## v3.6.11
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.6.12
+
+- Maven: If a package is both `"test"` and `"compile"`, it is no longer filtered.
+
 ## v3.6.11
 
 - Lib yarn protocol: When we encounter Yarn lib deps we should warn but not fail the scan ([#1134](https://github.com/fossas/fossa-cli/pull/1134))

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -159,6 +159,12 @@ buildGraph reactorOutput PluginOutput{..} =
     knownSubmodules :: Set.Set Text
     knownSubmodules = Set.fromList . map reactorArtifactName . reactorArtifacts $ reactorOutput
 
+    toBuildTag :: Text -> DepEnvironment
+    toBuildTag = \case
+      "compile" -> EnvProduction
+      "test" -> EnvTesting
+      other -> EnvOther other
+
     toDependency :: Has (Grapher Dependency) sig m => Artifact -> m Dependency
     toDependency Artifact{..} = do
       let dep =
@@ -167,7 +173,7 @@ buildGraph reactorOutput PluginOutput{..} =
               , dependencyName = artifactGroupId <> ":" <> artifactArtifactId
               , dependencyVersion = Just (CEq artifactVersion)
               , dependencyLocations = []
-              , dependencyEnvironments = Set.fromList $ [EnvTesting | "test" `elem` artifactScopes]
+              , dependencyEnvironments = Set.fromList $ toBuildTag <$> artifactScopes
               , dependencyTags =
                   Map.fromList $
                     ("scopes", artifactScopes)

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -67,7 +67,7 @@ packageMultiScope :: Dependency
 packageMultiScope =
   Dependency
     { dependencyType = MavenType
-    , dependencyName = "multiscope:pie"
+    , dependencyName = "multiscope:apple"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = mempty
     , dependencyEnvironments = Set.fromList [EnvProduction, EnvTesting, EnvOther "other"]
@@ -191,6 +191,15 @@ mavenMultiScopeOutput =
             { artifactNumericId = 0
             , artifactGroupId = "multiscope"
             , artifactArtifactId = "pie"
+            , artifactVersion = "1.0.0"
+            , artifactOptional = False
+            , artifactScopes = ["compile", "test", "other"]
+            , artifactIsDirect = True
+            }
+        , Artifact
+            { artifactNumericId = 0
+            , artifactGroupId = "multiscope"
+            , artifactArtifactId = "apple"
             , artifactVersion = "1.0.0"
             , artifactOptional = False
             , artifactScopes = ["compile", "test", "other"]

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -37,7 +37,7 @@ packageOne =
     , dependencyName = "mygroup:packageOne"
     , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = Set.singleton EnvTesting
+    , dependencyEnvironments = Set.fromList [EnvProduction, EnvTesting]
     , dependencyTags = Map.fromList [("scopes", ["compile", "test"])]
     }
 
@@ -48,7 +48,7 @@ packageTwo =
     , dependencyName = "mygroup:packageTwo"
     , dependencyVersion = Just (CEq "2.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = mempty
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.fromList [("scopes", ["compile"]), ("optional", ["true"])]
     }
 
@@ -59,7 +59,7 @@ packageFour =
     , dependencyName = "mygroup2:packageFour"
     , dependencyVersion = Just (CEq "4.0.0")
     , dependencyLocations = []
-    , dependencyEnvironments = mempty
+    , dependencyEnvironments = Set.singleton EnvProduction
     , dependencyTags = Map.fromList [("scopes", ["compile"])]
     }
 

--- a/test/Maven/PluginStrategySpec.hs
+++ b/test/Maven/PluginStrategySpec.hs
@@ -197,17 +197,21 @@ mavenMultiScopeOutput =
             , artifactIsDirect = True
             }
         , Artifact
-            { artifactNumericId = 0
+            { artifactNumericId = 1
             , artifactGroupId = "multiscope"
             , artifactArtifactId = "apple"
             , artifactVersion = "1.0.0"
             , artifactOptional = False
             , artifactScopes = ["compile", "test", "other"]
-            , artifactIsDirect = True
+            , artifactIsDirect = False
             }
         ]
     , outEdges =
-        []
+        [ Edge
+            { edgeFrom = 0
+            , edgeTo = 1
+            }
+        ]
     }
 
 mavenCrossDependentSubModules :: PluginOutput


### PR DESCRIPTION
# Overview

It is possible for a dependency to be included via multiple sub projects.
Repro case: [maven-demo-project.zip](https://github.com/fossas/fossa-cli/files/10416398/maven-demo-project.zip).

Roughly translated, given this graph:
```
pie
    apple
        commons-io
            scope: ["test"]
        commons-net
    crust
        commons-io
        commons-net
```

Prior to this PR, `commons-io` in this scenario is filtered, because we were only parsing `"test"` scopes: https://github.com/fossas/fossa-cli/blob/219bdc6f38d401df2bdb7991114c54083a75f56b/src/Strategy/Maven/PluginStrategy.hs#L170

In this PR, we instead now parse all scopes.
This causes the dependency to no longer be filtered, because rather than _excluding when test_, we _include when production_: https://github.com/fossas/fossa-cli/blob/41f1fbb99658e09c0b0b176acc637aad0217b04b/src/Srclib/Converter.hs#L94-L96

## Acceptance criteria

Dependencies with both `compile` and `test` scopes are still reported.

## Testing plan

Reproduction case attached above.

Running `fossa analyze` should result in both these dependencies being identified:
```
"mvn+commons-io:commons-io$2.6"
"mvn+commons-net:commons-net$3.3"
```

<img width="1545" alt="Screenshot 2023-01-13 at 7 11 44 PM" src="https://user-images.githubusercontent.com/55713231/212448204-4252449b-60f7-4653-82d8-7cd04f418783.png">

## Risks

This will result in more dependencies being reported, which may be confusing to users.
I think that this is likely to be relatively easily explained to users as being more accurate.

## References

- [ZD-4290](https://fossa.zendesk.com/agent/tickets/4290)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
