### PR TITLE
Origin paths support for RPM spec file analysis 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
 ## Unreleased
-
+- RPM: Support origin paths for RPM spec file analysis ([#1178](https://github.com/fossas/fossa-cli/pull/1178))
 - Swift: Do not stop analysis if we encounter a badly formatted project.pbxproj file ([#1177](https://github.com/fossas/fossa-cli/pull/1177))
 
 ## v3.7.5

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -80,7 +80,7 @@ findProjects = walkWithFilters' $ \dir _ files -> do
 
 data RpmProject = RpmProject
   { rpmDir :: Path Abs Dir
-  , rpmFiles :: Path Abs File
+  , rpmFile :: Path Abs File
   }
   deriving (Eq, Ord, Show, Generic)
 
@@ -100,7 +100,7 @@ mkProject project =
     }
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => RpmProject -> m DependencyResults
-getDeps = context "RPM" . context "Static analysis" . analyze . rpmFiles
+getDeps = context "RPM" . context "Static analysis" . analyze . rpmFile
 
 analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m DependencyResults
 analyze specFile = do


### PR DESCRIPTION
# Overview

Collect origin path information for RPM spec file analysis

## Acceptance criteria

- Spec files will upload origin path information that will show users in the UI which file an RPM came from.

## Testing plan

- Compile the CLI locally with this branch.
- Analyze a directory that has 2 spec files that have different RPMs in them.
- See in the UI that the origin paths are present.

## Risks

I changed RPM analysis, so I suppose I could have broken that for some people, but I'm not entirely sure how.

## References

[ANE-483](https://fossa.atlassian.net/browse/ANE-483)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-483]: https://fossa.atlassian.net/browse/ANE-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ