### PR TITLE
Custom binaries for dynamic analysis

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
+## v3.7.0
+
+- Support Maven wrapper (`mvnw`) usage in Maven projects, and user-provided binary overrides for Maven projects ([#1149](https://github.com/fossas/fossa-cli/pull/1149))
+  For more information, see the [Maven strategy documentation](./docs/references/strategies/languages/maven/maven.md).
+
 ## v3.6.17
 
 - Handle Leiningen deduped deps: expand groupID and artifactID in the leiningen tactic to satisfy the Maven fetcher ([#1152]](https://github.com/fossas/fossa-cli/pull/1152))

--- a/docs/features/strategy-command-selection.md
+++ b/docs/features/strategy-command-selection.md
@@ -1,0 +1,69 @@
+# Strategy command selection
+
+In some strategies, FOSSA CLI uses actual package managers or build tools in order to analyze the dependencies of a project.
+FOSSA refers to such strategies as "dynamic analysis strategies".
+
+Some dynamic analysis strategies have multiple command options to use, preferred in a fallback manner.
+FOSSA refers to these as "candidate commands".
+
+FOSSA CLI chooses which command in a list of _candidate commands_ to use by running each command
+with a set of flags suitable for determining whether the candidate will work for FOSSA CLI.
+The particular flags used are up to each strategy; sometimes they simply test whether the command is able to run,
+and sometimes they may test that the command is of a particular minimum version or supports some capability.
+FOSSA refers to these flags as _evaluation flags_.
+
+If the command, run with the _evaluation flag_, exits with a non-zero exit code FOSSA CLI
+determines that the candidate command is unsuitable and moves on to the next candidate.
+If no suitable command is found, the overall strategy fails.
+
+If a _candidate command_ was chosen, but then later fails, FOSSA CLI treats
+this as an overall strategy failure since that command was determined to be the correct
+one to use for the project.
+
+## Concrete example: Maven
+
+For example the "Maven" strategy prefers, in order:
+
+1. The command provided by the user via `FOSSA_MAVEN_CMD`, if present.
+2. The local `mvnw` command, if one is found in the project or an ancestor directory.
+3. The `mvn` command in `$PATH`.
+
+Suppose FOSSA CLI is analyzing the following project:
+```
+.
+├── mvnw
+├── pom.xml
+├── readme.md
+└── src
+   └── main
+      └── java
+         └── org
+            └── apache
+               └── maven
+                  └── wrapper
+                     └── BootstrapMainStarter.java
+```
+
+And that FOSSA CLI is being run with the following command:
+```
+FOSSA_MAVEN_CMD=/usr/local/bin/custom-mvn fossa analyze
+```
+
+This results in the following list of candidate commands,
+where the earlier in the list the command appears, the higher priority that command has:
+```
+[ "/usr/local/bin/custom-mvn"
+, "./mvnw"
+, "mvn"
+]
+```
+
+FOSSA CLI evaluates these candidates with the following commands in sequence,
+stopping after the first one evaluates with a non-zero exit code:
+```
+; /usr/local/bin/custom-mvn -v # exit code 1
+; ./mvnw -v # exit code 0
+```
+
+Since `./mvnw` appears suitable, FOSSA CLI chooses that as the command to use
+and performs analysis on this Maven project using the `./mvnw` command.

--- a/docs/features/strategy-command-selection.md
+++ b/docs/features/strategy-command-selection.md
@@ -12,7 +12,7 @@ The particular flags used are up to each strategy; sometimes they simply test wh
 and sometimes they may test that the command is of a particular minimum version or supports some capability.
 FOSSA refers to these flags as _evaluation flags_.
 
-If the command, run with the _evaluation flag_, exits with a non-zero exit code FOSSA CLI
+If the command, run with the _evaluation flags_, exits with a non-zero exit code FOSSA CLI
 determines that the candidate command is unsuitable and moves on to the next candidate.
 If no suitable command is found, the overall strategy fails.
 
@@ -59,7 +59,7 @@ where the earlier in the list the command appears, the higher priority that comm
 ```
 
 FOSSA CLI evaluates these candidates with the following commands in sequence,
-stopping after the first one evaluates with a non-zero exit code:
+stopping after the first one evaluates with exit code zero (signifying no error):
 ```
 ; /usr/local/bin/custom-mvn -v # exit code 1
 ; ./mvnw -v # exit code 0

--- a/docs/references/strategies/languages/maven/maven.md
+++ b/docs/references/strategies/languages/maven/maven.md
@@ -17,9 +17,9 @@ Maven analysis attempts these analysis methods in order:
 FOSSA CLI uses [strategy command selection](../../../../features/strategy-command-selection.md) for Maven commands:
 - Maven _candidate commands_ are:
   - If present, the command specified by the `FOSSA_MAVEN_CMD` environment variable.
-  - If present, the `mvnw` or `mvnw.bat` script in the project directory or any ancestor directory.
+  - If present, the `mvnw` and/or `mvnw.bat` script in the project directory or any ancestor directory.
   - Finally, the `mvn` command, which is searched for in `$PATH`.
-- The Maven _evaluation flag_ is `-v` for each _candidate command_.
+- To choose a command from the candidates, FOSSA CLI runs each candidate with `-v` and selects the first one that succeeds.
 
 ## FAQ
 

--- a/docs/references/strategies/languages/maven/maven.md
+++ b/docs/references/strategies/languages/maven/maven.md
@@ -17,7 +17,7 @@ Maven analysis attempts these analysis methods in order:
 FOSSA CLI uses [strategy command selection](../../../../features/strategy-command-selection.md) for Maven commands:
 - Maven _candidate commands_ are:
   - If present, the command specified by the `FOSSA_MAVEN_CMD` environment variable.
-  - If present, the `mvnw` and/or `mvnw.bat` script in the project directory or any ancestor directory.
+  - If present, the `mvnw` or `mvnw.bat` script in the project directory or any ancestor directory.
   - Finally, the `mvn` command, which is searched for in `$PATH`.
 - To choose a command from the candidates, FOSSA CLI runs each candidate with `-v` and selects the first one that succeeds.
 

--- a/docs/references/strategies/languages/maven/maven.md
+++ b/docs/references/strategies/languages/maven/maven.md
@@ -14,7 +14,15 @@ Maven analysis attempts these analysis methods in order:
 3. Run the maven plugin command version 3.3.0.
 4. Scan `pom.xml` files located in the file tree.
 
+FOSSA CLI uses [strategy command selection](../../../../features/strategy-command-selection.md) for Maven commands:
+- Maven _candidate commands_ are:
+  - If present, the command specified by the `FOSSA_MAVEN_CMD` environment variable.
+  - If present, the `mvnw` or `mvnw.bat` script in the project directory or any ancestor directory.
+  - Finally, the `mvn` command, which is searched for in `$PATH`.
+- The Maven _evaluation flag_ is `-v` for each _candidate command_.
+
 ## FAQ
+
 ### One of my transitive dependencies does not have path information
 The mavenplugin and treecmd tactic can result in transitive dependencies which do not display paths to parents. This example graph shows how that can happen:
 ```

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -305,6 +305,7 @@ library
     Data.Functor.Extra
     Data.Glob
     Data.List.Extra
+    Data.Maybe.Extra
     Data.Monoid.Extra
     Data.Rpm.DbHeaderBlob
     Data.Rpm.DbHeaderBlob.Internal

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -59,6 +59,7 @@ import App.Fossa.VSI.Types qualified as VSI
 import App.Fossa.VSIDeps (analyzeVSIDeps)
 import App.Types (
   BaseDir (..),
+  OverrideDynamicAnalysisBinary,
   ProjectRevision (..),
  )
 import Codec.Compression.GZip qualified as GZip
@@ -177,6 +178,7 @@ runDependencyAnalysis ::
   , Has Stack sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
   , Has (Reader AllFilters) sig m
+  , Has (Reader OverrideDynamicAnalysisBinary) sig m
   , Has Telemetry sig m
   ) =>
   -- | Analysis base directory
@@ -300,6 +302,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
       . runAtomicCounter
       . runReader (Config.experimental cfg)
       . runReader discoveryFilters
+      . runReader (Config.overrideDynamicAnalysis cfg)
       $ do
         runAnalyzers basedir filters
         when (fromFlag UnpackArchives $ Config.unpackArchives cfg) $

--- a/src/App/Fossa/Analyze/Discover.hs
+++ b/src/App/Fossa/Analyze/Discover.hs
@@ -3,7 +3,7 @@ module App.Fossa.Analyze.Discover (
   DiscoverFunc (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject, AnalyzeTaskEffs)
+import App.Fossa.Analyze.Types (AnalyzeProject, DiscoverTaskEffs)
 import Control.Effect.Reader (Has, Reader)
 import Data.Aeson qualified as Aeson
 import Discovery.Filters (AllFilters)
@@ -45,7 +45,7 @@ import Strategy.Scala qualified as Scala
 import Strategy.SwiftPM qualified as SwiftPM
 import Types (DiscoveredProject)
 
-discoverFuncs :: AnalyzeTaskEffs sig m => [DiscoverFunc m]
+discoverFuncs :: DiscoverTaskEffs sig m => [DiscoverFunc m]
 discoverFuncs =
   [ DiscoverFunc Bundler.discover
   , DiscoverFunc Cabal.discover

--- a/src/App/Fossa/Analyze/Log4jReport.hs
+++ b/src/App/Fossa/Analyze/Log4jReport.hs
@@ -23,6 +23,7 @@ import App.Fossa.Config.Common (baseDirArg, collectBaseDir)
 import App.Fossa.Subcommand (GetCommonOpts, GetSeverity, SubCommand (SubCommand))
 import App.Types (
   BaseDir (..),
+  OverrideDynamicAnalysisBinary,
  )
 import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
 import Control.Carrier.Debug (debugMetadata, ignoreDebug)
@@ -124,6 +125,7 @@ analyzeForLog4j basedir = do
 
   runReader withoutAnyExperimentalPreferences
     . runReader (mempty :: AllFilters)
+    . runReader (mempty :: OverrideDynamicAnalysisBinary)
     . ignoreDebug
     $ do
       (projectResults, ()) <-
@@ -172,6 +174,7 @@ runDependencyAnalysisForLog4j ::
   , Has (Output ProjectResult) sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
   , Has (Reader AllFilters) sig m
+  , Has (Reader OverrideDynamicAnalysisBinary) sig m
   , Has Stack sig m
   , Has Telemetry sig m
   ) =>

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -1,6 +1,7 @@
 module App.Fossa.Analyze.Types (
   AnalyzeProject (..),
   AnalysisScanResult (..),
+  DiscoverTaskEffs,
   AnalyzeTaskEffs,
   AnalyzeStaticTaskEffs,
   AnalyzeExperimentalPreferences (..),
@@ -30,9 +31,9 @@ newtype AnalyzeExperimentalPreferences = AnalyzeExperimentalPreferences
   {gradleOnlyConfigsAllowed :: Maybe (Set Text)}
   deriving (Show, Eq, Ord)
 
-type AnalyzeTaskEffs sig m =
-  ( CandidateCommandEffs sig m
-  , Has (Lift IO) sig m
+-- | Effects needed to discover projects.
+type DiscoverTaskEffs sig m =
+  ( Has (Lift IO) sig m
   , Has ReadFS sig m
   , Has Exec sig m
   , Has Logger sig m
@@ -43,10 +44,22 @@ type AnalyzeTaskEffs sig m =
   , Has Telemetry sig m
   )
 
+-- | Effects needed to analyze projects dynamically.
+type AnalyzeTaskEffs sig m =
+  ( CandidateCommandEffs sig m
+  , DiscoverTaskEffs sig m
+  )
+
+-- | Effects needed to analyze projects statically.
+--
+-- Currently a copy of @DiscoverTaskEffs@, but ideally wouldn't have @Exec@:
+-- @Exec@ is only there because we need to execute a binary to statically analyze BerkeleyDB,
+-- so ideally we'd either create a different effect to disambiguate this case or make the BDB analysis not a separate binary
+-- (either via FFI, WASM embedding, or rewriting it to Haskell).
 type AnalyzeStaticTaskEffs sig m =
   ( Has (Lift IO) sig m
   , Has ReadFS sig m
-  , Has Exec sig m -- May not exec dynamic strategies. TODO: Remove this and convert the BerkeleyDB driver to FFI.
+  , Has Exec sig m
   , Has Logger sig m
   , Has Diagnostics sig m
   , Has Debug sig m

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -10,6 +10,7 @@ module App.Fossa.Analyze.Types (
 
 import App.Fossa.Analyze.Project (ProjectResult)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig)
+import App.Types (OverrideDynamicAnalysisBinary)
 import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics, Has)
 import Control.Effect.Lift (Lift)
@@ -39,6 +40,7 @@ type AnalyzeTaskEffs sig m =
   , Has Debug sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
   , Has (Reader AllFilters) sig m
+  , Has (Reader OverrideDynamicAnalysisBinary) sig m
   , Has Telemetry sig m
   )
 

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -10,7 +10,6 @@ module App.Fossa.Analyze.Types (
 
 import App.Fossa.Analyze.Project (ProjectResult)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig)
-import App.Types (OverrideDynamicAnalysisBinary)
 import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics, Has)
 import Control.Effect.Lift (Lift)
@@ -20,7 +19,7 @@ import Data.Set (Set)
 import Data.Text (Text)
 import Diag.Result (Result (Failure, Success))
 import Discovery.Filters (AllFilters)
-import Effect.Exec (Exec)
+import Effect.Exec (CandidateCommandEffs, Exec)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
 import Path (Abs, Dir, Path)
@@ -32,7 +31,8 @@ newtype AnalyzeExperimentalPreferences = AnalyzeExperimentalPreferences
   deriving (Show, Eq, Ord)
 
 type AnalyzeTaskEffs sig m =
-  ( Has (Lift IO) sig m
+  ( CandidateCommandEffs sig m
+  , Has (Lift IO) sig m
   , Has ReadFS sig m
   , Has Exec sig m
   , Has Logger sig m
@@ -40,7 +40,6 @@ type AnalyzeTaskEffs sig m =
   , Has Debug sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
   , Has (Reader AllFilters) sig m
-  , Has (Reader OverrideDynamicAnalysisBinary) sig m
   , Has Telemetry sig m
   )
 

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -50,12 +50,13 @@ import App.Fossa.Config.ConfigFile (
   mergeFileCmdMetadata,
   resolveConfigFile,
  )
-import App.Fossa.Config.EnvironmentVars (EnvVars)
+import App.Fossa.Config.EnvironmentVars (EnvVars (..))
 import App.Fossa.Subcommand (EffStack, GetCommonOpts (getCommonOpts), GetSeverity (getSeverity), SubCommand (SubCommand))
 import App.Fossa.VSI.Types qualified as VSI
 import App.Types (
   BaseDir,
   MonorepoAnalysisOpts (MonorepoAnalysisOpts, monorepoAnalysisType),
+  OverrideDynamicAnalysisBinary (..),
   OverrideProject (OverrideProject),
   ProjectMetadata,
   ProjectRevision,
@@ -238,6 +239,7 @@ data StandardAnalyzeConfig = StandardAnalyzeConfig
   , jsonOutput :: Flag JsonOutput
   , includeAllDeps :: Flag IncludeAll
   , noDiscoveryExclusion :: Flag NoDiscoveryExclusion
+  , overrideDynamicAnalysis :: OverrideDynamicAnalysisBinary
   }
   deriving (Eq, Ord, Show, Generic)
 
@@ -432,6 +434,7 @@ mergeStandardOpts maybeConfig envvars cliOpts@AnalyzeCliOpts{..} = do
       filters = collectFilters maybeConfig cliOpts
       experimentalCfgs = collectExperimental maybeConfig
       vendoredDepsOptions = collectVendoredDeps maybeConfig cliOpts
+      dynamicAnalysisOverrides = OverrideDynamicAnalysisBinary $ envCmdOverrides envvars
 
   StandardAnalyzeConfig
     <$> basedir
@@ -446,6 +449,7 @@ mergeStandardOpts maybeConfig envvars cliOpts@AnalyzeCliOpts{..} = do
     <*> pure analyzeJsonOutput
     <*> pure analyzeIncludeAllDeps
     <*> pure analyzeNoDiscoveryExclusion
+    <*> pure dynamicAnalysisOverrides
 
 collectFilters ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Config/EnvironmentVars.hs
+++ b/src/App/Fossa/Config/EnvironmentVars.hs
@@ -6,9 +6,14 @@ module App.Fossa.Config.EnvironmentVars (
 import App.Fossa.Config.ConfigFile (ConfigTelemetryScope (FullTelemetry, NoTelemetry))
 import Control.Effect.Lift (Has, Lift, sendIO)
 import Data.Functor.Extra ((<$$>))
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe (catMaybes, mapMaybe)
+import Data.Maybe.Extra (maybeTuple)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import DepTypes (DepType (..))
 import Effect.Logger (Logger, Pretty (pretty), logWarn)
 import System.Environment (lookupEnv)
 
@@ -18,6 +23,7 @@ data EnvVars = EnvVars
   , envTelemetryDebug :: Bool
   , envTelemetryScope :: Maybe ConfigTelemetryScope
   , envDockerHost :: Maybe Text
+  , envCmdOverrides :: Map DepType Text
   }
   deriving (Eq, Ord, Show)
 
@@ -36,6 +42,9 @@ telemetryScopeKeyName = "FOSSA_TELEMETRY_SCOPE"
 dockerHostName :: String
 dockerHostName = "DOCKER_HOST"
 
+overridableCommands :: [DepType]
+overridableCommands = [(minBound :: DepType) ..]
+
 getEnvVars :: (Has (Lift IO) sig m, Has Logger sig m) => m EnvVars
 getEnvVars =
   EnvVars
@@ -44,6 +53,7 @@ getEnvVars =
     <*> lookupBool telemetryDebugName
     <*> lookUpTelemetryScope telemetryScopeKeyName
     <*> lookupName dockerHostName
+    <*> lookupNames mkCommandOverrideVar overridableCommands
 
 lookupName :: Has (Lift IO) sig m => String -> m (Maybe Text)
 lookupName name = toText <$$> sendIO (lookupEnv name)
@@ -67,6 +77,36 @@ lookUpTelemetryScope varName = do
         other -> do
           logWarn $ pretty ("You provided telemetry scope of: " <> other <> " " <> "which is not valid. Please choose between \"full\" or \"off\".")
           pure Nothing
+
+-- | Given a list of @a@, and a function that may generate an environment variable for a given instance of @a@,
+-- look up every environment variable and store its value next to the original instance in a map.
+--
+-- The "function that may generate an environment variable for a given instance of @a@" is done in order to
+-- make it possible to not support certain instances of @a@ for lookup.
+lookupNames :: (Has (Lift IO) sig m, Ord a) => (a -> Maybe String) -> [a] -> m (Map a Text)
+lookupNames mkVar names = Map.fromList . catMaybes <$> traverse lookupPair (mapMaybe (toPair mkVar) names)
+  where
+    toPair :: (a -> Maybe String) -> a -> Maybe (a, String)
+    toPair mkVar' a = maybeTuple a (mkVar' a)
+
+    lookupPair :: Has (Lift IO) sig m => (a, String) -> m (Maybe (a, Text))
+    lookupPair (a, name) = maybeTuple a <$> lookupName name
+
+-- | Users need to be able to override the command used during dynamic analyis.
+-- For example, users may have a custom Maven command at a specific path,
+-- or a custom Go version installed they wish to use for a specific project.
+--
+-- In order to specify these in a user-facing manner, we use the @DepType@ to
+-- generate an environment variable to use when overriding that command.
+--
+-- We don't use existing stringifications of @DepType@ (for example, @depTypeToFetcher@)
+-- because we do not want to tie internal representations to user facing contracts.
+mkCommandOverrideVar :: DepType -> Maybe String
+mkCommandOverrideVar MavenType = Just $ commandOverrideVarForName "MAVEN"
+mkCommandOverrideVar _ = Nothing
+
+commandOverrideVarForName :: String -> String
+commandOverrideVarForName name = "FOSSA_" <> name <> "_CMD"
 
 any' :: a -> [a -> Bool] -> Bool
 any' _ [] = False

--- a/src/App/Fossa/Config/ListTargets.hs
+++ b/src/App/Fossa/Config/ListTargets.hs
@@ -21,9 +21,9 @@ import App.Fossa.Config.ConfigFile (
   ExperimentalGradleConfigs (gradleConfigsOnly),
   resolveLocalConfigFile,
  )
-import App.Fossa.Config.EnvironmentVars (EnvVars, envCmdOverrides)
+import App.Fossa.Config.EnvironmentVars (EnvVars)
 import App.Fossa.Subcommand (EffStack, GetCommonOpts (getCommonOpts), GetSeverity (getSeverity), SubCommand (SubCommand))
-import App.Types (BaseDir, OverrideDynamicAnalysisBinary (..))
+import App.Types (BaseDir)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Lift)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
@@ -60,14 +60,12 @@ mergeOpts ::
   EnvVars ->
   ListTargetsCliOpts ->
   m ListTargetsConfig
-mergeOpts cfgfile envvars ListTargetsCliOpts{..} = do
+mergeOpts cfgfile _envvars ListTargetsCliOpts{..} = do
   let basedir = collectBaseDir cliBaseDir
       experimentalPrefs = collectExperimental cfgfile
-      dynamicAnalysisOverrides = OverrideDynamicAnalysisBinary $ envCmdOverrides envvars
   ListTargetsConfig
     <$> basedir
     <*> pure experimentalPrefs
-    <*> pure dynamicAnalysisOverrides
 
 collectExperimental :: Maybe ConfigFile -> ExperimentalAnalyzeConfig
 collectExperimental maybeCfg =
@@ -90,7 +88,6 @@ instance GetCommonOpts ListTargetsCliOpts where
 data ListTargetsConfig = ListTargetsConfig
   { baseDir :: BaseDir
   , experimental :: ExperimentalAnalyzeConfig
-  , overrideDynamicAnalysis :: OverrideDynamicAnalysisBinary
   }
   deriving (Show, Generic)
 

--- a/src/App/Fossa/Config/ListTargets.hs
+++ b/src/App/Fossa/Config/ListTargets.hs
@@ -21,8 +21,9 @@ import App.Fossa.Config.ConfigFile (
   ExperimentalGradleConfigs (gradleConfigsOnly),
   resolveLocalConfigFile,
  )
+import App.Fossa.Config.EnvironmentVars (EnvVars, envCmdOverrides)
 import App.Fossa.Subcommand (EffStack, GetCommonOpts (getCommonOpts), GetSeverity (getSeverity), SubCommand (SubCommand))
-import App.Types (BaseDir)
+import App.Types (BaseDir, OverrideDynamicAnalysisBinary (..))
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Lift)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
@@ -56,15 +57,17 @@ mergeOpts ::
   , Has ReadFS sig m
   ) =>
   Maybe ConfigFile ->
-  p ->
+  EnvVars ->
   ListTargetsCliOpts ->
   m ListTargetsConfig
-mergeOpts cfgfile _envvars ListTargetsCliOpts{..} = do
+mergeOpts cfgfile envvars ListTargetsCliOpts{..} = do
   let basedir = collectBaseDir cliBaseDir
       experimentalPrefs = collectExperimental cfgfile
+      dynamicAnalysisOverrides = OverrideDynamicAnalysisBinary $ envCmdOverrides envvars
   ListTargetsConfig
     <$> basedir
     <*> pure experimentalPrefs
+    <*> pure dynamicAnalysisOverrides
 
 collectExperimental :: Maybe ConfigFile -> ExperimentalAnalyzeConfig
 collectExperimental maybeCfg =
@@ -87,6 +90,7 @@ instance GetCommonOpts ListTargetsCliOpts where
 data ListTargetsConfig = ListTargetsConfig
   { baseDir :: BaseDir
   , experimental :: ExperimentalAnalyzeConfig
+  , overrideDynamicAnalysis :: OverrideDynamicAnalysisBinary
   }
   deriving (Show, Generic)
 

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -13,7 +13,7 @@ import App.Fossa.Config.ListTargets (
   mkSubCommand,
  )
 import App.Fossa.Subcommand (SubCommand)
-import App.Types (BaseDir (..))
+import App.Types (BaseDir (..), OverrideDynamicAnalysisBinary)
 import Control.Carrier.AtomicCounter (
   AtomicCounter,
   Has,
@@ -79,6 +79,7 @@ listTargetsMain ListTargetsConfig{..} = do
     . withTaskPool capabilities updateProgress
     . runAtomicCounter
     . runReader experimental
+    . runReader overrideDynamicAnalysis
     -- The current version of `fossa list-targets` does not support filters.
     -- TODO: support both discovery and post-discovery filtering.
     . runReader (mempty :: AllFilters)
@@ -95,6 +96,7 @@ runAll ::
   , Has Stack sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
   , Has (Reader AllFilters) sig m
+  , Has (Reader OverrideDynamicAnalysisBinary) sig m
   , Has Telemetry sig m
   ) =>
   Path Abs Dir ->

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -13,7 +13,7 @@ import App.Fossa.Config.ListTargets (
   mkSubCommand,
  )
 import App.Fossa.Subcommand (SubCommand)
-import App.Types (BaseDir (..), OverrideDynamicAnalysisBinary)
+import App.Types (BaseDir (..))
 import Control.Carrier.AtomicCounter (
   AtomicCounter,
   Has,
@@ -79,7 +79,6 @@ listTargetsMain ListTargetsConfig{..} = do
     . withTaskPool capabilities updateProgress
     . runAtomicCounter
     . runReader experimental
-    . runReader overrideDynamicAnalysis
     -- The current version of `fossa list-targets` does not support filters.
     -- TODO: support both discovery and post-discovery filtering.
     . runReader (mempty :: AllFilters)
@@ -96,7 +95,6 @@ runAll ::
   , Has Stack sig m
   , Has (Reader ExperimentalAnalyzeConfig) sig m
   , Has (Reader AllFilters) sig m
-  , Has (Reader OverrideDynamicAnalysisBinary) sig m
   , Has Telemetry sig m
   ) =>
   Path Abs Dir ->

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -93,3 +93,9 @@ newtype OverrideDynamicAnalysisBinary = OverrideDynamicAnalysisBinary
 
 instance ToJSON OverrideDynamicAnalysisBinary where
   toEncoding = genericToEncoding defaultOptions
+
+instance Semigroup OverrideDynamicAnalysisBinary where
+  (OverrideDynamicAnalysisBinary a1) <> (OverrideDynamicAnalysisBinary a2) = OverrideDynamicAnalysisBinary (a1 <> a2)
+
+instance Monoid OverrideDynamicAnalysisBinary where
+  mempty = OverrideDynamicAnalysisBinary mempty

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -57,9 +57,9 @@ instance FromJSON ReleaseGroupMetadata where
   parseJSON = withObject "ReleaseGroupMetadata" $ \obj ->
     ReleaseGroupMetadata
       <$> obj
-      .: "name"
+        .: "name"
       <*> obj
-      .: "release"
+        .: "release"
 
 newtype MonorepoAnalysisOpts = MonorepoAnalysisOpts
   { monorepoAnalysisType :: Maybe Text

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -6,10 +6,13 @@ module App.Types (
   ReleaseGroupMetadata (..),
   ProjectRevision (..),
   MonorepoAnalysisOpts (..),
+  OverrideDynamicAnalysisBinary (..),
 ) where
 
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toEncoding), defaultOptions, genericToEncoding, withObject, (.:))
+import Data.Map (Map)
 import Data.Text (Text)
+import DepTypes (DepType)
 import GHC.Generics (Generic)
 import Path (Abs, Dir, Path)
 
@@ -53,8 +56,10 @@ instance ToJSON ReleaseGroupMetadata where
 instance FromJSON ReleaseGroupMetadata where
   parseJSON = withObject "ReleaseGroupMetadata" $ \obj ->
     ReleaseGroupMetadata
-      <$> obj .: "name"
-      <*> obj .: "release"
+      <$> obj
+      .: "name"
+      <*> obj
+      .: "release"
 
 newtype MonorepoAnalysisOpts = MonorepoAnalysisOpts
   { monorepoAnalysisType :: Maybe Text
@@ -81,3 +86,10 @@ data NinjaGraphCLIOptions = NinjaGraphCLIOptions
   , ninjaScanId :: Text
   , ninjaBuildName :: Text
   }
+
+newtype OverrideDynamicAnalysisBinary = OverrideDynamicAnalysisBinary
+  {unOverrideDynamicAnalysisBinary :: Map DepType Text}
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON OverrideDynamicAnalysisBinary where
+  toEncoding = genericToEncoding defaultOptions

--- a/src/Data/Maybe/Extra.hs
+++ b/src/Data/Maybe/Extra.hs
@@ -1,0 +1,7 @@
+module Data.Maybe.Extra (
+  maybeTuple,
+) where
+
+maybeTuple :: a -> Maybe b -> Maybe (a, b)
+maybeTuple _ Nothing = Nothing
+maybeTuple a (Just b) = Just (a, b)

--- a/src/DepTypes.hs
+++ b/src/DepTypes.hs
@@ -15,6 +15,7 @@ import Data.Aeson (
   FromJSON,
   KeyValue ((.=)),
   ToJSON (toJSON),
+  ToJSONKey,
   Value,
   object,
  )
@@ -122,7 +123,7 @@ data DepType
     CarthageType
   | -- | A Swift Package Dependency -- effectively a "git" dependency. Name is repo path and version is tag/branch/hash
     SwiftType
-  deriving (Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Show, Generic, Enum, Bounded)
 
 data VerConstraint
   = -- | equal to, e.g., @CEq "2.0.0"@
@@ -149,6 +150,7 @@ data VerConstraint
 
 instance FromJSON DepType -- use the generic instance
 instance ToJSON DepType -- use the generic instance
+instance ToJSONKey DepType
 
 instance ToJSON Dependency where
   toJSON Dependency{..} =

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -21,10 +21,14 @@ module Effect.Exec (
   module System.Exit,
   execThrow',
   Has,
+  CandidateAnalysisCommands (..),
+  mkAnalysisCommand,
 ) where
 
 import App.Support (reportDefectMsg)
+import App.Types (OverrideDynamicAnalysisBinary (..))
 import Control.Algebra (Has)
+import Control.Carrier.Reader (Reader, ask)
 import Control.Carrier.Simple (
   Simple,
   SimpleC,
@@ -36,6 +40,9 @@ import Control.Effect.Diagnostics (
   ToDiagnostic (..),
   context,
   fatal,
+  fatalText,
+  recover,
+  warnOnErr,
  )
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Record (RecordableValue (..))
@@ -54,11 +61,15 @@ import Data.Aeson (
  )
 import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as BL
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+import Data.Map qualified as Map
 import Data.String (fromString)
 import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Void (Void)
+import DepTypes (DepType (..))
 import Effect.ReadFS (ReadFS, getCurrentDir)
 import GHC.Generics (Generic)
 import Path (Abs, Dir, Path, SomeBase (..), fromAbsDir)
@@ -116,8 +127,10 @@ instance RecordableValue CmdFailure
 instance FromJSON CmdFailure where
   parseJSON = withObject "CmdFailure" $ \obj ->
     CmdFailure
-      <$> obj .: "cmdFailureCmd"
-      <*> obj .: "cmdFailureDir"
+      <$> obj
+      .: "cmdFailureCmd"
+      <*> obj
+      .: "cmdFailureDir"
       <*> (obj .: "cmdFailureExit" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStdout" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStderr" >>= fromRecordedValue)
@@ -267,6 +280,74 @@ execThrow' :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => Comma
 execThrow' cmd = context ("Running command '" <> cmdName cmd <> "'") $ do
   dir <- getCurrentDir
   execThrow dir cmd
+
+-- | Describe a set of command names and the arguments used to validate the command names.
+-- Optionally, also specify the override kind for the command, which is used
+-- to look for a potential override command provided by the user from the environment.
+data CandidateAnalysisCommands = CandidateAnalysisCommands
+  { candidateCmdNames :: NonEmpty Text
+  , candidateCmdArgs :: [Text]
+  , candidateOverrideKind :: Maybe DepType
+  }
+  deriving (Show)
+
+-- | Create a @Command@ for dynamic analysis of a project of the given @DepType@ from the list of provided commands.
+--
+-- This function selects the appropriate binary to use given the environment
+-- and creates the command with the provided args and error handling semantics.
+--
+-- It is also possible that no supported command is valid in the provided context;
+-- in such a case a diagnostics error is thrown in @m@.
+mkAnalysisCommand ::
+  ( Has Diagnostics sig m
+  , Has Exec sig m
+  , Has (Reader OverrideDynamicAnalysisBinary) sig m
+  ) =>
+  CandidateAnalysisCommands ->
+  Path Abs Dir ->
+  [Text] ->
+  AllowErr ->
+  m Command
+mkAnalysisCommand candidates@CandidateAnalysisCommands{..} workdir args allowErr =
+  context ("Make analysis command from " <> toText (show candidates)) $ do
+    (overrideBinaries :: OverrideDynamicAnalysisBinary) <- ask
+    cmd <- case candidateOverrideKind of
+      Just dt -> case Map.lookup dt (unOverrideDynamicAnalysisBinary overrideBinaries) of
+        Nothing -> context "Command override supported, but not specified" $ selectBestCmd workdir candidates
+        Just cmd -> context ("Command override provided: " <> cmd) . selectBestCmd workdir $ withCmdOverride cmd
+      Nothing -> context "Override not supported for this command" $ selectBestCmd workdir candidates
+    pure $ Command{cmdName = cmd, cmdArgs = args, cmdAllowErr = allowErr}
+  where
+    withCmdOverride :: Text -> CandidateAnalysisCommands
+    withCmdOverride override =
+      CandidateAnalysisCommands
+        { candidateCmdNames = NE.cons override candidateCmdNames
+        , candidateCmdArgs = candidateCmdArgs
+        , candidateOverrideKind = candidateOverrideKind
+        }
+
+-- | Given a set of possible binaries to try, choose the best one to use for dynamic analysis of this @DepType@.
+selectBestCmd :: (Has Diagnostics sig m, Has Exec sig m) => Path Abs Dir -> CandidateAnalysisCommands -> m Text
+selectBestCmd workdir CandidateAnalysisCommands{..} = selectBestCmd' (NE.toList candidateCmdNames)
+  where
+    selectBestCmd' :: (Has Diagnostics sig m, Has Exec sig m) => [Text] -> m Text
+    selectBestCmd' (cmd : remaining) = context ("Evaluate command: " <> cmd) $ do
+      let attempt = Command{cmdName = cmd, cmdArgs = candidateCmdArgs, cmdAllowErr = Never}
+      output <- recover . warnOnErr (CandidateCommandFailed cmd candidateCmdArgs) $ execThrow workdir attempt
+      case output of
+        Nothing -> selectBestCmd' remaining
+        Just _ -> pure cmd
+    selectBestCmd' [] = fatalText "unable to select best binary to analyze project: none passed validation"
+
+data CandidateCommandFailed = CandidateCommandFailed {failedCommand :: Text, failedArgs :: [Text]}
+instance ToDiagnostic CandidateCommandFailed where
+  renderDiagnostic CandidateCommandFailed{..} =
+    pretty $
+      "Command "
+        <> show failedCommand
+        <> " not suitable: running with args "
+        <> show failedArgs
+        <> " resulted in a non-zero exit code"
 
 type ExecIOC = SimpleC ExecF
 

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -130,9 +130,9 @@ instance FromJSON CmdFailure where
   parseJSON = withObject "CmdFailure" $ \obj ->
     CmdFailure
       <$> obj
-      .: "cmdFailureCmd"
+        .: "cmdFailureCmd"
       <*> obj
-      .: "cmdFailureDir"
+        .: "cmdFailureDir"
       <*> (obj .: "cmdFailureExit" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStdout" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStderr" >>= fromRecordedValue)

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -129,9 +129,9 @@ instance FromJSON CmdFailure where
   parseJSON = withObject "CmdFailure" $ \obj ->
     CmdFailure
       <$> obj
-      .: "cmdFailureCmd"
+        .: "cmdFailureCmd"
       <*> obj
-      .: "cmdFailureDir"
+        .: "cmdFailureDir"
       <*> (obj .: "cmdFailureExit" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStdout" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStderr" >>= fromRecordedValue)

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -23,6 +23,7 @@ module Effect.Exec (
   Has,
   CandidateAnalysisCommands (..),
   mkAnalysisCommand,
+  mkSingleCandidateAnalysisCommand,
 ) where
 
 import App.Support (reportDefectMsg)
@@ -290,6 +291,10 @@ data CandidateAnalysisCommands = CandidateAnalysisCommands
   , candidateOverrideKind :: Maybe DepType
   }
   deriving (Show)
+
+-- | Convenience function for creating a @CandidateAnalysisCommands@ with a single candidate command.
+mkSingleCandidateAnalysisCommand :: Text -> [Text] -> Maybe DepType -> CandidateAnalysisCommands
+mkSingleCandidateAnalysisCommand cmd = CandidateAnalysisCommands (NE.singleton cmd)
 
 -- | Create a @Command@ for dynamic analysis of a project of the given @DepType@ from the list of provided commands.
 --

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -7,7 +7,6 @@ module Strategy.Maven (
 
 import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
 import App.Pathfinder.Types (LicenseAnalyzeProject, licenseAnalyzeProject)
-import App.Types (OverrideDynamicAnalysisBinary)
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, context, warnOnErr, (<||>))
 import Control.Effect.Lift (Lift)

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -109,20 +109,18 @@ getDepsDynamicAnalysis closure =
     $ (getDepsPlugin closure <||> getDepsTreeCmd closure <||> getDepsPluginLegacy closure)
 
 getDepsPlugin ::
-  ( Has (Lift IO) sig m
-  , Has Diagnostics sig m
+  ( CandidateCommandEffs sig m
+  , Has (Lift IO) sig m
   , Has ReadFS sig m
-  , Has Exec sig m
   ) =>
   MavenProjectClosure ->
   m (Graphing Dependency, GraphBreadth)
 getDepsPlugin closure = context "Plugin analysis" (Plugin.analyze' . parent $ PomClosure.closurePath closure)
 
 getDepsPluginLegacy ::
-  ( Has (Lift IO) sig m
-  , Has Diagnostics sig m
+  ( CandidateCommandEffs sig m
+  , Has (Lift IO) sig m
   , Has ReadFS sig m
-  , Has Exec sig m
   ) =>
   MavenProjectClosure ->
   m (Graphing Dependency, GraphBreadth)

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -16,7 +16,7 @@ import Data.Aeson (ToJSON)
 import Diag.Common (MissingDeepDeps (MissingDeepDeps), MissingEdges (MissingEdges))
 import Discovery.Filters (AllFilters)
 import Discovery.Simple (simpleDiscover)
-import Effect.Exec (Exec)
+import Effect.Exec (CandidateCommandEffs, Exec)
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
 import Graphing (Graphing)
@@ -66,7 +66,7 @@ getDeps ::
   , Has Diagnostics sig m
   , Has ReadFS sig m
   , Has Exec sig m
-  , Has (Reader OverrideDynamicAnalysisBinary) sig m
+  , CandidateCommandEffs sig m
   ) =>
   MavenProject ->
   m DependencyResults
@@ -99,7 +99,7 @@ getDepsDynamicAnalysis ::
   , Has Diagnostics sig m
   , Has ReadFS sig m
   , Has Exec sig m
-  , Has (Reader OverrideDynamicAnalysisBinary) sig m
+  , CandidateCommandEffs sig m
   ) =>
   MavenProjectClosure ->
   m (Graphing Dependency, GraphBreadth)
@@ -134,7 +134,7 @@ getDepsTreeCmd ::
   , Has Diagnostics sig m
   , Has ReadFS sig m
   , Has Exec sig m
-  , Has (Reader OverrideDynamicAnalysisBinary) sig m
+  , CandidateCommandEffs sig m
   ) =>
   MavenProjectClosure ->
   m (Graphing Dependency, GraphBreadth)

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -7,6 +7,7 @@ module Strategy.Maven (
 
 import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
 import App.Pathfinder.Types (LicenseAnalyzeProject, licenseAnalyzeProject)
+import App.Types (OverrideDynamicAnalysisBinary)
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, context, warnOnErr, (<||>))
 import Control.Effect.Lift (Lift)
@@ -65,6 +66,7 @@ getDeps ::
   , Has Diagnostics sig m
   , Has ReadFS sig m
   , Has Exec sig m
+  , Has (Reader OverrideDynamicAnalysisBinary) sig m
   ) =>
   MavenProject ->
   m DependencyResults
@@ -97,6 +99,7 @@ getDepsDynamicAnalysis ::
   , Has Diagnostics sig m
   , Has ReadFS sig m
   , Has Exec sig m
+  , Has (Reader OverrideDynamicAnalysisBinary) sig m
   ) =>
   MavenProjectClosure ->
   m (Graphing Dependency, GraphBreadth)
@@ -131,6 +134,7 @@ getDepsTreeCmd ::
   , Has Diagnostics sig m
   , Has ReadFS sig m
   , Has Exec sig m
+  , Has (Reader OverrideDynamicAnalysisBinary) sig m
   ) =>
   MavenProjectClosure ->
   m (Graphing Dependency, GraphBreadth)

--- a/src/Strategy/Maven/DepTree.hs
+++ b/src/Strategy/Maven/DepTree.hs
@@ -51,7 +51,7 @@ import Types (GraphBreadth (Complete))
 deptreeCmd :: CandidateCommandEffs sig m => Path Abs Dir -> Maybe (Path Abs File) -> Path Abs File -> m Command
 deptreeCmd workdir settingsFile outputFile = mkAnalysisCommand candidates workdir args allowErr
   where
-    candidates = CandidateAnalysisCommands ("mvn" :| ["mvnw"]) ["-v"] $ Just MavenType
+    candidates = CandidateAnalysisCommands ("mvnw" :| ["mvn"]) ["-v"] $ Just MavenType
     args =
       [ -- Run `dependency:tree`.
         --

--- a/src/Strategy/Maven/DepTree.hs
+++ b/src/Strategy/Maven/DepTree.hs
@@ -17,6 +17,7 @@ import Control.Effect.Lift (Lift, sendIO)
 import Control.Exception.Extra (safeTry)
 import Data.Char (isSpace)
 import Data.Foldable (for_)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.Set qualified as Set
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
@@ -28,7 +29,7 @@ import DepTypes (
   Dependency (..),
   VerConstraint (CEq),
  )
-import Effect.Exec (AllowErr (..), CandidateCommandEffs, Command (..), Exec, exec, mkAnalysisCommand, mkSingleCandidateAnalysisCommand)
+import Effect.Exec (AllowErr (..), CandidateAnalysisCommands (..), CandidateCommandEffs, Command (..), Exec, exec, mkAnalysisCommand)
 import Effect.Grapher (direct, edge, evalGrapher)
 import Effect.ReadFS (ReadFS, doesFileExist, readContentsParser)
 import Graphing (Graphing, gmap, shrinkRoots)
@@ -50,7 +51,7 @@ import Types (GraphBreadth (Complete))
 deptreeCmd :: CandidateCommandEffs sig m => Path Abs Dir -> Maybe (Path Abs File) -> Path Abs File -> m Command
 deptreeCmd workdir settingsFile outputFile = mkAnalysisCommand candidates workdir args allowErr
   where
-    candidates = mkSingleCandidateAnalysisCommand "mvn" ["-v"] $ Just MavenType
+    candidates = CandidateAnalysisCommands ("mvn" :| ["mvnw"]) ["-v"] $ Just MavenType
     args =
       [ -- Run `dependency:tree`.
         --

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -120,12 +120,12 @@ installPlugin dir path plugin = do
 execPlugin :: (Has Exec sig m, Has Diagnostics sig m) => (DepGraphPlugin -> Command) -> Path Abs Dir -> DepGraphPlugin -> m ()
 execPlugin pluginToCmd dir plugin = void $ execThrow dir $ pluginToCmd plugin
 
-execPluginAggregate :: (CandidateCommandEffs sig m) => Path Abs Dir -> DepGraphPlugin -> m ()
+execPluginAggregate :: CandidateCommandEffs sig m => Path Abs Dir -> DepGraphPlugin -> m ()
 execPluginAggregate dir plugin = do
   cmd <- mavenPluginDependenciesCmd dir plugin
   execPlugin (const cmd) dir plugin
 
-execPluginReactor :: (CandidateCommandEffs sig m) => Path Abs Dir -> DepGraphPlugin -> m ()
+execPluginReactor :: CandidateCommandEffs sig m => Path Abs Dir -> DepGraphPlugin -> m ()
 execPluginReactor dir plugin = do
   cmd <- mavenPluginReactorCmd dir plugin
   execPlugin (const cmd) dir plugin

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -30,6 +30,7 @@ import Data.ByteString qualified as BS
 import Data.FileEmbed.Extra (embedFile')
 import Data.Foldable (Foldable (fold), foldl')
 import Data.Functor (void)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (catMaybes, isNothing)
@@ -40,13 +41,12 @@ import Data.Tree (Tree (..))
 import DepTypes (DepType (MavenType))
 import Effect.Exec (
   AllowErr (Never),
-  CandidateAnalysisCommands,
+  CandidateAnalysisCommands (..),
   CandidateCommandEffs,
   Command (..),
   Exec,
   execThrow,
   mkAnalysisCommand,
-  mkSingleCandidateAnalysisCommand,
  )
 import Effect.ReadFS (
   ReadFS,
@@ -203,7 +203,7 @@ textArtifactToPluginOutput
                   }
 
 mavenCmdCandidates :: CandidateAnalysisCommands
-mavenCmdCandidates = mkSingleCandidateAnalysisCommand "mvn" ["-v"] $ Just MavenType
+mavenCmdCandidates = CandidateAnalysisCommands ("mvn" :| ["mvnw"]) ["-v"] $ Just MavenType
 
 mavenInstallPluginCmd :: CandidateCommandEffs sig m => Path Abs Dir -> FP.FilePath -> DepGraphPlugin -> m Command
 mavenInstallPluginCmd workdir pluginFilePath plugin = mkAnalysisCommand mavenCmdCandidates workdir args Never

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -203,7 +203,7 @@ textArtifactToPluginOutput
                   }
 
 mavenCmdCandidates :: CandidateAnalysisCommands
-mavenCmdCandidates = CandidateAnalysisCommands ("mvn" :| ["mvnw"]) ["-v"] $ Just MavenType
+mavenCmdCandidates = CandidateAnalysisCommands ("mvnw" :| ["mvn"]) ["-v"] $ Just MavenType
 
 mavenInstallPluginCmd :: CandidateCommandEffs sig m => Path Abs Dir -> FP.FilePath -> DepGraphPlugin -> m Command
 mavenInstallPluginCmd workdir pluginFilePath plugin = mkAnalysisCommand mavenCmdCandidates workdir args Never

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -218,6 +218,7 @@ mavenCmdCandidates dir =
     (Just nix, Nothing) -> pure . mkCmd $ (toText nix) :| ["mvn"]
     (Nothing, Nothing) -> pure . mkCmd $ NE.singleton "mvn"
   where
+    mkCmd :: NonEmpty Text -> CandidateAnalysisCommands
     mkCmd cmds = CandidateAnalysisCommands cmds ["-v"] $ Just MavenType
     -- Unlike with the gradle wrapper, it's not _expected_ for maven projects to use the maven wrapper.
     -- Given that, don't warn on failure to find a wrapper; only warn if we find a wrapper and it fails to execute.

--- a/src/Strategy/Maven/PluginStrategy.hs
+++ b/src/Strategy/Maven/PluginStrategy.hs
@@ -8,7 +8,6 @@ module Strategy.Maven.PluginStrategy (
 
 import Control.Algebra (Has, run)
 import Control.Effect.Diagnostics (
-  Diagnostics,
   ToDiagnostic (renderDiagnostic),
   context,
   errCtx,
@@ -28,7 +27,7 @@ import DepTypes (
   Dependency (..),
   VerConstraint (CEq),
  )
-import Effect.Exec (Exec)
+import Effect.Exec (CandidateCommandEffs)
 import Effect.Grapher (Grapher, edge, evalGrapher)
 import Effect.Grapher qualified as Grapher
 import Effect.ReadFS (ReadFS)
@@ -54,28 +53,25 @@ import Strategy.Maven.Plugin (
 import Types (GraphBreadth (..))
 
 analyze' ::
-  ( Has (Lift IO) sig m
+  ( CandidateCommandEffs sig m
+  , Has (Lift IO) sig m
   , Has ReadFS sig m
-  , Has Exec sig m
-  , Has Diagnostics sig m
   ) =>
   Path Abs Dir ->
   m (Graphing Dependency, GraphBreadth)
 analyze' dir = analyze dir depGraphPlugin
 
 analyzeLegacy' ::
-  ( Has (Lift IO) sig m
+  ( CandidateCommandEffs sig m
+  , Has (Lift IO) sig m
   , Has ReadFS sig m
-  , Has Exec sig m
-  , Has Diagnostics sig m
   ) =>
   Path Abs Dir ->
   m (Graphing Dependency, GraphBreadth)
 analyzeLegacy' dir = analyze dir depGraphPluginLegacy
 
 runReactor ::
-  ( Has Diagnostics sig m
-  , Has Exec sig m
+  ( CandidateCommandEffs sig m
   , Has ReadFS sig m
   ) =>
   Path Abs Dir ->
@@ -87,10 +83,9 @@ runReactor dir plugin =
       <||> pure (ReactorOutput [])
 
 analyze ::
-  ( Has (Lift IO) sig m
+  ( CandidateCommandEffs sig m
+  , Has (Lift IO) sig m
   , Has ReadFS sig m
-  , Has Exec sig m
-  , Has Diagnostics sig m
   ) =>
   Path Abs Dir ->
   DepGraphPlugin ->

--- a/test/App/Fossa/AnalyzeSpec.hs
+++ b/test/App/Fossa/AnalyzeSpec.hs
@@ -2,6 +2,7 @@ module App.Fossa.AnalyzeSpec (spec) where
 
 import App.Fossa.Analyze.Discover (DiscoverFunc, discoverFuncs)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig)
+import App.Types (OverrideDynamicAnalysisBinary)
 import Control.Carrier.Debug (DebugC)
 import Control.Carrier.Diagnostics (DiagnosticsC)
 import Control.Carrier.Reader (ReaderC)
@@ -14,7 +15,7 @@ import Effect.ReadFS (ReadFSIOC)
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Type.Operator (type ($))
 
-type SomeMonad = TelemetryC $ ReaderC ExperimentalAnalyzeConfig $ ReaderC AllFilters $ DebugC $ DiagnosticsC $ LoggerC $ ExecIOC $ ReadFSIOC $ StackC IO
+type SomeMonad = TelemetryC $ ReaderC OverrideDynamicAnalysisBinary $ ReaderC ExperimentalAnalyzeConfig $ ReaderC AllFilters $ DebugC $ DiagnosticsC $ LoggerC $ ExecIOC $ ReadFSIOC $ StackC IO
 
 spec :: Spec
 spec =

--- a/test/App/Fossa/Config/Utils.hs
+++ b/test/App/Fossa/Config/Utils.hs
@@ -59,4 +59,4 @@ itShouldFailWhenLabelsExceedFive parser =
     case getParseResult p of
       Nothing -> fatal ("test failed" :: Text)
       Just cliOpts -> do
-        expectFatal' $ mergeOpts Nothing (EnvVars Nothing False False Nothing Nothing) cliOpts
+        expectFatal' $ mergeOpts Nothing (EnvVars Nothing False False Nothing Nothing Nothing) cliOpts

--- a/test/App/Fossa/Config/Utils.hs
+++ b/test/App/Fossa/Config/Utils.hs
@@ -59,4 +59,4 @@ itShouldFailWhenLabelsExceedFive parser =
     case getParseResult p of
       Nothing -> fatal ("test failed" :: Text)
       Just cliOpts -> do
-        expectFatal' $ mergeOpts Nothing (EnvVars Nothing False False Nothing Nothing Nothing) cliOpts
+        expectFatal' $ mergeOpts Nothing (EnvVars Nothing False False Nothing Nothing mempty) cliOpts

--- a/test/App/Fossa/Configuration/TelemetryConfigSpec.hs
+++ b/test/App/Fossa/Configuration/TelemetryConfigSpec.hs
@@ -35,6 +35,7 @@ defaultEnvVars =
     , envTelemetryDebug = False
     , envTelemetryScope = Nothing
     , envDockerHost = Nothing
+    , envCmdOverrides = mempty
     }
 
 defaultCommonOpts :: CommonOpts

--- a/test/Effect/ExecSpec.hs
+++ b/test/Effect/ExecSpec.hs
@@ -4,7 +4,7 @@ module Effect.ExecSpec (
   spec,
 ) where
 
-import App.Types (OverrideDynamicAnalysisBinary (OverrideDynamicAnalysisBinary))
+import App.Types (OverrideDynamicAnalysisBinary (..))
 import Control.Carrier.Diagnostics (runDiagnostics)
 import Control.Carrier.Reader (runReader)
 import Control.Carrier.Stack (runStack)
@@ -44,11 +44,6 @@ spec = do
       res <- runExecIO $ exec dir (Command "lkajsdflkjasdlfkjas" [] Always)
       res `shouldSatisfy` isLeft
 
--- Windows doesn't have `false` or `true` binaries,
--- and doesn't have any easily accessible equivalent.
--- Fortunately this functionality should not change in Windows.
-#ifndef mingw32_HOST_OS
-
   describe "Command selection" $ do
     -- Use the unix "false" and "true" commands to test this.
     let candidates = CandidateAnalysisCommands ("false" :| ["true"]) [] Nothing
@@ -82,5 +77,3 @@ spec = do
     it "should respond with an error" $ case res of
       Failure _ _ -> pure ()
       Success _ cmd -> expectationFailure ("erroneously selected " <> toString (cmdName cmd))
-
-#endif

--- a/test/Effect/ExecSpec.hs
+++ b/test/Effect/ExecSpec.hs
@@ -1,17 +1,86 @@
+{-# LANGUAGE CPP #-}
+
 module Effect.ExecSpec (
   spec,
 ) where
 
+import App.Types (OverrideDynamicAnalysisBinary (OverrideDynamicAnalysisBinary))
+import Control.Carrier.Diagnostics (runDiagnostics)
+import Control.Carrier.Reader (runReader)
+import Control.Carrier.Stack (runStack)
 import Data.Either (isLeft)
-import Effect.Exec
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.Map qualified as Map
+import Data.String.Conversion (toString)
+import DepTypes (DepType (MavenType))
+import Diag.Result (Result (..))
+import Effect.Exec (
+  AllowErr (..),
+  CandidateAnalysisCommands (..),
+  Command (..),
+  exec,
+  mkAnalysisCommand,
+  mkSingleCandidateAnalysisCommand,
+  runExecIO,
+ )
 import Path.IO (getCurrentDir)
-import Test.Hspec
+import Test.Hspec (
+  Spec,
+  describe,
+  expectationFailure,
+  it,
+  runIO,
+  shouldBe,
+  shouldSatisfy,
+ )
 import Prelude
 
 spec :: Spec
 spec = do
+  dir <- runIO getCurrentDir
+
   describe "IO-based handler" $ do
     it "should return Left, and not throw an exception, when a command is not found" $ do
-      dir <- getCurrentDir
       res <- runExecIO $ exec dir (Command "lkajsdflkjasdlfkjas" [] Always)
       res `shouldSatisfy` isLeft
+
+-- Windows doesn't have `false` or `true` binaries,
+-- and doesn't have any easily accessible equivalent.
+-- Fortunately this functionality should not change in Windows.
+#ifndef mingw32_HOST_OS
+
+  describe "Command selection" $ do
+    -- Use the unix "false" and "true" commands to test this.
+    let candidates = CandidateAnalysisCommands ("false" :| ["true"]) [] Nothing
+    res <-
+      runIO . runStack . runExecIO . runDiagnostics . runReader (mempty :: OverrideDynamicAnalysisBinary) $
+        mkAnalysisCommand candidates dir [] Never
+
+    it "should choose the first successful command" $ case res of
+      Failure _ _ -> expectationFailure "could not run command selection"
+      Success _ cmd -> cmdName cmd `shouldBe` "true"
+
+  describe "Command selection with override" $ do
+    -- Use the unix "false" command by default, but override this deptype to also provide "true".
+    let candidates = mkSingleCandidateAnalysisCommand "false" [] (Just MavenType)
+    let override = OverrideDynamicAnalysisBinary $ Map.fromList [(MavenType, "true")]
+    res <-
+      runIO . runStack . runExecIO . runDiagnostics . runReader override $
+        mkAnalysisCommand candidates dir [] Never
+
+    it "should choose the first successful command" $ case res of
+      Failure _ _ -> expectationFailure "could not run command selection"
+      Success _ cmd -> cmdName cmd `shouldBe` "true"
+
+  describe "Command selection with no working option" $ do
+    -- Use the unix "false" command to test this.
+    let candidates = mkSingleCandidateAnalysisCommand "false" [] Nothing
+    res <-
+      runIO . runStack . runExecIO . runDiagnostics . runReader (mempty :: OverrideDynamicAnalysisBinary) $
+        mkAnalysisCommand candidates dir [] Never
+
+    it "should respond with an error" $ case res of
+      Failure _ _ -> pure ()
+      Success _ cmd -> expectationFailure ("erroneously selected " <> toString (cmdName cmd))
+
+#endif


### PR DESCRIPTION
# Overview

Adds the concept of overriding the binary used for analysis to the CLI, first used for maven here.
In the future we can add more binaries as desired.

Also adds `mvnw` as an option when analyzing maven projects.

## Acceptance criteria

- We are able to analyze maven projects as before.
- We are able to analyze maven projects that require `mvnw`.
- We are able to provide a custom maven binary to use.

## Testing plan

Relied on automated testing, plus:

- Validated that custom command fallback works by providing `FOSSA_MAVEN_CMD=go`:

<details>
<summary>Using 'go' as an override command</summary>

```
; wget https://github.com/google/guava/archive/refs/tags/v31.1.tar.gz
; tar -xzf v31.1.tar.gz
; FOSSA_MAVEN_CMD=go cabal run fossa -- analyze ~/projects/scratch/ -o
Up to date
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/android/guava-bom/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/futures/failureaccess/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/guava-bom/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/futures/listenablefuture9999/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/futures/listenablefuture1/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/android/
[ INFO]
[ INFO] Scan Summary
[ INFO] ------------
[ INFO] fossa-cli branch custom-binaries-dynamic-analysis (revision 2b048f43d1b7 compiled with ghc-9.0)
[ INFO] fossa endpoint server version: N/A
[ INFO]
[ INFO] 7 projects scanned;  0 skipped,  7 succeeded,  0 failed,  42 analysis warnings
[ INFO]
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/": succeeded with 6 warnings
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/android/": succeeded with 6 warnings
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/android/guava-bom/": succeeded with 6 warnings
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/futures/failureaccess/": succeeded with 6 warnings
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/futures/listenablefuture1/": succeeded with 6 warnings
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/futures/listenablefuture9999/": succeeded with 6 warnings
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/guava-bom/": succeeded with 6 warnings
[ INFO] -
[ INFO]
[ INFO]   Some projects may not appear in the summary if they were filtered during discovery.
[ INFO]   You can run `fossa list-targets` to see all discoverable projects.
[ INFO]
[ INFO] You can pass `--debug` option to eagerly show all warning and failure messages.
[ INFO] You can also view analysis summary with warning and error messages at: "/tmp/fossa-analyze-scan-summary.txt"
[ INFO] ------------
{ ... output snipped ... }

; cat /tmp/fossa-analyze-scan-summary.txt
Scan Summary
------------
fossa-cli branch custom-binaries-dynamic-analysis (revision 2b048f43d1b7 compiled with ghc-9.0)
fossa endpoint server version: N/A

7 projects scanned;  0 skipped,  7 succeeded,  0 failed,  42 analysis warnings

* maven project in "/home/jess/projects/scratch/guava-31.1/": succeeded with 6 warnings
* maven project in "/home/jess/projects/scratch/guava-31.1/android/": succeeded with 6 warnings
* maven project in "/home/jess/projects/scratch/guava-31.1/android/guava-bom/": succeeded with 6 warnings
* maven project in "/home/jess/projects/scratch/guava-31.1/futures/failureaccess/": succeeded with 6 warnings
* maven project in "/home/jess/projects/scratch/guava-31.1/futures/listenablefuture1/": succeeded with 6 warnings
* maven project in "/home/jess/projects/scratch/guava-31.1/futures/listenablefuture9999/": succeeded with 6 warnings
* maven project in "/home/jess/projects/scratch/guava-31.1/guava-bom/": succeeded with 6 warnings
-
----------
maven project in "/home/jess/projects/scratch/guava-31.1/": succeeded with 6 warnings

Warning

  Command "mvnw" not suitable: running with args ["-v"] resulted in a non-zero exit code

  >>> Relevant errors

    Error

      Could not find executable: `mvnw`.

      Please ensure `mvnw` exist in PATH prior to running fossa.

      If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com

      Traceback:
        - Running command 'mvnw'
        - Evaluate command: mvnw
        - Evaluate command: go
        - Command override provided: go
        - Make analysis command from CandidateAnalysisCommands {candidateCmdNames = "mvnw" :| ["mvn"], candidateCmdArgs = ["-v"], candidateOverrideKind = Just MavenType}
        - Running plugin to get dependency graph
        - Plugin analysis
        - Dynamic Analysis
        - Maven
        - Project Analysis: MavenProjectType



Warning

  Command "go" not suitable: running with args ["-v"] resulted in a non-zero exit code

  >>> Relevant errors

    Error

      Command execution failed:
          command: Command {cmdName = "go", cmdArgs = ["-v"], cmdAllowErr = Never}
          dir: /home/jess/projects/scratch/guava-31.1/
          exit: ExitFailure 2
          stdout:

          stderr:
            flag provided but not defined: -v
            Go is a tool for managing Go source code.

            Usage:

            	go <command> [arguments]

            The commands are:

            	bug         start a bug report
            	build       compile packages and dependencies
            	clean       remove object files and cached files
            	doc         show documentation for package or symbol
            	env         print Go environment information
            	fix         update packages to use new APIs
            	fmt         gofmt (reformat) package sources
            	generate    generate Go files by processing source
            	get         add dependencies to current module and install them
            	install     compile and install packages and dependencies
            	list        list packages or modules
            	mod         module maintenance
            	work        workspace maintenance
            	run         compile and run Go program
            	test        test packages
            	tool        run specified go tool
            	version     print Go version
            	vet         report likely mistakes in packages

            Use "go help <command>" for more information about a command.

            Additional help topics:

            	buildconstraint build constraints
            	buildmode       build modes
            	c               calling between Go and C
            	cache           build and test caching
            	environment     environment variables
            	filetype        file types
            	go.mod          the go.mod file
            	gopath          GOPATH environment variable
            	gopath-get      legacy GOPATH go get
            	goproxy         module proxy protocol
            	importpath      import path syntax
            	modules         modules, module versions, and more
            	module-get      module-aware go get
            	module-auth     module authentication using go.sum
            	packages        package lists and patterns
            	private         configuration for downloading non-public code
            	testflag        testing flags
            	testfunc        testing functions
            	vcs             controlling version control with GOVCS

            Use "go help <topic>" for more information about that topic.


      If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com

      Traceback:
        - Running command 'go'
        - Evaluate command: go
        - Command override provided: go
        - Make analysis command from CandidateAnalysisCommands {candidateCmdNames = "mvnw" :| ["mvn"], candidateCmdArgs = ["-v"], candidateOverrideKind = Just MavenType}
        - Running plugin to get dependency graph
        - Plugin analysis
        - Dynamic Analysis
        - Maven
        - Project Analysis: MavenProjectType



Warning

  Command "mvnw" not suitable: running with args ["-v"] resulted in a non-zero exit code

  >>> Relevant errors

    Error

      Could not find executable: `mvnw`.

      Please ensure `mvnw` exist in PATH prior to running fossa.

      If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com

      Traceback:
        - Running command 'mvnw'
        - Evaluate command: mvnw
        - Evaluate command: go
        - Command override provided: go
        - Make analysis command from CandidateAnalysisCommands {candidateCmdNames = "mvnw" :| ["mvn"], candidateCmdArgs = ["-v"], candidateOverrideKind = Just MavenType}
        - Running plugin to get submodule names
        - Plugin analysis
        - Dynamic Analysis
        - Maven
        - Project Analysis: MavenProjectType



Warning

  Command "go" not suitable: running with args ["-v"] resulted in a non-zero exit code

  >>> Relevant errors

    Error

      Command execution failed:
          command: Command {cmdName = "go", cmdArgs = ["-v"], cmdAllowErr = Never}
          dir: /home/jess/projects/scratch/guava-31.1/
          exit: ExitFailure 2
          stdout:

          stderr:
            flag provided but not defined: -v
            Go is a tool for managing Go source code.

            Usage:

            	go <command> [arguments]

            The commands are:

            	bug         start a bug report
            	build       compile packages and dependencies
            	clean       remove object files and cached files
            	doc         show documentation for package or symbol
            	env         print Go environment information
            	fix         update packages to use new APIs
            	fmt         gofmt (reformat) package sources
            	generate    generate Go files by processing source
            	get         add dependencies to current module and install them
            	install     compile and install packages and dependencies
            	list        list packages or modules
            	mod         module maintenance
            	work        workspace maintenance
            	run         compile and run Go program
            	test        test packages
            	tool        run specified go tool
            	version     print Go version
            	vet         report likely mistakes in packages

            Use "go help <command>" for more information about a command.

            Additional help topics:

            	buildconstraint build constraints
            	buildmode       build modes
            	c               calling between Go and C
            	cache           build and test caching
            	environment     environment variables
            	filetype        file types
            	go.mod          the go.mod file
            	gopath          GOPATH environment variable
            	gopath-get      legacy GOPATH go get
            	goproxy         module proxy protocol
            	importpath      import path syntax
            	modules         modules, module versions, and more
            	module-get      module-aware go get
            	module-auth     module authentication using go.sum
            	packages        package lists and patterns
            	private         configuration for downloading non-public code
            	testflag        testing flags
            	testfunc        testing functions
            	vcs             controlling version control with GOVCS

            Use "go help <topic>" for more information about that topic.


      If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com

      Traceback:
        - Running command 'go'
        - Evaluate command: go
        - Command override provided: go
        - Make analysis command from CandidateAnalysisCommands {candidateCmdNames = "mvnw" :| ["mvn"], candidateCmdArgs = ["-v"], candidateOverrideKind = Just MavenType}
        - Running plugin to get submodule names
        - Plugin analysis
        - Dynamic Analysis
        - Maven
        - Project Analysis: MavenProjectType



Warning

  Command "mvnw" not suitable: running with args ["-v"] resulted in a non-zero exit code

  >>> Relevant errors

    Error

      Could not find executable: `mvnw`.

      Please ensure `mvnw` exist in PATH prior to running fossa.

      If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com

      Traceback:
        - Running command 'mvnw'
        - Evaluate command: mvnw
        - Evaluate command: go
        - Command override provided: go
        - Make analysis command from CandidateAnalysisCommands {candidateCmdNames = "mvnw" :| ["mvn"], candidateCmdArgs = ["-v"], candidateOverrideKind = Just MavenType}
        - Installing plugin
        - Plugin analysis
        - Dynamic Analysis
        - Maven
        - Project Analysis: MavenProjectType



Warning

  Command "go" not suitable: running with args ["-v"] resulted in a non-zero exit code

  >>> Relevant errors

    Error

      Command execution failed:
          command: Command {cmdName = "go", cmdArgs = ["-v"], cmdAllowErr = Never}
          dir: /home/jess/projects/scratch/guava-31.1/
          exit: ExitFailure 2
          stdout:

          stderr:
            flag provided but not defined: -v
            Go is a tool for managing Go source code.

            Usage:

            	go <command> [arguments]

            The commands are:

            	bug         start a bug report
            	build       compile packages and dependencies
            	clean       remove object files and cached files
            	doc         show documentation for package or symbol
            	env         print Go environment information
            	fix         update packages to use new APIs
            	fmt         gofmt (reformat) package sources
            	generate    generate Go files by processing source
            	get         add dependencies to current module and install them
            	install     compile and install packages and dependencies
            	list        list packages or modules
            	mod         module maintenance
            	work        workspace maintenance
            	run         compile and run Go program
            	test        test packages
            	tool        run specified go tool
            	version     print Go version
            	vet         report likely mistakes in packages

            Use "go help <command>" for more information about a command.

            Additional help topics:

            	buildconstraint build constraints
            	buildmode       build modes
            	c               calling between Go and C
            	cache           build and test caching
            	environment     environment variables
            	filetype        file types
            	go.mod          the go.mod file
            	gopath          GOPATH environment variable
            	gopath-get      legacy GOPATH go get
            	goproxy         module proxy protocol
            	importpath      import path syntax
            	modules         modules, module versions, and more
            	module-get      module-aware go get
            	module-auth     module authentication using go.sum
            	packages        package lists and patterns
            	private         configuration for downloading non-public code
            	testflag        testing flags
            	testfunc        testing functions
            	vcs             controlling version control with GOVCS

            Use "go help <topic>" for more information about that topic.


      If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com

      Traceback:
        - Running command 'go'
        - Evaluate command: go
        - Command override provided: go
        - Make analysis command from CandidateAnalysisCommands {candidateCmdNames = "mvnw" :| ["mvn"], candidateCmdArgs = ["-v"], candidateOverrideKind = Just MavenType}
        - Installing plugin
        - Plugin analysis
        - Dynamic Analysis
        - Maven
        - Project Analysis: MavenProjectType

# ... more of the same warnings for other targets in this directory omitted
```
</details>

- Validated that custom commands are preferred by providing `which mvn` as a custom command:

```
; FOSSA_MAVEN_CMD=`which mvn` cabal run fossa -- analyze ~/projects/scratch/ -o
Warning: The package list for 'hackage.haskell.org' is 27 days old.
Run 'cabal update' to get the latest list of available packages.
Resolving dependencies...
Up to date
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/android/guava-bom/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/guava-bom/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/futures/listenablefuture9999/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/futures/listenablefuture1/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/futures/failureaccess/
[ INFO] Analyzing maven project at /home/jess/projects/scratch/guava-31.1/android/
[ INFO]
[ INFO] Scan Summary
[ INFO] ------------
[ INFO] fossa-cli branch custom-binaries-dynamic-analysis (revision 2b048f43d1b7 compiled with ghc-9.0)
[ INFO] fossa endpoint server version: N/A
[ INFO]
[ INFO] 7 projects scanned;  0 skipped,  7 succeeded,  0 failed,  0 analysis warnings
[ INFO]
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/": succeeded
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/android/": succeeded
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/android/guava-bom/": succeeded
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/futures/failureaccess/": succeeded
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/futures/listenablefuture1/": succeeded
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/futures/listenablefuture9999/": succeeded
[ INFO] * maven project in "/home/jess/projects/scratch/guava-31.1/guava-bom/": succeeded
[ INFO] -
[ INFO]
[ INFO]   Some projects may not appear in the summary if they were filtered during discovery.
[ INFO]   You can run `fossa list-targets` to see all discoverable projects.
[ INFO]
[ INFO] You can pass `--debug` option to eagerly show all warning and failure messages.
[ INFO] You can also view analysis summary with warning and error messages at: "/tmp/fossa-analyze-scan-summary.txt"
[ INFO] ------------
```

## Risks

The primary risk is that this implementation is confusing to users and opens a new can of worms for CLI configuration.

Secondarily, if this feature is buggy, users won't be happy.

## References

[ANE-778](https://fossa.atlassian.net/browse/ANE-778)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-778]: https://fossa.atlassian.net/browse/ANE-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ