### PR TITLE
Handle Leiningens deduping of maven groupID and artifactID

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 # FOSSA CLI Changelog
 
-<!-- title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
+<!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
+
+## v3.6.17
+
+- Handle Leinging deduped deps: expand groupID and artifactID in the leiningen tactic to satisfy the Maven fetcher ([#1152]](https://github.com/fossas/fossa-cli/pull/1152))
 
 ## v3.6.17
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ## v3.6.17
 
-- Handle Leinging deduped deps: expand groupID and artifactID in the leiningen tactic to satisfy the Maven fetcher ([#1152]](https://github.com/fossas/fossa-cli/pull/1152))
+- Handle Leiningen deduped deps: expand groupID and artifactID in the leiningen tactic to satisfy the Maven fetcher ([#1152]](https://github.com/fossas/fossa-cli/pull/1152))
 
 ## v3.6.17
 

--- a/docs/references/strategies/languages/clojure/clojure.md
+++ b/docs/references/strategies/languages/clojure/clojure.md
@@ -24,3 +24,4 @@ In order to find Leiningen projects, we look for `project.clj` files which speci
   [org.clojure/spec.alpha "0.2.176"] nil}}
 ```
 2. Parse this output to determine the full dependency graph and dependency versions.
+3. Dependencies which have the same groupID and artifactID (nrepl above) are expanded to satisfy Maven's repository standard. The differences can be seen in [this link](https://clojars.org/nrepl) where only `nrepl` is required by Leiningen, but nrepl:nrepl is required by Gradle and Maven.

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -201,7 +201,12 @@ buildEdges deps = Map.traverseWithKey single (depsTree deps) $> ()
           buildEdges deeper
 
 toClojureNode :: ClojureDep -> ClojureNode
-toClojureNode dep = ClojureNode (Text.replace "/" ":" (depName dep)) (depVersion dep)
+toClojureNode dep = ClojureNode (reverseDepNameMerge $ Text.replace "/" ":" (depName dep)) (depVersion dep)
+
+-- When a dependencies groupID and artifactID are identical, leiningen merges them. 
+-- In order to satisfy the Maven dependency format, we reverse the merge of these names.
+reverseDepNameMerge :: Text -> Text
+reverseDepNameMerge dep = if Text.any (== ':') dep then dep else dep <> ":" <> dep 
 
 toDependency :: ClojureNode -> Set ClojureLabel -> Dependency
 toDependency node = foldr applyLabel start

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -206,7 +206,7 @@ toClojureNode dep = ClojureNode (reverseDepNameMerge $ Text.replace "/" ":" (dep
 -- When a dependencies groupID and artifactID are identical, leiningen merges them.
 -- In order to satisfy the Maven dependency format, we reverse the merge of these names.
 reverseDepNameMerge :: Text -> Text
-reverseDepNameMerge dep = if Text.any (== ':') dep then dep else dep <> ":" <> dep
+reverseDepNameMerge dep = if ':' `Text.elem` dep then dep else dep <> ":" <> dep
 
 toDependency :: ClojureNode -> Set ClojureLabel -> Dependency
 toDependency node = foldr applyLabel start

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -203,10 +203,10 @@ buildEdges deps = Map.traverseWithKey single (depsTree deps) $> ()
 toClojureNode :: ClojureDep -> ClojureNode
 toClojureNode dep = ClojureNode (reverseDepNameMerge $ Text.replace "/" ":" (depName dep)) (depVersion dep)
 
--- When a dependencies groupID and artifactID are identical, leiningen merges them. 
+-- When a dependencies groupID and artifactID are identical, leiningen merges them.
 -- In order to satisfy the Maven dependency format, we reverse the merge of these names.
 reverseDepNameMerge :: Text -> Text
-reverseDepNameMerge dep = if Text.any (== ':') dep then dep else dep <> ":" <> dep 
+reverseDepNameMerge dep = if Text.any (== ':') dep then dep else dep <> ":" <> dep
 
 toDependency :: ClojureNode -> Set ClojureLabel -> Dependency
 toDependency node = foldr applyLabel start
@@ -252,9 +252,9 @@ ednVecToMap = go Map.empty
     go m vec
       | V.null vec = pure m
       | otherwise = do
-          key <- EDN.vecGet 0 vec
-          value <- EDN.vecGet 1 vec
-          go (Map.insert key value m) (V.drop 2 vec)
+        key <- EDN.vecGet 0 vec
+        value <- EDN.vecGet 1 vec
+        go (Map.insert key value m) (V.drop 2 vec)
 
 -- | The FromEDN type for lein deps output
 newtype Deps = Deps

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -252,9 +252,9 @@ ednVecToMap = go Map.empty
     go m vec
       | V.null vec = pure m
       | otherwise = do
-        key <- EDN.vecGet 0 vec
-        value <- EDN.vecGet 1 vec
-        go (Map.insert key value m) (V.drop 2 vec)
+          key <- EDN.vecGet 0 vec
+          value <- EDN.vecGet 1 vec
+          go (Map.insert key value m) (V.drop 2 vec)
 
 -- | The FromEDN type for lein deps output
 newtype Deps = Deps

--- a/test/Clojure/ClojureSpec.hs
+++ b/test/Clojure/ClojureSpec.hs
@@ -29,7 +29,7 @@ clojureComplete :: Dependency
 clojureComplete =
   Dependency
     { dependencyType = MavenType
-    , dependencyName = "clojure-complete"
+    , dependencyName = "clojure-complete:clojure-complete"
     , dependencyVersion = Just (CEq "0.2.5")
     , dependencyLocations = []
     , dependencyEnvironments = mempty
@@ -41,7 +41,7 @@ koanEngine :: Dependency
 koanEngine =
   Dependency
     { dependencyType = MavenType
-    , dependencyName = "koan-engine"
+    , dependencyName = "koan-engine:koan-engine"
     , dependencyVersion = Just (CEq "0.2.5")
     , dependencyLocations = []
     , dependencyEnvironments = mempty
@@ -52,7 +52,7 @@ fresh :: Dependency
 fresh =
   Dependency
     { dependencyType = MavenType
-    , dependencyName = "fresh"
+    , dependencyName = "fresh:fresh"
     , dependencyVersion = Just (CEq "1.0.2")
     , dependencyLocations = []
     , dependencyEnvironments = mempty
@@ -64,7 +64,7 @@ leinKoan :: Dependency
 leinKoan =
   Dependency
     { dependencyType = MavenType
-    , dependencyName = "lein-koan"
+    , dependencyName = "lein-koan:lein-koan"
     , dependencyVersion = Just (CEq "0.1.5")
     , dependencyLocations = []
     , dependencyEnvironments = Set.singleton EnvTesting
@@ -76,7 +76,7 @@ nrepl :: Dependency
 nrepl =
   Dependency
     { dependencyType = MavenType
-    , dependencyName = "nrepl"
+    , dependencyName = "nrepl:nrepl"
     , dependencyVersion = Just (CEq "0.6.0")
     , dependencyLocations = []
     , dependencyEnvironments = mempty


### PR DESCRIPTION
# Overview

The Leiningen tactic “dedupes” the groupID and artifcatID if they are the same. This results in locators that cannot be resolved because they don’t match maven dependency formats.

## Acceptance criteria

Scanning a leiningen repository with deps that appear as "unknown license" now resolve in the FOSSA UI. My test repo has been https://github.com/pedestal/pedestal.

## Testing plan

1. Download https://github.com/pedestal/pedestal.
1. Run `fossa analyze` with an existing version and observe all the unknown license dependencies
1. Run `fossa analyze` with the updated version and observe that these deps are found and that there are no regressions with the previously found dependencies.

Pedestal - https://github.com/pedestal/pedestal
Eastwood - https://github.com/jonase/eastwood
I don't know the specific number of deps that are fixed between the two of these, but it seems like 5% of deps are unknown. After I applied the fixes from this PR I found that all of these unknown licensed deps are fixed but the total count remained the same.

## Risks

The biggest risk is that the parser addition I'm writing accidentally breaks a dependency format that we are unaware of and are not currently testing for. The only way I see this happening is if there is a dep in the leiningen manifest file that has `:` in its name, although I'm fairly confident this is not an accepted dependency format because it would lead to oddly formated Maven dependencies.

## References

[ANE-718](https://fossa.atlassian.net/browse/ANE-718)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-718]: https://fossa.atlassian.net/browse/ANE-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ