### PR TITLE
Adds cabal update step to CI

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -32,6 +32,7 @@ jobs:
           ghcup set ghc 9.0.2
           ghcup install cabal 3.6.2.0
           ghcup set cabal 3.6.2.0
+          cabal update
 
       - name: Run dependency scan on Spectrometer
         env:


### PR DESCRIPTION
# Overview

Looks like the CLI isn't able to run cabal commands because the cabal package index is out of date in the CI.  This leads to only Cargo projects being detected.

The solution is to do a `cabal update` before running `fossa analyze`.

## Acceptance criteria

CI passes and detects both the Cargo and Cabal projects.

## Testing plan

Run it in CI!

## Risks

Low to none.  This is just a CI project.  The worst case is probably that CI takes longer.

## References

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
