### PR TITLE
[No Ticket] Early error if invalid version or empty string in `fossa-deps` (1/2)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## v3.7.11
 - `fossa-deps.yml`: Adds strict parsing to so that required field with only whitespace strings are prohibited early. Also throws an error, if incompatible character is used in vendor dependency's version field. ([#1192](https://github.com/fossas/fossa-cli/pull/1192))
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
 # FOSSA CLI Changelog
+
+## Unreleased
+- `fossa-deps.yml`: Adds strict parsing to so that required field with only whitespace strings are prohibited early. Also throws an error, if incompatible character is used in vendor dependency's version field. ([#1192](https://github.com/fossas/fossa-cli/pull/1192))
+
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
 ## v3.7.10

--- a/sandbox/pr1191/fossa-deps.yml
+++ b/sandbox/pr1191/fossa-deps.yml
@@ -1,9 +1,0 @@
-remote-dependencies:
-  - name: "xx"
-    version: "ss"
-    url: "ss"
-
-vendored-dependencies:
-  - name: "hello"
-    version: "1#1"
-    path: .

--- a/sandbox/pr1191/fossa-deps.yml
+++ b/sandbox/pr1191/fossa-deps.yml
@@ -1,0 +1,9 @@
+remote-dependencies:
+  - name: "xx"
+    version: "ss"
+    url: "ss"
+
+vendored-dependencies:
+  - name: "hello"
+    version: "1#1"
+    path: .

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -42,7 +42,7 @@ import Data.Aeson (
   (.:),
   (.:?),
  )
-import Data.Aeson.Extra (TextLike (unTextLike), forbidMembers)
+import Data.Aeson.Extra (TextLike (unTextLike), forbidMembers, neText)
 import Data.Aeson.Types (Object, Parser, prependFailure)
 import Data.Functor.Extra ((<$$>))
 import Data.List.NonEmpty (NonEmpty)
@@ -446,19 +446,25 @@ instance FromJSON ReferencedDependency where
 instance FromJSON CustomDependency where
   parseJSON = withObject "CustomDependency" $ \obj ->
     CustomDependency
-      <$> obj .: "name"
-      <*> (unTextLike <$> obj .: "version")
-      <*> obj .: "license"
-      <*> obj .:? "metadata"
+      <$> obj
+      `neText` "name"
+      <*> (unTextLike <$> obj `neText` "version")
+      <*> obj
+      `neText` "license"
+      <*> obj
+      .:? "metadata"
       <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
 
 instance FromJSON RemoteDependency where
-  parseJSON = withObject "RemoteDependency" $ \obj ->
+  parseJSON = withObject "RemoteDependency" $ \obj -> do
     RemoteDependency
-      <$> obj .: "name"
-      <*> (unTextLike <$> obj .: "version")
-      <*> obj .: "url"
-      <*> obj .:? "metadata"
+      <$> obj
+      `neText` "name"
+      <*> (unTextLike <$> obj `neText` "version")
+      <*> obj
+      `neText` "url"
+      <*> obj
+      .:? "metadata"
       <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
 
 -- Dependency "metadata" section for both Remote and Custom Dependencies

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -365,7 +365,7 @@ instance FromJSON ReferencedDependency where
       parseManagedDependency obj depType =
         Managed
           <$> ( ManagedReferenceDependency
-                  <$> obj .: "name"
+                  <$> (obj `neText` "name")
                   <*> pure depType
                   <*> (unTextLike <$$> obj .:? "version")
                   <* forbidNonRefDepFields obj
@@ -390,7 +390,7 @@ instance FromJSON ReferencedDependency where
       parseLinuxDependency :: Object -> DepType -> Parser LinuxReferenceDependency
       parseLinuxDependency obj depType =
         LinuxReferenceDependency
-          <$> obj .: "name"
+          <$> (obj `neText` "name")
           <*> pure depType
           <*> (unTextLike <$$> obj .:? "version")
           <*> parseArch obj
@@ -446,25 +446,19 @@ instance FromJSON ReferencedDependency where
 instance FromJSON CustomDependency where
   parseJSON = withObject "CustomDependency" $ \obj ->
     CustomDependency
-      <$> obj
-      `neText` "name"
+      <$> (obj `neText` "name")
       <*> (unTextLike <$> obj `neText` "version")
-      <*> obj
-      `neText` "license"
-      <*> obj
-      .:? "metadata"
+      <*> (obj `neText` "license")
+      <*> obj .:? "metadata"
       <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
 
 instance FromJSON RemoteDependency where
   parseJSON = withObject "RemoteDependency" $ \obj -> do
     RemoteDependency
-      <$> obj
-      `neText` "name"
+      <$> (obj `neText` "name")
       <*> (unTextLike <$> obj `neText` "version")
-      <*> obj
-      `neText` "url"
-      <*> obj
-      .:? "metadata"
+      <*> (obj `neText` "url")
+      <*> obj .:? "metadata"
       <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
 
 -- Dependency "metadata" section for both Remote and Custom Dependencies

--- a/src/App/Fossa/VendoredDependency.hs
+++ b/src/App/Fossa/VendoredDependency.hs
@@ -19,12 +19,10 @@ import Codec.Archive.Tar qualified as Tar
 import Codec.Compression.GZip qualified as GZip
 import Control.Algebra (Has)
 import Control.Carrier.Diagnostics (Diagnostics, fatalText)
-import Control.Monad (when)
 import Crypto.Hash (Digest, MD5, hashlazy)
-import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:?))
 import Data.Aeson.Extra (TextLike (unTextLike), forbidMembers, neText)
 import Data.ByteString.Lazy qualified as BS
-import Data.Foldable (for_)
 import Data.Functor.Extra ((<$$>))
 import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty)
@@ -69,9 +67,9 @@ instance FromJSON VendoredDependency where
           then pure vendorDep
           else
             fail $
-              "field 'version' conatins forbidden character '"
+              "field 'version' conatins forbidden character(s): "
                 <> show fcInVersion
-                <> "'! Do not use anyof: "
+                <> "! Do not use anyof: "
                 <> show forbiddenChars
     where
       -- If following charcters are allowed in version

--- a/src/Data/Aeson/Extra.hs
+++ b/src/Data/Aeson/Extra.hs
@@ -72,7 +72,7 @@ neText obj key = do
 onlyNonEmpty :: (ToString a) => Key -> a -> Parser a
 onlyNonEmpty key val =
   if (Text.null . Text.strip . toText . toString $ val)
-    then fail $ "expected field '" <> toString key <> "' to be non-empty, but recieved: '" <> toString val <> "'"
+    then fail $ "expected field '" <> toString key <> "' to be non-empty, but received: '" <> toString val <> "'"
     else pure val
 
 -- | Like 'Data.Aeson.encode', but produces @Text@ instead of @ByteString@

--- a/src/Data/Aeson/Extra.hs
+++ b/src/Data/Aeson/Extra.hs
@@ -59,7 +59,7 @@ forbidMembers typename names obj = traverse_ (badMember obj) names
         fail . toString $
           "Invalid field name for " <> typename <> ": " <> toText name
 
--- | Parses non-empty string value. It considers string with only
+-- | Parses non-empty value. It considers string of value with only
 -- whitespaces to be empty.
 --
 -- >  parseJSON = withObject "MyDataType" $ \obj ->
@@ -71,7 +71,7 @@ neText obj key = do
 
 onlyNonEmpty :: (ToString a) => Key -> a -> Parser a
 onlyNonEmpty key val =
-  if (Text.null . Text.strip . toText $ toString val)
+  if (Text.null . Text.strip . toText . toString $ val)
     then fail $ "expected field '" <> toString key <> "' to be non-empty, but recieved: '" <> toString val <> "'"
     else pure val
 

--- a/test/App/Fossa/ManualDepsSpec.hs
+++ b/test/App/Fossa/ManualDepsSpec.hs
@@ -166,6 +166,11 @@ referenceDepSpec = do
         (encodeUtf8 managedReferenceDepWithOS)
         "Invalid field name for referenced dependencies (of dependency type: gem): os"
 
+    it "should fail when linux reference dependency of deb or apk contains epoch" $
+      exceptionContains
+        (encodeUtf8 managedReferenceDepWithEmptyName)
+        "expected field 'name' to be non-empty"
+
 remoteDepSpec :: Spec
 remoteDepSpec = do
   describe "remote dependency" $ do
@@ -205,6 +210,16 @@ customDepSpec = do
 vendorDepSpec :: Spec
 vendorDepSpec = do
   describe "vendor dependency" $ do
+    it "should fail when vendor dependency has empty name or only whitespace" $ do
+      exceptionContains
+        (encodeUtf8 vendorDepWithEmptyName)
+        "expected field 'name' to be non-empty"
+
+    it "should fail when vendor dependency has empty path or only whitespace" $ do
+      exceptionContains
+        (encodeUtf8 vendorDepWithEmptyPath)
+        "expected field 'path' to be non-empty"
+
     it "should fail when vendor dependency has version with not supported character" $ do
       exceptionContains
         (encodeUtf8 vendorDepWithHashtagInVersion)
@@ -373,4 +388,30 @@ vendored-dependencies:
 - name: example
   version: "1?os=linux"
   path: .
+|]
+
+vendorDepWithEmptyName :: Text
+vendorDepWithEmptyName =
+  [r|
+vendored-dependencies:
+- name: " "
+  version: "1"
+  path: .
+|]
+
+vendorDepWithEmptyPath :: Text
+vendorDepWithEmptyPath =
+  [r|
+vendored-dependencies:
+- name: example
+  version: "1"
+  path: " "
+|]
+
+managedReferenceDepWithEmptyName :: Text
+managedReferenceDepWithEmptyName =
+  [r|
+referenced-dependencies:
+- name: " "
+  type: gem
 |]

--- a/test/App/Fossa/ManualDepsSpec.hs
+++ b/test/App/Fossa/ManualDepsSpec.hs
@@ -85,6 +85,9 @@ spec = do
       exceptionContains licenseInRefDepBS "Invalid field name for referenced dependencies: license"
 
     referenceDepSpec
+    remoteDepSpec
+    customDepSpec
+    vendorDepSpec
 
   describe "getScanCfg" $ do
     it' "should fail if you try to force a license scan but the FOSSA server does not support it" $ do
@@ -162,6 +165,54 @@ referenceDepSpec = do
       exceptionContains
         (encodeUtf8 managedReferenceDepWithOS)
         "Invalid field name for referenced dependencies (of dependency type: gem): os"
+
+remoteDepSpec :: Spec
+remoteDepSpec = do
+  describe "remote dependency" $ do
+    it "should fail when remote dependency has empty name or only whitespace" $
+      exceptionContains
+        (encodeUtf8 remoteDepWithEmptyName)
+        "expected field 'name' to be non-empty"
+
+    it "should fail when remote dependency has empty version or only whitespace" $
+      exceptionContains
+        (encodeUtf8 remoteDepWithEmptyVersion)
+        "expected field 'version' to be non-empty"
+
+    it "should fail when remote dependency has empty url or only whitespace" $
+      exceptionContains
+        (encodeUtf8 remoteDepWithEmptyUrl)
+        "expected field 'url' to be non-empty"
+
+customDepSpec :: Spec
+customDepSpec = do
+  describe "custom dependency" $ do
+    it "should fail when custom dependency has empty name or only whitespace" $
+      exceptionContains
+        (encodeUtf8 customDepWithEmptyName)
+        "expected field 'name' to be non-empty"
+
+    it "should fail when custom dependency has empty version or only whitespace" $
+      exceptionContains
+        (encodeUtf8 customDepWithEmptyVersion)
+        "expected field 'version' to be non-empty"
+
+    it "should fail when custom dependency has empty license or only whitespace" $
+      exceptionContains
+        (encodeUtf8 customDepWithEmptyLicense)
+        "expected field 'license' to be non-empty"
+
+vendorDepSpec :: Spec
+vendorDepSpec = do
+  describe "vendor dependency" $ do
+    it "should fail when vendor dependency has version with not supported character" $ do
+      exceptionContains
+        (encodeUtf8 vendorDepWithHashtagInVersion)
+        "field 'version' conatins forbidden character '#'"
+
+      exceptionContains
+        (encodeUtf8 vendorDepWithQuestionInVersion)
+        "field 'version' conatins forbidden character '?'"
 
 linuxReferenceDep :: Text
 linuxReferenceDep =
@@ -251,3 +302,75 @@ linuxRefManualDep os epoch =
     mempty
     mempty
     mempty
+
+customDepWithEmptyVersion :: Text
+customDepWithEmptyVersion =
+  [r|
+custom-dependencies:
+- name: example
+  version: " "
+  license: "mit"
+|]
+
+customDepWithEmptyName :: Text
+customDepWithEmptyName =
+  [r|
+custom-dependencies:
+- name: ""
+  version: 1.0
+  license: "mit"
+|]
+
+customDepWithEmptyLicense :: Text
+customDepWithEmptyLicense =
+  [r|
+custom-dependencies:
+- name: example
+  version: 1.0
+  license: " "
+|]
+
+remoteDepWithEmptyName :: Text
+remoteDepWithEmptyName =
+  [r|
+remote-dependencies:
+- name: " "
+  version: "1"
+  url: "https://github.com/fossas/fossa-cli/archive/refs/heads/master.zip"
+|]
+
+remoteDepWithEmptyVersion :: Text
+remoteDepWithEmptyVersion =
+  [r|
+remote-dependencies:
+- name: example
+  version: " "
+  url: "https://github.com/fossas/fossa-cli/archive/refs/heads/master.zip"
+|]
+
+remoteDepWithEmptyUrl :: Text
+remoteDepWithEmptyUrl =
+  [r|
+remote-dependencies:
+- name: example
+  version: "1.0.0"
+  url: " "
+|]
+
+vendorDepWithHashtagInVersion :: Text
+vendorDepWithHashtagInVersion =
+  [r|
+vendored-dependencies:
+- name: example
+  version: "1#1"
+  path: .
+|]
+
+vendorDepWithQuestionInVersion :: Text
+vendorDepWithQuestionInVersion =
+  [r|
+vendored-dependencies:
+- name: example
+  version: "1?os=linux"
+  path: .
+|]

--- a/test/App/Fossa/ManualDepsSpec.hs
+++ b/test/App/Fossa/ManualDepsSpec.hs
@@ -223,11 +223,11 @@ vendorDepSpec = do
     it "should fail when vendor dependency has version with not supported character" $ do
       exceptionContains
         (encodeUtf8 vendorDepWithHashtagInVersion)
-        "field 'version' conatins forbidden character '#'"
+        "field 'version' conatins forbidden character(s): [\"#\"]"
 
       exceptionContains
         (encodeUtf8 vendorDepWithQuestionInVersion)
-        "field 'version' conatins forbidden character '?'"
+        "field 'version' conatins forbidden character(s): [\"?\"]"
 
 linuxReferenceDep :: Text
 linuxReferenceDep =


### PR DESCRIPTION
# Overview

Ran into triage session over some invalid chars in s3 upload for version attribute in vendor dep, but found that similar issue exist for other attributes. 

This PR, 

- Throws an error early, if version field of vendor dependency in`fossa-deps` contains known incompatible character (ANE-980). This should be permanent fix - adding this as stopgap for now.
- Throws an error early, if required field in `custom-dependencies` in fossa-deps has empty `name`, such as " ", or ""
- Throws an error early, if required field in `custom-dependencies` in fossa-deps has empty `version`, such as " ", or ""
- Throws an error early, if required field in `custom-dependencies` in fossa-deps has empty `license`, such as " ", or ""
- Throws an error early, if required field in `remote-dependencies` in fossa-deps has empty `name`, such as " ", or ""
- Throws an error early, if required field in `remote-dependencies` in fossa-deps has empty `url`, such as " ", or ""
- Throws an error early, if required field in `remote-dependencies` in fossa-deps has empty `version`, such as " ", or ""
- Throws an error early, if required field in `vendored-dependencies` in fossa-deps has empty `name`, such as " ", or ""
- Throws an error early, if required field in `vendored-dependencies` in fossa-deps has empty `path`, such as " ", or ""
- Throws an error early, if required field in `reference-dependencies` in fossa-deps has empty `name`, such as " ", or ""

## Acceptance criteria

- Throws an error early if value of fossa-deps are incompatible (required field of object, are empty or only contain whitespace, rather than waiting for harder diagnose network error

## Testing plan

- `make install-dev`
- Add valid `fossa-deps.yml`, and perform `fossa-dev analyze -o`, it should succeed
- Modify `fossa-deps.yml` making it invalid (only whitespace entry on required field, etc.), and perform `fossa-dev analyze -o`, it should fail

Example of valid `fossa-deps.yaml`
```yaml
referenced-dependencies:
  - name: "name"
    type: gem

custom-dependencies:
  - name: "name"
    version: "version"
    license: "license"

remote-dependencies:
  - name: "name"
    version: "version"
    url: "url"

vendored-dependencies:
  - name: "name"
    path: "."

```
I added unit test for each condition.

## Risks

N/A

## References

This is similar to ane-885

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
