### PR TITLE
Exports the Themis command

### DIFF
--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -3,6 +3,7 @@
 module App.Fossa.RunThemis (
   execThemis,
   execRawThemis,
+  -- `themisCommand` is used by Hubble.
   themisCommand,
   themisFlags,
 ) where

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -3,6 +3,7 @@
 module App.Fossa.RunThemis (
   execThemis,
   execRawThemis,
+  themisCommand,
   themisFlags,
 ) where
 


### PR DESCRIPTION
# Overview

Hubble needs to be able to cancel Themis execution.  We can't use the current `Exec` effect because it runs the process synchronously and does not provide a process handle to send the signal to. 

This change just exports the `themisCommand` so that Hubble can create and run the same Themis command that the CLI does, but can use some slightly lower-level functions to manage the timeout.

## Acceptance criteria

The Themis command is available to Hubble.

## Testing plan

I have a Hubble PoC using this change already.

## Risks

None, just an export.  There's a chance that we won't end up using this and forget to hide it, but the threat is low.

## References

- [PLAT-555](https://fossa.atlassian.net/browse/PLAT-555): Themis timeouts should be considered partial successes

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[PLAT-555]: https://fossa.atlassian.net/browse/PLAT-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ