### PR TITLE
[ANE-875] Adds --json to fossa container analyze

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,11 +1,12 @@
 # FOSSA CLI Changelog
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
+## Unreleased
+- Adds `--json` flag to `fossa container analyze`
 
 ## v3.7.6
 - RPM: Support origin paths for RPM spec file analysis ([#1178](https://github.com/fossas/fossa-cli/pull/1178))
 - Swift: Do not stop analysis if we encounter a badly formatted project.pbxproj file ([#1177](https://github.com/fossas/fossa-cli/pull/1177))
-- Adds `--json` flag to `fossa container analyze`
 
 ## v3.7.5
 - Go: Introduce `--experimental-use-v3-go-resolver` to preview a new [tactic](./docs/references/strategies/languages/golang/gomodules.md#experimental-strategy-use-go-list-on-packages) for Go dependency scanning. ([#1168](https://github.com/fossas/fossa-cli/pull/1168),[#1173](https://github.com/fossas/fossa-cli/pull/1173))

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ## Unreleased
 
 - Swift: Do not stop analysis if we encounter a badly formatted project.pbxproj file ([#1177](https://github.com/fossas/fossa-cli/pull/1177))
+- Adds `--json` flag to `fossa container analyze`
 
 ## v3.7.5
 - Go: Introduce `--experimental-use-v3-go-resolver` to preview a new [tactic](./docs/references/strategies/languages/golang/gomodules.md#experimental-strategy-use-go-list-on-packages) for Go dependency scanning. ([#1168](https://github.com/fossas/fossa-cli/pull/1168),[#1173](https://github.com/fossas/fossa-cli/pull/1173))

--- a/src/App/Fossa/Config/Container/Analyze.hs
+++ b/src/App/Fossa/Config/Container/Analyze.hs
@@ -125,7 +125,7 @@ cliParser =
     <*> switch (long "only-system-deps" <> help "Only analyzes system dependencies (e.g. apk, dep, rpm).")
 
 mergeOpts ::
-  Has Diagnostics sig m =>
+  (Has Diagnostics sig m) =>
   Maybe ConfigFile ->
   EnvVars ->
   ContainerAnalyzeOptions ->
@@ -158,7 +158,7 @@ mergeOpts cfgfile envvars cliOpts@ContainerAnalyzeOptions{..} = do
     <*> pure scanFilters
 
 collectScanDestination ::
-  Has Diagnostics sig m =>
+  (Has Diagnostics sig m) =>
   Maybe ConfigFile ->
   EnvVars ->
   ContainerAnalyzeOptions ->

--- a/src/App/Fossa/Config/Container/Analyze.hs
+++ b/src/App/Fossa/Config/Container/Analyze.hs
@@ -2,6 +2,7 @@
 
 module App.Fossa.Config.Container.Analyze (
   NoUpload (..),
+  JsonOutput (..),
   ContainerAnalyzeConfig (..),
   ContainerAnalyzeOptions (..),
   cliParser,
@@ -58,11 +59,13 @@ import Options.Applicative (
  )
 
 data NoUpload = NoUpload
+data JsonOutput = JsonOutput deriving (Generic)
 
 data ContainerAnalyzeConfig = ContainerAnalyzeConfig
   { scanDestination :: ScanDestination
   , revisionOverride :: OverrideProject
   , imageLocator :: ImageText
+  , jsonOutput :: Flag JsonOutput
   , -- \* For Experimental Scanner
     usesExperimentalScanner :: Bool
   , dockerHost :: Text
@@ -79,6 +82,7 @@ instance ToJSON ContainerAnalyzeConfig where
 data ContainerAnalyzeOptions = ContainerAnalyzeOptions
   { analyzeCommons :: CommonOpts
   , containerNoUpload :: Flag NoUpload
+  , containerJsonOutput :: Flag JsonOutput
   , containerBranch :: Maybe Text
   , containerMetadata :: ProjectMetadata
   , containerAnalyzeImage :: ImageText
@@ -107,6 +111,7 @@ cliParser =
           <> short 'o'
           <> help "Output results to stdout instead of uploading to fossa"
       )
+    <*> flagOpt JsonOutput (long "json" <> help "Output project metadata as json to the console. Useful for communicating with the FOSSA API")
     <*> optional
       ( strOption
           ( long "branch"
@@ -129,6 +134,7 @@ mergeOpts cfgfile envvars cliOpts@ContainerAnalyzeOptions{..} = do
   let scanDest = collectScanDestination cfgfile envvars cliOpts
       severity = getSeverity cliOpts
       imageLoc = containerAnalyzeImage
+      jsonOutput = containerJsonOutput
       arch = collectArch
       onlySystemDeps = containerExperimentalOnlySysDependencies
       scanFilters = collectFilters cfgfile
@@ -143,6 +149,7 @@ mergeOpts cfgfile envvars cliOpts@ContainerAnalyzeOptions{..} = do
     <$> scanDest
     <*> pure revOverride
     <*> pure imageLoc
+    <*> pure jsonOutput
     <*> pure containerExperimentalScanner
     <*> collectDockerHost envvars
     <*> pure arch

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -12,9 +12,8 @@ import App.Fossa.Config.Common (
   ScanDestination (OutputStdout, UploadScan),
  )
 import App.Fossa.Config.Container.Analyze (
-  ContainerAnalyzeConfig (arch, dockerHost, filterSet, imageLocator, onlySystemDeps, revisionOverride, scanDestination),
+  ContainerAnalyzeConfig (..),
   JsonOutput (JsonOutput),
-  jsonOutput,
  )
 import App.Fossa.Config.Container.Analyze qualified as Config
 import App.Fossa.Container.Scan (extractRevision, scanImage)

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -142,7 +142,7 @@ uploadScan revision projectMeta jsonOutput containerScan =
 
         when (fromFlag JsonOutput jsonOutput) $ do
           summary <-
-            context "i don't know what's going on here" $
+            context "Analysis upload succeeded" $
               buildJsonSummary revision locator buildUrl
           logStdout . decodeUtf8 $ Aeson.encode summary
         -- We return locator for purely for testing.

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -12,7 +12,9 @@ import App.Fossa.Config.Common (
   ScanDestination (OutputStdout, UploadScan),
  )
 import App.Fossa.Config.Container.Analyze (
-  ContainerAnalyzeConfig (arch, dockerHost, filterSet, imageLocator, onlySystemDeps, revisionOverride, scanDestination), JsonOutput (JsonOutput), jsonOutput,
+  ContainerAnalyzeConfig (arch, dockerHost, filterSet, imageLocator, onlySystemDeps, revisionOverride, scanDestination),
+  JsonOutput (JsonOutput),
+  jsonOutput,
  )
 import App.Fossa.Config.Container.Analyze qualified as Config
 import App.Fossa.Container.Scan (extractRevision, scanImage)
@@ -27,7 +29,7 @@ import Container.Types (ContainerScan (..))
 import Control.Carrier.Debug (Debug, ignoreDebug)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.FossaApiClient (runFossaApiClient)
-import Control.Effect.Diagnostics (Diagnostics, fatal, context, fromMaybeText)
+import Control.Effect.Diagnostics (Diagnostics, context, fatal, fromMaybeText)
 import Control.Effect.FossaApiClient (FossaApiClient, getOrganization, uploadNativeContainerScan)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Telemetry (Telemetry)
@@ -35,8 +37,8 @@ import Control.Monad (void, when)
 import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BL
+import Data.Flag (Flag, fromFlag)
 import Data.Foldable (traverse_)
-import Data.Flag (fromFlag, Flag)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (
   ConvertUtf8 (decodeUtf8),
@@ -138,22 +140,22 @@ uploadScan revision projectMeta jsonOutput containerScan =
         logInfo ("  " <> pretty buildUrl)
         traverse_ (\err -> logError $ "FOSSA error: " <> viaShow err) (uploadError resp)
 
-        when (fromFlag JsonOutput jsonOutput) $ do 
-          summary <- 
+        when (fromFlag JsonOutput jsonOutput) $ do
+          summary <-
             context "i don't know what's going on here" $
               buildJsonSummary revision locator buildUrl
           logStdout . decodeUtf8 $ Aeson.encode summary
         -- We return locator for purely for testing.
         pure locator
 
-buildJsonSummary :: Has Diagnostics sig m => ProjectRevision -> Locator -> Text -> m Aeson.Value
+buildJsonSummary :: (Has Diagnostics sig m) => ProjectRevision -> Locator -> Text -> m Aeson.Value
 buildJsonSummary project locator projectUrl = do
   revision <- fromMaybeText "Server returned an invalid project revision" $ locatorRevision locator
-  pure $ 
+  pure $
     Aeson.object
       [ "project" .= locatorProject locator
       , "revision" .= revision
       , "branch" .= projectBranch project
       , "url" .= projectUrl
       , "id" .= renderLocator locator
-      ]  
+      ]

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -12,7 +12,7 @@ import App.Fossa.Config.Common (
   ScanDestination (OutputStdout, UploadScan),
  )
 import App.Fossa.Config.Container.Analyze (
-  ContainerAnalyzeConfig (arch, dockerHost, filterSet, imageLocator, onlySystemDeps, revisionOverride, scanDestination),
+  ContainerAnalyzeConfig (arch, dockerHost, filterSet, imageLocator, onlySystemDeps, revisionOverride, scanDestination), JsonOutput (JsonOutput), jsonOutput,
  )
 import App.Fossa.Config.Container.Analyze qualified as Config
 import App.Fossa.Container.Scan (extractRevision, scanImage)
@@ -27,14 +27,16 @@ import Container.Types (ContainerScan (..))
 import Control.Carrier.Debug (Debug, ignoreDebug)
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.FossaApiClient (runFossaApiClient)
-import Control.Effect.Diagnostics (Diagnostics, fatal)
+import Control.Effect.Diagnostics (Diagnostics, fatal, context, fromMaybeText)
 import Control.Effect.FossaApiClient (FossaApiClient, getOrganization, uploadNativeContainerScan)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Telemetry (Telemetry)
-import Control.Monad (void)
+import Control.Monad (void, when)
+import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)
+import Data.Flag (fromFlag, Flag)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (
   ConvertUtf8 (decodeUtf8),
@@ -55,7 +57,7 @@ import Effect.Logger (
 import Effect.ReadFS (ReadFS)
 import Fossa.API.Types (Organization (orgSupportsNativeContainerScan), UploadResponse (uploadError), uploadLocator)
 import Path (Abs, File, Path)
-import Srclib.Types (Locator)
+import Srclib.Types (Locator (locatorRevision), locatorProject, renderLocator)
 
 data ContainerImageSource
   = DockerArchive (Path Abs File)
@@ -109,18 +111,20 @@ analyze cfg = do
   case scanDestination cfg of
     OutputStdout -> logStdout . decodeUtf8 $ Aeson.encode scannedImage
     UploadScan apiOpts projectMeta ->
-      void $ runFossaApiClient apiOpts $ uploadScan revision projectMeta scannedImage
+      void $ runFossaApiClient apiOpts $ uploadScan revision projectMeta (jsonOutput cfg) scannedImage
 
 uploadScan ::
   ( Has Diagnostics sig m
   , Has FossaApiClient sig m
   , Has Logger sig m
+  , Has (Lift IO) sig m
   ) =>
   ProjectRevision ->
   ProjectMetadata ->
+  Flag JsonOutput ->
   ContainerScan ->
   m Locator
-uploadScan revision projectMeta containerScan =
+uploadScan revision projectMeta jsonOutput containerScan =
   do
     supportsNativeScan <- orgSupportsNativeContainerScan <$> getOrganization
     if not supportsNativeScan
@@ -134,5 +138,22 @@ uploadScan revision projectMeta containerScan =
         logInfo ("  " <> pretty buildUrl)
         traverse_ (\err -> logError $ "FOSSA error: " <> viaShow err) (uploadError resp)
 
+        when (fromFlag JsonOutput jsonOutput) $ do 
+          summary <- 
+            context "i don't know what's going on here" $
+              buildJsonSummary revision locator buildUrl
+          logStdout . decodeUtf8 $ Aeson.encode summary
         -- We return locator for purely for testing.
         pure locator
+
+buildJsonSummary :: Has Diagnostics sig m => ProjectRevision -> Locator -> Text -> m Aeson.Value
+buildJsonSummary project locator projectUrl = do
+  revision <- fromMaybeText "Server returned an invalid project revision" $ locatorRevision locator
+  pure $ 
+    Aeson.object
+      [ "project" .= locatorProject locator
+      , "revision" .= revision
+      , "branch" .= projectBranch project
+      , "url" .= projectUrl
+      , "id" .= renderLocator locator
+      ]  

--- a/test/App/Fossa/Container/AnalyzeNativeUploadSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeUploadSpec.hs
@@ -1,18 +1,18 @@
 module App.Fossa.Container.AnalyzeNativeUploadSpec (spec) where
 
+import App.Fossa.Config.Container.Analyze (JsonOutput (..))
 import App.Fossa.Container.AnalyzeNative (uploadScan)
 import App.Types (ProjectMetadata (..), ProjectRevision (..))
 import Container.Types (ContainerScan (..), ContainerScanImage (..))
 import Control.Algebra (Has)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
+import Data.Flag (Flag, toFlag)
 import Fossa.API.Types (Organization (..), uploadLocator)
 import Srclib.Types (Locator)
 import Test.Effect (expectFatal', it', shouldBe')
 import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec, describe)
 import Test.MockApi (MockApi, alwaysReturns)
-import Data.Flag (Flag, toFlag)
-import App.Fossa.Config.Container.Analyze (JsonOutput (..))
 
 spec :: Spec
 spec = do
@@ -53,7 +53,7 @@ fixtureRevision = ProjectRevision "some-tag" "some-digest" $ Just "master"
 fixtureJsonOutput :: Bool -> Flag JsonOutput
 fixtureJsonOutput = toFlag JsonOutput
 
-expectUploadSuccess :: Has MockApi sig m => m ()
+expectUploadSuccess :: (Has MockApi sig m) => m ()
 expectUploadSuccess =
   UploadNativeContainerScan fixtureRevision fixtureProjectMetadata fixtureContainerScan
     `alwaysReturns` Fixtures.uploadResponse


### PR DESCRIPTION
# Overview

This mirrors the `--json` flag that is present for `fossa analyze` in `fossa container analyze`

![image](https://user-images.githubusercontent.com/34497797/232593674-35b042a1-ba26-45fd-81c5-fe7245b9a672.png)

## Acceptance criteria

_If this PR is successful, what impact does it have on the user experience?_

When users type `fossa container analyze --json`, they receive the scan result information in a JSON structure:

```
{
  "branch": string,
  "id": string,
  "project": string,
  "revision": string,
  "url": string
}
```

## Testing plan

A test was added mirroring the test from `fossa analyze --json`, but this can also be tested by compiling this version of the CLI, and running `fossa container analyze <container> --json`

## Risks

This is my first significant change to the CLI, and I would gladly appreciate a thorough check of my code, although I tried to base it on existing code as much as possible.

## References

_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

_Example:_

- [ANE-875](https://fossa.atlassian.net/browse/ANE-875)

## Checklist

- [X] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [X] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-875]: https://fossa.atlassian.net/browse/ANE-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ