### PR TITLE
Add missing swift link for strategies

### DIFF
--- a/docs/references/strategies/README.md
+++ b/docs/references/strategies/README.md
@@ -144,6 +144,7 @@ It is important to note that neither type of strategy has an inherent benefit wh
 | [Haskell (stack)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/haskell/stack.md)                        | ✅       | ❌      | ❌                    | Dynamic          |
 | [iOS (carthage)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/platforms/ios/carthage.md)                          | ❌       | ✅      | ❌                    | Static           |
 | [iOS (cocoapods)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/platforms/ios/cocoapods.md)                        | ❌       | ✅      | ❌                    | Static           |
+| [iOS (swift)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/platforms/ios/swift.md)                                | ❌       | ✅      | ❌                    | Static           |
 | [Maven](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/maven/maven.md)                                    | ✅       | ✅      | ❌                    | Dynamic          |
 | [NodeJS (NPM/Yarn/pnpm)](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/nodejs/nodejs.md)                 | ❌       | ✅      | ❌                    | Static           |
 | [Perl](https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/languages/perl/perl.md)                                       | ❌       | ✅      | ❌                    | Static           |

--- a/src/Strategy/Fpm.hs
+++ b/src/Strategy/Fpm.hs
@@ -1,3 +1,4 @@
+-- | Fpm, the fortran package manager.
 module Strategy.Fpm (discover) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)

--- a/src/Strategy/Mix.hs
+++ b/src/Strategy/Mix.hs
@@ -1,3 +1,4 @@
+-- | Mix, the Elixir dependency manager.
 module Strategy.Mix (
   discover,
   findProjects,

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -1,3 +1,4 @@
+-- | Pub, the Dart dependency manager.
 module Strategy.Pub (discover) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)

--- a/src/Strategy/Rebar3.hs
+++ b/src/Strategy/Rebar3.hs
@@ -1,3 +1,4 @@
+-- | Rebar, the Erlang dependency manager.
 module Strategy.Rebar3 (
   RebarProject (..),
   discover,


### PR DESCRIPTION
# Overview

Add missing link to swift documentation in strategies list.
I also added some comments for modules where the language the package manager is for isn't immediately obvious.
