### PR TITLE
recover from errors parsing project.pbxproj files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,13 +2,17 @@
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
+## Unreleased
+
+- Swift: Do not stop analysis if we encounter a badly formatted project.pbxproj file ([#1177](https://github.com/fossas/fossa-cli/pull/1177))
+
 ## v3.7.5
 - Go: Introduce `--experimental-use-v3-go-resolver` to preview a new [tactic](./docs/references/strategies/languages/golang/gomodules.md#experimental-strategy-use-go-list-on-packages) for Go dependency scanning. ([#1168](https://github.com/fossas/fossa-cli/pull/1168),[#1173](https://github.com/fossas/fossa-cli/pull/1173))
 - Themis: Update tag to support a new rule for the libdivide dependency. ([#1172](https://github.com/fossas/fossa-cli/pull/1172)
-       
+
 ## v3.7.4
 - Gradle: Fix possible ConcurrentModificationException that can occur when getting dependencies ([#1171](https://github.com/fossas/fossa-cli/pull/1171))
-        
+
 ## v3.7.3
 - Go: Collects environment variables in debug bundle. ([#1132](https://github.com/fossas/fossa-cli/pull/1132))
 - Diagnostics: Improves user-facing error messages and debugging tips for external commands and some HTTP error conditions ([#1165](https://github.com/fossas/fossa-cli/pull/1165))

--- a/integration-test/Analysis/SwiftSpec.hs
+++ b/integration-test/Analysis/SwiftSpec.hs
@@ -25,4 +25,3 @@ exampleProject =
 spec :: Spec
 spec = do
   testSuiteDepResultSummary exampleProject SwiftProjectType (DependencyResultsSummary 6 6 0 1 Partial)
-

--- a/integration-test/Analysis/SwiftSpec.hs
+++ b/integration-test/Analysis/SwiftSpec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.SwiftSpec (spec) where
+
+import Analysis.FixtureExpectationUtils
+import Analysis.FixtureUtils
+import Path
+import Strategy.SwiftPM qualified as SwiftPM
+import Test.Hspec
+import Types (DiscoveredProjectType (..), GraphBreadth (Partial))
+
+exampleProject :: AnalysisTestFixture (SwiftPM.SwiftProject)
+exampleProject =
+  AnalysisTestFixture
+    "example_project"
+    SwiftPM.discover
+    LocalEnvironment
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/fossas/example-pbxproj-project/archive/refs/heads/main.tar.gz"
+      [reldir|swift/example_project/|]
+      [reldir|example-pbxproj-project-main/myproj/|]
+
+spec :: Spec
+spec = do
+  testSuiteDepResultSummary exampleProject SwiftProjectType (DependencyResultsSummary 6 6 0 1 Partial)
+

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -666,6 +666,7 @@ test-suite integration-tests
     Analysis.RubySpec
     Analysis.RustSpec
     Analysis.ScalaSpec
+    Analysis.SwiftSpec
 
   build-tool-depends: hspec-discover:hspec-discover ^>=2.10.0.1
   build-depends:

--- a/src/Strategy/Swift/Xcode/Pbxproj.hs
+++ b/src/Strategy/Swift/Xcode/Pbxproj.hs
@@ -8,7 +8,7 @@ module Strategy.Swift.Xcode.Pbxproj (
   swiftPackageReferencesOf,
 ) where
 
-import Control.Effect.Diagnostics (Diagnostics, context, errCtx, fatalText, recover, warnOnErr, ToDiagnostic (renderDiagnostic))
+import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (renderDiagnostic), context, errCtx, fatalText, recover, warnOnErr)
 import Data.Map (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
@@ -19,6 +19,7 @@ import Diag.Common (MissingDeepDeps (MissingDeepDeps))
 import Effect.ReadFS (Has, ReadFS, readContentsJson, readContentsParser)
 import Graphing (Graphing, deeps, directs, promoteToDirect)
 import Path
+import Prettyprinter
 import Strategy.Swift.Errors (
   MissingPackageResolvedFile (MissingPackageResolvedFile),
  )
@@ -29,7 +30,6 @@ import Strategy.Swift.PackageSwift (
   toConstraint,
  )
 import Strategy.Swift.Xcode.PbxprojParser (AsciiValue (..), PbxProj (..), lookupText, objectsFromIsa, parsePbxProj, textOf)
-import Prettyprinter
 
 -- | Represents the version rules for a Swift Package as defined in Xcode project file.
 data XCRemoteSwiftPackageReference = XCRemoteSwiftPackageReference

--- a/src/Strategy/Swift/Xcode/Pbxproj.hs
+++ b/src/Strategy/Swift/Xcode/Pbxproj.hs
@@ -107,9 +107,7 @@ instance ToDiagnostic FailedToParseProjFile where
 hasSomeSwiftDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m Bool
 hasSomeSwiftDeps projFile = do
   xCodeProjContent <- recover $ warnOnErr (FailedToParseProjFile projFile) (readContentsParser parsePbxProj projFile)
-  case xCodeProjContent of
-    Nothing -> pure False
-    Just proj -> pure $ (not . null) (swiftPackageReferencesOf proj)
+pure $ maybe False (not . null . swiftPackageReferencesOf) xCodeProjContent
 
 analyzeXcodeProjForSwiftPkg :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> Maybe (Path Abs File) -> m (Graphing.Graphing Dependency)
 analyzeXcodeProjForSwiftPkg xcodeProjFile resolvedFile = do

--- a/src/Strategy/Swift/Xcode/Pbxproj.hs
+++ b/src/Strategy/Swift/Xcode/Pbxproj.hs
@@ -107,7 +107,7 @@ instance ToDiagnostic FailedToParseProjFile where
 hasSomeSwiftDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m Bool
 hasSomeSwiftDeps projFile = do
   xCodeProjContent <- recover $ warnOnErr (FailedToParseProjFile projFile) (readContentsParser parsePbxProj projFile)
-pure $ maybe False (not . null . swiftPackageReferencesOf) xCodeProjContent
+  pure $ maybe False (not . null . swiftPackageReferencesOf) xCodeProjContent
 
 analyzeXcodeProjForSwiftPkg :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> Maybe (Path Abs File) -> m (Graphing.Graphing Dependency)
 analyzeXcodeProjForSwiftPkg xcodeProjFile resolvedFile = do

--- a/src/Strategy/SwiftPM.hs
+++ b/src/Strategy/SwiftPM.hs
@@ -3,6 +3,7 @@
 module Strategy.SwiftPM (
   discover,
   mkProject,
+  SwiftProject,
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject (..))


### PR DESCRIPTION
# Overview

[Delivers ANE-660](https://fossa.atlassian.net/browse/ANE-660)

If an analysis directory contains multiple `project.pbxproj` files and one is invalid, the parser will return an error and any other valid `project.pbxproj` files will not be parsed. This affects both fossa analyze and fossa list-targets.

This happens in the wild because many react-native projects have an empty `project.pbxproj` file that is required for some reason or another. This forces the user to manually delete each file in their projects before scanning to get fossa analyze to scan.

## Acceptance criteria

- When we encounter an invalid `project.pbxproj` file we should emit a warning and keep going
- This should work for both `fossa analyze` and `fossa list-targets`
- The resulting analysis should be what you would get if the broken `project.pbxproj` files did not exist

## Testing plan

Download the test archive from https://fossa.atlassian.net/browse/ANE-660.

I edited one of the project.pbxproj files that just contained "yolo" and made it an empty file, as this is one of the test cases we want to validate.

Run `fossa analyze` and `fossa list-targets` on the unzipped directory.

```
fossa-dev list-targets .

fossa-dev list-targets .                                   
[ WARN] fossa list-targets does not apply any filtering, you may see projects which are not present in the final analysis.
[ WARN] ----------
  A task succeeded with warnings

  Warning

    Could not parse project.pbxproj file "/Users/scott/tmp/pbxproj/repro/invalid-2/project.pbxproj"

    >>> Relevant errors

      Error

        Error parsing file: /Users/scott/tmp/pbxproj/repro/invalid-2/project.pbxproj.

            /Users/scott/tmp/pbxproj/repro/invalid-2/project.pbxproj:1:1:
              |
            1 | yolo
              | ^^^^^
            unexpected "yolo<newline>"
            expecting to have UTF8 Encoding!


        If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com, with a copy of:
          /Users/scott/tmp/pbxproj/repro/invalid-2/project.pbxproj

        Traceback:
          - Parsing file '/Users/scott/tmp/pbxproj/repro/invalid-2/project.pbxproj'
          - Walking the filetree
          - Finding xcode projects using swift package manager
          - Finding Projects
          - swift



  Warning

    Could not parse project.pbxproj file "/Users/scott/tmp/pbxproj/repro/invalid/project.pbxproj"

    >>> Relevant errors

      Error

        Error parsing file: /Users/scott/tmp/pbxproj/repro/invalid/project.pbxproj.

            /Users/scott/tmp/pbxproj/repro/invalid/project.pbxproj:1:1:
              |
            1 | <empty line>
              | ^
            unexpected end of input
            expecting to have UTF8 Encoding!


        If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com, with a copy of:
          /Users/scott/tmp/pbxproj/repro/invalid/project.pbxproj

        Traceback:
          - Parsing file '/Users/scott/tmp/pbxproj/repro/invalid/project.pbxproj'
          - Walking the filetree
          - Finding xcode projects using swift package manager
          - Finding Projects
          - swift



[ INFO] Found project: swift@repro/my-project/
[ INFO] Found target: swift@repro/my-project/
```

```
fossa-dev analyze --output . | jq '.'
```

## Risks

None

## References

https://fossa.atlassian.net/browse/ANE-660

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
