### PR TITLE
fix: Fix badge count

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -1,0 +1,17 @@
+name: Update badges
+on:
+  schedule:
+    - cron: "0 0 * * 0" # At 00:00 every Sunday
+  workflow_dispatch:
+
+jobs:
+  downloads:
+    name: update-downloads-badge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update badge
+        run: |
+          CLI_DOWNLOADS=$(gh api /repos/fossas/fossa-cli/releases --paginate --cache 1h | jq '.[] | .assets | .[] | .download_count' | jq --slurp 'add')
+          SPECTROMETER_DOWNLOADS=$(gh api /repos/fossas/spectrometer/releases --paginate --cache 1h | jq '.[] | .assets | .[] | .download_count' | jq --slurp 'add')
+          DOWNLOADS=$(numfmt --to=si $(($CLI_DOWNLOADS + $SPECTROMETER_DOWNLOADS)))

--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -15,3 +15,5 @@ jobs:
           CLI_DOWNLOADS=$(gh api /repos/fossas/fossa-cli/releases --paginate --cache 1h | jq '.[] | .assets | .[] | .download_count' | jq --slurp 'add')
           SPECTROMETER_DOWNLOADS=$(gh api /repos/fossas/spectrometer/releases --paginate --cache 1h | jq '.[] | .assets | .[] | .download_count' | jq --slurp 'add')
           DOWNLOADS=$(numfmt --to=si $(($CLI_DOWNLOADS + $SPECTROMETER_DOWNLOADS)))
+          SED_CMD='s/\[!\[FOSSA Downloads\](https:\/\/img\.shields\.io\/badge\/downloads-.*-brightgreen)\](https:\/\/github\.com\/fossas\/fossa-cli\/releases)/\[!\[FOSSA Downloads\](https:\/\/img\.shields\.io\/badge\/downloads-'$DOWNLOADS'-brightgreen)\](https:\/\/github\.com\/fossas\/fossa-cli\/releases)/g'
+          sed --in-place $SED_CMD ./README.md

--- a/README.md
+++ b/README.md
@@ -3,15 +3,14 @@
 
 # FOSSA CLI
 
-[![Build](https://github.com/fossas/fossa-cli/actions/workflows/build-all.yml/badge.svg)](https://github.com/fossas/fossa-cli/actions/workflows/build.yml)
-[![Dependency scan](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml/badge.svg)](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml) 
-<!-- markdown-link-check-disable-next-line -->
-[![FOSSA License Status](https://app.fossa.com/api/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli.svg?type=shield)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield) 
-<!-- markdown-link-check-disable-next-line -->
-[![FOSSA Security Status](https://app.fossa.com/api/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli.svg?type=shield&issueType=security)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield) 
-<!-- markdown-link-check-disable-next-line -->
-[![FOSSA Downloads](https://img.shields.io/github/downloads/fossas/fossa-cli/total.svg)](https://github.com/fossas/fossa-cli/releases)
-
+<!-- markdown-link-check-disable -->
+<!-- GITHUB_ACTION_DOWNLOADS_BADGE_HERE -->
+[![FOSSA Downloads](https://img.shields.io/badge/downloads-5.8M-brightgreen)](https://github.com/fossas/fossa-cli/releases)
+[![Build](https://img.shields.io/github/actions/workflow/status/fossas/fossa-cli/build.yml)](https://github.com/fossas/fossa-cli/actions/workflows/build.yml)
+[![Dependency scan](https://img.shields.io/github/actions/workflow/status/fossas/fossa-cli/dependency-scan.yml?label=dependency%20scan)](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml)
+[![FOSSA License Status](https://app.fossa.com/api/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli.svg?type=shield)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield)
+[![FOSSA Security Status](https://app.fossa.com/api/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli.svg?type=shield&issueType=security)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield)
+<!-- markdown-link-check-enable-->
 
 `fossa-cli` is a zero-configuration polyglot dependency analysis tool. You can point fossa CLI at any codebase or build, and it will automatically detect dependencies being used by your project.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # FOSSA CLI
 
 <!-- markdown-link-check-disable -->
-<!-- GITHUB_ACTION_DOWNLOADS_BADGE_HERE -->
+<!-- NOTE: If you change the format of the "FOSSA Downloads" badge, make sure to also update the CI action at `./github/workflows/badges.yml` that updates the download count. -->
 [![FOSSA Downloads](https://img.shields.io/badge/downloads-5.8M-brightgreen)](https://github.com/fossas/fossa-cli/releases)
 [![Build](https://img.shields.io/github/actions/workflow/status/fossas/fossa-cli/build.yml)](https://github.com/fossas/fossa-cli/actions/workflows/build.yml)
 [![Dependency scan](https://img.shields.io/github/actions/workflow/status/fossas/fossa-cli/dependency-scan.yml?label=dependency%20scan)](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml)

--- a/docs/references/subcommands/container/podman.md
+++ b/docs/references/subcommands/container/podman.md
@@ -1,12 +1,12 @@
 ## Experimental Scanner - Podman
 
-`fossa-cli` can use podman client to perform container image scanning analysis. 
+`fossa-cli` can use podman client to perform container image scanning analysis.
 
 # Integration via Podman's Docker Compatible API
 
 `fossa-cli` will look for environment variable `DOCKER_HOST`,
 to infer docker engine api's socket location. As of now, `fossa-cli`
-only works with `unix://` socket. 
+only works with `unix://` socket.
 
 For podman, you can use `podman machine start` command, to retrieve
 Docker client compatible `DOCKER_HOST`.
@@ -19,7 +19,7 @@ Mounting volume... /Users/fossa:/Users/fossa
 
 This machine is currently configured in rootless mode. If your containers
 require root permissions (e.g. ports < 1024), or if you run into compatibility
-issues with non-podman clients, you can switch using the following command: 
+issues with non-podman clients, you can switch using the following command:
 
 	podman machine set --rootful
 
@@ -40,7 +40,7 @@ following command in your terminal session:
 Machine "podman-machine-default" started successfully
 ```
 
-Now we can specify `DOCKER_HOST` when running `fossa-cli`. 
+Now we can specify `DOCKER_HOST` when running `fossa-cli`.
 
 ```bash
 DOCKER_HOST='unix:///Users/fossa/.local/share/containers/podman/machine/podman-machine-default/podman.sock' fossa container analyze
@@ -49,7 +49,7 @@ DOCKER_HOST='unix:///Users/fossa/.local/share/containers/podman/machine/podman-m
 Likewise, if you are using `podman-remote`, you should be able to use generate unix socket, and use it with `fossa-cli`. Refer to documentation below for more details.
 
 Refer to documentation here:
-- https://podman.io/blogs/2020/07/01/rest-versioning.html
+- https://web.archive.org/web/20230405171636/https://podman.io/blogs/2020/07/01/rest-versioning.html
 - https://docs.podman.io/en/latest/_static/api.html
 - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_using-the-container-tools-api_building-running-and-managing-containers
 
@@ -62,7 +62,7 @@ Refer to documentation here:
 # check if image exists
 podman image inspect <ARG>
 
-# export said image to temporary location, 
+# export said image to temporary location,
 # and perform analysis on exported image.
 podman save --format docker-archive -o <temp-path>
 ```
@@ -74,7 +74,7 @@ podman save --format docker-archive -o <temp-path>
 # Integration via Docker Archive
 
 We can manually export image using podman, and analyze such image
-with `fossa-cli`.  
+with `fossa-cli`.
 
 ```bash
 podman build . -t someImg:1.0.0


### PR DESCRIPTION
## Background

The shields.io downloads badge seems to be undercounting our actual download count. The badge shows 1.1M downloads:

![](https://img.shields.io/github/downloads/fossas/fossa-cli/total.svg)

But if you actually use the API to calculate all downloads of all releases, we actually have 5.8M downloads. I suspect this is because Shields is being rate-limited by the GitHub API, and they might not be correctly paginating to view all of our releases.

## This PR

This PR fixes the download count issue by:

1. Using a manually set badge for downloads, instead of using the native Shields GitHub badge.
2. Updating that badge's contents on a weekly basis using a GitHub Actions cron job.

This PR also refactors the badges to have uniform styles.