### PR TITLE
Error messages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
+## Unreleased
+- Diagnostics: Improves user-facing error messages and debugging tips for external commands and some HTTP error conditions ([#1165](https://github.com/fossas/fossa-cli/pull/1165))
+
 ## v3.7.2
 - License Scanning: Add four new licenses: Pushwoosh, PalletsFlaskLogo, IntelDisclaimer and Instabug
 

--- a/src/App/Support.hs
+++ b/src/App/Support.hs
@@ -11,6 +11,7 @@ module App.Support (
   reportDefectWithFileMsg,
   reportDefectWithDebugBundle,
   requestDebugBundle,
+  requestReportIfPersists,
   FossaEnvironment (..),
 ) where
 
@@ -76,18 +77,14 @@ reportNetworkErrorMsg =
       , "This means that often such errors are transient, or are caused by local network configuration."
       , ""
       , "Trying again in a few minutes may resolve this issue."
-      , "If this issue persists, please report a bug to FOSSA support at " <> pretty supportUrl
+      , requestReportIfPersists
       ]
 
 -- | For errors which almost definitely are a bug in the FOSSA CLI.
 reportCliBugErrorMsg :: Doc ann
 reportCliBugErrorMsg =
-  withDebugBundle $
-    vsep
-      [ "This is likely a bug in the FOSSA CLI."
-      , ""
-      , "If this issue persists, please report a bug to FOSSA support at " <> pretty supportUrl
-      ]
+  withDebugBundle . withRequestReportIfPersists $
+    "This is likely a bug in the FOSSA CLI."
 
 -- | For errors which almost definitely are a bug in FOSSA.
 reportFossaBugErrorMsg :: FossaEnvironment -> Doc ann
@@ -101,7 +98,7 @@ reportFossaBugErrorMsg FossaEnvironmentCloud =
       , "For current status, see the FOSSA status page at " <> pretty statusPageUrl
       , ""
       , "Trying again in a few minutes may resolve this issue."
-      , "If this issue persists, please report a bug to FOSSA support at " <> pretty supportUrl
+      , requestReportIfPersists
       ]
 reportFossaBugErrorMsg FossaEnvironmentOnprem =
   withDebugBundle $
@@ -110,7 +107,7 @@ reportFossaBugErrorMsg FossaEnvironmentOnprem =
       , "or a network appliance (e.g. a firewall) between FOSSA CLI and the FOSSA endpoint."
       , ""
       , "Trying again in a few minutes may resolve this issue."
-      , "If this issue persists, please report a bug to FOSSA support at " <> pretty supportUrl
+      , requestReportIfPersists
       ]
 
 -- | For temporary errors, explain that the error is transient and to wait a bit to try again.
@@ -118,12 +115,20 @@ reportFossaBugErrorMsg FossaEnvironmentOnprem =
 -- If this is a networking error, consider 'reportNetworkErrorMsg' instead.
 reportTransientErrorMsg :: Doc ann
 reportTransientErrorMsg =
-  withDebugBundle $
-    vsep
-      [ "This error is often transient, so trying again in a few minutes may resolve the issue."
-      , ""
-      , "If this issue persists, please report a bug to FOSSA support at " <> pretty supportUrl
-      ]
+  withDebugBundle . withRequestReportIfPersists $
+    "This error is often transient, so trying again in a few minutes may resolve the issue."
+
+-- | Request a report if the issue persists.
+requestReportIfPersists :: Doc ann
+requestReportIfPersists = "If this issue persists, please contact FOSSA support at " <> pretty supportUrl
+
+withRequestReportIfPersists :: Doc ann -> Doc ann
+withRequestReportIfPersists msg =
+  vsep
+    [ msg
+    , ""
+    , requestReportIfPersists
+    ]
 
 withDebugBundle :: Doc ann -> Doc ann
 withDebugBundle msg =

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -179,9 +179,9 @@ instance FromJSON FossaPublicFacingError where
   parseJSON = withObject "FossaPublicFacingError" $ \v ->
     FossaPublicFacingError
       <$> v
-      .: "message"
+        .: "message"
       <*> v
-      .: "uuid"
+        .: "uuid"
 
 newtype FossaReq m a = FossaReq {unFossaReq :: m a}
   deriving (Functor, Applicative, Monad, Algebra sig)
@@ -579,12 +579,12 @@ uploadNativeContainerScan apiOpts ProjectRevision{..} metadata scan = fossaReq $
             "locator"
               =: locator
               <> "cliVersion"
-              =: cliVersion
+                =: cliVersion
               <> "managedBuild"
-              =: True
+                =: True
               <> maybe mempty ("branch" =:) projectBranch
               <> "scanType"
-              =: ("native" :: Text)
+                =: ("native" :: Text)
               <> mkMetadataOpts metadata projectName
       resp <- req POST (containerUploadUrl baseUrl) (ReqBodyJson scan) jsonResponse (baseOpts <> opts)
       pure $ responseBody resp
@@ -603,9 +603,9 @@ uploadAnalysis apiOpts ProjectRevision{..} metadata sourceUnits = fossaReq $ do
         "locator"
           =: renderLocator (Locator "custom" projectName (Just projectRevision))
           <> "cliVersion"
-          =: cliVersion
+            =: cliVersion
           <> "managedBuild"
-          =: True
+            =: True
           <> mkMetadataOpts metadata projectName
           -- Don't include branch if it doesn't exist, core may not handle empty string properly.
           <> maybe mempty ("branch" =:) projectBranch
@@ -1002,11 +1002,11 @@ getAttributionJson apiOpts ProjectRevision{..} = fossaReq $ do
       opts =
         baseOpts
           <> "includeDeepDependencies"
-          =: True
+            =: True
           <> "includeHashAndVersionData"
-          =: True
+            =: True
           <> "dependencyInfoOptions[]"
-          =: packageDownloadUrl
+            =: packageDownloadUrl
   orgId <- organizationId <$> getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision)) ReportJson) NoReqBody jsonResponse opts
   pure (responseBody response)

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -52,6 +52,7 @@ import App.Support (
   reportFossaBugErrorMsg,
   reportNetworkErrorMsg,
   reportTransientErrorMsg,
+  requestReportIfPersists,
  )
 import App.Types (
   ProjectMetadata (..),
@@ -119,6 +120,7 @@ import Fossa.API.Types (
   UploadResponse,
   useApiOpts,
  )
+import Network.HTTP.Client (responseStatus)
 import Network.HTTP.Client qualified as C
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Req (
@@ -149,9 +151,11 @@ import Network.HTTP.Req (
   (=:),
  )
 import Network.HTTP.Req.Extra (httpConfigRetryTimeouts)
+import Network.HTTP.Types (statusCode)
 import Network.HTTP.Types qualified as HTTP
 import Parse.XML (FromXML (..), child, parseXML, xmlErrorPretty)
 import Path (File, Path, Rel, toFilePath)
+import Prettyprinter (viaShow)
 import Srclib.Types (
   LicenseSourceUnit,
   Locator (..),
@@ -174,8 +178,10 @@ data FossaPublicFacingError = FossaPublicFacingError
 instance FromJSON FossaPublicFacingError where
   parseJSON = withObject "FossaPublicFacingError" $ \v ->
     FossaPublicFacingError
-      <$> v .: "message"
-      <*> v .: "uuid"
+      <$> v
+      .: "message"
+      <*> v
+      .: "uuid"
 
 newtype FossaReq m a = FossaReq {unFossaReq :: m a}
   deriving (Functor, Applicative, Monad, Algebra sig)
@@ -323,14 +329,37 @@ instance ToDiagnostic FossaError where
         , reportDefectMsg
         ]
     StatusCodeError ereq eres ->
-      vsep
-        [ "The FOSSA endpoint returned an unexpected status code:"
-        , ""
-        , indent 4 $ "Request:" <+> renderRequest ereq
-        , indent 4 $ "Response:" <+> renderResponse eres
-        , ""
-        , reportTransientErrorMsg
-        ]
+      case statusCode $ responseStatus eres of
+        403 ->
+          vsep
+            [ "The FOSSA endpoint returned status code 403, which means that"
+            , "the FOSSA API key provided does not have access to FOSSA."
+            , ""
+            , "Please double check that the FOSSA API key provided to FOSSA CLI is correct."
+            , ""
+            , "Note that while this response typically come from the FOSSA API,"
+            , "it's also possible that some other device on the network sent this response."
+            , ""
+            , indent 4 $ "Request:" <+> renderRequest ereq
+            , indent 4 $ "Response:" <+> renderResponse eres
+            , ""
+            , reportDefectMsg
+            ]
+        other ->
+          vsep
+            [ "The FOSSA endpoint returned an unexpected status code: " <> viaShow other
+            , ""
+            , "While HTTP responses typically come from the FOSSA API,"
+            , "it's also possible that some other device on the network sent this response."
+            , ""
+            , "For a list of HTTP status codes and what they typically mean, see:"
+            , "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status."
+            , ""
+            , indent 4 $ "Request:" <+> renderRequest ereq
+            , indent 4 $ "Response:" <+> renderResponse eres
+            , ""
+            , reportTransientErrorMsg
+            ]
     TooManyRedirectsError txns ->
       newlineTrailing
         "Too many redirects were encountered when communicating with the FOSSA endpoint."
@@ -355,11 +384,19 @@ instance ToDiagnostic FossaError where
         ]
     ConnectionTimeoutError ereq ->
       vsep
-        [ "Connecting to the FOSSA endpoint took too long."
+        [ "The request to the FOSSA endpoint took too long to send."
+        , ""
+        , "This typically means that the CLI is being asked to send too much data"
+        , "with the current network speed (for example, uploading large archives),"
+        , "although this can also be a transient error caused by congested"
+        , "networking conditions between the CLI and the FOSSA API."
+        , ""
+        , "To reduce the likelihood of this error, ensure that only data you really"
+        , "need FOSSA to scan is being uploaded."
         , ""
         , indent 4 "Request:" <+> renderRequest ereq
         , ""
-        , reportNetworkErrorMsg
+        , requestReportIfPersists
         ]
     ConnectionFailureError ereq err ->
       vsep
@@ -540,11 +577,15 @@ uploadNativeContainerScan apiOpts ProjectRevision{..} metadata scan = fossaReq $
       (baseUrl, baseOpts) <- useApiOpts apiOpts
       let locator = renderLocator $ Locator "custom" projectName (Just projectRevision)
           opts =
-            "locator" =: locator
-              <> "cliVersion" =: cliVersion
-              <> "managedBuild" =: True
+            "locator"
+              =: locator
+              <> "cliVersion"
+              =: cliVersion
+              <> "managedBuild"
+              =: True
               <> maybe mempty ("branch" =:) projectBranch
-              <> "scanType" =: ("native" :: Text)
+              <> "scanType"
+              =: ("native" :: Text)
               <> mkMetadataOpts metadata projectName
       resp <- req POST (containerUploadUrl baseUrl) (ReqBodyJson scan) jsonResponse (baseOpts <> opts)
       pure $ responseBody resp
@@ -560,9 +601,12 @@ uploadAnalysis apiOpts ProjectRevision{..} metadata sourceUnits = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
   let opts =
-        "locator" =: renderLocator (Locator "custom" projectName (Just projectRevision))
-          <> "cliVersion" =: cliVersion
-          <> "managedBuild" =: True
+        "locator"
+          =: renderLocator (Locator "custom" projectName (Just projectRevision))
+          <> "cliVersion"
+          =: cliVersion
+          <> "managedBuild"
+          =: True
           <> mkMetadataOpts metadata projectName
           -- Don't include branch if it doesn't exist, core may not handle empty string properly.
           <> maybe mempty ("branch" =:) projectBranch
@@ -958,9 +1002,12 @@ getAttributionJson apiOpts ProjectRevision{..} = fossaReq $ do
       packageDownloadUrl = "PackageDownloadUrl"
       opts =
         baseOpts
-          <> "includeDeepDependencies" =: True
-          <> "includeHashAndVersionData" =: True
-          <> "dependencyInfoOptions[]" =: packageDownloadUrl
+          <> "includeDeepDependencies"
+          =: True
+          <> "includeHashAndVersionData"
+          =: True
+          <> "dependencyInfoOptions[]"
+          =: packageDownloadUrl
   orgId <- organizationId <$> getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision)) ReportJson) NoReqBody jsonResponse opts
   pure (responseBody response)

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -332,18 +332,17 @@ instance ToDiagnostic FossaError where
       case statusCode $ responseStatus eres of
         403 ->
           vsep
-            [ "The FOSSA endpoint returned status code 403, which means that"
-            , "the FOSSA API key provided does not have access to FOSSA."
+            [ "The endpoint returned status code 403."
             , ""
-            , "Please double check that the FOSSA API key provided to FOSSA CLI is correct."
-            , ""
-            , "Note that while this response typically come from the FOSSA API,"
-            , "it's also possible that some other device on the network sent this response."
+            , "Typically, this status code indicates an authentication problem with the API."
+            , "However, FOSSA reports invalid API keys using a different mechanism;"
+            , "this likely means that some other service on your network intercepted the request"
+            , "and reported this status code. This might be a proxy or some other network appliance."
             , ""
             , indent 4 $ "Request:" <+> renderRequest ereq
             , indent 4 $ "Response:" <+> renderResponse eres
             , ""
-            , reportDefectMsg
+            , reportNetworkErrorMsg
             ]
         other ->
           vsep

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -130,9 +130,9 @@ instance FromJSON CmdFailure where
   parseJSON = withObject "CmdFailure" $ \obj ->
     CmdFailure
       <$> obj
-      .: "cmdFailureCmd"
+        .: "cmdFailureCmd"
       <*> obj
-      .: "cmdFailureDir"
+        .: "cmdFailureDir"
       <*> (obj .: "cmdFailureExit" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStdout" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStderr" >>= fromRecordedValue)

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -208,6 +208,9 @@ renderCmdFailure CmdFailure{..} =
     expectedCmdNotFoundErrStr :: Text
     expectedCmdNotFoundErrStr = cmdName cmdFailureCmd <> ": startProcess: exec: invalid argument (Bad file descriptor)"
 
+    prettyCommand :: Command -> Doc AnsiStyle
+    prettyCommand Command{..} = pretty $ cmdName <> " " <> Text.intercalate " " cmdArgs
+
     stdErr :: Text
     stdErr = decodeUtf8 cmdFailureStderr
 
@@ -223,7 +226,7 @@ renderCmdFailure CmdFailure{..} =
     details :: Doc AnsiStyle
     details =
       vsep
-        [ "Attempted to run the command '" <> viaShow cmdFailureCmd <> "'"
+        [ "Attempted to run the command '" <> prettyCommand cmdFailureCmd <> "'"
         , "inside the working directory '" <> pretty cmdFailureDir <> "',"
         , "but failed, because the command exited with code '" <> exitCode <> "'."
         , ""
@@ -263,7 +266,7 @@ renderCmdFailure CmdFailure{..} =
 
     prettyStdErr :: Doc AnsiStyle
     prettyStdErr =
-      if Text.null stdOut
+      if Text.null stdErr
         then "Command did not write an error log."
         else
           vsep

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -76,7 +76,7 @@ import Effect.ReadFS (ReadFS, getCurrentDir)
 import GHC.Generics (Generic)
 import Path (Abs, Dir, Path, SomeBase (..), fromAbsDir)
 import Path.IO (AnyPath (makeAbsolute))
-import Prettyprinter (Doc, indent, line, pretty, viaShow, vsep)
+import Prettyprinter (Doc, indent, pretty, viaShow, vsep)
 import Prettyprinter.Render.Terminal (AnsiStyle)
 import System.Exit (ExitCode (..))
 import System.Process.Typed (
@@ -130,9 +130,9 @@ instance FromJSON CmdFailure where
   parseJSON = withObject "CmdFailure" $ \obj ->
     CmdFailure
       <$> obj
-        .: "cmdFailureCmd"
+      .: "cmdFailureCmd"
       <*> obj
-        .: "cmdFailureDir"
+      .: "cmdFailureDir"
       <*> (obj .: "cmdFailureExit" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStdout" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStderr" >>= fromRecordedValue)
@@ -181,31 +181,23 @@ data ExecErr
   deriving (Eq, Ord, Show, Generic)
 
 renderCmdFailure :: CmdFailure -> Doc AnsiStyle
-renderCmdFailure err =
+renderCmdFailure CmdFailure{..} =
   if isCmdNotAvailable
     then
-      pretty ("Could not find executable: `" <> cmdName (cmdFailureCmd err) <> "`.")
-        <> line
-        <> line
-        <> pretty ("Please ensure `" <> cmdName (cmdFailureCmd err) <> "` exist in PATH prior to running fossa.")
-        <> line
-        <> line
-        <> reportDefectMsg
+      vsep
+        [ pretty $ "Could not find executable: `" <> cmdName cmdFailureCmd <> "`."
+        , pretty $ "Please ensure `" <> cmdName cmdFailureCmd <> "` exists in PATH prior to running fossa."
+        , ""
+        , reportDefectMsg
+        ]
     else
-      "Command execution failed: "
-        <> line
-        <> indent
-          4
-          ( vsep
-              [ "command: " <> viaShow (cmdFailureCmd err)
-              , "dir: " <> pretty (cmdFailureDir err)
-              , "exit: " <> viaShow (cmdFailureExit err)
-              , "stdout: " <> line <> indent 2 (pretty @Text (decodeUtf8 (cmdFailureStdout err)))
-              , "stderr: " <> line <> indent 2 (pretty stdErr)
-              ]
-          )
-        <> line
-        <> reportDefectMsg
+      vsep
+        [ "Command execution failed: "
+        , ""
+        , indent 4 details
+        , ""
+        , reportDefectMsg
+        ]
   where
     -- Infer if the stderr is caused by not having executable in path.
     -- There is no easy way to check for @EBADF@ within process exception,
@@ -214,10 +206,71 @@ renderCmdFailure err =
     isCmdNotAvailable = expectedCmdNotFoundErrStr == stdErr
 
     expectedCmdNotFoundErrStr :: Text
-    expectedCmdNotFoundErrStr = cmdName (cmdFailureCmd err) <> ": startProcess: exec: invalid argument (Bad file descriptor)"
+    expectedCmdNotFoundErrStr = cmdName cmdFailureCmd <> ": startProcess: exec: invalid argument (Bad file descriptor)"
 
     stdErr :: Text
-    stdErr = decodeUtf8 (cmdFailureStderr err)
+    stdErr = decodeUtf8 cmdFailureStderr
+
+    stdOut :: Text
+    stdOut = decodeUtf8 cmdFailureStdout
+
+    exitCode :: Doc AnsiStyle
+    exitCode = case cmdFailureExit of
+      ExitSuccess -> "0"
+      ExitFailure n -> viaShow n
+
+    -- Render details of a failed command to error text.
+    details :: Doc AnsiStyle
+    details =
+      vsep
+        [ "Attempted to run the command '" <> viaShow cmdFailureCmd <> "'"
+        , "inside the working directory '" <> pretty cmdFailureDir <> "',"
+        , "but failed, because the command exited with code '" <> exitCode <> "'."
+        , ""
+        , "Often, this kind of error is caused by the project not being ready to build;"
+        , "please ensure that the project at '" <> pretty cmdFailureDir <> "'"
+        , "builds successfully before running fossa."
+        , ""
+        , outputPreamble
+        , prettyStdOut
+        , prettyStdErr
+        ]
+
+    outputPreamble :: Doc AnsiStyle
+    outputPreamble =
+      if Text.null stdOut && Text.null stdErr
+        then
+          vsep
+            [ "The command did not log any output!"
+            , "Please check the project documentation for this command for troubleshooting guidance."
+            ]
+        else
+          vsep
+            [ "The logs for the command are listed below."
+            , "They will likely provide guidance on how to resolve this error."
+            ]
+
+    prettyStdOut :: Doc AnsiStyle
+    prettyStdOut =
+      if Text.null stdOut
+        then "Command did not write a standard log."
+        else
+          vsep
+            [ ""
+            , "Command standard log:"
+            , indent 2 $ pretty stdOut
+            ]
+
+    prettyStdErr :: Doc AnsiStyle
+    prettyStdErr =
+      if Text.null stdOut
+        then "Command did not write an error log."
+        else
+          vsep
+            [ ""
+            , "Command error log:"
+            , indent 2 $ pretty stdErr
+            ]
 
 instance ToDiagnostic ExecErr where
   renderDiagnostic = \case


### PR DESCRIPTION
# Overview

During my onduty cycle I've noticed several instances where the error messages reported when running external commands were confusing. This PR is an attempt to make them nicer and more useful.

Additionally, I've added special handling to a couple HTTP error cases:
- HTTP 403 errors now indicate they likely are caused by a networking appliance intercepting the request.
- HTTP RequestTimeout errors to suggest users ensure they're not uploading a bunch of noise.

Example error text for 403:
```
The endpoint returned status code 403.

Typically, this status code indicates an authentication problem with the API.
However, FOSSA reports invalid API keys using a different mechanism;
this likely means that some other service on your network intercepted the request
and reported this status code. This might be a proxy or some other network appliance.

    Request: GET https://app.fossa.com/api/<some/example/endpoint>
    Response: 403

This is a networking error.

Networking errors are typically caused by actual network failure or a network appliance
(e.g. a firewall) between the FOSSA CLI and the FOSSA backend.
This means that often such errors are transient, or are caused by local network configuration.

Trying again in a few minutes may resolve this issue.

If this issue persists, please contact FOSSA support at https://support.fossa.com
```

Example error text for the request timeout:
```
The request to the FOSSA endpoint took too long to send.

This typically means that the CLI is being asked to send too much data
with the current network speed (for example, uploading large archives),
although this can also be a transient error caused by congested
networking conditions between the CLI and the FOSSA API.

To reduce the likelihood of this error, ensure that only data you really
need FOSSA to scan is being uploaded.

    Request: POST https://app.fossa.com/api/<some/example/endpoint>

If this issue persists, please contact FOSSA support at https://support.fossa.com
```

Examples for the command errors are below, in testing steps.

## Acceptance criteria

Users and FOSSA support staff have more actionable and easy to read error messages, which provide more debugging guidance.

## Testing plan

To test exec error rendering in the case of "executable not found", I ran:
```
; PATH=/home/jess/.ghcup/bin cabal run fossa -- analyze -o ~/projects/scratch/
Up to date
[ INFO] Analyzing cargo project at /home/jess/projects/scratch/
[ERROR] ----------
  An issue occurred

  >>> Details

    Could not generate lock file for cargo manifest: "/home/jess/projects/scratch/Cargo.toml"

  >>> Relevant errors

    Error

      Could not find executable: `cargo`.
      Please ensure `cargo` exists in PATH prior to running fossa.

      If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com

      Traceback:
        - Running command 'cargo'
        - Generating lockfile
        - Dynamic analysis
        - Cargo
        - Project Analysis: CargoProjectType
```

To test executable failing due to build issues, I made `Cargo.toml` invalid syntax and ran:
```
[ERROR] ----------
  An issue occurred

  >>> Details

    Could not generate lock file for cargo manifest: "/home/jess/projects/scratch/Cargo.toml"

  >>> Relevant errors

    Error

      Command execution failed:

          Attempted to run the command 'cargo generate-lockfile'
          inside the working directory '/home/jess/projects/scratch/',
          but failed, because the command exited with code '101'.

          Often, this kind of error is caused by the project not being ready to build;
          please ensure that the project at '/home/jess/projects/scratch/'
          builds successfully before running fossa.

          The logs for the command are listed below.
          They will likely provide guidance on how to resolve this error.
          Command did not write a standard log.

          Command error log:
            error: failed to parse manifest at `/home/jess/projects/scratch/Cargo.toml`

            Caused by:
              could not parse input as TOML

            Caused by:
              TOML parse error at line 1, column 9
                |
              1 | [package
                |         ^
              Unexpected `
              `
              Expected `.` or `]`
              While parsing a Table Header


      If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com

      Traceback:
        - Running command 'cargo'
        - Generating lockfile
        - Dynamic analysis
        - Cargo
        - Project Analysis: CargoProjectType
```

I don't have a great way to test the two networking errors, as I'm pretty sure they're generally caused by local networking conditions. I think since this is only a change in the documentation rendered in the face of these errors it's safe, but reviewer, if you want me to set up an environment that'd allow me to test these please let me know.

## Risks

This change is only to help text rendered in the case of an error, as such I think it's low risk from the standpoint of "successfully executing FOSSA CLI" but medium risk from the standpoint of "not confusing users".

I would love any thoughts folks have on the formatting or content of these messages!

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
