### PR TITLE
Redact file contents during `experimental-enable-binary-discovery` and `detect-vendored`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.7.12
+
+- `experimental-enable-binary-discovery`, `detect-vendored`: Redact file contents in debug bundles. ([#1201](https://github.com/fossas/fossa-cli/pull/1201))
+
 ## v3.7.11
 - `fossa-deps.yml`: Adds strict parsing to so that required field with only whitespace strings are prohibited early. Also throws an error, if incompatible character is used in vendor dependency's version field. ([#1192](https://github.com/fossas/fossa-cli/pull/1192))
 

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -253,8 +253,12 @@ readFSToDebug = interpret $ \case
   cons@ResolveFile'{} -> recording cons
   cons@ResolveDir'{} -> recording cons
   cons@ResolvePath{} -> recording cons
+  -- These are redacted, so it's safe to record them, they'll redact themselves
+  cons@ReadRedactedContentsBS'{} -> recording cons
+  cons@ReadRedactedContentsText'{} -> recording cons
   -- Unneeded or excessive for debug bundles
   cons@ReadContentsBSLimit'{} -> ignoring cons
+  cons@ReadRedactedContentsBSLimit'{} -> ignoring cons
   cons@ListDir{} -> ignoring cons
   cons@GetIdentifier{} -> ignoring cons
   cons@GetCurrentDir{} -> ignoring cons

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -19,7 +19,6 @@ import Control.Effect.Diagnostics (
   context,
   errCtx,
   fatalText,
-  fromEither,
   fromEitherShow,
   fromMaybe,
   recover,
@@ -220,7 +219,7 @@ detectYarnVersion ::
   m YarnVersion
 detectYarnVersion yarnfile = do
   -- we expect the v1 header to end at char 82
-  contents <- decodeUtf8 <$> (readContentsBSLimit yarnfile 100 >>= fromEither)
+  contents <- decodeUtf8 <$> readContentsBSLimit yarnfile 100
   if "yarn lockfile v1" `Text.isInfixOf` contents
     then pure V1
     else pure V2Compatible


### PR DESCRIPTION
# Overview

We discovered a bug in FOSSA CLI where using `experimental-enable-binary-discovery` or `detect-vendored`, and sending in the FOSSA CLI debug bundle, would potentially result in sending the full contents of the files read by FOSSA CLI.

While normally this wouldn't be a concern since FOSSA CLI normally only reads files which don't contain private information (generally, package manifest files such as `package.json`), unfortunately those two modes in FOSSA CLI cause it to read _every_ file in the project that isn't excluded by filters.

This PR resolves this bug, causing the result of reading those files to be correctly redacted in the FOSSA CLI debug bundle.

We always recommend users validate that debug bundles do not contain information they don't want to send to FOSSA before sending it, although we do our best to not include information that users wouldn't want to send to us. This PR was implemented as soon as possible after discovering this bug, and we highly recommend users upgrade to this version or manually clean their debug bundles when running older FOSSA CLI versions.

For more information on how to read debug bundles, view our [debugging reference here](https://github.com/fossas/fossa-cli/tree/master/docs/references/debugging).

## Acceptance criteria

FOSSA CLI no longer records full file contents during `Effect.ReadFS.ReadContentsBSLimit'`.

## Testing plan

We don't have good tests for debug output. Instead, I tested locally.
Using this branch, I created an example project:

```
❯ cd ~/projects/scratch
❯ cargo init binary-example
❯ cd binary-example
❯ cargo build
```

I then ran FOSSA CLI:
```
❯ cabal run fossa -- analyze /home/jess/projects/scratch/binary-example -o --debug --experimental-enable-binary-discovery > output.json
```

I then inspected the results.
First, I validated that binaries are still detected correctly:
```
❯ gron output.json | grep "Binary discovered in source tree" -A3
...
json.sourceUnits[0].AdditionalDependencyData.UserDefinedDependencies[11].Description = "Binary discovered in source tree";
json.sourceUnits[0].AdditionalDependencyData.UserDefinedDependencies[11].Homepage = null;
json.sourceUnits[0].AdditionalDependencyData.UserDefinedDependencies[11].License = "";
json.sourceUnits[0].AdditionalDependencyData.UserDefinedDependencies[11].Name = "target/debug/.fingerprint/binary-example-ac60743f3987ba93/dep-bin-binary-example";
...
```

And that non-binaries aren't reported:
```
❯ gron output.json| grep '\.rs'
❯ echo $?
1
```

I then inspected the debug bundle to validate that the content is redacted:
```
❯ gunzip fossa.debug.json.gz
❯ gron fossa.debug.json| grep 'ReadContentBSLimit'
❯ echo $?
1

❯ gron fossa.debug.json| grep 'Effect.ReadFS.ReadRedactedContentsBSLimit' -A4
...
json.bundleJournals.bundleJournalReadFS[73][0][0] = "Effect.ReadFS.ReadRedactedContentsBSLimit'";
json.bundleJournals.bundleJournalReadFS[73][0][1] = "/home/jess/projects/scratch/binary-example/target/debug/binary-example";
json.bundleJournals.bundleJournalReadFS[73][0][2] = 8000;
json.bundleJournals.bundleJournalReadFS[73][1] = {};
json.bundleJournals.bundleJournalReadFS[73][1].Right = "<REDACTED>";
...
```

## Risks

Not risky in implementation.

## References

https://fossa.atlassian.net/browse/ANE-909

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
