### PR TITLE
Do not use UPX on macos

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install MacOS binary dependencies
       if: ${{ contains(matrix.os, 'macos') }}
       run: |
-        brew install upx jq
+        brew install jq
 
     # Set up Haskell.
     - uses: haskell/actions/setup@v1

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,10 @@
 # FOSSA CLI Changelog
+<!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
-## Unreleased
+## v3.8.0
+- License Scanning: Fix a bug where the license scanner did not run on MacOS 13 on M1 Macs ([#1193](https://github.com/fossas/fossa-cli/pull/1193))
 - Debug bundle: The raw dependency graph FOSSA CLI discovers is output in the FOSSA Debug Bundle. ([#1188](https://github.com/fossas/fossa-cli/pull/1188))
 
-<!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 ## v3.7.9
 - License Scanning: Add support for "full file uploads" for CLI-side license scans. ([#1181](https://github.com/fossas/fossa-cli/pull/1181))
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
-## v3.8.0
+## v3.7.10
 - License Scanning: Fix a bug where the license scanner did not run on MacOS 13 on M1 Macs ([#1193](https://github.com/fossas/fossa-cli/pull/1193))
 - Debug bundle: The raw dependency graph FOSSA CLI discovers is output in the FOSSA Debug Bundle. ([#1188](https://github.com/fossas/fossa-cli/pull/1188))
 

--- a/docs/references/subcommands/container/podman.md
+++ b/docs/references/subcommands/container/podman.md
@@ -51,8 +51,7 @@ Likewise, if you are using `podman-remote`, you should be able to use generate u
 Refer to documentation here:
 - https://web.archive.org/web/20230405171636/https://podman.io/blogs/2020/07/01/rest-versioning.html
 - https://docs.podman.io/en/latest/_static/api.html
-- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_using-the-container-tools-api_building-running-and-managing-containers
-
+- https://web.archive.org/web/20220926013308/https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_using-the-container-tools-api_building-running-and-managing-containers
 
 # Integration via Podman Executables
 

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -119,10 +119,6 @@ chmod +x vendor-bins/*
 
 echo "Compressing index.gob"
 xz vendor-bins/index.gob
-if [ $ASSET_POSTFIX != "darwin" ]; then
-  echo "Compressing binaries"
-  find vendor-bins -type f -not -name '*.xz' | xargs upx || echo "WARN: 'upx' command not found, binaries will not be compressed"
-fi
 
 echo "Vendored binaries are ready for use"
 ls -lh vendor-bins/

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -117,9 +117,12 @@ echo
 echo "Marking binaries executable"
 chmod +x vendor-bins/*
 
-echo "Compressing binaries"
+echo "Compressing index.gob"
 xz vendor-bins/index.gob
-find vendor-bins -type f -not -name '*.xz' | xargs upx || echo "WARN: 'upx' command not found, binaries will not be compressed"
+if [ $ASSET_POSTFIX != "darwin" ]; then
+  echo "Compressing binaries"
+  find vendor-bins -type f -not -name '*.xz' | xargs upx || echo "WARN: 'upx' command not found, binaries will not be compressed"
+fi
 
 echo "Vendored binaries are ready for use"
 ls -lh vendor-bins/


### PR DESCRIPTION
# Overview

[Delivers ANE-982](https://fossa.atlassian.net/browse/ANE-982)

Megh ran into an issue with UPX compressed binaries on MacOS Ventura. The fix is to just not use UPX for MacOS.

I'm pretty sure that MacOS is the last place that we were using UPX, so I just removed all uses of UPX.

## Acceptance criteria

- We do not use UPX to compress embedded files
- We can run `fossa license-scan direct` on MacOS Ventura on an M1 Mac
- This actually fixes the problem that Megh saw

## Testing plan

Run `vendor_download.sh` with an M1 Mac running MacOS ventura. Then compile with those vendored binaries and run `fossa license-scan direct` on a directory.

It should succeed.

```
./vendor_download.sh
cabal clean
make install-dev
fossa-dev license-scan direct <some directory>
```

## Risks

Our binaries get slightly bigger. themis-cli goes from 5.9 MB -> 17 MB, and Wiggins goes from 7.0 MB -> 18 MB.

## References

[ANE-982](https://fossa.atlassian.net/browse/ANE-982)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-982]: https://fossa.atlassian.net/browse/ANE-982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ