### PR TITLE
Nicer doc only PRs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,9 @@
 name: Benchmarks
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - README
 
 jobs:
   benchmarks:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -2,7 +2,11 @@
 #
 # Binaries on each platform are stripped. This removes debug symbols.
 name: Build
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - README
 
 jobs:
   build-all:

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,5 +1,9 @@
 name: Dependency scan
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - README
 
 jobs:
   dependency-scan:

--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -1,5 +1,9 @@
 name: Test Installation Scripts
-on: push
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - README
 
 jobs:
   test-nix:

--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -4,6 +4,9 @@ name: Integration Tests
 # Refer to https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_dispatch
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - README
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * *" # At 05:00 on every day.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Static analysis
-on: push
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - README
 
 jobs:
   # Run linter and format checkers independently, so you see errors from both.


### PR DESCRIPTION
# Overview

Doc only PRs are annoying due to how long it takes for CI.
This PR makes these less frustrating by skipping most CI checks if the entire changeset is documentation.

## Acceptance criteria

Checks that aren't relevant to doc only PRs are skipped.

## Testing plan

I performed all the testing in CI 🥲 
