### PR TITLE
Add winget install option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Alternatively, install using [Scoop](https://scoop.sh/):
 ```
 scoop install fossa
 ```
+<!-- markdown-link-check-disable-next-line -->
+Or [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/):
+
+```
+winget install FOSSA.FOSSA-cli
+```
 
 Please refer to detailed walkthrough [Installing FOSSA CLI](./docs/walkthroughs/installing-fossa-cli.md), for installing [FOSSA CLI 1.x](./docs/walkthroughs/installing-fossa-cli.md#installing-cli-1x-using-installation-script) and using [GitHub Releases](https://github.com/fossas/fossa-cli/releases) to install [FOSSA CLI manually](./docs/walkthroughs/installing-fossa-cli.md#installing-manually-with-github-releases).
 


### PR DESCRIPTION
# Overview

FOSSA cli was added to the winget package manager and is now installable through there. This method allows a user who wants to install fossa without having to install an additional package manager before getting fossa.

## Acceptance criteria

User now has another method of getting fossa on windows.

## Testing plan

```
PS C:\Users\sacha> winget show FOSSA.FOSSA-cli
Found fossa-cli [FOSSA.FOSSA-cli]
Version: 3.7.11
Publisher: FOSSA
Moniker: fossa
Description: Fast, portable and reliable dependency analysis for any codebase.
License: MPL-2.0
Installer:
  Installer Type: portable (zip)
  Installer Url: https://github.com/fossas/fossa-cli/releases/download/v3.7.11/fossa_3.7.11_windows_amd64.zip
  Installer SHA256: 01e62c3ae6e3e2e62add8ab45edcdabd187867a4345bf64a92f8d71fc3bcbec3
PS C:\Users\sacha>
```

## Risks

I'm not sure if maintainers want this on the README.

## References

https://github.com/microsoft/winget-pkgs/pull/107419#issuecomment-1555375226

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
