### PR TITLE
ANE-901: Full File Uploads in CLI License Scans

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
-## Unreleased
+## v3.7.9
 
 - License Scanning: Add support for "full file uploads" for CLI-side license scans. ([#1181](https://github.com/fossas/fossa-cli/pull/1181))
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,6 @@
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 ## v3.7.9
-
 - License Scanning: Add support for "full file uploads" for CLI-side license scans. ([#1181](https://github.com/fossas/fossa-cli/pull/1181))
 
 ## v3.7.8

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,13 @@
 # FOSSA CLI Changelog
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
+## Unreleased
+
+- License Scanning: Add support for "full file uploads" for CLI-side license scans. ([#1181](https://github.com/fossas/fossa-cli/pull/1181))
 
 ## v3.7.8
 - Go: Do not fall back to module based analysis when using `--experimental-use-go-v3-resolver`. ([#1184](https://github.com/fossas/fossa-cli/pull/1184))
-        
+
 ## v3.7.7
 - Adds `--json` flag to `fossa container analyze` ([#1180](https://github.com/fossas/fossa-cli/pull/1180))
 - License Scanning: Reduce false positives caused by indicator matches. This is done by only reporting indicator matches to SPDX keys and license names when we are scanning a manifest file ([#1182](https://github.com/fossas/fossa-cli/pull/1182))

--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -27,7 +27,8 @@ import Srclib.Types (
   LicenseSourceUnit (licenseSourceUnitLicenseUnits),
   LicenseUnit (licenseUnitData, licenseUnitFiles, licenseUnitName),
   LicenseUnitData (licenseUnitDataContents, licenseUnitDataMatchData),
-  emptyLicenseUnit, LicenseUnitMatchData (licenseUnitMatchDataMatchString),
+  LicenseUnitMatchData (licenseUnitMatchDataMatchString),
+  emptyLicenseUnit,
  )
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Types (GlobFilter (GlobFilter), LicenseScanPathFilters (..))
@@ -106,7 +107,7 @@ spec = do
           NE.sort (licenseUnitFiles mitUnit) `shouldBe` NE.fromList ["vendor/foo/bar/MIT_LICENSE", "vendor/foo/bar/baz/SOMETHING_LICENSE", "vendor/foo/bar/baz/quux/QUUX_LICENSE"]
           NE.sort (licenseUnitFiles apacheUnit) `shouldBe` NE.fromList ["vendor/foo/bar/bar_apache.rb", "vendor/foo/bar/baz/something.rb"]
           -- matchData should exist
-          let matchData = concatMap NE.toList $ NE.toList (fromMaybe ( NE.fromList [] ) . licenseUnitDataMatchData <$> licenseUnitData mitUnit)
+          let matchData = concatMap NE.toList $ NE.toList (fromMaybe (NE.fromList []) . licenseUnitDataMatchData <$> licenseUnitData mitUnit)
           licenseUnitMatchDataMatchString <$> matchData `shouldBe` [Just mitLicense, Just mitLicense, Just mitLicense]
           -- no Contents since we're running themis with --srclib-with-matches
           licenseUnitDataContents <$> licenseUnitData mitUnit `shouldBe` NE.fromList [Nothing, Nothing, Nothing]
@@ -131,7 +132,7 @@ spec = do
           -- We should get Contents since we're running themis with --srclib-with-full-files
           licenseUnitDataContents <$> licenseUnitData mitUnit `shouldBe` NE.fromList [Just mitLicense, Just mitLicense, Just mitLicense]
           -- matchData should be all Nothing
-          let matchData = concatMap NE.toList $ NE.toList (fromMaybe ( NE.fromList [] ) . licenseUnitDataMatchData <$> licenseUnitData mitUnit)
+          let matchData = concatMap NE.toList $ NE.toList (fromMaybe (NE.fromList []) . licenseUnitDataMatchData <$> licenseUnitData mitUnit)
           licenseUnitMatchDataMatchString <$> matchData `shouldBe` [Nothing, Nothing, Nothing]
           where
             mitUnit :: LicenseUnit

--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -110,8 +110,6 @@ spec = do
           licenseUnitMatchDataMatchString <$> matchData `shouldBe` [Just mitLicense, Just mitLicense, Just mitLicense]
           -- no Contents since we're running themis with --srclib-with-matches
           licenseUnitDataContents <$> licenseUnitData mitUnit `shouldBe` NE.fromList [Nothing, Nothing, Nothing]
-
-          -- let match = maybe (NE.fromList []) (licenseUnitDataMatchData <$> licenseUnitData mitUnit)
           where
             mitUnit :: LicenseUnit
             mitUnit = fromMaybe emptyLicenseUnit (head' $ NE.filter (\u -> licenseUnitName u == "mit") us)

--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -17,7 +17,6 @@ import Data.List.Extra (head')
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Data.Text qualified as Text
 import Diag.Result (Result (Failure, Success), renderFailure)
 import Effect.Exec (runExecIO)
 import Effect.ReadFS (runReadFSIO)
@@ -31,6 +30,7 @@ import Srclib.Types (
   emptyLicenseUnit,
  )
 import Test.Hspec (Spec, describe, it, shouldBe)
+import Text.RawString.QQ (r)
 import Types (GlobFilter (GlobFilter), LicenseScanPathFilters (..))
 
 recursiveArchive :: FixtureArtifact
@@ -68,28 +68,24 @@ vendoredDep =
 
 mitLicense :: Text
 mitLicense =
-  Text.dropEnd 1 $
-    Text.unlines
-      ( [ "Permission is hereby granted, free of charge, to any person obtaining"
-        , "a copy of this software and associated documentation files (the"
-        , "\"Software\"), to deal in the Software without restriction, including"
-        , "without limitation the rights to use, copy, modify, merge, publish,"
-        , "distribute, sublicense, and/or sell copies of the Software, and to"
-        , "permit persons to whom the Software is furnished to do so, subject to"
-        , "the following conditions:"
-        , ""
-        , "The above copyright notice and this permission notice shall be"
-        , "included in all copies or substantial portions of the Software."
-        , ""
-        , "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,"
-        , "EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF"
-        , "MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT."
-        , "IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY"
-        , "CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,"
-        , "TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE"
-        , "SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-        ]
-      )
+  [r|[ Permission is hereby granted, free of charge, to any person obtaining
+        a copy of this software and associated documentation files (the
+        "Software"), to deal in the Software without restriction, including
+        without limitation the rights to use, copy, modify, merge, publish,
+        distribute, sublicense, and/or sell copies of the Software, and to
+        permit persons to whom the Software is furnished to do so, subject to
+        the following conditions:
+
+        The above copyright notice and this permission notice shall be
+        included in all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+        IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+        CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+        TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+        SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.]|]
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -68,24 +68,24 @@ vendoredDep =
 
 mitLicense :: Text
 mitLicense =
-  [r|[ Permission is hereby granted, free of charge, to any person obtaining
-        a copy of this software and associated documentation files (the
-        "Software"), to deal in the Software without restriction, including
-        without limitation the rights to use, copy, modify, merge, publish,
-        distribute, sublicense, and/or sell copies of the Software, and to
-        permit persons to whom the Software is furnished to do so, subject to
-        the following conditions:
+  [r|Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-        The above copyright notice and this permission notice shall be
-        included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-        IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-        CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-        TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-        SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.]|]
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.|]
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -66,7 +66,7 @@ spec = do
     it "should find licenses in nested archives" $ do
       extractedDir <- getArtifact recursiveArchive
       let scanDir = extractedDir </> [reldir|cli-license-scan-integration-test-fixtures-main/recursive-archive|]
-      units <- runStack . runDiagnostics . ignoreStickyLogger . runExecIO . runReadFSIO . fmap licenseSourceUnitLicenseUnits $ scanVendoredDep scanDir Nothing vendoredDep
+      units <- runStack . runDiagnostics . ignoreStickyLogger . runExecIO . runReadFSIO . fmap licenseSourceUnitLicenseUnits $ scanVendoredDep scanDir Nothing False vendoredDep
       PIO.removeDirRecur extractedDir
       case units of
         Failure ws eg -> fail (show (renderFailure ws eg "An issue occurred"))
@@ -85,7 +85,7 @@ spec = do
       extractedDir <- getArtifact recursiveArchive
       let scanDir = extractedDir </> [reldir|cli-license-scan-integration-test-fixtures-main/recursive-archive|]
       let licenseScanPathFilters = LicenseScanPathFilters{licenseScanPathFiltersOnly = [GlobFilter "**.rb"], licenseScanPathFiltersExclude = []}
-      units <- runStack . runDiagnostics . ignoreStickyLogger . runExecIO . runReadFSIO . fmap licenseSourceUnitLicenseUnits $ scanVendoredDep scanDir (Just licenseScanPathFilters) vendoredDep
+      units <- runStack . runDiagnostics . ignoreStickyLogger . runExecIO . runReadFSIO . fmap licenseSourceUnitLicenseUnits $ scanVendoredDep scanDir (Just licenseScanPathFilters) False vendoredDep
       PIO.removeDirRecur extractedDir
       case units of
         Failure ws eg -> fail (show (renderFailure ws eg "An issue occurred"))

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -95,6 +95,8 @@ outputVendoredDeps (BaseDir dir) = runStickyLogger SevInfo $ do
   resultMap <- UploadUnits <$> runLicenseScan dir licenseScanPathFilters vendoredDeps
   logStdout . decodeUtf8 $ Aeson.encode resultMap
 
+-- runLicenseScan does not require an API key, so we can't get the FullFileUploads param from the organization,
+-- so we just default FullFileUploads to False.
 runLicenseScan ::
   ( Has Diagnostics sig m
   , Has ReadFS sig m

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -106,4 +106,4 @@ runLicenseScan ::
   Maybe LicenseScanPathFilters ->
   NonEmpty VendoredDependency ->
   m (NonEmpty LicenseSourceUnit)
-runLicenseScan basedir licenseScanPathFilters vdeps = dedupVendoredDeps vdeps >>= traverse (scanVendoredDep basedir licenseScanPathFilters)
+runLicenseScan basedir licenseScanPathFilters vdeps = dedupVendoredDeps vdeps >>= traverse (scanVendoredDep basedir licenseScanPathFilters False)

--- a/src/App/Fossa/LicenseScan.hs
+++ b/src/App/Fossa/LicenseScan.hs
@@ -21,7 +21,7 @@ import App.Fossa.VendoredDependency (
   VendoredDependency,
   dedupVendoredDeps,
  )
-import App.Types (BaseDir (BaseDir))
+import App.Types (BaseDir (BaseDir), FullFileUploads (FullFileUploads))
 import Control.Carrier.StickyLogger (
   Has,
   StickyLogger,
@@ -106,4 +106,4 @@ runLicenseScan ::
   Maybe LicenseScanPathFilters ->
   NonEmpty VendoredDependency ->
   m (NonEmpty LicenseSourceUnit)
-runLicenseScan basedir licenseScanPathFilters vdeps = dedupVendoredDeps vdeps >>= traverse (scanVendoredDep basedir licenseScanPathFilters False)
+runLicenseScan basedir licenseScanPathFilters vdeps = dedupVendoredDeps vdeps >>= traverse (scanVendoredDep basedir licenseScanPathFilters $ FullFileUploads False)

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -73,6 +73,7 @@ import Srclib.Types (
   Locator (..),
  )
 import Types (LicenseScanPathFilters)
+import App.Types (FullFileUploads)
 
 data LicenseScanErr
   = NoSuccessfulScans
@@ -100,7 +101,7 @@ runLicenseScanOnDir ::
   ) =>
   Text ->
   Maybe LicenseScanPathFilters ->
-  Bool ->
+  FullFileUploads ->
   Path Abs Dir ->
   m [LicenseUnit]
 runLicenseScanOnDir pathPrefix licenseScanPathFilters fullFileUploads scanDir = do
@@ -120,7 +121,7 @@ recursivelyScanArchives ::
   ) =>
   Text ->
   Maybe LicenseScanPathFilters ->
-  Bool ->
+  FullFileUploads ->
   Path Abs Dir ->
   m [LicenseUnit]
 recursivelyScanArchives pathPrefix licenseScanPathFilters fullFileUploads dir = flip walk' dir $
@@ -163,13 +164,13 @@ themisRunner ::
   ) =>
   Text ->
   Maybe LicenseScanPathFilters ->
-  Bool ->
+  FullFileUploads ->
   Path Abs Dir ->
   ThemisBins ->
   m [LicenseUnit]
 themisRunner pathPrefix licenseScanPathFilters fullFileUploads scanDir themisBins = runThemis themisBins pathPrefix licenseScanPathFilters fullFileUploads scanDir
 
-runThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Maybe LicenseScanPathFilters -> Bool -> Path Abs Dir -> m [LicenseUnit]
+runThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Maybe LicenseScanPathFilters -> FullFileUploads -> Path Abs Dir -> m [LicenseUnit]
 runThemis themisBins pathPrefix licenseScanPathFilters fullFileUploads scanDir = do
   context "Running license scan binary" $ execThemis themisBins pathPrefix scanDir $ themisFlags licenseScanPathFilters fullFileUploads
 
@@ -188,7 +189,7 @@ scanAndUploadVendoredDep ::
   ) =>
   Path Abs Dir ->
   Maybe LicenseScanPathFilters ->
-  Bool ->
+  FullFileUploads ->
   VendoredDependency ->
   m (Maybe Archive)
 scanAndUploadVendoredDep baseDir licenseScanPathFilters fullFileUploads vdep = context "Processing vendored dependency" $ do
@@ -206,7 +207,7 @@ scanVendoredDep ::
   ) =>
   Path Abs Dir ->
   Maybe LicenseScanPathFilters ->
-  Bool ->
+  FullFileUploads ->
   VendoredDependency ->
   m LicenseSourceUnit
 scanVendoredDep baseDir licenseScanPathFilters fullFileUploads VendoredDependency{..} = context "Scanning vendored deps for license data" $ do
@@ -234,7 +235,7 @@ scanArchive ::
   ) =>
   Path Abs Dir ->
   Maybe LicenseScanPathFilters ->
-  Bool ->
+  FullFileUploads ->
   ScannableArchive ->
   m (NonEmpty LicenseUnit)
 scanArchive baseDir licenseScanPathFilters fullFileUploads file = runFinally $ do
@@ -257,7 +258,7 @@ scanDirectory ::
   Maybe ScannableArchive ->
   Text ->
   Maybe LicenseScanPathFilters ->
-  Bool ->
+  FullFileUploads ->
   Path Abs Dir ->
   m (NonEmpty LicenseUnit)
 scanDirectory origin pathPrefix licenseScanPathFilters fullFileUploads path = do
@@ -291,7 +292,7 @@ scanNonEmptyDirectory ::
   ) =>
   Text ->
   Maybe LicenseScanPathFilters ->
-  Bool ->
+  FullFileUploads ->
   Path Abs Dir ->
   m (NonEmpty LicenseUnit)
 scanNonEmptyDirectory pathPrefix licenseScanPathFilters fullFileUploads cliScanDir = do
@@ -335,7 +336,7 @@ licenseScanSourceUnit ::
   ) =>
   VendoredDependencyScanMode ->
   Maybe LicenseScanPathFilters ->
-  Bool ->
+  FullFileUploads ->
   Path Abs Dir ->
   NonEmpty VendoredDependency ->
   m (NonEmpty Locator)

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -100,13 +100,14 @@ runLicenseScanOnDir ::
   ) =>
   Text ->
   Maybe LicenseScanPathFilters ->
+  Bool ->
   Path Abs Dir ->
   m [LicenseUnit]
-runLicenseScanOnDir pathPrefix licenseScanPathFilters scanDir = do
+runLicenseScanOnDir pathPrefix licenseScanPathFilters fullFileUploads scanDir = do
   -- license scan the root directory
-  rootDirUnits <- withThemisAndIndex $ themisRunner pathPrefix licenseScanPathFilters scanDir
+  rootDirUnits <- withThemisAndIndex $ themisRunner pathPrefix licenseScanPathFilters fullFileUploads scanDir
   -- recursively unpack archives and license scan them too
-  otherArchiveUnits <- runFinally $ recursivelyScanArchives pathPrefix licenseScanPathFilters scanDir
+  otherArchiveUnits <- runFinally $ recursivelyScanArchives pathPrefix licenseScanPathFilters fullFileUploads scanDir
   -- when we scan multiple archives, we need to combine the results
   pure $ combineLicenseUnits (rootDirUnits <> otherArchiveUnits)
 
@@ -119,14 +120,15 @@ recursivelyScanArchives ::
   ) =>
   Text ->
   Maybe LicenseScanPathFilters ->
+  Bool ->
   Path Abs Dir ->
   m [LicenseUnit]
-recursivelyScanArchives pathPrefix licenseScanPathFilters dir = flip walk' dir $
+recursivelyScanArchives pathPrefix licenseScanPathFilters fullFileUploads dir = flip walk' dir $
   \_ _ files -> do
     let process file unpackedDir = do
           let updatedPathPrefix = pathPrefix <> getPathPrefix dir (parent file)
-          currentDirResults <- withThemisAndIndex $ themisRunner updatedPathPrefix licenseScanPathFilters unpackedDir
-          recursiveResults <- recursivelyScanArchives updatedPathPrefix licenseScanPathFilters unpackedDir
+          currentDirResults <- withThemisAndIndex $ themisRunner updatedPathPrefix licenseScanPathFilters fullFileUploads unpackedDir
+          recursiveResults <- recursivelyScanArchives updatedPathPrefix licenseScanPathFilters fullFileUploads unpackedDir
           pure $ currentDirResults <> recursiveResults
     -- withArchive' emits Nothing when archive type is not supported.
     archives <- traverse (\file -> withArchive' file (process file)) files
@@ -161,14 +163,15 @@ themisRunner ::
   ) =>
   Text ->
   Maybe LicenseScanPathFilters ->
+  Bool ->
   Path Abs Dir ->
   ThemisBins ->
   m [LicenseUnit]
-themisRunner pathPrefix licenseScanPathFilters scanDir themisBins = runThemis themisBins pathPrefix licenseScanPathFilters scanDir
+themisRunner pathPrefix licenseScanPathFilters fullFileUploads scanDir themisBins = runThemis themisBins pathPrefix licenseScanPathFilters fullFileUploads scanDir
 
-runThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Maybe LicenseScanPathFilters -> Path Abs Dir -> m [LicenseUnit]
-runThemis themisBins pathPrefix licenseScanPathFilters scanDir = do
-  context "Running license scan binary" $ execThemis themisBins pathPrefix scanDir $ themisFlags licenseScanPathFilters
+runThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Maybe LicenseScanPathFilters -> Bool -> Path Abs Dir -> m [LicenseUnit]
+runThemis themisBins pathPrefix licenseScanPathFilters fullFileUploads scanDir = do
+  context "Running license scan binary" $ execThemis themisBins pathPrefix scanDir $ themisFlags licenseScanPathFilters fullFileUploads
 
 calculateVendoredHash :: Path Abs Dir -> Text -> Path Abs Dir -> IO Text
 calculateVendoredHash baseDir vendoredPath tmpDir = do
@@ -185,10 +188,11 @@ scanAndUploadVendoredDep ::
   ) =>
   Path Abs Dir ->
   Maybe LicenseScanPathFilters ->
+  Bool ->
   VendoredDependency ->
   m (Maybe Archive)
-scanAndUploadVendoredDep baseDir licenseScanPathFilters vdep = context "Processing vendored dependency" $ do
-  maybeLicenseUnits <- recover $ scanVendoredDep baseDir licenseScanPathFilters vdep
+scanAndUploadVendoredDep baseDir licenseScanPathFilters fullFileUploads vdep = context "Processing vendored dependency" $ do
+  maybeLicenseUnits <- recover $ scanVendoredDep baseDir licenseScanPathFilters fullFileUploads vdep
   case maybeLicenseUnits of
     Nothing -> pure Nothing
     Just licenseUnits -> uploadVendoredDep baseDir vdep licenseUnits
@@ -202,16 +206,17 @@ scanVendoredDep ::
   ) =>
   Path Abs Dir ->
   Maybe LicenseScanPathFilters ->
+  Bool ->
   VendoredDependency ->
   m LicenseSourceUnit
-scanVendoredDep baseDir licenseScanPathFilters VendoredDependency{..} = context "Scanning vendored deps for license data" $ do
+scanVendoredDep baseDir licenseScanPathFilters fullFileUploads VendoredDependency{..} = context "Scanning vendored deps for license data" $ do
   logSticky $ "License Scanning '" <> vendoredName <> "' at '" <> vendoredPath <> "'"
   scanPath <- resolvePath' baseDir $ toString vendoredPath
   licenseUnits <- case scanPath of
-    SomeFile (Abs path) -> scanArchive baseDir licenseScanPathFilters $ ScannableArchive path
-    SomeFile (Rel path) -> scanArchive baseDir licenseScanPathFilters . ScannableArchive $ baseDir </> path
-    SomeDir (Abs path) -> scanDirectory Nothing (getPathPrefix baseDir path) licenseScanPathFilters path
-    SomeDir (Rel path) -> scanDirectory Nothing (toText path) licenseScanPathFilters (baseDir </> path)
+    SomeFile (Abs path) -> scanArchive baseDir licenseScanPathFilters fullFileUploads $ ScannableArchive path
+    SomeFile (Rel path) -> scanArchive baseDir licenseScanPathFilters fullFileUploads . ScannableArchive $ baseDir </> path
+    SomeDir (Abs path) -> scanDirectory Nothing (getPathPrefix baseDir path) licenseScanPathFilters fullFileUploads path
+    SomeDir (Rel path) -> scanDirectory Nothing (toText path) licenseScanPathFilters fullFileUploads (baseDir </> path)
   pure $ LicenseSourceUnit vendoredPath CliLicenseScanned licenseUnits
 
 getPathPrefix :: Path Abs Dir -> Path Abs t -> Text
@@ -229,12 +234,13 @@ scanArchive ::
   ) =>
   Path Abs Dir ->
   Maybe LicenseScanPathFilters ->
+  Bool ->
   ScannableArchive ->
   m (NonEmpty LicenseUnit)
-scanArchive baseDir licenseScanPathFilters file = runFinally $ do
+scanArchive baseDir licenseScanPathFilters fullFileUploads file = runFinally $ do
   -- withArchive' emits Nothing when archive type is not supported.
   logSticky $ "scanning archive at " <> toText (scanFile file)
-  result <- withArchive' (scanFile file) (scanDirectory (Just file) pathPrefix licenseScanPathFilters)
+  result <- withArchive' (scanFile file) (scanDirectory (Just file) pathPrefix licenseScanPathFilters fullFileUploads)
   case result of
     Nothing -> fatal . UnsupportedArchive $ scanFile file
     Just units -> pure units
@@ -251,12 +257,13 @@ scanDirectory ::
   Maybe ScannableArchive ->
   Text ->
   Maybe LicenseScanPathFilters ->
+  Bool ->
   Path Abs Dir ->
   m (NonEmpty LicenseUnit)
-scanDirectory origin pathPrefix licenseScanPathFilters path = do
+scanDirectory origin pathPrefix licenseScanPathFilters fullFileUploads path = do
   hasFiles <- hasAnyFiles path
   if hasFiles
-    then scanNonEmptyDirectory pathPrefix licenseScanPathFilters path
+    then scanNonEmptyDirectory pathPrefix licenseScanPathFilters fullFileUploads path
     else maybe (fatal $ EmptyDirectory path) (fatal . EmptyArchive . scanFile) origin
 
 hasAnyFiles ::
@@ -284,10 +291,11 @@ scanNonEmptyDirectory ::
   ) =>
   Text ->
   Maybe LicenseScanPathFilters ->
+  Bool ->
   Path Abs Dir ->
   m (NonEmpty LicenseUnit)
-scanNonEmptyDirectory pathPrefix licenseScanPathFilters cliScanDir = do
-  themisScanResult <- runLicenseScanOnDir pathPrefix licenseScanPathFilters cliScanDir
+scanNonEmptyDirectory pathPrefix licenseScanPathFilters fullFileUploads cliScanDir = do
+  themisScanResult <- runLicenseScanOnDir pathPrefix licenseScanPathFilters fullFileUploads cliScanDir
   case NE.nonEmpty themisScanResult of
     Nothing -> fatal $ NoLicenseResults cliScanDir
     Just results -> pure results
@@ -327,10 +335,11 @@ licenseScanSourceUnit ::
   ) =>
   VendoredDependencyScanMode ->
   Maybe LicenseScanPathFilters ->
+  Bool ->
   Path Abs Dir ->
   NonEmpty VendoredDependency ->
   m (NonEmpty Locator)
-licenseScanSourceUnit vendoredDependencyScanMode licenseScanPathFilters baseDir vendoredDeps = do
+licenseScanSourceUnit vendoredDependencyScanMode licenseScanPathFilters fullFileUploads baseDir vendoredDeps = do
   uniqDeps <- dedupVendoredDeps vendoredDeps
 
   -- The organizationID is needed to prefix each locator name. The FOSSA API automatically prefixes the locator when queuing the build
@@ -349,7 +358,7 @@ licenseScanSourceUnit vendoredDependencyScanMode licenseScanPathFilters baseDir 
 
   -- At this point, we have a good list of deps, so go for it.
   -- If none of the dependencies need scanning we still need to do `finalizeLicenseScan`, so keep going
-  maybeScannedArchives <- traverse (scanAndUploadVendoredDep baseDir licenseScanPathFilters) (needScanningDeps needScanning)
+  maybeScannedArchives <- traverse (scanAndUploadVendoredDep baseDir licenseScanPathFilters fullFileUploads) (needScanningDeps needScanning)
 
   -- We need to include both scanned and skipped archives in this list so that they all get included in the build in FOSSA
   let skippedArchives = map forceVendoredToArchive $ skippableDeps skippable

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -366,7 +366,7 @@ licenseScanSourceUnit vendoredDependencyScanMode licenseScanPathFilters fullFile
 
   -- finalizeLicenseScan takes archives without Organization information. This orgID is appended when creating the build on the backend.
   -- We don't care about the response here because if the build has already been queued, we get a 401 response.
-  finalizeLicenseScan $ ArchiveComponents (NE.toList archives) (vendoredDependencyScanMode == SkippingDisabledViaFlag)
+  finalizeLicenseScan $ ArchiveComponents (NE.toList archives) (vendoredDependencyScanMode == SkippingDisabledViaFlag) fullFileUploads
 
   let archivesWithOrganization :: OrgId -> NonEmpty Archive -> NonEmpty Archive
       archivesWithOrganization org = NE.map $ includeOrgId org

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -24,6 +24,7 @@ import App.Fossa.VendoredDependency (
   hashFile,
   skippedDepsDebugLog,
  )
+import App.Types (FullFileUploads)
 import Control.Carrier.Finally (Finally, runFinally)
 import Control.Carrier.FossaApiClient.Internal.FossaAPIV1 (renderLocatorUrl)
 import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic (renderDiagnostic), context, fatal, fromMaybe, recover)
@@ -73,7 +74,6 @@ import Srclib.Types (
   Locator (..),
  )
 import Types (LicenseScanPathFilters)
-import App.Types (FullFileUploads)
 
 data LicenseScanErr
   = NoSuccessfulScans

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -28,6 +28,7 @@ import App.Fossa.VendoredDependency (
   arcToLocator,
   forceVendoredToArchive,
  )
+import App.Types (FullFileUploads (..))
 import Control.Carrier.FossaApiClient (runFossaApiClient)
 import Control.Effect.Diagnostics (Diagnostics, context, fatalText)
 import Control.Effect.FossaApiClient (FossaApiClient, getOrganization)
@@ -60,7 +61,6 @@ import Path.Extra (tryMakeRelative)
 import Srclib.Converter (depTypeToFetcher)
 import Srclib.Types (AdditionalDepData (..), Locator (..), SourceRemoteDep (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (SourceUnitDependency), SourceUserDefDep (..))
 import Types (ArchiveUploadType (..), GraphBreadth (..))
-import App.Types (FullFileUploads(..))
 
 data FoundDepsFile
   = ManualYaml (Path Abs File)

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -167,10 +167,11 @@ scanAndUpload ::
 scanAndUpload root vdeps vendoredDepsOptions = do
   org <- getOrganization
   (archiveOrCLI, vendoredDependencyScanMode) <- getScanCfg org vendoredDepsOptions
+  let fullFileUploads = orgRequiresFullFileUploads org
   let pathFilters = licenseScanPathFilters vendoredDepsOptions
   let scanner = case archiveOrCLI of
         ArchiveUpload -> archiveUploadSourceUnit
-        CLILicenseScan -> licenseScanSourceUnit vendoredDependencyScanMode pathFilters
+        CLILicenseScan -> licenseScanSourceUnit vendoredDependencyScanMode pathFilters fullFileUploads
 
   when (archiveOrCLI == ArchiveUpload && isJust pathFilters) $
     fatalText "You have provided path filters in the vendoredDependencies.licenseScanPathFilters section of your .fossa.yml file. Path filters are not allowed when doing archive uploads."

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -60,6 +60,7 @@ import Path.Extra (tryMakeRelative)
 import Srclib.Converter (depTypeToFetcher)
 import Srclib.Types (AdditionalDepData (..), Locator (..), SourceRemoteDep (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (SourceUnitDependency), SourceUserDefDep (..))
 import Types (ArchiveUploadType (..), GraphBreadth (..))
+import App.Types (FullFileUploads(..))
 
 data FoundDepsFile
   = ManualYaml (Path Abs File)
@@ -167,7 +168,7 @@ scanAndUpload ::
 scanAndUpload root vdeps vendoredDepsOptions = do
   org <- getOrganization
   (archiveOrCLI, vendoredDependencyScanMode) <- getScanCfg org vendoredDepsOptions
-  let fullFileUploads = orgRequiresFullFileUploads org
+  let fullFileUploads = FullFileUploads $ orgRequiresFullFileUploads org
   let pathFilters = licenseScanPathFilters vendoredDepsOptions
   let scanner = case archiveOrCLI of
         ArchiveUpload -> archiveUploadSourceUnit

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -56,10 +56,10 @@ generateThemisArgs taggedThemisIndex pathPrefix flags =
     <> flags
     <> ["."]
 
-themisFlags :: Maybe LicenseScanPathFilters -> [Text]
-themisFlags Nothing = ["--srclib-with-matches"]
-themisFlags (Just filters) =
-  let defaultFilter = ["--srclib-with-matches"]
+themisFlags :: Maybe LicenseScanPathFilters -> Bool -> [Text]
+themisFlags Nothing fullFileUploads = if fullFileUploads then ["srclib-with-full-files"] else ["--srclib-with-matches"]
+themisFlags (Just filters) fullFileUploads =
+  let defaultFilter = if fullFileUploads then ["srclib-with-full-files"] else ["--srclib-with-matches"]
       onlyFilters = concatMap (\only -> ["--only-paths", unGlobFilter only]) $ licenseScanPathFiltersOnly filters
       exceptFilters = concatMap (\exclude -> ["--exclude-paths", unGlobFilter exclude]) $ licenseScanPathFiltersExclude filters
    in defaultFilter ++ onlyFilters ++ exceptFilters

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -14,6 +14,7 @@ import App.Fossa.EmbeddedBinary (
   ThemisIndex,
   toPath,
  )
+import App.Types (FullFileUploads (unFullFileUploads))
 import Control.Effect.Diagnostics (Diagnostics, Has)
 import Data.ByteString.Lazy qualified as BL
 import Data.String.Conversion (toText)
@@ -29,7 +30,6 @@ import Effect.Exec (
 import Path (Abs, Dir, Path, parent)
 import Srclib.Types (LicenseUnit)
 import Types (GlobFilter (unGlobFilter), LicenseScanPathFilters (..))
-import App.Types (FullFileUploads (unFullFileUploads))
 
 execRawThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> [Text] -> m BL.ByteString
 execRawThemis themisBins scanDir flags = execThrow scanDir $ themisCommand themisBins "" flags

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -29,6 +29,7 @@ import Effect.Exec (
 import Path (Abs, Dir, Path, parent)
 import Srclib.Types (LicenseUnit)
 import Types (GlobFilter (unGlobFilter), LicenseScanPathFilters (..))
+import App.Types (FullFileUploads (unFullFileUploads))
 
 execRawThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> [Text] -> m BL.ByteString
 execRawThemis themisBins scanDir flags = execThrow scanDir $ themisCommand themisBins "" flags
@@ -56,10 +57,10 @@ generateThemisArgs taggedThemisIndex pathPrefix flags =
     <> flags
     <> ["."]
 
-themisFlags :: Maybe LicenseScanPathFilters -> Bool -> [Text]
-themisFlags Nothing fullFileUploads = if fullFileUploads then ["--srclib-with-full-files"] else ["--srclib-with-matches"]
+themisFlags :: Maybe LicenseScanPathFilters -> FullFileUploads -> [Text]
+themisFlags Nothing fullFileUploads = if unFullFileUploads fullFileUploads then ["--srclib-with-full-files"] else ["--srclib-with-matches"]
 themisFlags (Just filters) fullFileUploads =
-  let defaultFilter = if fullFileUploads then ["--srclib-with-full-files"] else ["--srclib-with-matches"]
+  let defaultFilter = if unFullFileUploads fullFileUploads then ["--srclib-with-full-files"] else ["--srclib-with-matches"]
       onlyFilters = concatMap (\only -> ["--only-paths", unGlobFilter only]) $ licenseScanPathFiltersOnly filters
       exceptFilters = concatMap (\exclude -> ["--exclude-paths", unGlobFilter exclude]) $ licenseScanPathFiltersExclude filters
    in defaultFilter ++ onlyFilters ++ exceptFilters

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -57,9 +57,9 @@ generateThemisArgs taggedThemisIndex pathPrefix flags =
     <> ["."]
 
 themisFlags :: Maybe LicenseScanPathFilters -> Bool -> [Text]
-themisFlags Nothing fullFileUploads = if fullFileUploads then ["srclib-with-full-files"] else ["--srclib-with-matches"]
+themisFlags Nothing fullFileUploads = if fullFileUploads then ["--srclib-with-full-files"] else ["--srclib-with-matches"]
 themisFlags (Just filters) fullFileUploads =
-  let defaultFilter = if fullFileUploads then ["srclib-with-full-files"] else ["--srclib-with-matches"]
+  let defaultFilter = if fullFileUploads then ["--srclib-with-full-files"] else ["--srclib-with-matches"]
       onlyFilters = concatMap (\only -> ["--only-paths", unGlobFilter only]) $ licenseScanPathFiltersOnly filters
       exceptFilters = concatMap (\exclude -> ["--exclude-paths", unGlobFilter exclude]) $ licenseScanPathFiltersExclude filters
    in defaultFilter ++ onlyFilters ++ exceptFilters

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -103,9 +103,3 @@ instance Monoid OverrideDynamicAnalysisBinary where
   mempty = OverrideDynamicAnalysisBinary mempty
 
 newtype FullFileUploads = FullFileUploads {unFullFileUploads :: Bool} deriving (Eq, Ord, Show, Generic)
-
--- instance ToJSON FullFileUploads where
---   toEncoding = genericToEncoding defaultOptions
-
--- instance FromJSON FullFileUploads where
---   parseJSON obj = FullFileUploads <$> obj

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -7,6 +7,7 @@ module App.Types (
   ProjectRevision (..),
   MonorepoAnalysisOpts (..),
   OverrideDynamicAnalysisBinary (..),
+  FullFileUploads (..),
 ) where
 
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toEncoding), defaultOptions, genericToEncoding, withObject, (.:))
@@ -100,3 +101,11 @@ instance Semigroup OverrideDynamicAnalysisBinary where
 
 instance Monoid OverrideDynamicAnalysisBinary where
   mempty = OverrideDynamicAnalysisBinary mempty
+
+newtype FullFileUploads = FullFileUploads {unFullFileUploads :: Bool} deriving (Eq, Ord, Show, Generic)
+
+-- instance ToJSON FullFileUploads where
+--   toEncoding = genericToEncoding defaultOptions
+
+-- instance FromJSON FullFileUploads where
+--   parseJSON obj = FullFileUploads <$> obj

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -804,7 +804,7 @@ archiveBuildUpload apiOpts archive = runEmpty $
     let opts = "dependency" =: True <> "rawLicenseScan" =: True
     -- The API route expects an array of archives, but doesn't properly handle multiple archives so we upload
     -- an array of a single archive.
-    let archiveProjects = ArchiveComponents [archive] False
+    let archiveProjects = ArchiveComponents [archive] False False
     -- The response appears to either be "Created" for new builds, or an error message for existing builds.
     -- Making the actual return value of "Created" essentially worthless.
     resp <-

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -114,7 +114,7 @@ import Fossa.API.Types (
   Contributors,
   Issues,
   OrgId,
-  Organization (orgSupportsIssueDiffs, orgSupportsNativeContainerScan, organizationId, orgRequiresFullFileUploads, Organization),
+  Organization (Organization, orgRequiresFullFileUploads, orgSupportsIssueDiffs, orgSupportsNativeContainerScan, organizationId),
   Project,
   RevisionDependencyCache,
   SignedURL (signedURL),
@@ -751,7 +751,7 @@ getAnalyzedRevisions ::
   NonEmpty VendoredDependency ->
   m [Text]
 getAnalyzedRevisions apiOpts vDeps = fossaReq $ do
-  Organization{organizationId=orgId, orgRequiresFullFileUploads=fullFileUploads} <- getOrganization apiOpts
+  Organization{organizationId = orgId, orgRequiresFullFileUploads = fullFileUploads} <- getOrganization apiOpts
   (baseUrl, baseOpts) <- useApiOpts apiOpts
   let locatorBody = GetAnalyzedRevisionsBody (NE.map (renderLocatorUrl orgId . vendoredDepToLocator) vDeps) fullFileUploads
   responseBody <$> req POST (getAnalyzedRevisionsEndpoint baseUrl) (ReqBodyJson locatorBody) jsonResponse baseOpts

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -807,6 +807,7 @@ archiveBuildUpload apiOpts archive = runEmpty $
     let opts = "dependency" =: True <> "rawLicenseScan" =: True
     -- The API route expects an array of archives, but doesn't properly handle multiple archives so we upload
     -- an array of a single archive.
+    -- forceRebuild and fullFiles are ignored by this endpoint. They are only used by the licenseScanFinalize endpoint.
     let archiveProjects = ArchiveComponents [archive] False $ FullFileUploads False
     -- The response appears to either be "Created" for new builds, or an error message for existing builds.
     -- Making the actual return value of "Created" essentially worthless.

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -57,7 +57,7 @@ import App.Support (
 import App.Types (
   ProjectMetadata (..),
   ProjectRevision (..),
-  ReleaseGroupMetadata (releaseGroupName, releaseGroupRelease),
+  ReleaseGroupMetadata (releaseGroupName, releaseGroupRelease), FullFileUploads (FullFileUploads),
  )
 import App.Version (versionNumber)
 import Codec.Compression.GZip qualified as GZIP
@@ -804,7 +804,7 @@ archiveBuildUpload apiOpts archive = runEmpty $
     let opts = "dependency" =: True <> "rawLicenseScan" =: True
     -- The API route expects an array of archives, but doesn't properly handle multiple archives so we upload
     -- an array of a single archive.
-    let archiveProjects = ArchiveComponents [archive] False False
+    let archiveProjects = ArchiveComponents [archive] False $ FullFileUploads False
     -- The response appears to either be "Created" for new builds, or an error message for existing builds.
     -- Making the actual return value of "Created" essentially worthless.
     resp <-

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -55,9 +55,10 @@ import App.Support (
   requestReportIfPersists,
  )
 import App.Types (
+  FullFileUploads (FullFileUploads),
   ProjectMetadata (..),
   ProjectRevision (..),
-  ReleaseGroupMetadata (releaseGroupName, releaseGroupRelease), FullFileUploads (FullFileUploads),
+  ReleaseGroupMetadata (releaseGroupName, releaseGroupRelease),
  )
 import App.Version (versionNumber)
 import Codec.Compression.GZip qualified as GZIP

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -441,6 +441,7 @@ data Organization = Organization
   , orgSupportsIssueDiffs :: Bool
   , orgSupportsNativeContainerScan :: Bool
   , orgSupportsDependenciesCachePolling :: Bool
+  , orgRequiresFullFileUploads :: Bool
   }
   deriving (Eq, Ord, Show)
 
@@ -469,6 +470,9 @@ instance FromJSON Organization where
         .!= False
       <*> obj
         .:? "supportsDependenciesCachePolling"
+        .!= False
+      <*> obj
+        .:? "requiresFullFileUPloads"
         .!= False
 
 data Project = Project

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -31,6 +31,7 @@ module Fossa.API.Types (
   defaultApiPollDelay,
 ) where
 
+import App.Types (FullFileUploads (..))
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, Has, fatalText)
 import Control.Timeout (Duration (Seconds))
@@ -76,7 +77,6 @@ import Text.URI (URI, render)
 import Text.URI.QQ (uri)
 import Types (ArchiveUploadType (..))
 import Unsafe.Coerce qualified as Unsafe
-import App.Types ( FullFileUploads(..) )
 
 newtype ApiKey = ApiKey {unApiKey :: Text}
   deriving (Eq, Ord)

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -76,6 +76,7 @@ import Text.URI (URI, render)
 import Text.URI.QQ (uri)
 import Types (ArchiveUploadType (..))
 import Unsafe.Coerce qualified as Unsafe
+import App.Types ( FullFileUploads(..) )
 
 newtype ApiKey = ApiKey {unApiKey :: Text}
   deriving (Eq, Ord)
@@ -116,7 +117,7 @@ instance FromJSON SignedURL where
 data ArchiveComponents = ArchiveComponents
   { archives :: [Archive]
   , forceRebuild :: Bool
-  , fullFiles :: Bool
+  , fullFiles :: FullFileUploads
   }
   deriving (Eq, Ord, Show)
 
@@ -125,7 +126,7 @@ instance ToJSON ArchiveComponents where
     object
       [ "archives" .= archives
       , "forceRebuild" .= forceRebuild
-      , "fullFiles" .= fullFiles
+      , "fullFiles" .= unFullFileUploads fullFiles
       ]
 
 data Archive = Archive

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -472,7 +472,7 @@ instance FromJSON Organization where
         .:? "supportsDependenciesCachePolling"
         .!= False
       <*> obj
-        .:? "requiresFullFileUPloads"
+        .:? "requireFullFileUploads"
         .!= False
 
 data Project = Project

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -116,6 +116,7 @@ instance FromJSON SignedURL where
 data ArchiveComponents = ArchiveComponents
   { archives :: [Archive]
   , forceRebuild :: Bool
+  , fullFiles :: Bool
   }
   deriving (Eq, Ord, Show)
 
@@ -124,6 +125,7 @@ instance ToJSON ArchiveComponents where
     object
       [ "archives" .= archives
       , "forceRebuild" .= forceRebuild
+      , "fullFiles" .= fullFiles
       ]
 
 data Archive = Archive

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -117,7 +117,7 @@ data LicenseUnitData = LicenseUnitData
   , licenseUnitDataThemisVersion :: Text
   , licenseUnitDataMatchData :: Maybe (NonEmpty LicenseUnitMatchData)
   , licenseUnitDataCopyrights :: Maybe (NonEmpty Text)
-  , licenseUnitDataContents :: Maybe (NonEmpty Text)
+  , licenseUnitDataContents :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -117,6 +117,7 @@ data LicenseUnitData = LicenseUnitData
   , licenseUnitDataThemisVersion :: Text
   , licenseUnitDataMatchData :: Maybe (NonEmpty LicenseUnitMatchData)
   , licenseUnitDataCopyrights :: Maybe (NonEmpty Text)
+  , licenseUnitDataContents :: Maybe Text
   }
   deriving (Eq, Ord, Show)
 
@@ -128,6 +129,7 @@ emptyLicenseUnitData =
     , licenseUnitDataThemisVersion = ""
     , licenseUnitDataMatchData = Nothing
     , licenseUnitDataCopyrights = Nothing
+    , licenseUnitDataContents = Nothing
     }
 
 instance ToJSON LicenseUnitData where
@@ -138,6 +140,7 @@ instance ToJSON LicenseUnitData where
       , "ThemisVersion" .= licenseUnitDataThemisVersion
       , "match_data" .= licenseUnitDataMatchData
       , "Copyrights" .= licenseUnitDataCopyrights
+      , "Contents" .= licenseUnitDataContents
       ]
 
 instance FromJSON LicenseUnitData where
@@ -148,6 +151,7 @@ instance FromJSON LicenseUnitData where
       <*> obj .: "ThemisVersion"
       <*> obj .:? "match_data"
       <*> obj .:? "Copyrights"
+      <*> obj .:? "Contents"
 
 data LicenseUnitMatchData = LicenseUnitMatchData
   { licenseUnitMatchDataMatchString :: Maybe Text

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -117,7 +117,7 @@ data LicenseUnitData = LicenseUnitData
   , licenseUnitDataThemisVersion :: Text
   , licenseUnitDataMatchData :: Maybe (NonEmpty LicenseUnitMatchData)
   , licenseUnitDataCopyrights :: Maybe (NonEmpty Text)
-  , licenseUnitDataContents :: Maybe Text
+  , licenseUnitDataContents :: Maybe (NonEmpty Text)
   }
   deriving (Eq, Ord, Show)
 

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -41,7 +41,7 @@ spec = do
     describe "SAML URL builder" $ do
       it' "should render simple locators" $ do
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
-            org = Just $ Organization (OrgId 1) True False True CLILicenseScan True True True
+            org = Just $ Organization (OrgId 1) True False True CLILicenseScan True True True False
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -49,7 +49,7 @@ spec = do
 
       it' "should render git@ locators" $ do
         let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
-            org = Just $ Organization (OrgId 103) True False True CLILicenseScan True True True
+            org = Just $ Organization (OrgId 103) True False True CLILicenseScan True True True False
             revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -57,7 +57,7 @@ spec = do
 
       it' "should render full url correctly" $ do
         let locator = Locator "a" "b" $ Just "c"
-            org = Just $ Organization (OrgId 33) True False True CLILicenseScan True True True
+            org = Just $ Organization (OrgId 33) True False True CLILicenseScan True True True False
             revision = ProjectRevision "" "not this revision" $ Just "master"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -74,7 +74,7 @@ spec = do
     describe "Fossa URL Builder" $
       it' "should render from API info" $ do
         GetApiOpts `returnsOnce` Fixtures.apiOpts
-        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True True True
+        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True True True False
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getFossaBuildUrl revision locator

--- a/test/App/Fossa/LicenseScannerSpec.hs
+++ b/test/App/Fossa/LicenseScannerSpec.hs
@@ -22,6 +22,7 @@ import Test.Effect (it', shouldBe')
 import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec, describe, it, runIO, shouldBe)
 import Test.MockApi (MockApi, alwaysReturns, returnsOnce, returnsOnceForAnyRequest)
+import App.Types (FullFileUploads(..))
 
 -- test data for combineLicenseUnits tests
 info :: LicenseUnitInfo
@@ -96,7 +97,7 @@ spec = do
       expectGetOrganization
       expectEverythingScannedAlready
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing False scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing (FullFileUploads False) scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should scan all if Core does not know about the revisions" $ do
@@ -108,7 +109,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing False scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing (FullFileUploads False) scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should scan all if the revisions are still being scanned" $ do
@@ -120,7 +121,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing False scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing (FullFileUploads False) scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should scan one if one revision is still being scanned" $ do
@@ -130,7 +131,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "first-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.firstLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing False scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing (FullFileUploads False) scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should always scan all if vendor dependency skipping is not supported" $ do
@@ -141,7 +142,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkippingNotSupported Nothing False scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkippingNotSupported Nothing (FullFileUploads False) scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should always scan all if the --force-vendor-dependency-rescans flag is used" $ do
@@ -152,7 +153,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScanWithForceRebuild Fixtures.archives
-      locators <- licenseScanSourceUnit SkippingDisabledViaFlag Nothing False scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkippingDisabledViaFlag Nothing (FullFileUploads False) scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should upload with the fullFiles flag if the org requires full files" $ do
@@ -164,7 +165,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScanWithFullFiles Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing True scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing (FullFileUploads True) scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
 
@@ -207,12 +208,12 @@ expectUploadLicenseScanResult licenseUnit =
 
 expectFinalizeScan :: Has MockApi sig m => [Archive] -> m ()
 expectFinalizeScan as =
-  (FinalizeLicenseScan ArchiveComponents{archives = as, forceRebuild = False, fullFiles = False}) `returnsOnce` ()
+  (FinalizeLicenseScan ArchiveComponents{archives = as, forceRebuild = False, fullFiles = (FullFileUploads False)}) `returnsOnce` ()
 
 expectFinalizeScanWithForceRebuild :: Has MockApi sig m => [Archive] -> m ()
 expectFinalizeScanWithForceRebuild as =
-  (FinalizeLicenseScan ArchiveComponents{archives = as, forceRebuild = True, fullFiles = False}) `returnsOnce` ()
+  (FinalizeLicenseScan ArchiveComponents{archives = as, forceRebuild = True, fullFiles = (FullFileUploads False)}) `returnsOnce` ()
 
 expectFinalizeScanWithFullFiles :: Has MockApi sig m => [Archive] -> m ()
 expectFinalizeScanWithFullFiles as =
-  (FinalizeLicenseScan ArchiveComponents{archives = as, forceRebuild = False, fullFiles = True}) `returnsOnce` ()
+  (FinalizeLicenseScan ArchiveComponents{archives = as, forceRebuild = False, fullFiles = (FullFileUploads True)}) `returnsOnce` ()

--- a/test/App/Fossa/LicenseScannerSpec.hs
+++ b/test/App/Fossa/LicenseScannerSpec.hs
@@ -96,7 +96,7 @@ spec = do
       expectGetOrganization
       expectEverythingScannedAlready
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing False scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should scan all if Core does not know about the revisions" $ do
@@ -108,7 +108,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing False scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should scan all if the revisions are still being scanned" $ do
@@ -120,7 +120,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing False scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should scan one if one revision is still being scanned" $ do
@@ -130,7 +130,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "first-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.firstLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing False scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should always scan all if vendor dependency skipping is not supported" $ do
@@ -141,7 +141,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScan Fixtures.archives
-      locators <- licenseScanSourceUnit SkippingNotSupported Nothing scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkippingNotSupported Nothing False scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
     it' "should always scan all if the --force-vendor-dependency-rescans flag is used" $ do
@@ -152,7 +152,7 @@ spec = do
       expectGetSignedUrl PackageRevision{packageName = "second-archive-test", packageVersion = "0.0.1"}
       expectUploadLicenseScanResult Fixtures.secondLicenseSourceUnit
       expectFinalizeScanWithForceRebuild Fixtures.archives
-      locators <- licenseScanSourceUnit SkippingDisabledViaFlag Nothing scanDir Fixtures.vendoredDeps
+      locators <- licenseScanSourceUnit SkippingDisabledViaFlag Nothing False scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
 
 expectGetApiOpts :: Has MockApi sig m => m ()

--- a/test/App/Fossa/LicenseScannerSpec.hs
+++ b/test/App/Fossa/LicenseScannerSpec.hs
@@ -4,6 +4,7 @@ module App.Fossa.LicenseScannerSpec (spec) where
 
 import App.Fossa.LicenseScanner (combineLicenseUnits, licenseScanSourceUnit)
 import App.Fossa.VendoredDependency (VendoredDependencyScanMode (..))
+import App.Types (FullFileUploads (..))
 import Control.Algebra (Has)
 import Control.Effect.FossaApiClient (FossaApiClientF (..), PackageRevision (..))
 import Data.List.NonEmpty qualified as NE
@@ -22,7 +23,6 @@ import Test.Effect (it', shouldBe')
 import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec, describe, it, runIO, shouldBe)
 import Test.MockApi (MockApi, alwaysReturns, returnsOnce, returnsOnceForAnyRequest)
-import App.Types (FullFileUploads(..))
 
 -- test data for combineLicenseUnits tests
 info :: LicenseUnitInfo
@@ -167,7 +167,6 @@ spec = do
       expectFinalizeScanWithFullFiles Fixtures.archives
       locators <- licenseScanSourceUnit SkipPreviouslyScanned Nothing (FullFileUploads True) scanDir Fixtures.vendoredDeps
       locators `shouldBe'` Fixtures.locators
-
 
 expectGetApiOpts :: Has MockApi sig m => m ()
 expectGetApiOpts =

--- a/test/App/Fossa/LicenseScannerSpec.hs
+++ b/test/App/Fossa/LicenseScannerSpec.hs
@@ -7,7 +7,7 @@ import App.Fossa.VendoredDependency (VendoredDependencyScanMode (..))
 import Control.Algebra (Has)
 import Control.Effect.FossaApiClient (FossaApiClientF (..), PackageRevision (..))
 import Data.List.NonEmpty qualified as NE
-import Fossa.API.Types (Archive, ArchiveComponents (ArchiveComponents, archives, forceRebuild))
+import Fossa.API.Types (Archive, ArchiveComponents (ArchiveComponents, archives, forceRebuild, fullFiles))
 import Path (Dir, Path, Rel, mkRelDir, (</>))
 import Path.IO (getCurrentDir)
 import Srclib.Types (
@@ -191,8 +191,8 @@ expectUploadLicenseScanResult licenseUnit =
 
 expectFinalizeScan :: Has MockApi sig m => [Archive] -> m ()
 expectFinalizeScan as =
-  (FinalizeLicenseScan ArchiveComponents{archives = as, forceRebuild = False}) `returnsOnce` ()
+  (FinalizeLicenseScan ArchiveComponents{archives = as, forceRebuild = False, fullFiles = False}) `returnsOnce` ()
 
 expectFinalizeScanWithForceRebuild :: Has MockApi sig m => [Archive] -> m ()
 expectFinalizeScanWithForceRebuild as =
-  (FinalizeLicenseScan ArchiveComponents{archives = as, forceRebuild = True}) `returnsOnce` ()
+  (FinalizeLicenseScan ArchiveComponents{archives = as, forceRebuild = True, fullFiles = False}) `returnsOnce` ()

--- a/test/App/Fossa/RunThemisSpec.hs
+++ b/test/App/Fossa/RunThemisSpec.hs
@@ -1,9 +1,9 @@
 module App.Fossa.RunThemisSpec (spec) where
 
 import App.Fossa.RunThemis (themisFlags)
+import App.Types (FullFileUploads (..))
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Types (GlobFilter (GlobFilter), LicenseScanPathFilters (..))
-import App.Types (FullFileUploads(..))
 
 spec :: Spec
 spec = do

--- a/test/App/Fossa/RunThemisSpec.hs
+++ b/test/App/Fossa/RunThemisSpec.hs
@@ -8,7 +8,10 @@ spec :: Spec
 spec = do
   describe "themisFlags" $ do
     it "should return the default flag if LicenseScanPathFilters is Nothing" $
-      themisFlags Nothing `shouldBe` ["--srclib-with-matches"]
+      themisFlags Nothing False `shouldBe` ["--srclib-with-matches"]
+
+    it "should return the full-files flag if LicenseScanPathFilters is Nothing and fulFiles is true" $
+      themisFlags Nothing True `shouldBe` ["--srclib-with-full-files"]
 
     it "should add multiple only flags if provided" $
       let licenseScanPathFilters =
@@ -17,7 +20,7 @@ spec = do
                 { licenseScanPathFiltersOnly = [GlobFilter "**.rb", GlobFilter "**.html"]
                 , licenseScanPathFiltersExclude = []
                 }
-       in themisFlags licenseScanPathFilters `shouldBe` ["--srclib-with-matches", "--only-paths", "**.rb", "--only-paths", "**.html"]
+       in themisFlags licenseScanPathFilters False `shouldBe` ["--srclib-with-matches", "--only-paths", "**.rb", "--only-paths", "**.html"]
 
     it "should add only and exclude flags if provided" $
       let licenseScanPathFilters =
@@ -26,4 +29,4 @@ spec = do
                 { licenseScanPathFiltersOnly = [GlobFilter "**.rb", GlobFilter "**.html"]
                 , licenseScanPathFiltersExclude = [GlobFilter "**.jsx"]
                 }
-       in themisFlags licenseScanPathFilters `shouldBe` ["--srclib-with-matches", "--only-paths", "**.rb", "--only-paths", "**.html", "--exclude-paths", "**.jsx"]
+       in themisFlags licenseScanPathFilters False `shouldBe` ["--srclib-with-matches", "--only-paths", "**.rb", "--only-paths", "**.html", "--exclude-paths", "**.jsx"]

--- a/test/App/Fossa/RunThemisSpec.hs
+++ b/test/App/Fossa/RunThemisSpec.hs
@@ -3,15 +3,16 @@ module App.Fossa.RunThemisSpec (spec) where
 import App.Fossa.RunThemis (themisFlags)
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Types (GlobFilter (GlobFilter), LicenseScanPathFilters (..))
+import App.Types (FullFileUploads(..))
 
 spec :: Spec
 spec = do
   describe "themisFlags" $ do
     it "should return the default flag if LicenseScanPathFilters is Nothing" $
-      themisFlags Nothing False `shouldBe` ["--srclib-with-matches"]
+      themisFlags Nothing (FullFileUploads False) `shouldBe` ["--srclib-with-matches"]
 
     it "should return the full-files flag if LicenseScanPathFilters is Nothing and fulFiles is true" $
-      themisFlags Nothing True `shouldBe` ["--srclib-with-full-files"]
+      themisFlags Nothing (FullFileUploads True) `shouldBe` ["--srclib-with-full-files"]
 
     it "should add multiple only flags if provided" $
       let licenseScanPathFilters =
@@ -20,7 +21,7 @@ spec = do
                 { licenseScanPathFiltersOnly = [GlobFilter "**.rb", GlobFilter "**.html"]
                 , licenseScanPathFiltersExclude = []
                 }
-       in themisFlags licenseScanPathFilters False `shouldBe` ["--srclib-with-matches", "--only-paths", "**.rb", "--only-paths", "**.html"]
+       in themisFlags licenseScanPathFilters (FullFileUploads False) `shouldBe` ["--srclib-with-matches", "--only-paths", "**.rb", "--only-paths", "**.html"]
 
     it "should add only and exclude flags if provided" $
       let licenseScanPathFilters =
@@ -29,4 +30,4 @@ spec = do
                 { licenseScanPathFiltersOnly = [GlobFilter "**.rb", GlobFilter "**.html"]
                 , licenseScanPathFiltersExclude = [GlobFilter "**.jsx"]
                 }
-       in themisFlags licenseScanPathFilters False `shouldBe` ["--srclib-with-matches", "--only-paths", "**.rb", "--only-paths", "**.html", "--exclude-paths", "**.jsx"]
+       in themisFlags licenseScanPathFilters (FullFileUploads False) `shouldBe` ["--srclib-with-matches", "--only-paths", "**.rb", "--only-paths", "**.html", "--exclude-paths", "**.jsx"]

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -71,7 +71,7 @@ apiOpts =
     }
 
 organization :: API.Organization
-organization = API.Organization (API.OrgId 42) True True True CLILicenseScan True True True
+organization = API.Organization (API.OrgId 42) True True True CLILicenseScan True True True False
 
 project :: API.Project
 project =

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -79,7 +79,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2023-04-17-24f42c2-1681765273"
+THEMIS_TAG="2023-04-25-95b18b6-1682456045"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

Delivers the fossa-cli part of [ANE-901](https://fossa.atlassian.net/browse/ANE-901).

ANE-901 adds a feature flag that makes the CLI upload the full contents of files with licenses in them. The CLI gets this feature flag in the response to `GET /api/cli/organization`.

When scanning with the `fullFiles` flag, the CLI will:
- pass the `--srclib-with-full-files` flag to Themis instead of the default `--srclib-with-matches` flag
- set `fullFiles` to true in the POST body when POSTing to `/api/license_scan/finalize`

There are also changes to Themis and Core for this ticket:
- Themis: https://github.com/fossas/basis/pull/1789
- Core: https://github.com/fossas/FOSSA/pull/10113

## Acceptance criteria

- If the org has the full-files flag on, then we will get the full file contents from the Themis license scan 
- If the org has the full-files flag on, we will set `fullFiles` to true when POSTING to `/api/license_scan/finalize`
- This version of the CLI should still work with versions of Core that do not have full-file upload support. It should just fall back to MatchData uploads in this case.

## Testing plan

You can test using any vendored dependency. I used the [two-vendored-dependencies](https://github.com/fossas/example-projects/tree/main/fossa-deps/two-vendored-dependencies) project from the [example-projects](https://github.com/fossas/example-projects) repo.

I found it easier to work with the dependency in its own directory so that there was no git revision for the directory.

```
git clone https://github.com/fossas/example-projects
cp -r example-projects/fossa-deps/two-vendored-dependencies .
cd two-vendored-dependencies
```

Set up fossa-cli:

```
cd ~/fossa/fossa-cli
git checkout ane-901-full-file-uploads
make install-dev
```

Set up core:

```
cd ~/fossa/FOSSA
git checkout ane-901-full-file-uploads
```

In three separate terminals:

```
docker compose up
yarn boot:dev
docker compose up core-worker
```

Now that we're set up, we can test things.

Analyze once. It should say that it is scanning and uploading the dependencies and complete successfully

```
fossa-dev analyze -e http://localhost:9578 --debug
[DEBUG] Loading configuration file from "/Users/scott/tmp/two-vendored-dependencies/"
[DEBUG] None of the current vendored dependencies have been previously scanned. License scanning all vendored dependencies
[DEBUG] License Scanning 'first-dir-aaa11' at 'first-dir'
[DEBUG] Uploading 'first-dir-aaa11' to secure S3 bucket
[DEBUG] License Scanning 'second-dir-aaa11' at 'second-dir'
[DEBUG] Uploading 'second-dir-aaa11' to secure S3 bucket
```

Wait for the build to complete and then analyze it again. You should see that we skip rescanning.

```
fossa-dev analyze -e http://localhost:9578 --debug
[DEBUG] Loading configuration file from "/Users/scott/tmp/two-vendored-dependencies/"
[DEBUG] All of the current vendored dependencies have been previously scanned, reusing previous results.
```

Open the project up in local FOSSA and navigate to where you view a file. One good method is to go to the dependencies tab, click on a dependency, click "View File Matches" and then click on a file. You should see something like this:

<img width="1174" alt="CleanShot 2023-04-24 at 15 13 31@2x" src="https://user-images.githubusercontent.com/13045/234128377-4b46d096-66c4-4074-ab4d-e1010549dc46.png">

The "found on lines 1-24" text means we scanned and displayed this dependency with match data, not with full file uploads.

Now, on the admin panel in local FOSSA, turn on the "Full-file uploads for CLI License scans" feature flag. Scan again. You should see that we re-scan this time:

```
fossa-dev analyze -e http://localhost:9578 --debug
[DEBUG] Loading configuration file from "/Users/scott/tmp/two-vendored-dependencies/"
[DEBUG] None of the current vendored dependencies have been previously scanned. License scanning all vendored dependencies
[DEBUG] License Scanning 'first-dir-aaa11' at 'first-dir'
[DEBUG] Uploading 'first-dir-aaa11' to secure S3 bucket
[DEBUG] License Scanning 'second-dir-aaa11' at 'second-dir'
[DEBUG] Uploading 'second-dir-aaa11' to secure S3 bucket
```

Scan again without changing the feature flag. We should skip scanning this time:

```
fossa-dev analyze -e http://localhost:9578 --debug
[DEBUG] Loading configuration file from "/Users/scott/tmp/two-vendored-dependencies/"
[DEBUG] All of the current vendored dependencies have been previously scanned, reusing previous results.
```

Once the build has completed, look at it in the UI. This time you should see the "full file" UI:

<img width="1139" alt="CleanShot 2023-04-24 at 15 17 48@2x" src="https://user-images.githubusercontent.com/13045/234128623-427db18c-202a-49e7-b8f1-67fdca511ec1.png">

Test against a version of Core that does not have this functionality. You can just use production or staging.

```
fossa-dev analyze --debug
```

Once the build completes, verify that it worked and that it is showing the "match data" UI. 

## Risks


## References

https://fossa.atlassian.net/browse/ANE-901

## Checklist

- [X] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-901]: https://fossa.atlassian.net/browse/ANE-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ