### PR TITLE
[No Ticket] Fix "Property name is not allowed" error for RPM deps

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+### Unreleased
+
+- Doc only: Fixed an issue in the `fossa-deps` schema suggesting against the use of `name` for referenced RPM dependencies [#1199](https://github.com/fossas/fossa-cli/pull/1199). If your IDE is utilizing SchemaStore, this file should now lint properly.
+
 ## v3.7.11
 - `fossa-deps.yml`: Adds strict parsing to so that required field with only whitespace strings are prohibited early. Also throws an error, if incompatible character is used in vendor dependency's version field. ([#1192](https://github.com/fossas/fossa-cli/pull/1192))
 

--- a/docs/references/files/fossa-deps.schema.json
+++ b/docs/references/files/fossa-deps.schema.json
@@ -103,6 +103,11 @@
         },
         "referenced-rpm-dependency": {
             "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Name of the dependency. This name will be used to search for dependency in relevant registries."
+                  },
                 "type": {
                     "enum": [
                         "rpm-generic"


### PR DESCRIPTION
# Overview

This PR should hopefully fix a tiny issue with the fossa-deps schema that's been bugging me for some time.

When using a `fossa-deps.yml` file with an RPM dependency, the "name" field would be deemed invalid.

## Acceptance criteria

No more squiggly red lines! Names are valid, and should be considered as such.

## Testing plan

With JSON and YAML Schema Download enabled in VSC, create a `fossa-deps.yml` file with the following:
```yaml
referenced-dependencies:
- type: rpm-generic
  name: cpio
  os: sles
  osVersion: "15.4"
  arch: x86_64
  version: 0:2.13-9.fc34
```
Open the file in VSC, it should inform you that "Property `name` is not allowed"

After checking out this branch, or downloading the `fossa-deps.schema.json` file:
1. Open your VSC Settings
2. Search for "Schema"
3. Select "Yaml: Schemas" > "Edit in settings.json"
4. Add the following:
```json
"yaml.schemas": {
            "file:/path/to/folder/fossa-cli/docs/references/files/fossa-deps.schema.json": "fossa-deps.yml"
        }
```

## Risks

I'm not sure if I need to change anything else, can reviewers please confirm whether I need to modify any additional files to reflect the change?

I also don't know if this will actualy fix the issue! Tested locally, but unsure what needs to be done for the changes to propagate.

## References

No references.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
