### PR TITLE
Update themis release 4-6-2023

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 - Go: Introduce `--experimental-use-v3-go-resolver` to preview a new [tactic](./docs/references/strategies/languages/golang/gomodules.md#experimental-strategy-use-go-list-on-packages) for Go dependency scanning. ([#1168](https://github.com/fossas/fossa-cli/pull/1168)
+- Themis: Update tag to support a new rule for the libdivide dependency. ([#1172](https://github.com/fossas/fossa-cli/pull/1172)
        
 ## v3.7.4
 - Gradle: Fix possible ConcurrentModificationException that can occur when getting dependencies ([#1171](https://github.com/fossas/fossa-cli/pull/1171))

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -79,7 +79,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2023-03-22-22c316e-1679336268"
+THEMIS_TAG="2023-04-05-56f29a8-1680734040"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

Adds support for a rule in libdivide.

## Acceptance criteria

Themis is updated

## Risks

None
