### PR TITLE
Enable sha256 verification of downloads with install-latest.sh.

### DIFF
--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -27,8 +27,9 @@ jobs:
       - name: install latest script can install a specific version
         shell: bash
         run: |
-          ./install-latest.sh -b . v3.1.1
-          ./fossa --version | grep -q "3.1.1"
+          # 3.4.7 is the first version with linux tarballs
+          ./install-latest.sh -b . v3.4.7
+          ./fossa --version | grep -q "3.4.7"
           rm fossa
 
       - name: install-v1 script does not install v2 or greater version

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
+## Unreleased
+- Installation Script: Verify that the sha256sum of the downloaded archive matches the recorded one. ([#1158](https://github.com/fossas/fossa-cli/pull/1158))
+
 ## v3.6.18
 - License Scanning: Emit a warning if unarchiving fails rather than a fatal error. ([#1153](https://github.com/fossas/fossa-cli/pull/1153))
 

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -43,8 +43,8 @@ execute() {
   tmpdir=$(mktmpdir)
   log_debug "downloading files into ${tmpdir}"
   http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
-  # http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
-  # hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
+  http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
+  hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
   srcdir="${tmpdir}"
   (cd "${tmpdir}" && untar "${TARBALL}")
   log_debug "setting up bindir: $BINDIR"
@@ -448,7 +448,7 @@ TARBALL=${NAME}.${FORMAT}
 TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
 log_info "found fossa-cli ${VERSION} binary for ${PLATFORM} at ${TARBALL_URL}"
 
-CHECKSUM=${PROJECT_NAME}_${VERSION}_checksums.txt
+CHECKSUM=${TARBALL}.sha256
 CHECKSUM_URL=${GITHUB_DOWNLOAD}/${TAG}/${CHECKSUM}
 
 print_telemetry_disclaimer


### PR DESCRIPTION
# Overview

This re-enables checking that the archives we download from GH are checked against their checksums by `install_latest.sh`.

## Acceptance criteria

* `install_latest.sh` checks that the sha256 of the downloaded archive matches what is published by GH.

## Testing plan

I ran the script and made sure that it succeeded.

## Risks

* People who use this in CI that don't happen to have the `sha256sum` program installed could have this start to break.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
