### PR TITLE
Do not fall back to module based analysis with new Go strategy.

### DIFF
--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -92,7 +92,6 @@ getDeps project goDynamicTactic = do
         case goDynamicTactic of
           GoPackagesBasedTactic ->
             context "analysis using go list (V3 Resolver)" (GoListPackages.analyze (gomodulesDir project))
-              <||> defaultDynamicAnalysis
           GoModulesBasedTactic -> defaultDynamicAnalysis
 
     defaultDynamicAnalysis :: (Has Diagnostics sig m, Has Exec sig m) => m (Graphing Dependency, GraphBreadth)


### PR DESCRIPTION
# Overview

To make the experimental go analysis behave more like it will when it is GA'ed, do not fall back to `go mod graph` based analysis on failure.

## Acceptance criteria

* It should not fall back to module based analysis.

## Testing plan

I had to make the experimental code-path fail unconditionally with `fatal` and verified that it fell back to static analysis when running `fossa analyze --experimental-use-v3-go-resolver`. I then took the `fatal` call away and ran again and verified that the new strategy ran. 

I still need to add an integration test for Go. I think that would be a better context for testing this in an automated fashion.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
