### PR TITLE
Fix release numbering in the Changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
-## v3.7.1
+## v3.7.2
 - License Scanning: Add four new licenses: Pushwoosh, PalletsFlaskLogo, IntelDisclaimer and Instabug
 
 ## v3.7.1


### PR DESCRIPTION
# Overview

I messed up when putting the release number in the Changelog, and set the version to v3.7.1 when it should have been v3.7.2.

## Acceptance criteria

The numbering in the Changelog is correct

## Testing plan

## Risks

None

## References


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
