### PR TITLE
Include analysis output in debug bundle

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- Debug bundle: The raw dependency graph FOSSA CLI discovers is output in the FOSSA Debug Bundle. ([#1188](https://github.com/fossas/fossa-cli/pull/1188))
+
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 ## v3.7.9
 - License Scanning: Add support for "full file uploads" for CLI-side license scans. ([#1181](https://github.com/fossas/fossa-cli/pull/1181))

--- a/src/App/Fossa/Container.hs
+++ b/src/App/Fossa/Container.hs
@@ -20,6 +20,7 @@ import Control.Effect.Diagnostics (
  )
 import Control.Effect.Lift (Lift)
 import Control.Effect.Telemetry (Telemetry)
+import Control.Monad (void)
 import Effect.Exec (Exec)
 import Effect.Logger (
   Logger,
@@ -77,6 +78,6 @@ dispatch = \case
             , indent 4 $ pretty supportUrl
             ]
 
-    AnalyzeNative.analyzeExperimental cfg
+    void $ AnalyzeNative.analyzeExperimental cfg
   TestCfg cfg -> Test.test cfg
   ListTargetsCfg cfg -> listTargets cfg

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -79,7 +79,7 @@ analyzeExperimental ::
   , Has Telemetry sig m
   ) =>
   ContainerAnalyzeConfig ->
-  m ()
+  m Aeson.Value
 analyzeExperimental cfg =
   case Config.severity cfg of
     SevDebug -> do
@@ -98,7 +98,7 @@ analyze ::
   , Has Debug sig m
   ) =>
   ContainerAnalyzeConfig ->
-  m ()
+  m Aeson.Value
 analyze cfg = do
   scannedImage <- scanImage (filterSet cfg) (onlySystemDeps cfg) (imageLocator cfg) (dockerHost cfg) (arch cfg)
   let revision = extractRevision (revisionOverride cfg) scannedImage
@@ -113,6 +113,8 @@ analyze cfg = do
     OutputStdout -> logStdout . decodeUtf8 $ Aeson.encode scannedImage
     UploadScan apiOpts projectMeta ->
       void $ runFossaApiClient apiOpts $ uploadScan revision projectMeta (jsonOutput cfg) scannedImage
+
+  pure $ Aeson.toJSON scannedImage
 
 uploadScan ::
   ( Has Diagnostics sig m


### PR DESCRIPTION
# Overview

Analysis output (the equivalent of running with `-o`) is now included in FOSSA CLI debug bundles, at the `bundleOutput` top level field.

## Acceptance criteria

- We no longer have to guess at analysis output, or ask users for the result of `fossa analyze -o` when we need to know the output dependency graph.
- We no longer need to go to Core to fetch the output for a build if we have the debug bundle available.

## Testing plan

I tested this locally.
We currently don't seem to have tests for debug bundle output, and I think adding them is out of scope for me at the moment. Also I think this change is very non-risky as it's very strongly type defined.

```
; cabal run fossa -- analyze ~/projects/broker -o --debug
; gunzip --to-stdout fossa.debug.json.gz | jq '.bundleOutput.sourceUnits | map(.Manifest)'
[
  "/home/jess/projects/broker/"
]

; cabal run fossa -- analyze --only-target cargo --only-target cabal --debug -o
; gunzip --to-stdout fossa.debug.json.gz | jq '.bundleOutput.sourceUnits | map(.Manifest)'
[
  "/home/jess/projects/fossa-cli/",
  "/home/jess/projects/fossa-cli/"
]

; mkdir empty
; cabal run fossa -- analyze empty --debug -o
; gunzip --to-stdout fossa.debug.json.gz | jq '.bundleOutput'                             
"scan was not successful, no output"

; cabal run fossa -- container analyze postgres:11.6 --debug -o
; gunzip --to-stdout fossa.debug.json.gz | jq '.bundleOutput.image.os'
"debian"
```

## Risks

I don't think this is risky at all.

## References

This is something we've wanted to do for a while, I was prompted [here](https://teamfossa.slack.com/archives/C0155DTGWB1/p1683316539017289?thread_ts=1683313729.875339&cid=C0155DTGWB1), and I thought it'd be easy. It was, so here goes!

## Checklist

Note: I plan to update https://github.com/fossas/fossa-cli/pull/1186 prior to merging it with these changes.

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [n/a] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
