### PR TITLE
Work around script bug

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -24,7 +24,10 @@ jobs:
           ./install-latest.sh -d
 
       - name: Use Spectrometer's GHC and Cabal
+        # The first line works around a ghcup issue:
+        # https://github.com/actions/runner-images/issues/7061#issuecomment-1422639889
         run: |
+          sudo chown -R $USER /usr/local/.ghcup
           ghcup install ghc 9.0.2
           ghcup set ghc 9.0.2
           ghcup install cabal 3.6.2.0


### PR DESCRIPTION
# Overview

Works around this error: https://github.com/fossas/fossa-cli/actions/runs/4138901331/jobs/7156295792
Which is caused by ghcup: https://github.com/actions/runner-images/issues/7061
Using this workaround: https://github.com/actions/runner-images/issues/7061#issuecomment-1422639889

## Acceptance criteria

FOSSA scans stop failing in CI.

## Testing plan

I ran this in CI and the scan worked.

## Risks

None

## References

None

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
