### PR TITLE
[ANE-265] [Docs Only] Conan (1/n)

### DIFF
--- a/docs/walkthroughs/conan.md
+++ b/docs/walkthroughs/conan.md
@@ -12,14 +12,11 @@ Visual Studio (MSBuild), Makefiles, etc., including proprietary ones.
 
 ## Integration
 
-We will use the `conan graph info` command to retrieve the dependency graph, and 
-source code for all of your packages. From this data, we will generate
-[fossa-deps](./../references/files/fossa-deps.md) file to use 
-[vendor-dependencies](./../features/vendored-dependencies.md) and [custom-dependencies](../features/manual-dependencies.md)
-functionalities.
+This integration uses the `conan graph info` command to retrieve the dependency graph and source code for all dependencies. From this data, it generates [fossa-deps](./../references/files/fossa-deps.md) file with 
+[vendor-dependencies](./../features/vendored-dependencies.md) and [custom-dependencies](../features/manual-dependencies.md).
 
-For this,
-1. Download [make_fossa_deps_conan.py](./make_fossa_deps_conan.py) python script, and place it in the same directory as `conanfile.txt`
+To use this integration,
+1. Download [make_fossa_deps_conan.py](./make_fossa_deps_conan.py) python script, and place it in the same directory as `conanfile.txt` or `conanfile.py.`
 2. Build your project (ensure it compiles)
 3. Run `python make_fossa_deps_conan.py` (this will generate `fossa-deps.yaml` in the same directory)
 4. Run `fossa analyze && fossa test`
@@ -29,9 +26,9 @@ For this,
 In this approach, `make_fossa_deps_conan.py` does the followings:
 
 1. Retrieve the project's dependency graph via the `conan graph info` command
-2. Use `-c tools.build:download_source=True` option to ensure Conan always [retrieves source code](https://docs.conan.io/2.0/reference/conanfile/methods/source.html#forced-retrieval-of-sources)
-3. For each requirement with non `build` context and source code directory, build a vendor-dependency entry in the `fossa-deps.yaml` file
-4. For each requirement with non `build` context and empty source code directory, build a custom-dependency entry in the `fossa-deps.yaml` file
+2. Uses `-c tools.build:download_source=True` option to ensure Conan always [retrieves source code](https://docs.conan.io/2.0/reference/conanfile/methods/source.html#forced-retrieval-of-sources)
+3. For each requirement with non `build` context and source code directory, it builds a vendor-dependency entry in the `fossa-deps.yaml` file
+4. For each requirement with non `build` context and empty source code directory, it builds a custom-dependency entry in the `fossa-deps.yaml` file
 
 ### Limitations
 
@@ -41,14 +38,13 @@ functionalities, and as such, it does not provide the following,
 - Security functionalities (FOSSA will not be able to identify vulnerabilities, only licensing and copyright issues)
 - Author information (in dependency view)
 
-This integration example uses the best alternative mode of analysis for each dependency. The script will try to
+This integration example uses the best alternative mode of analysis for each dependency. It tries to
 locate the source code for each dependency, and if it fails to locate the source code, it will create this dependency
 as [custom-dependency](../features/manual-dependencies.md) entry in the [fossa-deps](./../references/files/fossa-deps.md) file.
-It will use a declared license for this dependency. In addition, it will use the homepage and description provided in the recipe.
+In this case, it will use a declared license for this dependency.
 
 If the script locates the source code, it will create [vendor-dependency](./../features/vendored-dependencies.md) entry in
-the [fossa-deps](./../references/files/fossa-deps.md) file. It will not be able to use the homepage and description provided in the
-recipe.
+the [fossa-deps](./../references/files/fossa-deps.md) file.
 
 ### Example
 
@@ -94,7 +90,7 @@ the script is supplied as a potential option if you want to start using FOSSA fo
 #### 2. Why do I need Conan `v2` or greater?
 
 This integration example uses the `conan graph info` command with `--format json` and
-`-c tools.build:download_source=True` option, which are only available in Conan v2.
+`-c tools.build:download_source=True` option, which are only available in Conan v2 (`v2.0.0+`).
 
 #### 3. I want to use a custom profile or provide additional options. 
 

--- a/docs/walkthroughs/conan.md
+++ b/docs/walkthroughs/conan.md
@@ -7,7 +7,7 @@ Visual Studio (MSBuild), Makefiles, etc., including proprietary ones.
 
 ## Prerequisite
 
-- Conan v2 (you can check the version by running: `conan -v`)
+- Conan v2.0.0 or greater (you can check the version by running: `conan -v`)
 - Python v3 (so you can run the script)
 
 ## Integration
@@ -85,7 +85,7 @@ fossa test
 #### 1. Why doesn't FOSSA offer native Conan package manager analysis?
 
 FOSSA is actively working to develop native Conan support. We want to build a functionality that provides accurate and repeatable analysis for all versions of the Conan package manager. This integration
-the script is supplied as a potential option if you want to start using FOSSA for Conan immediately. 
+script is supplied as a potential option if you want to start using FOSSA for Conan immediately.
 
 #### 2. Why do I need Conan `v2` or greater?
 
@@ -94,8 +94,7 @@ This integration example uses the `conan graph info` command with `--format json
 
 #### 3. I want to use a custom profile or provide additional options. 
 
-You can provide any additional [`conan graph info`](https://docs.conan.io/2.0/reference/commands/graph/info.html) options, 
-other than `--format`. 
+You can provide any additional [`conan graph info`](https://docs.conan.io/2.0/reference/commands/graph/info.html) options (except `--format` or `-f`)
 
 To do so, provide options to the Python script. For example, 
 

--- a/docs/walkthroughs/conan.md
+++ b/docs/walkthroughs/conan.md
@@ -1,0 +1,62 @@
+# Custom Integration with Conan Package Manager
+
+Conan is a dependency and package manager for C and C++ languages. It is free and open-source, works on all 
+platforms (Windows, Linux, OSX, FreeBSD, Solaris, etc.), and can be used to develop for all targets including 
+embedded, mobile (iOS, Android), and bare metal. It also integrates with all build systems like CMake, 
+Visual Studio (MSBuild), Makefiles, SCons, etc., including proprietary ones.
+
+## Prerequisite
+
+- Conan V2 (you can check the version with running `conan version` command)
+
+## Analysis
+
+We will use, `conan show` to retrieve dependency graph, and download source code for all of your packages
+to local disk. We will use fossa-cli's [] to 
+
+```python
+# filename: mk_fossa_deps_for_conan.py
+# python3 
+
+
+def main():
+    pass
+
+```
+
+To use this script, 
+
+```bash
+>> python3 mk_fossa_deps_for_conan.py
+>> 
+
+>> fossa analyze . --include node --exclude node
+>> 
+
+```
+
+## F.A.Q
+
+#### 1. Why doesn't FOSSA offer native conan package manager analysis?
+
+FOSSA is actively working to develop native conan support. We want to build functionality that
+provides accurate and repeatable analysis for all version of conan package manager. 
+
+#### 2. Why do I need conan `` or greater?
+
+FOSSA uses `` flag, to force conan to download source code of package. This is done so, 
+FOSSA can perform license scan and copyright detection on the actual source code of the
+package as opposed to binary artifact retrieved from the conan registry.
+
+#### 3. With current custom integration, what functionality of FOSSA I'm unable to use?
+
+With custom integration provided in this document, FOSSA will not be able to,
+
+- view author information
+- view homepage information
+- use security features (vulnerability)
+
+#### 4. How can I get help in this integration?
+
+You can file a support ticket with [FOSSA helpdesk]().
+

--- a/docs/walkthroughs/conan.md
+++ b/docs/walkthroughs/conan.md
@@ -73,12 +73,15 @@ conan install . --output-folder=build --build=missing
 # download make_fossa_deps_conan.py
 wget https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/walkthroughs/make_fossa_deps_conan.py
 
+# Set your API key. Get this from the FOSSA web application.
+export FOSSA_API_KEY=XXXX
+
 # Perform analysis
 python3 make_fossa_deps_conan.py
-FOSSA_API_KEY=XXX fossa analyze
+fossa analyze
 
 # Perform test
-FOSSA_API_KEY=XXX fossa test
+fossa test
 ```
 
 ## F.A.Q

--- a/docs/walkthroughs/conan.md
+++ b/docs/walkthroughs/conan.md
@@ -52,7 +52,7 @@ recipe.
 
 ### Example
 
-```
+```bash
 # install Conan and some prerequisites
 apt-get -y install python3 pip git wget
 pip3 install conan
@@ -66,8 +66,12 @@ conan --version
 git clone https://github.com/conan-io/examples2.git
 cd /examples2/tutorial/consuming_packages/simple_cmake_project
 
+# build
+conan profile detect --force
+conan install . --output-folder=build --build=missing
+
 # download make_fossa_deps_conan.py
-wget https://github.com/fossas/fossa-cli/blob/master/docs/walkthroughs/make_fossa_deps_conan.py
+wget https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/walkthroughs/make_fossa_deps_conan.py
 
 # Perform analysis
 python3 make_fossa_deps_conan.py

--- a/docs/walkthroughs/conan.md
+++ b/docs/walkthroughs/conan.md
@@ -1,50 +1,65 @@
 # Custom Integration with Conan Package Manager
 
 Conan is a dependency and package manager for C and C++ languages. It is free and open-source, works on all 
-platforms (Windows, Linux, OSX, FreeBSD, Solaris, etc.), and can be used to develop for all targets including 
+platforms (Windows, Linux, OSX, FreeBSD, Solaris, etc.), and can be used to develop for all targets, including 
 embedded, mobile (iOS, Android), and bare metal. It also integrates with all build systems like CMake, 
 Visual Studio (MSBuild), Makefiles, etc., including proprietary ones.
 
 ## Prerequisite
 
-- Conan v2 (you can check the version with running: `conan -v`)
+- Conan v2 (you can check the version by running: `conan -v`)
 - Python v3 (so you can run the script)
 
 ## Integration
 
-We will use, `conan graph info` command to retrieve dependency graph, and 
+We will use the `conan graph info` command to retrieve the dependency graph, and 
 source code for all of your packages. From this data, we will generate
 [fossa-deps](./../references/files/fossa-deps.md) file to use 
 [vendor-dependencies](./../features/vendored-dependencies.md) and [custom-dependencies](../features/manual-dependencies.md)
 functionalities.
 
 For this,
-1. Download [make_fossa_deps_conan.py](./make_fossa_deps_conan.py) python script, and place it in same directory as `conanfile.txt`
+1. Download [make_fossa_deps_conan.py](./make_fossa_deps_conan.py) python script, and place it in the same directory as `conanfile.txt`
 2. Build your project (ensure it compiles)
-3. Run `python make_fossa_deps_conan.py` (this will generate `fossa-deps.yaml` in same directory)
+3. Run `python make_fossa_deps_conan.py` (this will generate `fossa-deps.yaml` in the same directory)
 4. Run `fossa analyze && fossa test`
 
 ### Analysis
 
 In this approach, `make_fossa_deps_conan.py` does the followings:
 
-1. Retrieve project's dependency graph via `conan graph info` command
+1. Retrieve the project's dependency graph via the `conan graph info` command
 2. Use `-c tools.build:download_source=True` option to ensure Conan always [retrieves source code](https://docs.conan.io/2.0/reference/conanfile/methods/source.html#forced-retrieval-of-sources)
-3. For each requirement with non `build` context, and source code directory, build vendor-dependency entry in `fossa-deps.yaml` file
-4. For each requirement with non `build` context, and empty source code directory, build custom-dependency entry in `fossa-deps.yaml` file
+3. For each requirement with non `build` context and source code directory, build a vendor-dependency entry in the `fossa-deps.yaml` file
+4. For each requirement with non `build` context and empty source code directory, build a custom-dependency entry in the `fossa-deps.yaml` file
 
 ### Limitations
+
+This integration method uses [vendor-dependencies](./../features/vendored-dependencies.md) and [custom-dependencies](../features/manual-dependencies.md)
+functionalities, and as such, it does not provide the following,
+
+- Security functionalities (FOSSA will not be able to identify vulnerabilities, only licensing and copyright issues)
+- Author information (in dependency view)
+
+This integration example uses the best alternative mode of analysis for each dependency. The script will try to
+locate the source code for each dependency, and if it fails to locate the source code, it will create this dependency
+as [custom-dependency](../features/manual-dependencies.md) entry in the [fossa-deps](./../references/files/fossa-deps.md) file.
+It will use a declared license for this dependency. In addition, it will use the homepage and description provided in the recipe.
+
+If the script locates the source code, it will create [vendor-dependency](./../features/vendored-dependencies.md) entry in
+the [fossa-deps](./../references/files/fossa-deps.md) file. It will not be able to use the homepage and description provided in the
+recipe.
 
 ### Example
 
 ```
-# install conan and some prerequisites
+# install Conan and some prerequisites
 apt-get -y install python3 pip git wget
 pip3 install conan
 wget https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh
 bash install-latest.sh
 
-# check conan version
+# check the Conan version
 conan --version
 
 # retrieve example projects
@@ -66,20 +81,20 @@ FOSSA_API_KEY=XXX fossa test
 
 #### 1. Why doesn't FOSSA offer native Conan package manager analysis?
 
-FOSSA is actively working to develop native Conan support. We want to build functionality that
-provides accurate and repeatable analysis for all version of Conan package manager.
+FOSSA is actively working to develop native Conan support. We want to build the functionality that
+provides accurate and repeatable analysis for all versions of the Conan package manager.
 
 #### 2. Why do I need Conan `v2` or greater?
 
-This integration example uses `conan graph info` command with `--format json` and
+This integration example uses the `conan graph info` command with `--format json` and
 `-c tools.build:download_source=True` option, which are only available in Conan v2.
 
-#### 3. I want to use custom profile or provide additional options. 
+#### 3. I want to use a custom profile or provide additional options. 
 
 You can provide any additional [`conan graph info`](https://docs.conan.io/2.0/reference/commands/graph/info.html) options, 
 other than `--format`. 
 
-To do so, provide option to the python script. For example, 
+To do so, provide options to the Python script. For example, 
 
 ```bash
 >> python3 make_fossa_deps_conan.py -s compiler=gcc
@@ -89,6 +104,11 @@ To do so, provide option to the python script. For example,
 
 You can file a support ticket with [FOSSA helpdesk](https://support.fossa.com/hc/en-us).
 
+#### 5. How do I always use a declared license?
+
+This can be achieved by modifying [make_fossa_deps_conan.py](./make_fossa_deps_conan.py). In the script,
+you can choose to always create [custom-dependency](../features/manual-dependencies.md) entry, this will ensure
+that declared license is always used.
 
 ### References
 

--- a/docs/walkthroughs/conan.md
+++ b/docs/walkthroughs/conan.md
@@ -88,8 +88,8 @@ fossa test
 
 #### 1. Why doesn't FOSSA offer native Conan package manager analysis?
 
-FOSSA is actively working to develop native Conan support. We want to build the functionality that
-provides accurate and repeatable analysis for all versions of the Conan package manager.
+FOSSA is actively working to develop native Conan support. We want to build a functionality that provides accurate and repeatable analysis for all versions of the Conan package manager. This integration
+the script is supplied as a potential option if you want to start using FOSSA for Conan immediately. 
 
 #### 2. Why do I need Conan `v2` or greater?
 

--- a/docs/walkthroughs/conan.md
+++ b/docs/walkthroughs/conan.md
@@ -3,60 +3,95 @@
 Conan is a dependency and package manager for C and C++ languages. It is free and open-source, works on all 
 platforms (Windows, Linux, OSX, FreeBSD, Solaris, etc.), and can be used to develop for all targets including 
 embedded, mobile (iOS, Android), and bare metal. It also integrates with all build systems like CMake, 
-Visual Studio (MSBuild), Makefiles, SCons, etc., including proprietary ones.
+Visual Studio (MSBuild), Makefiles, etc., including proprietary ones.
 
 ## Prerequisite
 
-- Conan V2 (you can check the version with running `conan version` command)
+- Conan v2 (you can check the version with running: `conan -v`)
+- Python v3 (so you can run the script)
 
-## Analysis
+## Integration
 
-We will use, `conan show` to retrieve dependency graph, and download source code for all of your packages
-to local disk. We will use fossa-cli's [] to 
+We will use, `conan graph info` command to retrieve dependency graph, and 
+source code for all of your packages. From this data, we will generate
+[fossa-deps](./../references/files/fossa-deps.md) file to use 
+[vendor-dependencies](./../features/vendored-dependencies.md) and [custom-dependencies](../features/manual-dependencies.md)
+functionalities.
 
-```python
-# filename: mk_fossa_deps_for_conan.py
-# python3 
+For this,
+1. Download [make_fossa_deps_conan.py](./make_fossa_deps_conan.py) python script, and place it in same directory as `conanfile.txt`
+2. Build your project (ensure it compiles)
+3. Run `python make_fossa_deps_conan.py` (this will generate `fossa-deps.yaml` in same directory)
+4. Run `fossa analyze && fossa test`
 
+### Analysis
 
-def main():
-    pass
+In this approach, `make_fossa_deps_conan.py` does the followings:
+
+1. Retrieve project's dependency graph via `conan graph info` command
+2. Use `-c tools.build:download_source=True` option to ensure Conan always [retrieves source code](https://docs.conan.io/2.0/reference/conanfile/methods/source.html#forced-retrieval-of-sources)
+3. For each requirement with non `build` context, and source code directory, build vendor-dependency entry in `fossa-deps.yaml` file
+4. For each requirement with non `build` context, and empty source code directory, build custom-dependency entry in `fossa-deps.yaml` file
+
+### Limitations
+
+### Example
 
 ```
+# install conan and some prerequisites
+apt-get -y install python3 pip git wget
+pip3 install conan
+wget https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh
+bash install-latest.sh
 
-To use this script, 
+# check conan version
+conan --version
 
-```bash
->> python3 mk_fossa_deps_for_conan.py
->> 
+# retrieve example projects
+git clone https://github.com/conan-io/examples2.git
+cd /examples2/tutorial/consuming_packages/simple_cmake_project
 
->> fossa analyze . --include node --exclude node
->> 
+# download make_fossa_deps_conan.py
+wget https://github.com/fossas/fossa-cli/blob/master/docs/walkthroughs/make_fossa_deps_conan.py
 
+# Perform analysis
+python3 make_fossa_deps_conan.py
+FOSSA_API_KEY=XXX fossa analyze
+
+# Perform test
+FOSSA_API_KEY=XXX fossa test
 ```
 
 ## F.A.Q
 
-#### 1. Why doesn't FOSSA offer native conan package manager analysis?
+#### 1. Why doesn't FOSSA offer native Conan package manager analysis?
 
-FOSSA is actively working to develop native conan support. We want to build functionality that
-provides accurate and repeatable analysis for all version of conan package manager. 
+FOSSA is actively working to develop native Conan support. We want to build functionality that
+provides accurate and repeatable analysis for all version of Conan package manager.
 
-#### 2. Why do I need conan `` or greater?
+#### 2. Why do I need Conan `v2` or greater?
 
-FOSSA uses `` flag, to force conan to download source code of package. This is done so, 
-FOSSA can perform license scan and copyright detection on the actual source code of the
-package as opposed to binary artifact retrieved from the conan registry.
+This integration example uses `conan graph info` command with `--format json` and
+`-c tools.build:download_source=True` option, which are only available in Conan v2.
 
-#### 3. With current custom integration, what functionality of FOSSA I'm unable to use?
+#### 3. I want to use custom profile or provide additional options. 
 
-With custom integration provided in this document, FOSSA will not be able to,
+You can provide any additional [`conan graph info`](https://docs.conan.io/2.0/reference/commands/graph/info.html) options, 
+other than `--format`. 
 
-- view author information
-- view homepage information
-- use security features (vulnerability)
+To do so, provide option to the python script. For example, 
 
-#### 4. How can I get help in this integration?
+```bash
+>> python3 make_fossa_deps_conan.py -s compiler=gcc
+```
 
-You can file a support ticket with [FOSSA helpdesk]().
+#### 4. How can I get help with this integration?
+
+You can file a support ticket with [FOSSA helpdesk](https://support.fossa.com/hc/en-us).
+
+
+### References
+
+- [Conan Package Manager](https://docs.conan.io)
+- [Conan graph command](https://docs.conan.io/2.0/reference/commands/graph/info.html)
 

--- a/docs/walkthroughs/make_fossa_deps_conan.py
+++ b/docs/walkthroughs/make_fossa_deps_conan.py
@@ -1,0 +1,176 @@
+"""FOSSA CLI integration script for conan package manager.
+
+Requires:
+    - python3 to run this script
+    - Conan package manager v2
+
+Usage:
+    1. Place this script in same directory as your `conanfile.txt`
+    2. Run `python3 make_fossa_deps_conan.py`
+        * This will generate `fossa-deps.yml` file from project's dependency graph.
+        * You can provide any optional arguments, other than --format from `conan graph info` command
+            * For example,
+                python3 make_fossa_deps_conan.py -s compiler=gcc
+
+    3. Run `fossa analyze` in the directory where `fossa-deps.yml` is generated.
+
+If you run into any issues with integration, please reach out to us at:
+    - https://support.fossa.com/hc/en-us
+    
+Docs:
+    - https://github.com/fossas/fossa-cli
+    - https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-deps.md
+    - https://github.com/fossas/fossa-cli/blob/master/docs/walkthroughs/conan.md
+"""
+
+import sys
+import json
+import subprocess
+import logging
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+from datetime import datetime
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler()]
+)
+
+@dataclass
+class FossaVendorDep:
+    name: str
+    version: str
+    path: str
+
+@dataclass
+class FossaCustomDepMetadata:
+    homepage: Optional[str]
+    description: Optional[str]
+
+@dataclass
+class FossaCustomDep:
+    name: str
+    version: str
+    license: str
+    metadata: Optional[FossaCustomDepMetadata]
+
+
+@dataclass
+class FossaDep:
+    vendored_dependencies: List[FossaVendorDep]
+    custom_dependencies: List[FossaCustomDep]
+
+    def dump(self):
+        comments = [
+            "# This is auto-generated fossa-deps file for conan.",
+            "# This file was generated at: " + datetime.now().isoformat(),
+            "# ",
+            "# Docs: https://github.com/fossas/fossa-cli/blob/master/docs/walkthroughs/conan.md",
+            "# FOSSA: https://fossa.com",
+            "# FOSSA Support: https://support.fossa.com/hc/en-us",
+            "\n"
+        ]
+
+        fossa_deps_yaml = []
+        if self.vendored_dependencies:
+            fossa_deps_yaml.append("vendored-dependencies:")
+            for dep in self.vendored_dependencies:
+                fossa_deps_yaml.append(f"- name: {json.dumps(dep.name)}")
+                fossa_deps_yaml.append(f"  version: {json.dumps(dep.version)}")
+                fossa_deps_yaml.append(f"  path: {json.dumps(dep.path)}")
+                fossa_deps_yaml.append("\n")
+
+        if self.custom_dependencies:
+            fossa_deps_yaml.append("custom-dependencies:")
+            for dep in self.custom_dependencies:
+                fossa_deps_yaml.append(f"- name: {json.dumps(dep.name)}")
+                fossa_deps_yaml.append(f"  version: {json.dumps(dep.version)}")
+                fossa_deps_yaml.append(f"  license: {json.dumps(dep.license)}")
+
+                if dep.metadata is not None and (dep.metadata.homepage is not None or dep.metadata.description is not None):
+                    fossa_deps_yaml.append("  meatdata:")
+                    if dep.metadata.homepage:
+                        fossa_deps_yaml.append(f"    homepage: {json.dumps(dep.metadata.homepage)}")
+                    if dep.metadata.description:
+                        fossa_deps_yaml.append(f"    description: {json.dumps(dep.metadata.description)}")
+                fossa_deps_yaml.append("\n")
+
+        with open('fossa-deps.yml', 'w+') as f:
+            f.writelines(s + '\n' for s in comments + fossa_deps_yaml)
+
+
+def name_version_of(label: str) -> Tuple[str, str]:
+    if "/" not in label:
+        raise ValueError(f"coult not parse name and version for: {label}")
+    name, version = label.split("/", 1)
+    return name, version
+
+def license_of(node: dict) -> Optional[str]:
+    return node.get("license")
+
+def homepage_of(node: dict) -> Optional[str]:
+    candidate = node.get("homepage")
+    if not candidate:
+        return node.get("url")
+    return candidate
+
+def description_of(node: dict) -> Optional[str]:
+    return node.get("description")
+
+def mk_fossa_deps(graph):
+    if 'root' not in graph or 'nodes' not in graph:
+        raise ValueError("root and nodes must exist in the conan graph")
+
+    vendored_deps = []
+    custom_deps = []
+    for node in graph.get('nodes', []):
+        label = node.get("label")
+        if "conanfile.txt" == label:
+            logging.info(f"excluding {label} from fossa-deps, as this is manifest file not a dependency")
+            continue
+
+        # https://docs.conan.io/2.0/tutorial/consuming_packages/cross_building_with_conan.html
+        if "build" == node.get("context"):
+            logging.info(f"excluding {label} from fossa-deps, as this package as build context, and is build dependency.")
+            continue
+
+        name, version = name_version_of(label)
+        license = license_of(node)
+        homepage = homepage_of(node)
+        description = description_of(node)
+        src_dir = node.get("source_folder")
+
+        if src_dir is not None:
+            logging.info(f"found source code for: {label}, using this as vendored dependency for fossa-deps.")
+            vendored_deps.append(FossaVendorDep(name, version, src_dir))
+        else:
+            logging.info(f"could not find source code in disk for: {label}, using this as vendored dependency for fossa-deps")
+            custom_deps.append(FossaCustomDep(name, version, license, FossaCustomDepMetadata(homepage, description)))
+
+    fossa_dep_yml = FossaDep(vendored_deps, custom_deps)
+    fossa_dep_yml.dump()
+
+def get_graph(user_args = []):
+    logging.info(f"user provided args: {user_args}")
+    if ('-f' in user_args or '--format' in user_args):
+        raise ValueError("You cannot provide -f | --format opts, as script requires json output from cmd")
+
+    # https://docs.conan.io/2.0/reference/commands/graph/info.html
+    graph_cmd = ["conan", "graph", "info", ".", "-f", "json"]
+
+    # https://docs.conan.io/2.0/reference/conanfile/methods/source.html#forced-retrieval-of-sources
+    arg_to_download_src = ["-c", "tools.build:download_source=True"]
+    
+    cmd = graph_cmd + user_args + arg_to_download_src
+    logging.info(f"running cmd: {(' ').join(cmd)}")
+    result = subprocess.run(cmd, stdout=subprocess.PIPE)
+
+    if (result.returncode != 0):
+        exit(result.returncode)
+    
+    return json.loads(result.stdout)
+
+if __name__ == "__main__":
+    graph = get_graph(sys.argv[1:])
+    mk_fossa_deps(graph)


### PR DESCRIPTION
# Overview

This PR, 
- Adds doc for custom conan integration by using python script to generate fossa-deps file

Pretty link: https://github.com/fossas/fossa-cli/blob/docs/conan/docs/walkthroughs/conan.md

I intend to remove this, if we end up having all encompassing native Conan analysis in cli in later PRs. 

## Acceptance criteria

- Adds docs for basic conan integration

## Testing plan

1. Follow the provided example in the docs
2. Ensure you are able to run analysis end to end (you should be able to see the dependencies in FOSSA Web App after analysis)

## Risks

N/A

## References

[ANE-265](https://fossa.atlassian.net/browse/ANE-265) 

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-265]: https://fossa.atlassian.net/browse/ANE-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ