### PR TITLE
Try gradle_7

### DIFF
--- a/integration-test/Analysis/GradleSpec.hs
+++ b/integration-test/Analysis/GradleSpec.hs
@@ -18,7 +18,7 @@ import Test.Hspec (Spec, aroundAll, describe, it, shouldBe)
 import Types (DiscoveredProjectType (..))
 
 gradleEnv :: FixtureEnvironment
-gradleEnv = NixEnv ["gradle"]
+gradleEnv = NixEnv ["gradle_7"]
 
 springBoot :: AnalysisTestFixture (Gradle.GradleProject)
 springBoot =


### PR DESCRIPTION
# Overview

I noticed integration tests were failing for Gradle in my Go PR. Strangely they seemed to not work on master locally, or when done in CI on a commit that worked previously. When I tried running them locally the error I saw was about using a jdk that didn't support java 17. I never figured out what changed to break the tests, but when I change the test to use a version of [gradle in nix](https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/development/tools/build-managers/gradle/default.nix#L129) that uses jdk17 it [appears to work](https://github.com/fossas/fossa-cli/tree/fix-gradle-integration-test).

## Acceptance criteria

* Both gradle integration tests should pass.

## Testing plan

Look at the github actions for this PR.

## Risks

I don't know why this test suddenly started failing around a week ago. My guess is something in the nix package for gradle changed, but I haven't found any changes in Nix that coincide with that time-frame. #1168 Does change the fixture utils in a trivial way, but the test succeeded for that PR and on master. The currently failing master is from when I tried running integration tests again to see if a previously successful revision would fail.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
