### PR TITLE
Support project labels

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # FOSSA CLI Changelog
 
+<!-- title: description ([PR#](https://github.com/fossas/fossa-cli/pull/PR#)) -->
+
+## v3.6.16
+
+- Project labels: Support project labels from command line and configuration file ([1145](https://github.com/fossas/fossa-cli/pull/1145))
+
 ## v3.6.15
 
 - Container scanning: support more tar formats. ([1142](https://github.com/fossas/fossa-cli/pull/1142))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # FOSSA CLI Changelog
 
-<!-- title: description ([PR#](https://github.com/fossas/fossa-cli/pull/PR#)) -->
+<!-- title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
 ## v3.6.16
 

--- a/docs/references/files/fossa-yml.md
+++ b/docs/references/files/fossa-yml.md
@@ -131,9 +131,9 @@ The `name:` and `release:` of the release group's release to add your project to
 If you choose to associate a project with a release group, you **must** supply both name and release.
 
 #### `project.labels:`
-The `labels` field allows you to add labels to projects so that you can classify certain projects how you would like. This adds a more flexible way to query for projects as opposed to assigning a project to a team.
+The `labels` field allows you to add labels to projects so that you can classify certain projects how you would like. This adds a more flexible way to query for projects in the FOSSA UI as opposed to assigning a project to a team.
 
-Up to 5 labels are allowed to be associated with a project at a time.
+Up to 5 labels are allowed to be associated with a project at a time. Labels will be applied in order up to the limit of 5 labels and then ignored.
 
 ### `revision:`
 The revision fields are used to help FOSSA differentiate between one upload for a project and another, just as GitHub uses commit hashes and branch names.

--- a/docs/references/files/fossa-yml.md
+++ b/docs/references/files/fossa-yml.md
@@ -22,6 +22,9 @@ project:
   releaseGroup:
     name: release-group-name
     release: 123-release-candidate
+  labels:
+    - project-label-1
+    - test-project
 
 revision:
   commit: "12345"
@@ -126,6 +129,11 @@ The Jira Project Key to associate with your project for improved issue triage. R
 The `name:` and `release:` of the release group's release to add your project to in the FOSSA dashboard.
 
 If you choose to associate a project with a release group, you **must** supply both name and release.
+
+#### `project.labels:`
+The `labels` field allows you to add labels to projects so that you can classify certain projects how you would like. This adds a more flexible way to query for projects as opposed to assigning a project to a team.
+
+Up to 5 labels are allowed to be associated with a project at a time.
 
 ### `revision:`
 The revision fields are used to help FOSSA differentiate between one upload for a project and another, just as GitHub uses commit hashes and branch names.

--- a/docs/references/files/fossa-yml.v3.schema.json
+++ b/docs/references/files/fossa-yml.v3.schema.json
@@ -69,7 +69,6 @@
                         "type": "string"
                     }
                 }
-
             }
         },
         "telemetry": {

--- a/docs/references/files/fossa-yml.v3.schema.json
+++ b/docs/references/files/fossa-yml.v3.schema.json
@@ -61,7 +61,15 @@
                         "name",
                         "release"
                     ]
+                },
+                "labels": {
+                    "type": "array",
+                    "description": "A list of labels that are assigned to the project",
+                    "items": {
+                        "type": "string"
+                    }
                 }
+
             }
         },
         "telemetry": {

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -57,7 +57,7 @@ import App.Types (
   BaseDir,
   MonorepoAnalysisOpts (MonorepoAnalysisOpts, monorepoAnalysisType),
   OverrideProject (OverrideProject),
-  ProjectMetadata,
+  ProjectMetadata (projectLabel),
   ProjectRevision,
  )
 import Control.Effect.Diagnostics (
@@ -517,6 +517,7 @@ collectScanDestination maybeCfgFile envvars AnalyzeCliOpts{..} =
     else do
       apiOpts <- collectApiOpts maybeCfgFile envvars commons
       let metaMerged = maybe analyzeMetadata (mergeFileCmdMetadata analyzeMetadata) (maybeCfgFile)
+      when (length (projectLabel metaMerged) > 5) $ fatalText "Projects are only allowed to have 5 associated project labels"
       pure $ UploadScan apiOpts metaMerged
 
 collectModeOptions ::

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -22,6 +22,7 @@ module App.Fossa.Config.Analyze (
   mkSubCommand,
   loadConfig,
   cliParser,
+  mergeOpts,
 ) where
 
 import App.Fossa.Config.Common (

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -98,7 +98,6 @@ import Fossa.API.Types (ApiKey (ApiKey), ApiOpts (ApiOpts), defaultApiPollDelay)
 import GHC.Generics (Generic)
 import Options.Applicative (
   Alternative (many),
-  ParseError (ShowHelpText),
   Parser,
   ReadM,
   argument,
@@ -108,7 +107,6 @@ import Options.Applicative (
   metavar,
   option,
   optional,
-  parserFailure,
   short,
   str,
   strOption,

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -66,7 +66,7 @@ import App.OptionExtensions (uriOption)
 import App.Types (
   BaseDir (BaseDir),
   OverrideProject (..),
-  ProjectMetadata,
+  ProjectMetadata (ProjectMetadata),
   ProjectRevision,
   ReleaseGroupMetadata (ReleaseGroupMetadata),
  )

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -66,7 +66,7 @@ import App.OptionExtensions (uriOption)
 import App.Types (
   BaseDir (BaseDir),
   OverrideProject (..),
-  ProjectMetadata (ProjectMetadata, projectLabel),
+  ProjectMetadata,
   ProjectRevision,
   ReleaseGroupMetadata (ReleaseGroupMetadata),
  )

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -141,7 +141,7 @@ defaultTimeoutDuration :: Duration
 defaultTimeoutDuration = Minutes 60
 
 metadataOpts :: Parser ProjectMetadata
-metadataOpts = do
+metadataOpts =
   ProjectMetadata
     <$> optional (strOption (long "title" <> short 't' <> help "the title of the FOSSA project. (default: the project name)"))
     <*> optional (strOption (long "project-url" <> short 'P' <> help "this repository's home page"))

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -66,7 +66,7 @@ import App.OptionExtensions (uriOption)
 import App.Types (
   BaseDir (BaseDir),
   OverrideProject (..),
-  ProjectMetadata (ProjectMetadata),
+  ProjectMetadata (ProjectMetadata, projectLabel),
   ProjectRevision,
   ReleaseGroupMetadata (ReleaseGroupMetadata),
  )
@@ -97,6 +97,8 @@ import Effect.ReadFS (ReadFS, doesDirExist, doesFileExist)
 import Fossa.API.Types (ApiKey (ApiKey), ApiOpts (ApiOpts), defaultApiPollDelay)
 import GHC.Generics (Generic)
 import Options.Applicative (
+  Alternative (many),
+  ParseError (ShowHelpText),
   Parser,
   ReadM,
   argument,
@@ -106,6 +108,7 @@ import Options.Applicative (
   metavar,
   option,
   optional,
+  parserFailure,
   short,
   str,
   strOption,
@@ -138,7 +141,7 @@ defaultTimeoutDuration :: Duration
 defaultTimeoutDuration = Minutes 60
 
 metadataOpts :: Parser ProjectMetadata
-metadataOpts =
+metadataOpts = do
   ProjectMetadata
     <$> optional (strOption (long "title" <> short 't' <> help "the title of the FOSSA project. (default: the project name)"))
     <*> optional (strOption (long "project-url" <> short 'P' <> help "this repository's home page"))
@@ -146,6 +149,7 @@ metadataOpts =
     <*> optional (strOption (long "link" <> short 'L' <> help "a link to attach to the current build"))
     <*> optional (strOption (long "team" <> short 'T' <> help "this repository's team inside your organization"))
     <*> optional (strOption (long "policy" <> help "the policy to assign to this project in FOSSA"))
+    <*> many (strOption (long "project-label" <> help "assign up to 5 labels to the project"))
     <*> optional releaseGroupMetadataOpts
 
 releaseGroupMetadataOpts :: Parser ReleaseGroupMetadata

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -260,7 +260,7 @@ instance FromJSON ConfigProject where
       <*> obj .:? "jiraProjectKey"
       <*> obj .:? "url"
       <*> obj .:? "policy"
-      <*> obj .:? "label" .!= []
+      <*> obj .:? "labels" .!= []
       <*> obj .:? "releaseGroup"
 
 instance FromJSON ConfigRevision where

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -166,6 +166,7 @@ mergeFileCmdMetadata meta file =
     , projectLink = projectLink meta <|> (configProject file >>= configLink)
     , projectTeam = projectTeam meta <|> (configProject file >>= configTeam)
     , projectPolicy = projectPolicy meta <|> (configProject file >>= configPolicy)
+    , projectLabel = projectLabel meta <|> (maybe [] configLabel (configProject file))
     , projectReleaseGroup = projectReleaseGroup meta <|> (configProject file >>= configReleaseGroup)
     }
 
@@ -194,6 +195,7 @@ data ConfigProject = ConfigProject
   , configJiraKey :: Maybe Text
   , configUrl :: Maybe Text
   , configPolicy :: Maybe Text
+  , configLabel :: [Text]
   , configReleaseGroup :: Maybe ReleaseGroupMetadata
   }
   deriving (Eq, Ord, Show)
@@ -258,6 +260,7 @@ instance FromJSON ConfigProject where
       <*> obj .:? "jiraProjectKey"
       <*> obj .:? "url"
       <*> obj .:? "policy"
+      <*> obj .:? "label" .!= []
       <*> obj .:? "releaseGroup"
 
 instance FromJSON ConfigRevision where

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -34,6 +34,7 @@ data ProjectMetadata = ProjectMetadata
   , projectLink :: Maybe Text
   , projectTeam :: Maybe Text
   , projectPolicy :: Maybe Text
+  , projectLabel :: [Text]
   , projectReleaseGroup :: Maybe ReleaseGroupMetadata
   }
   deriving (Eq, Ord, Show, Generic)

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -570,7 +570,7 @@ uploadAnalysis apiOpts ProjectRevision{..} metadata sourceUnits = fossaReq $ do
   pure (responseBody resp)
 
 mkMetadataOpts :: ProjectMetadata -> Text -> Option scheme
-mkMetadataOpts ProjectMetadata{..} projectName = mconcat $ catMaybes maybes
+mkMetadataOpts ProjectMetadata{..} projectName = mconcat totalMaybes
   where
     title = Just $ fromMaybe projectName projectTitle
     maybes =
@@ -583,6 +583,8 @@ mkMetadataOpts ProjectMetadata{..} projectName = mconcat $ catMaybes maybes
       , ("releaseGroupRelease" =:) . releaseGroupRelease <$> projectReleaseGroup
       , ("title" =:) <$> title
       ]
+    labelsArray = map ("labels[]" =:) projectLabel
+    totalMaybes = catMaybes maybes ++ labelsArray
 
 mangleError :: HttpException -> FossaError
 mangleError err = case errWithoutSensitiveInfo of

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -570,10 +570,10 @@ uploadAnalysis apiOpts ProjectRevision{..} metadata sourceUnits = fossaReq $ do
   pure (responseBody resp)
 
 mkMetadataOpts :: ProjectMetadata -> Text -> Option scheme
-mkMetadataOpts ProjectMetadata{..} projectName = mconcat totalMaybes
+mkMetadataOpts ProjectMetadata{..} projectName = mconcat totalOptions
   where
     title = Just $ fromMaybe projectName projectTitle
-    maybes =
+    maybeOptions =
       [ ("projectURL" =:) <$> projectUrl
       , ("jiraProjectKey" =:) <$> projectJiraKey
       , ("link" =:) <$> projectLink
@@ -583,8 +583,8 @@ mkMetadataOpts ProjectMetadata{..} projectName = mconcat totalMaybes
       , ("releaseGroupRelease" =:) . releaseGroupRelease <$> projectReleaseGroup
       , ("title" =:) <$> title
       ]
-    labelsArray = map ("labels[]" =:) projectLabel
-    totalMaybes = catMaybes maybes ++ labelsArray
+    labelOptions = map ("labels[]" =:) projectLabel
+    totalOptions = catMaybes maybeOptions ++ labelOptions
 
 mangleError :: HttpException -> FossaError
 mangleError err = case errWithoutSensitiveInfo of

--- a/test/App/Fossa/Config/AnalyzeSpec.hs
+++ b/test/App/Fossa/Config/AnalyzeSpec.hs
@@ -4,10 +4,13 @@ import App.Fossa.Config.Analyze (
   cliParser,
   loadConfig,
  )
-import App.Fossa.Config.Utils (itShouldLoadFromTheConfiguredBaseDir)
+import App.Fossa.Config.Utils (itShouldLoadFromTheConfiguredBaseDir, itShouldFailWhenLabelsExceedFive)
 import Test.Hspec (Spec, describe)
 
 spec :: Spec
 spec = do
   describe "loadConfig" $ do
     itShouldLoadFromTheConfiguredBaseDir cliParser loadConfig
+  describe "5 labels are the max" $ 
+    itShouldFailWhenLabelsExceedFive cliParser
+    

--- a/test/App/Fossa/Config/AnalyzeSpec.hs
+++ b/test/App/Fossa/Config/AnalyzeSpec.hs
@@ -4,13 +4,12 @@ import App.Fossa.Config.Analyze (
   cliParser,
   loadConfig,
  )
-import App.Fossa.Config.Utils (itShouldLoadFromTheConfiguredBaseDir, itShouldFailWhenLabelsExceedFive)
+import App.Fossa.Config.Utils (itShouldFailWhenLabelsExceedFive, itShouldLoadFromTheConfiguredBaseDir)
 import Test.Hspec (Spec, describe)
 
 spec :: Spec
 spec = do
   describe "loadConfig" $ do
     itShouldLoadFromTheConfiguredBaseDir cliParser loadConfig
-  describe "5 labels are the max" $ 
+  describe "5 labels are the max" $
     itShouldFailWhenLabelsExceedFive cliParser
-    

--- a/test/App/Fossa/Config/Utils.hs
+++ b/test/App/Fossa/Config/Utils.hs
@@ -2,17 +2,18 @@
 
 module App.Fossa.Config.Utils (parseArgString, itShouldLoadFromTheConfiguredBaseDir, itShouldFailWhenLabelsExceedFive) where
 
+import App.Fossa.Config.Analyze (AnalyzeCliOpts, mergeOpts)
 import App.Fossa.Config.ConfigFile (ConfigFile (..))
+import App.Fossa.Config.EnvironmentVars (EnvVars (EnvVars))
 import Control.Effect.Lift (Lift, sendIO)
 import Data.ByteString qualified as BS
-import Options.Applicative (Parser, execParserPure, handleParseResult, header, info, prefs, getParseResult)
-import Path (mkRelFile, toFilePath, (</>))
-import Test.Effect (EffectStack, it', shouldBe', withTempDir, expectFatal')
-import Test.Hspec (Spec)
-import App.Fossa.Config.Analyze (AnalyzeCliOpts, mergeOpts)
-import App.Fossa.Config.EnvironmentVars ( EnvVars(EnvVars) )
 import Data.Flag ()
--- import App.Fossa.Config.Container.Analyze 
+import Options.Applicative (Parser, execParserPure, getParseResult, handleParseResult, header, info, prefs)
+import Path (mkRelFile, toFilePath, (</>))
+import Test.Effect (EffectStack, expectFatal', it', shouldBe', withTempDir)
+import Test.Hspec (Spec)
+
+-- import App.Fossa.Config.Container.Analyze
 import Control.Carrier.Diagnostics
 import Data.Text (Text)
 
@@ -23,20 +24,20 @@ parseArgString parser = sendIO . handleParseResult . execParserPure (prefs mempt
     progInfo =
       header "Test Arg Parser"
 
-configFile :: ConfigFile 
+configFile :: ConfigFile
 configFile =
-      ConfigFile
-        { configVersion = 42
-        , configServer = Nothing
-        , configApiKey = Nothing
-        , configProject = Nothing
-        , configRevision = Nothing
-        , configTargets = Nothing
-        , configPaths = Nothing
-        , configExperimental = Nothing
-        , configVendoredDependencies = Nothing
-        , configTelemetry = Nothing
-        }
+  ConfigFile
+    { configVersion = 42
+    , configServer = Nothing
+    , configApiKey = Nothing
+    , configProject = Nothing
+    , configRevision = Nothing
+    , configTargets = Nothing
+    , configPaths = Nothing
+    , configExperimental = Nothing
+    , configVendoredDependencies = Nothing
+    , configTelemetry = Nothing
+    }
 
 -- | Tests that the config loader uses the directory set in the arguments
 itShouldLoadFromTheConfiguredBaseDir ::
@@ -50,6 +51,7 @@ itShouldLoadFromTheConfiguredBaseDir parser loadConfig =
         options <- sendIO $ parseArgString parser (toFilePath tempDir)
         maybeConfigFile <- loadConfig options
         maybeConfigFile `shouldBe'` Just configFile
+
 itShouldFailWhenLabelsExceedFive :: Parser AnalyzeCliOpts -> Spec
 itShouldFailWhenLabelsExceedFive parser =
   it' "should fail when labels exceed 5" $ do
@@ -58,4 +60,3 @@ itShouldFailWhenLabelsExceedFive parser =
       Nothing -> fatal ("test failed" :: Text)
       Just cliOpts -> do
         expectFatal' $ mergeOpts Nothing (EnvVars Nothing False False Nothing Nothing) cliOpts
-

--- a/test/App/Fossa/Config/Utils.hs
+++ b/test/App/Fossa/Config/Utils.hs
@@ -3,17 +3,15 @@
 module App.Fossa.Config.Utils (parseArgString, itShouldLoadFromTheConfiguredBaseDir, itShouldFailWhenLabelsExceedFive) where
 
 import App.Fossa.Config.ConfigFile (ConfigFile (..))
-import Control.Algebra (Has)
 import Control.Effect.Lift (Lift, sendIO)
 import Data.ByteString qualified as BS
 import Options.Applicative (Parser, execParserPure, handleParseResult, header, info, prefs, getParseResult)
 import Path (mkRelFile, toFilePath, (</>))
-import Test.Effect (EffectStack, it', shouldBe', withTempDir, expectFailure', expectFatal')
-import ResultUtil (expectFailure)
+import Test.Effect (EffectStack, it', shouldBe', withTempDir, expectFatal')
 import Test.Hspec (Spec)
-import App.Fossa.Config.Analyze (mergeOpts, AnalyzeCliOpts (AnalyzeCliOpts))
+import App.Fossa.Config.Analyze (AnalyzeCliOpts, mergeOpts)
 import App.Fossa.Config.EnvironmentVars ( EnvVars(EnvVars) )
-import Data.Flag (toFlag)
+import Data.Flag ()
 -- import App.Fossa.Config.Container.Analyze 
 import Control.Carrier.Diagnostics
 import Data.Text (Text)

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -53,6 +53,7 @@ expectedConfigProject =
     , configJiraKey = Just "key"
     , configUrl = Just "fossa.com"
     , configPolicy = Just "license-policy"
+    , configLabel = []
     , configReleaseGroup = Just expectedReleaseGroup
     }
 

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -53,7 +53,7 @@ expectedConfigProject =
     , configJiraKey = Just "key"
     , configUrl = Just "fossa.com"
     , configPolicy = Just "license-policy"
-    , configLabel = []
+    , configLabel = ["project-label", "label-2"]
     , configReleaseGroup = Just expectedReleaseGroup
     }
 

--- a/test/App/Fossa/Configuration/testdata/valid-default-yaml/.fossa.yaml
+++ b/test/App/Fossa/Configuration/testdata/valid-default-yaml/.fossa.yaml
@@ -14,6 +14,9 @@ project:
     name: test-release
     release: "123"
   jiraProjectKey: key
+  labels:
+    - project-label
+    - label-2
 
 revision:
   commit: "12345"

--- a/test/App/Fossa/Configuration/testdata/valid-default/.fossa.yml
+++ b/test/App/Fossa/Configuration/testdata/valid-default/.fossa.yml
@@ -14,6 +14,9 @@ project:
     name: test-release
     release: "123"
   jiraProjectKey: key
+  labels:
+    - project-label
+    - label-2
 
 revision:
   commit: "12345"

--- a/test/App/Fossa/Container/AnalyzeNativeUploadSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeUploadSpec.hs
@@ -30,7 +30,7 @@ spec = do
       expectFatal' $ uploadScan fixtureRevision fixtureProjectMetadata fixtureContainerScan
 
 fixtureProjectMetadata :: ProjectMetadata
-fixtureProjectMetadata = ProjectMetadata Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+fixtureProjectMetadata = ProjectMetadata Nothing Nothing Nothing Nothing Nothing Nothing [] Nothing
 
 fixtureContainerScan :: ContainerScan
 fixtureContainerScan = ContainerScan (ContainerScanImage "alpine" "3.1.4" []) "some-digest" "some-tag"

--- a/test/App/Fossa/Container/AnalyzeNativeUploadSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeUploadSpec.hs
@@ -30,7 +30,7 @@ spec = do
       expectFatal' $ uploadScan fixtureRevision fixtureProjectMetadata fixtureContainerScan
 
 fixtureProjectMetadata :: ProjectMetadata
-fixtureProjectMetadata = ProjectMetadata Nothing Nothing Nothing Nothing Nothing Nothing [] Nothing
+fixtureProjectMetadata = ProjectMetadata Nothing Nothing Nothing Nothing Nothing Nothing ["label-1", "label-2"] Nothing
 
 fixtureContainerScan :: ContainerScan
 fixtureContainerScan = ContainerScan (ContainerScanImage "alpine" "3.1.4" []) "some-digest" "some-tag"

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -105,6 +105,7 @@ projectMetadata =
     , App.projectLink = Nothing
     , App.projectTeam = Nothing
     , App.projectPolicy = Nothing
+    , App.projectLabel = []
     , App.projectReleaseGroup = Nothing
     }
 

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -105,7 +105,7 @@ projectMetadata =
     , App.projectLink = Nothing
     , App.projectTeam = Nothing
     , App.projectPolicy = Nothing
-    , App.projectLabel = []
+    , App.projectLabel = ["label-1", "label-2"]
     , App.projectReleaseGroup = Nothing
     }
 


### PR DESCRIPTION
# Overview

The CLI should be able to handle a new “label” option which will allow a string parameter with the label name. Up to 5 label options can be provided. This data will be accepted by the CLI upload route.

The CLI route accepts an array of strings as a query param “labels”.

## Acceptance criteria

- Project labels are accepted through the command line and the configuration file.
- Only 5 are accepted at a time

## Testing plan

The route is already supported on FOSSA cloud, so testing this was as easy as enabling labels and ensuring that the correct behavior was met when setting a `--project-label` flag.

## References

- [ANE-715](https://fossa.atlassian.net/browse/ANE-715): Implement .

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-715]: https://fossa.atlassian.net/browse/ANE-715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ