### PR TITLE
Ane 665 warn on unarchiving error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
+## v3.6.18
+- License Scanning: Emit a warning if unarchiving fails rather than a fatal error. ([#1153](https://github.com/fossas/fossa-cli/pull/1153))
+
 ## v3.6.17
 
 - Handle Leiningen deduped deps: expand groupID and artifactID in the leiningen tactic to satisfy the Maven fetcher ([#1152]](https://github.com/fossas/fossa-cli/pull/1152))

--- a/src/App/Fossa/BinaryDeps/Jar.hs
+++ b/src/App/Fossa/BinaryDeps/Jar.hs
@@ -16,7 +16,7 @@ import Control.Carrier.Diagnostics (
  )
 import Control.Carrier.Finally (runFinally)
 import Control.Effect.Lift (Lift)
-import Control.Monad (when)
+import Control.Monad (join, when)
 import Data.List (isSuffixOf, sortOn)
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -65,7 +65,7 @@ resolveJar root file = do
     . runFinally
     $ withArchive extractZip file
     $ \dir -> tacticPom dir <||> tacticMetaInf dir
-  pure $ fmap (toUserDefDep root file) result
+  pure $ fmap (toUserDefDep root file) (join result)
 
 newtype FailedToResolveJar = FailedToResolveJar (Path Abs File)
 instance ToDiagnostic FailedToResolveJar where

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -27,6 +27,7 @@ module Control.Effect.Diagnostics (
   fatalOnIOException',
   fatalOnSomeException,
   fatalOnSomeException',
+  warnOnSomeException,
   fromEither,
   fromEitherShow,
   fromEitherParser,
@@ -201,6 +202,20 @@ fatalOnException ::
   m a ->
   m a
 fatalOnException mangle ctx go = context ctx $ safeCatch go (fatal . mangle)
+
+-- | Throw a warning from a generic exception, wrapped in a new 'context' using the provided text.
+warnOnSomeException ::
+  forall exc err sig m a.
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , ToDiagnostic err
+  , Exception exc
+  ) =>
+  (exc -> err) ->
+  Text ->
+  m a ->
+  m (Maybe a)
+warnOnSomeException mangle ctx go = context ctx $ safeCatch (Just <$> go) (fmap (const Nothing) . warn . mangle)
 
 -- | Run a list of actions, combining the results of successful actions.
 --

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -9,6 +9,7 @@ module Discovery.Archive (
   extractTarBz2,
   extractZip,
   selectUnarchiver,
+  unpackFailurePath,
 ) where
 
 import Codec.Archive.Tar qualified as Tar
@@ -44,6 +45,9 @@ import Prettyprinter (Pretty (pretty), hsep, viaShow, vsep)
 import Prelude hiding (zip)
 
 data ArchiveUnpackFailure = ArchiveUnpackFailure (Path Abs File) SomeException
+
+unpackFailurePath :: ArchiveUnpackFailure -> Path Abs File
+unpackFailurePath (ArchiveUnpackFailure path _) = path
 
 instance ToDiagnostic ArchiveUnpackFailure where
   renderDiagnostic (ArchiveUnpackFailure file exc) =
@@ -101,6 +105,8 @@ withArchive' file go =
 -- | Extract an archive to a temporary directory, and run the provided callback
 -- on the temporary directory. Archive contents are removed when the callback
 -- finishes.
+--
+-- Exceptions thrown during archive extraction are emitted as warnings and 'Nothing' is returned.
 withArchive ::
   (Has (Lift IO) sig m, Has Diagnostics sig m, Has Finally sig m) =>
   -- | Archive extraction function


### PR DESCRIPTION
# Overview

When we fail to unpack an archive, we should emit a warning rather than failing. 

## Acceptance criteria

  * When we fail to unarchive a file, we should keep going and still scan the vendored dependency

  * When we fail to unarchive a file, we should emit a warning

## Testing plan

1. Find a project with a bad archive in and and use it as a vendored dep. I made an empty project folder and used [grafana](https://github.com/grafana/grafana) as a vendored dep with:
```
vendored-dependencies:
- name: Grafana
  path: grafana/
  version: master
```
2. Run the `master` branch cli with: `fossa analyze --force-vendored-dependency-rescans <dir>`
This should emit errors for the targets which have bad archives.

3. Using the cli from this branch, run the same thing. The failing targets from (2) should succeed with warnings. Use `--debug` to see the warnings printed out. 

## Risks

This change touches all code that does unarchiving. The only place a bit outside of license scanning where we do this is with Jar [BinaryDeps](https://github.com/fossas/fossa-cli/blob/ANE-665-warn-on-unarchiving-error/src/App/Fossa/BinaryDeps/Jar.hs#L62). I think this is ok because we `warnOnErr` in that code anyways and I have documented the new behavior.

## References

[ANE-665](https://fossa.atlassian.net/browse/ANE-665)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-665]: https://fossa.atlassian.net/browse/ANE-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ