### PR TITLE
Update themis release 20230322

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 - License Scanning: Scan the full contents of "license.html" and "licence.html" for license content, not just the comments. ([#1169](https://github.com/fossas/fossa-cli/pull/1169))
 
 ## v3.7.2
-- License Scanning: Add four new licenses: Pushwoosh, PalletsFlaskLogo, IntelDisclaimer and Instabug
+- License Scanning: Add four new licenses: Pushwoosh, PalletsFlaskLogo, IntelDisclaimer and Instabug ([#1163](https://github.com/fossas/fossa-cli/pull/1163))
 
 ## v3.7.1
 - Stack: Git based dependencies are detected and handled correctly. ([#1160](https://github.com/fossas/fossa-cli/pull/1160))

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
-## Unreleased
+## v3.7.3
 - Go: Collects environment variables in debug bundle. ([#1132](https://github.com/fossas/fossa-cli/pull/1132))
 - Diagnostics: Improves user-facing error messages and debugging tips for external commands and some HTTP error conditions ([#1165](https://github.com/fossas/fossa-cli/pull/1165))
 - License Scanning: Scan the full contents of "license.html" and "licence.html" for license content, not just the comments. ([#1169](https://github.com/fossas/fossa-cli/pull/1169))

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ## Unreleased
 - Go: Collects environment variables in debug bundle. ([#1132](https://github.com/fossas/fossa-cli/pull/1132))
 - Diagnostics: Improves user-facing error messages and debugging tips for external commands and some HTTP error conditions ([#1165](https://github.com/fossas/fossa-cli/pull/1165))
+- License Scanning: Scan the full contents of "license.html" and "licence.html" for license content, not just the comments.
 
 ## v3.7.2
 - License Scanning: Add four new licenses: Pushwoosh, PalletsFlaskLogo, IntelDisclaimer and Instabug

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 ## Unreleased
 - Go: Collects environment variables in debug bundle. ([#1132](https://github.com/fossas/fossa-cli/pull/1132))
 - Diagnostics: Improves user-facing error messages and debugging tips for external commands and some HTTP error conditions ([#1165](https://github.com/fossas/fossa-cli/pull/1165))
-- License Scanning: Scan the full contents of "license.html" and "licence.html" for license content, not just the comments.
+- License Scanning: Scan the full contents of "license.html" and "licence.html" for license content, not just the comments. ([#1169](https://github.com/fossas/fossa-cli/pull/1169))
 
 ## v3.7.2
 - License Scanning: Add four new licenses: Pushwoosh, PalletsFlaskLogo, IntelDisclaimer and Instabug

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -79,7 +79,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2023-03-09-df717b7-1678319522"
+THEMIS_TAG="2023-03-22-22c316e-1679336268"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

Updates the basis release tag for Themis. This new version scans the full contents of files named "license.html" and "licence.html" for license content, not just the comments. 

## Acceptance criteria

We should find licenses in files called license.html or licence.html, ignoring the case of the file.

## Testing plan
Update the version of themis that you are running:

```
GITHUB_TOKEN=<your token> ./vendor_download.sh
cabal clean
make install-dev
```

Download a license file and scan it:

```
mkdir ~/tmp/license-html
cd license-html
wget https://www.bouncycastle.org/licence.html
fossa-dev license-scan direct
```

It should find the MIT and bouncy-castle licenses.

## Risks

None

## References

https://github.com/fossas/basis/pull/1785
https://teamfossa.slack.com/archives/C0155DTGWB1/p1678824160240919

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
