### PR TITLE
[ANE-461] Adds setup.cfg support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,8 +8,6 @@
 ## v3.7.11
 - `fossa-deps.yml`: Adds strict parsing to so that required field with only whitespace strings are prohibited early. Also throws an error, if incompatible character is used in vendor dependency's version field. ([#1192](https://github.com/fossas/fossa-cli/pull/1192))
 
-
-
 ## v3.7.10
 - License Scanning: Fix a bug where the license scanner did not run on MacOS 13 on M1 Macs ([#1193](https://github.com/fossas/fossa-cli/pull/1193))
 - Debug bundle: The raw dependency graph FOSSA CLI discovers is output in the FOSSA Debug Bundle. ([#1188](https://github.com/fossas/fossa-cli/pull/1188))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,14 @@
 # FOSSA CLI Changelog
 
+<!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
+
+## v3.7.12
+- `setup.cfg`: Adds support for setup.cfg, in conjuction with `setup.py`. ([#1195](https://github.com/fossas/fossa-cli/pull/1195))
+
 ## v3.7.11
 - `fossa-deps.yml`: Adds strict parsing to so that required field with only whitespace strings are prohibited early. Also throws an error, if incompatible character is used in vendor dependency's version field. ([#1192](https://github.com/fossas/fossa-cli/pull/1192))
 
-<!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
+
 
 ## v3.7.10
 - License Scanning: Fix a bug where the license scanner did not run on MacOS 13 on M1 Macs ([#1193](https://github.com/fossas/fossa-cli/pull/1193))

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 <!-- - title: description ([#](https://github.com/fossas/fossa-cli/pull/#)) -->
 
-## v3.7.12
+## Unreleased
 - `setup.cfg`: Adds support for setup.cfg, in conjuction with `setup.py`. ([#1195](https://github.com/fossas/fossa-cli/pull/1195))
 
 ## v3.7.11

--- a/docs/references/strategies/languages/python/setuptools.md
+++ b/docs/references/strategies/languages/python/setuptools.md
@@ -32,6 +32,12 @@ unintended consequences!), reliable output from setup.py is difficult to obtain.
 Entries in the `install_requires` array are parsed compliant to the
 [PEP-508][pep-508] spec, similar to requirements.txt
 
+If `setup.cfg` exists in the same directory as `setup.py`, `fossa-cli` also naively 
+scans for its `install_requires=[...]` attributes, similar to `setup.py`. If both `setup.cfg` and
+`setup.py` exists and both have `install_requires` attribute, `fossa-cli` concatenates requirements
+from both files.
+
+[setup.cfg docs]: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
 [requirements-file-format]: https://pip.pypa.io/en/stable/cli/pip_install/#requirements-file-format
 [pep-508]: https://www.python.org/dev/peps/pep-0508/
 

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -45,6 +45,19 @@ installRequiresParser = do
     symbol = L.symbol space
 
 -- | Parses install requirements listed in setup.cfg
+-- Setup.cfg has install_requires attribute in [options] block
+-- which is formatted as danfling list.
+-- -
+-- Example setup.cfg's install_requires block
+-- -
+-- > install_requires =
+-- >     importlib-metadata; python_version<"3.8"
+-- >     # platformdirs>=2
+-- >     configupdater>=3.0  # some comment
+-- >     packaging>=20.7
+-- >     colorama>=0.4.4; sys_platform == "win32"
+-- >
+-- >
 -- Docs: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
 installRequiresParserSetupCfg :: Parser [Req]
 installRequiresParserSetupCfg = do

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -44,7 +44,7 @@ installRequiresParser = do
     symbol :: Text -> Parser Text
     symbol = L.symbol space
 
--- | Parses install requirements listed in setup.cfg 
+-- | Parses install requirements listed in setup.cfg
 -- Docs: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
 installRequiresParserSetupCfg :: Parser [Req]
 installRequiresParserSetupCfg = do

--- a/src/Strategy/Python/SetupPy.hs
+++ b/src/Strategy/Python/SetupPy.hs
@@ -1,8 +1,10 @@
 module Strategy.Python.SetupPy (
   analyze',
+  installRequiresParserSetupCfg,
 ) where
 
 import Control.Effect.Diagnostics
+import Control.Monad (void)
 import Data.Text (Text)
 import Data.Void (Void)
 import Effect.ReadFS
@@ -14,10 +16,12 @@ import Text.Megaparsec.Char
 import Text.Megaparsec.Char.Lexer qualified as L
 import Types
 
-analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
-analyze' file = do
+analyze' :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> Maybe (Path Abs File) -> m (Graphing Dependency)
+analyze' file setupCfg = do
   reqs <- readContentsParser installRequiresParser file
-  context "Building dependency graph" $ pure (buildGraph reqs)
+  reqsFromCfg <- maybe (pure []) (readContentsParser installRequiresParserSetupCfg) setupCfg
+
+  context "Building dependency graph" $ pure (buildGraph $ reqs ++ reqsFromCfg)
 
 type Parser = Parsec Void Text
 
@@ -39,3 +43,43 @@ installRequiresParser = do
 
     symbol :: Text -> Parser Text
     symbol = L.symbol space
+
+-- | Parses install requirements listed in setup.cfg 
+-- Docs: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
+installRequiresParserSetupCfg :: Parser [Req]
+installRequiresParserSetupCfg = do
+  maybePrefix <- optional (try prefix)
+  case maybePrefix of
+    Nothing -> pure []
+    Just _ -> parseReqs
+  where
+    prefix :: Parser Text
+    prefix = skipManyTill anySingle $ lookAhead parseHeader
+
+    parseHeader :: Parser Text
+    parseHeader = lexeme $ symbol "install_requires" <* chunk "="
+
+    lineComment :: Parser ()
+    lineComment = L.skipLineComment "#"
+
+    scn :: Parser ()
+    scn = L.space space1 lineComment empty
+
+    sc :: Parser ()
+    sc = L.space (void $ some (char ' ' <|> char '\t')) lineComment empty
+
+    lexeme :: Parser a -> Parser a
+    lexeme = L.lexeme sc
+
+    symbol :: Text -> Parser Text
+    symbol = L.symbol space
+
+    parseReqs :: Parser [Req]
+    parseReqs = L.nonIndented scn (L.indentBlock scn p)
+      where
+        p = do
+          void parseHeader
+          pure $ L.IndentMany Nothing pure parseReq
+
+    parseReq :: Parser Req
+    parseReq = lexeme requirementParser <?> "requirement"

--- a/src/Strategy/Python/Setuptools.hs
+++ b/src/Strategy/Python/Setuptools.hs
@@ -47,11 +47,13 @@ findProjects = walkWithFilters' $ \dir _ files -> do
           files
 
   let setupPyFile = findFileNamed "setup.py" files
+  let setupCfgFile = findFileNamed "setup.cfg" files
 
   let project =
         SetuptoolsProject
           { setuptoolsReqTxt = reqTxtFiles
           , setuptoolsSetupPy = setupPyFile
+          , setuptoolsSetupCfg = setupCfgFile
           , setuptoolsDir = dir
           }
 
@@ -80,11 +82,12 @@ analyzeReqTxts = context "Analyzing requirements.txt files" . fmap mconcat . tra
 analyzeSetupPy :: (Has ReadFS sig m, Has Diagnostics sig m) => SetuptoolsProject -> m (Graphing Dependency)
 analyzeSetupPy project = context "Analyzing setup.py" $ do
   setupPy <- Diag.fromMaybeText "No setup.py found in this project" (setuptoolsSetupPy project)
-  SetupPy.analyze' setupPy
+  SetupPy.analyze' setupPy (setuptoolsSetupCfg project)
 
 data SetuptoolsProject = SetuptoolsProject
   { setuptoolsReqTxt :: [Path Abs File]
   , setuptoolsSetupPy :: Maybe (Path Abs File)
+  , setuptoolsSetupCfg :: Maybe (Path Abs File)
   , setuptoolsDir :: Path Abs Dir
   }
   deriving (Eq, Ord, Show, Generic)


### PR DESCRIPTION
# Overview

This PR, 
- Adds support for `setup.cfg` for `setup.py` analysis.

## Acceptance criteria

- `install_requires` attributes from `setup.cfg` are considered when analyzing via setuptools. 

## Testing plan

```bash
git pull origin && git checkout feat/setup-cfg && make install-dev
mkdir sandbox && cd sandbox && git clone https://github.com/Greg-Myers-SB/localstack.git
fossa-dev analyze -o | jq
```

You should see locators for: 
```
    boto3>=1.20
    click>=7.0
    cachetools>=3.1.1,<4.0.0
    dataclasses; python_version < '3.7'
    localstack-client>=1.31
    localstack-ext>=0.14.1
    plux>=1.3.1
    psutil>=5.4.8,<6.0.0
    python-dotenv>=0.19.1
    pyyaml>=5.1
    rich>=10.7.0
    requests>=2.20.0,<2.26
    semver>=2.10
    stevedore>=3.4.0
    typing-extensions; python_version < '3.8'
    tailer>=0.4.1
```

## Risks
Sometimes users have complicated dependency config in python world where, they may have `setup.cfg` && `setup.py`, and `reqs.txt` - in which case we would be duplicating
found deps,  but this is what happens right now if the users have `setup.py` and `reqs.txt`. 

## References

[ANE-461](https://fossa.atlassian.net/browse/ANE-461)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] ~If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).~


[ANE-461]: https://fossa.atlassian.net/browse/ANE-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ