### PR TITLE
Improve support for additional tar archive formats

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,12 @@
 # FOSSA CLI Changelog
 
+## v3.6.15
+
+- Container scanning: support more tar formats. ([1142](https://github.com/fossas/fossa-cli/pull/1142))
+
 ## v3.6.14
-- Fossa Test: Improved reporting from `fossa test`. ([#1135](https://github.com/fossas/fossa-cli/pull/1135))
+
+- `fossa test`: Improved reporting from `fossa test`. ([#1135](https://github.com/fossas/fossa-cli/pull/1135))
 
 ## v3.6.13
 

--- a/cabal.project
+++ b/cabal.project
@@ -54,6 +54,11 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
+source-repository-package
+  type: git
+  location: https://github.com/fossas/tar
+  tag: 6bd13acc541ae60b5c831823243040e18bd1d957
+
 index-state: hackage.haskell.org 2023-01-11T00:56:49Z
 
 package *

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -61,4 +61,9 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
+source-repository-package
+  type: git
+  location: https://github.com/fossas/tar
+  tag: 6bd13acc541ae60b5c831823243040e18bd1d957
+
 index-state: hackage.haskell.org 2023-01-11T00:56:49Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -59,4 +59,9 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
+source-repository-package
+  type: git
+  location: https://github.com/fossas/tar
+  tag: 6bd13acc541ae60b5c831823243040e18bd1d957
+
 index-state: hackage.haskell.org 2023-01-11T00:56:49Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -61,4 +61,9 @@ source-repository-package
   tag: d93afd2dc78c2f6910766fabc2f5e4452bcae2f2
   subdir: x509-system
 
+source-repository-package
+  type: git
+  location: https://github.com/fossas/tar
+  tag: 6bd13acc541ae60b5c831823243040e18bd1d957
+
 index-state: hackage.haskell.org 2023-01-11T00:56:49Z

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -115,7 +115,7 @@ common deps
     , semver                       ^>=0.4.0.1
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
-    , tar                          ^>=0.5.1.1
+    , tar                          ^>=0.6.0.0
     , template-haskell             ^>=2.17
     , text                         ^>=1.2.3
     , th-lift-instances            ^>=0.1.17

--- a/src/App/Fossa/Container/Sources/DockerArchive.hs
+++ b/src/App/Fossa/Container/Sources/DockerArchive.hs
@@ -132,7 +132,7 @@ analyzeFromDockerArchive systemDepsOnly filters tarball = do
     then do
       logInfo "Analyzing Other Layers"
       let squashedDigest = layerDigest . otherLayersSquashed $ image
-      fs <- context "Building squashed FS from other layers" $ mkFsFromChangeset $ otherLayersSquashed image
+      fs <- context "Building squashed FS from other layers" . mkFsFromChangeset $ otherLayersSquashed image
       otherUnits <-
         context "Analyzing from Other Layers" $
           analyzeLayer systemDepsOnly filters capabilities osInfo fs tarball

--- a/test/Container/TarballReadFSSpec.hs
+++ b/test/Container/TarballReadFSSpec.hs
@@ -58,7 +58,7 @@ spec = do
       lastContent <- readContentsText lastFile
       lastContent `shouldBe'` "01-01-2022\n"
 
-    withStandardTarFileIt ("should read content of symbolic link's target in tarball with content: " <> show emptyPathTarFileTree) $ do
+    withStandardTarFileIt "should read content of symbolic link's target in tarball" $ do
       let healthFile :: Path Abs File = Path "logs-archive/feb/last_health"
       healthFileContent <- readContentsText healthFile
       healthFileContent `shouldBe'` "OK\n"
@@ -67,7 +67,7 @@ spec = do
       lastContent <- readContentsText lastFile
       lastContent `shouldBe'` "01-01-2022\n"
 
-    withEmptyRootTarFileIt ("should read content of file in tarball when root has no name with content: " <> show emptyPathTarFileTree) $ do
+    withEmptyRootTarFileIt "should read content of file in tarball when root has no name" $ do
       let awsLambdaRie :: Path Abs File = Path "usr/local/bin/aws-lambda-rie"
       awsLambdaRieContent <- readContentsBS awsLambdaRie
       -- This is a binary, so just check the length rather than embedding the content in code.
@@ -81,7 +81,7 @@ spec = do
       listedDirs `shouldMatchList'` [Path "logs-archive/jan/", Path "logs-archive/feb/"]
       listedFiles `shouldMatchList'` [Path "logs-archive/last.txt"]
 
-    withEmptyRootTarFileIt ("should list directories and files when root has no name with content: " <> show emptyPathTarFileTree) $ do
+    withEmptyRootTarFileIt "should list directories and files when root has no name" $ do
       let parent :: Path Abs Dir = Path "usr/local/bin/"
       (parentDirs, parentFiles) <- listDir parent
       parentDirs `shouldMatchList'` []
@@ -98,7 +98,7 @@ spec = do
       resolvedFile <- resolveFile logsArchive "last.txt"
       resolvedFile `shouldBe'` Path "logs-archive/last.txt"
 
-    withEmptyRootTarFileIt ("should resolve file when root has no name with content: " <> show emptyPathTarFileTree) $ do
+    withEmptyRootTarFileIt "should resolve file when root has no name" $ do
       let parent :: Path Abs Dir = Path "usr/local/bin"
       resolvedFile <- resolveFile parent "aws-lambda-rie"
       resolvedFile `shouldBe'` Path "usr/local/bin/aws-lambda-rie"
@@ -109,7 +109,7 @@ spec = do
       resolvedDir <- resolveDir logsArchive "jan"
       resolvedDir `shouldBe'` Path "logs-archive/jan/"
 
-    withEmptyRootTarFileIt ("should resolve directory when root has no name with content: " <> show emptyPathTarFileTree) $ do
+    withEmptyRootTarFileIt "should resolve directory when root has no name" $ do
       let parent :: Path Abs Dir = Path "usr/local/"
       resolvedDir <- resolveDir parent "bin"
       resolvedDir `shouldBe'` Path "usr/local/bin/"

--- a/test/Container/TarballReadFSSpec.hs
+++ b/test/Container/TarballReadFSSpec.hs
@@ -58,7 +58,7 @@ spec = do
       lastContent <- readContentsText lastFile
       lastContent `shouldBe'` "01-01-2022\n"
 
-    withStandardTarFileIt "should read content of symbolic link's target in tarball" $ do
+    withStandardTarFileIt ("should read content of symbolic link's target in tarball with content: " <> show emptyPathTarFileTree) $ do
       let healthFile :: Path Abs File = Path "logs-archive/feb/last_health"
       healthFileContent <- readContentsText healthFile
       healthFileContent `shouldBe'` "OK\n"
@@ -67,7 +67,7 @@ spec = do
       lastContent <- readContentsText lastFile
       lastContent `shouldBe'` "01-01-2022\n"
 
-    withEmptyRootTarFileIt "should read content of file in tarball when root has no name" $ do
+    withEmptyRootTarFileIt ("should read content of file in tarball when root has no name with content: " <> show emptyPathTarFileTree) $ do
       let awsLambdaRie :: Path Abs File = Path "usr/local/bin/aws-lambda-rie"
       awsLambdaRieContent <- readContentsBS awsLambdaRie
       -- This is a binary, so just check the length rather than embedding the content in code.
@@ -81,7 +81,7 @@ spec = do
       listedDirs `shouldMatchList'` [Path "logs-archive/jan/", Path "logs-archive/feb/"]
       listedFiles `shouldMatchList'` [Path "logs-archive/last.txt"]
 
-    withEmptyRootTarFileIt "should list directories and files when root has no name" $ do
+    withEmptyRootTarFileIt ("should list directories and files when root has no name with content: " <> show emptyPathTarFileTree) $ do
       let parent :: Path Abs Dir = Path "usr/local/bin/"
       (parentDirs, parentFiles) <- listDir parent
       parentDirs `shouldMatchList'` []
@@ -98,7 +98,7 @@ spec = do
       resolvedFile <- resolveFile logsArchive "last.txt"
       resolvedFile `shouldBe'` Path "logs-archive/last.txt"
 
-    withEmptyRootTarFileIt "should resolve file when root has no name" $ do
+    withEmptyRootTarFileIt ("should resolve file when root has no name with content: " <> show emptyPathTarFileTree) $ do
       let parent :: Path Abs Dir = Path "usr/local/bin"
       resolvedFile <- resolveFile parent "aws-lambda-rie"
       resolvedFile `shouldBe'` Path "usr/local/bin/aws-lambda-rie"
@@ -109,7 +109,7 @@ spec = do
       resolvedDir <- resolveDir logsArchive "jan"
       resolvedDir `shouldBe'` Path "logs-archive/jan/"
 
-    withEmptyRootTarFileIt "should resolve directory when root has no name" $ do
+    withEmptyRootTarFileIt ("should resolve directory when root has no name with content: " <> show emptyPathTarFileTree) $ do
       let parent :: Path Abs Dir = Path "usr/local/"
       resolvedDir <- resolveDir parent "bin"
       resolvedDir `shouldBe'` Path "usr/local/bin/"

--- a/test/Container/testdata/emptypath.tar
+++ b/test/Container/testdata/emptypath.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab2a3957016133a786eee89fbbbce6af1f7cc55172b8f0e04616d6f1d2394b08
+size 5377536


### PR DESCRIPTION
# Overview

Improves support for additional tar formats in the `fossa container analyze` subcommand, as well as handles the ability for entries in the tar file to not have corresponding file names. 

This addresses the `TarParserError: BadTrailer :| [TarParserError: BadTrailer,TarParserError: BadTrailer]` issue seen periodically.

## Acceptance criteria

The JIRA ticket ([link](https://fossa.atlassian.net/browse/ANE-689)) contains two examples:

- A privately shared example, reference that JIRA ticket
- `public.ecr.aws/lambda/python:3.9`

Both of these images are now able to be scanned with `fossa container analyze`. For example:

```
; cabal run fossa -- container analyze -o <private repro case>
Up to date
[ WARN] NOTICE

  FOSSA CLI is using new native container scanner, which scans for application
  dependencies in the container image by default. To only scan for system
  dependencies, provide `--only-system-deps` flag.

  To learn more,
      https://github.com/fossas/fossa-cli/blob/fix-tar-bad-trailer/docs/references/subcommands/container/scanner.md

  In future release of FOSSA CLI, this notice will not be displayed.

  If you are running into a performance issue or poor results on image analysis
  with new scanner, please contact FOSSA support at:
      https://support.fossa.com
[ INFO] Analyzing Base Layer
[ INFO] Analyzing dpkgdb project at var/lib/dpkg/
[ INFO] Analyzing Other Layers
[ERROR] ----------
  An issue occurred

  >>> Relevant errors

    Error

      An exception occurred: NotTarFormat

      Traceback:
        - discovery/analysis tasks
        - Analyzing from Other Layers
        - Analyzing via docker archive


[ INFO] Analyzing dpkgdb project at var/lib/dpkg/
[ INFO] Analyzing setuptools project at usr/lib/python3.7/test/libregrtest/
[ INFO] Analyzing setuptools project at usr/local/lib/node_modules/npm/node_modules/node-gyp/gyp/
[ INFO] Analyzing setuptools project at usr/share/mercurial/help/internals/
[ INFO] Analyzing rpm project at usr/lib/gcc/x86_64-linux-gnu/8/
[ INFO] Using project name: `<snip>`
[ INFO] Using project revision: `sha256:1f68c77f2a3e1d2b3d3cdd0d9b493b3a780096c83f403a4ad3a7b709eda4b2d1`
[ INFO] Using branch: `No branch (detached HEAD)`
{"image":{"layers":[{ <snip> }] }}
```

Note: both of these images are not scanned completely error free; the private case above displays a `NotTarFormat` error from one of the analysis strategies, and the `public.ecr.aws/lambda/python:3.9` example has an issue scanning its berkeleydb package.

However, I'm _not_ addressing these in this PR: as far as I can determine, these are not directly related to the tar decompression issue and need to be researched as separate issues:

- RPM DB issue: https://fossa.atlassian.net/browse/ANE-708
- NotTarFormat issue: https://fossa.atlassian.net/browse/ANE-774

## Testing plan

I created automated tests, and also validated that we get at least some information out of the reproduction cases where before we got none.

## Risks

Not risky- this is probably not the last word on TAR support, but this improves it a little.

## References

https://fossa.atlassian.net/browse/ANE-689

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
