### PR TITLE
Restrict indicator matches to manifest files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 ## Unreleased
-- Adds `--json` flag to `fossa container analyze`
+- Adds `--json` flag to `fossa container analyze` ([#1180](https://github.com/fossas/fossa-cli/pull/1180))
+- License Scanning: Reduce false positives caused by indicator matches. This is done by only reporting indicator matches to SPDX keys and license names when we are scanning a manifest file ([#1182](https://github.com/fossas/fossa-cli/pull/1182))
 
 ## v3.7.6
 - RPM: Support origin paths for RPM spec file analysis ([#1178](https://github.com/fossas/fossa-cli/pull/1178))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
-## Unreleased
+## v3.7.7
 - Adds `--json` flag to `fossa container analyze` ([#1180](https://github.com/fossas/fossa-cli/pull/1180))
 - License Scanning: Reduce false positives caused by indicator matches. This is done by only reporting indicator matches to SPDX keys and license names when we are scanning a manifest file ([#1182](https://github.com/fossas/fossa-cli/pull/1182))
 

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -79,7 +79,7 @@ rm $WIGGINS_RELEASE_JSON
 echo "Wiggins download successful"
 echo
 
-THEMIS_TAG="2023-04-05-56f29a8-1680734040"
+THEMIS_TAG="2023-04-17-24f42c2-1681765273"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

This PR just updates Themis to the latest release, which includes the changes that will restrict indicator matches to only occur inside of manifest files.

## Acceptance criteria

Themis is updated to the latest release

## Test plan

Run `vendor_download.sh` and verify that it downloads themis properly and that the version downloaded has a version of `24f42c24d5c4e1d3b35a9e6b4c21f79f72b3cb7a`

```
vendor_download.sh
./vendor-bins/themis-cli --version
2023/04/18 12:54:27 maxprocs: Leaving GOMAXPROCS=10: CPU quota undefined
2023/04/18 12:54:27 Version: 24f42c24d5c4e1d3b35a9e6b4c21f79f72b3cb7a
```

## Risks

None

## References

[ANE-871](https://fossa.atlassian.net/browse/ANE-871)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-871]: https://fossa.atlassian.net/browse/ANE-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ