### PR TITLE
Ane 635 add links to cli issues

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 <!-- title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
+## v3.6.17
+
+- `fossa test`: Display CVE, fixed version information, and issue dashboard links when possible. ([#1146](https://github.com/fossas/fossa-cli/pull/1146))
+
 ## v3.6.16
 
 - Project labels: Support project labels from command line and configuration file ([1145](https://github.com/fossas/fossa-cli/pull/1145))

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -288,6 +288,8 @@ data Issue = Issue
   , issueRule :: Maybe IssueRule
   , issueLicense :: Maybe Text
   , issueDashURL :: Maybe Text
+  , issueCVE :: Maybe Text
+  , issueFixedIn :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 
@@ -365,6 +367,8 @@ instance FromJSON Issue where
       <*> obj .:? "rule"
       <*> obj .:? "license"
       <*> obj .:? "issueDashURL"
+      <*> obj .:? "cve"
+      <*> obj .:? "fixedIn"
 
 instance ToJSON Issue where
   toJSON Issue{..} =
@@ -377,6 +381,8 @@ instance ToJSON Issue where
       , "rule" .= issueRule
       , "license" .= issueLicense
       , "issueDashURL" .= issueDashURL
+      , "cve" .= issueCVE
+      , "fixedIn" .= issueFixedIn
       ]
 
 instance FromJSON IssueType where
@@ -632,6 +638,8 @@ renderedIssues issues = rendered
       vsep
         ( map format . catMaybes $
             [ Just issueTitle
+            , cveMessage
+            , fixedIn
             , issueLink
             ]
         )
@@ -675,6 +683,12 @@ renderedIssues issues = rendered
 
         issueLink :: Maybe Text
         issueLink = ("More information: " <>) <$> issueDashURL
+
+        cveMessage :: Maybe Text
+        cveMessage = ("CVE ID: " <>) <$> issueCVE
+
+        fixedIn :: Maybe Text
+        fixedIn = ("Fixed in: " <>) <$> issueFixedIn
 
         issuePolicyFlagMessage :: Text
         issuePolicyFlagMessage = fromMaybe missingRuleIdMsg (issuePolicyFlagMsg <|> missingLicenseIdMsg)

--- a/test/Fossa/API/TypesSpec.hs
+++ b/test/Fossa/API/TypesSpec.hs
@@ -54,6 +54,7 @@ genIssue =
     <*> genIssueType
     <*> Gen.maybe genIssueRule
     <*> Gen.maybe arbitraryText
+    <*> Gen.maybe arbitraryText
 
 genIssueType :: Gen IssueType
 genIssueType =

--- a/test/Fossa/API/TypesSpec.hs
+++ b/test/Fossa/API/TypesSpec.hs
@@ -55,6 +55,8 @@ genIssue =
     <*> Gen.maybe genIssueRule
     <*> Gen.maybe arbitraryText
     <*> Gen.maybe arbitraryText
+    <*> Gen.maybe arbitraryText
+    <*> Gen.maybe arbitraryText
 
 genIssueType :: Gen IssueType
 genIssueType =

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -227,6 +227,7 @@ issuesAvailable =
           , API.issueType = issueType
           , API.issueRule = Nothing
           , API.issueLicense = Nothing
+          , API.issueDashURL = Nothing
           }
       issueList = zipWith makeIssue [1 ..] issueTypes
    in API.Issues
@@ -256,6 +257,7 @@ issuesDiffAvailable =
           , API.issueType = issueType
           , API.issueRule = Nothing
           , API.issueLicense = Nothing
+          , API.issueDashURL = Nothing
           }
       issueList = zipWith makeIssue [1 ..] issueTypes
    in API.Issues

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -207,6 +207,21 @@ emptyIssues =
     , API.issuesSummary = Nothing
     }
 
+makeIssue :: Int -> API.IssueType -> API.Issue
+makeIssue issueId issueType =
+  API.Issue
+    { API.issueId = issueId
+    , API.issuePriorityString = Nothing
+    , API.issueResolved = False
+    , API.issueRevisionId = "IssueRevisionId" <> showT issueId
+    , API.issueType = issueType
+    , API.issueRule = Nothing
+    , API.issueLicense = Nothing
+    , API.issueDashURL = Nothing
+    , API.issueCVE = Nothing
+    , API.issueFixedIn = Nothing
+    }
+
 issuesAvailable :: API.Issues
 issuesAvailable =
   let issueTypes =
@@ -217,19 +232,7 @@ issuesAvailable =
         , API.IssueOutdatedDependency
         , API.IssueOther "TestIssueOther"
         ]
-      makeIssue :: Int -> API.IssueType -> API.Issue
-      makeIssue issueId issueType =
-        API.Issue
-          { API.issueId = 200 + issueId
-          , API.issuePriorityString = Nothing
-          , API.issueResolved = False
-          , API.issueRevisionId = "IssueRevisionId" <> showT issueId
-          , API.issueType = issueType
-          , API.issueRule = Nothing
-          , API.issueLicense = Nothing
-          , API.issueDashURL = Nothing
-          }
-      issueList = zipWith makeIssue [1 ..] issueTypes
+      issueList = zipWith makeIssue [201 ..] issueTypes
    in API.Issues
         { API.issuesCount = length issueList
         , API.issuesIssues = issueList
@@ -247,19 +250,7 @@ issuesDiffAvailable =
         , API.IssueOutdatedDependency
         , API.IssueOther "TestIssueOther"
         ]
-      makeIssue :: Int -> API.IssueType -> API.Issue
-      makeIssue issueId issueType =
-        API.Issue
-          { API.issueId = 100 + issueId
-          , API.issuePriorityString = Nothing
-          , API.issueResolved = False
-          , API.issueRevisionId = "IssueRevisionId" <> showT issueId
-          , API.issueType = issueType
-          , API.issueRule = Nothing
-          , API.issueLicense = Nothing
-          , API.issueDashURL = Nothing
-          }
-      issueList = zipWith makeIssue [1 ..] issueTypes
+      issueList = zipWith makeIssue [101 ..] issueTypes
    in API.Issues
         { API.issuesCount = length issueList
         , API.issuesIssues = issueList


### PR DESCRIPTION
# Overview

This PR adds cve and next safe version information to vulnerability issues and adds dashboard links for all issues in fossa test.

## Acceptance criteria

 * The output of the fossa test shows how the weblink to ENDPOINT’s web app’s issue page for all issues, not just CVE issues.
* The output of the fossa test, shows CVE ID for vulnerability issues if CVE ID exists.
* The output of the fossa test shows version fixing vulnerability for vulnerability.
* `fossa test` should also work for versions of FOSSA which do not provide CVE or link information.

## Testing plan
I ran manual tests against a local build of FOSSA which outputs the new data and verified that it was present.
1. Populate the local database with vuln information
2. I created an npm project with one of those vulnerabilities in it and analyzed it.
3. I ran `fossa test` and verified that the output was correct and links were valid.

I also ran repeated this against FOSSA in production to ensure that `fossa test` still behaves properly for versions of FOSSA that don't output this information.

## Risks

* I didn't add automated testing since the output is human readable text, which we don't generally test. The responses from the API are also arbitrary text, so I felt there wasn't a lot of value to testing. Reviewers should read this with an eye towards any automated testing they'd like that I haven't thought of.

## References

[ANE-635](https://fossa.atlassian.net/browse/ANE-635)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-635]: https://fossa.atlassian.net/browse/ANE-635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ