### PR TITLE
[ANE-689] [Hand off] Container can be scanned when tar entry with path of `''` exists! 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unrealsed
+
+- Container Scanning: Works with tar files which have content with path of ''. 
+
 ## v3.6.11
 
 - Lib yarn protocol: When we encounter Yarn lib deps we should warn but not fail the scan ([#1134](https://github.com/fossas/fossa-cli/pull/1134))

--- a/cabal.project
+++ b/cabal.project
@@ -54,6 +54,15 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
+-- Since haskell/tar has terminal block defect, preventing analysis of tar
+-- files which have entry with title of ''. 
+-- 
+-- Refer to: https://github.com/haskell/tar/issues/73
+source-repository-package
+  type: git
+  location: https://github.com/meghfossa/tar
+  tag: 66f0a287fbdd9609d66e8a5c0e152a8c28c66bc0
+
 index-state: hackage.haskell.org 2022-08-15T18:24:28Z
 
 package *

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -61,4 +61,13 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
+-- Since haskell/tar has terminal block defect, preventing analysis of tar
+-- files which have entry with title of ''. 
+-- 
+-- Refer to: https://github.com/haskell/tar/issues/73
+source-repository-package
+  type: git
+  location: https://github.com/meghfossa/tar
+  tag: 66f0a287fbdd9609d66e8a5c0e152a8c28c66bc0
+
 index-state: hackage.haskell.org 2022-08-15T18:24:28Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -59,4 +59,13 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
+-- Since haskell/tar has terminal block defect, preventing analysis of tar
+-- files which have entry with title of ''. 
+-- 
+-- Refer to: https://github.com/haskell/tar/issues/73
+source-repository-package
+  type: git
+  location: https://github.com/meghfossa/tar
+  tag: 66f0a287fbdd9609d66e8a5c0e152a8c28c66bc0
+
 index-state: hackage.haskell.org 2022-08-15T18:24:28Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -61,4 +61,13 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
+-- Since haskell/tar has terminal block defect, preventing analysis of tar
+-- files which have entry with title of ''. 
+-- 
+-- Refer to: https://github.com/haskell/tar/issues/73
+source-repository-package
+  type: git
+  location: https://github.com/meghfossa/tar
+  tag: 66f0a287fbdd9609d66e8a5c0e152a8c28c66bc0
+
 index-state: hackage.haskell.org 2022-08-15T18:24:28Z

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -115,7 +115,7 @@ common deps
     , semver                       ^>=0.4.0.1
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
-    , tar                          ^>=0.5.1.1
+    , tar                          ^>=0.6.0.0
     , template-haskell             ^>=2.17
     , text                         ^>=1.2.3
     , th-lift-instances            ^>=0.1.17

--- a/test/BerkeleyDB/BerkeleyDBSpec.hs
+++ b/test/BerkeleyDB/BerkeleyDBSpec.hs
@@ -2,6 +2,7 @@ module BerkeleyDB.BerkeleyDBSpec (spec) where
 
 import Control.Carrier.Diagnostics (runDiagnostics)
 import Control.Carrier.Stack (runStack)
+import Data.Either (rights)
 import Effect.Exec (runExecIO)
 import Effect.ReadFS (runReadFSIO)
 import Path (Abs, File, Path)
@@ -18,7 +19,7 @@ spec = do
 
     it "parses berkeleydb contents" $
       assertOnSuccess result $ \_ c ->
-        c `shouldBe` expectedEntries
+        rights c `shouldBe` expectedEntries
 
 -- | 'extlib/berkeleydb/tests' contains a more complete set of tests for parsing various container formats.
 -- The goal of this test is to prove end-to-end flow; for that reason, we just test with the 'CentOS5 Plain' package list

--- a/test/Container/TarballSpec.hs
+++ b/test/Container/TarballSpec.hs
@@ -69,7 +69,7 @@ exampleImgLayers =
 
 mkEntriesSpec :: Spec
 mkEntriesSpec = do
-  tarFile <- runIO $ Tar.read <$> ByteStringLazy.readFile exampleImg
+  tarFile <- runIO $ Tar.read' <$> ByteStringLazy.readFile exampleImg
 
   describe "mkEntries" $
     it "should include entries of files with offsets" $
@@ -187,7 +187,7 @@ expectedLayerChangeSets =
 mkImageSpec :: Spec
 mkImageSpec = do
   tarFileBs <- runIO $ ByteStringLazy.readFile exampleImg
-  let tarFile = Tar.read tarFileBs
+  let tarFile = Tar.read' tarFileBs
 
   tarFileBsSymEntries <- runIO $ ByteStringLazy.readFile exampleImgSymLinkEntries
 


### PR DESCRIPTION
# Overview

Works on ANE-689

This PR, 
- uses modified haskell/tar
- updates `barkelydb` strategy, such that single pkg parsing failure does not cause entire tactic to fail

## Acceptance criteria

- can scan following without fatal failure!

## Testing plan

```bash
git checkout uses-safe-tar-reader
cabal clean
make install-local

# Before
fossa -V # ensure latest
fossa container analyze -o cypress/base:16.13.0  

# After
./fossa container analyze -o cypress/base:16.13.0  
```

Remaining tests,

- [ ] `alpine:edge`
- [ ] `public.ecr.aws/lambda/python:3.9`
- [ ] and many more ... 
- [ ] Please test ticketed container images (refer to ane-689 references)
- [ ] Berkely db output with redhat base image (refer to output in FOSSA web ui to ensure only non-parsable pkgs were not reported)


## Risks

N/A.

## References

ANE-689

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
