### PR TITLE
Stack git locator

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,10 @@
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
-## v3.7.0
+## v3.7.1
+- Stack: Git based dependencies are detected and handled correctly. ([#1160](https://github.com/fossas/fossa-cli/pull/1160))
 
+## v3.7.0
 - Support Maven wrapper (`mvnw`) usage in Maven projects, and user-provided binary overrides for Maven projects ([#1149](https://github.com/fossas/fossa-cli/pull/1149))
   For more information, see the [Maven strategy documentation](./docs/references/strategies/languages/maven/maven.md).
 - Installation Script: Verify that the sha256sum of the downloaded archive matches the recorded one. ([#1158](https://github.com/fossas/fossa-cli/pull/1158))

--- a/test/Haskell/StackSpec.hs
+++ b/test/Haskell/StackSpec.hs
@@ -36,8 +36,8 @@ gitDepUrl = "https://domain.com/user/git-pkg"
 gitDepUncorrectedName :: StackDep
 gitDepUncorrectedName = StackDep (PackageName "git-pkg") "abc123" [] (Git (GitUrl gitDepUrl) (GitSha "abc123"))
 
-parsedAllDeps :: [StackDep]
-parsedAllDeps = gitDepUncorrectedName : baseDeps
+allDepsParsed :: [StackDep]
+allDepsParsed = gitDepUncorrectedName : baseDeps
 
 spec :: Test.Spec
 spec = do
@@ -46,10 +46,10 @@ spec = do
     Test.it "should parse a json dependencies file" $
       case eitherDecode jsonBytes of
         Left err -> Test.expectationFailure $ "Failed to parse: " ++ show err
-        Right deps -> deps `Test.shouldMatchList` parsedAllDeps
+        Right deps -> deps `Test.shouldMatchList` allDepsParsed
 
   Test.describe "Stack graph builder" $ do
-    let result = run . runStack . runDiagnostics . buildGraph $ parsedAllDeps
+    let result = run . runStack . runDiagnostics . buildGraph $ allDepsParsed
 
     Test.it "should build a correct graph" $
       assertOnSuccess result $ \_ graph -> do

--- a/test/Haskell/testdata/stack.json
+++ b/test/Haskell/testdata/stack.json
@@ -6,7 +6,8 @@
         "name": "remote",
         "version": "remote-ver",
         "dependencies": [
-            "deep"
+            "deep",
+            "git-pkg"
         ]
     },
     {
@@ -31,5 +32,14 @@
     {
         "name": "builtin",
         "version": "builtin-ver"
+    },
+    { "name": "git-pkg",
+      "version": "ignored",
+      "dependencies": [],
+      "location": {
+          "type": "git",
+          "url": "https://domain.com/user/git-pkg",
+          "commit": "abc123"
+      }
     }
 ]


### PR DESCRIPTION
# Overview

Stack allows the specification of git repos as `extra-deps` in `stack.yml`. We don't report them from the CLI in a way that FOSSA can scan them, however.

## Acceptance criteria

* Stack projects that define `extra-deps` pointing to a git repo shouldn't break fossa-cli and should appear correctly in FOSSA.

## Testing plan

Use the procedure [here](https://gist.github.com/gfarrell/051d96ec26b4d165abe4d958772baf8f) to create a new stack project with the supplied `stack.yaml`. 

Run the version of fossa from this branch against the project directory: `fossa analyze --only-target stack <project dir>`.

Make sure to include the `--only-target` option or the cli will try to analyze it as a cabal project as well as a stack one. 

## Risks


## References

ZD-5728

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
