### PR TITLE
Update themis-license-data, 2023-03-08 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,9 @@
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
 ## v3.7.1
+- License Scanning: Add four new licenses: Pushwoosh, PalletsFlaskLogo, IntelDisclaimer and Instabug
+
+## v3.7.1
 - Stack: Git based dependencies are detected and handled correctly. ([#1160](https://github.com/fossas/fossa-cli/pull/1160))
 
 ## v3.7.0

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -79,7 +79,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2023-01-13-330c1a9-1673649513"
+THEMIS_TAG="2023-03-09-df717b7-1678319522"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

Delivers 4 tickets by pulling in the changes made in these PRs to themis-license-data:
- https://github.com/fossas/themis-license-data/pull/42 (fixes  https://fossa.zendesk.com/agent/tickets/5721)
- https://github.com/fossas/themis-license-data/pull/41 (fixes https://fossa.zendesk.com/agent/tickets/5789)
- https://github.com/fossas/themis-license-data/pull/39 (fixes https://fossa.atlassian.net/browse/ANE-770)
- https://github.com/fossas/themis-license-data/pull/38 (fixes  https://fossa.zendesk.com/agent/tickets/5572)

This ends up adding the following licenses to Themis:

- Instabug
- IntelDisclaimer
- PalletsFlaskLogo
- Pushwoosh

This is done by updating the basis tag to the current release, https://github.com/fossas/basis/releases/tag/2023-03-09-df717b7-1678319522

## Testing

## Acceptance criteria

The version of Themis and its index downloaded by `vendor_download.sh` should find the new licenses

## Testing plan
Download this repository, which contains all four licenses: https://github.com/spatten/new-licenses-20230308

```
cd ~/tmp
git clone https://github.com/spatten/new-licenses-20230308
```

Run `vendor_download.sh`, unzip the `index.gob.xz` file that is downloaded and test that it finds the unity license.

```bash
./vendor_download.sh 
xz -d vendor-bins/index.gob.xz
./vendor-bins/themis-cli --license-data-dir ./vendor-bins  --exclude-paths=".git/**" ~/tmp/new-licenses-20230308
```

It should find the following licenses in each file:

- cl_va_api_media_sharing_intel.h: Apache-2.0 and intel-disclaimer
- instabug.LICENSE: instabug
- pallets.LICENSE: pallets-flask-logo
- push.LICENSE: pushwoosh

## Risks

None

## References

See tickets in the description

## Checklist

- [X] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
