### PR TITLE
Retires network request incase of timeout error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # FOSSA CLI Changelog
 
 ## Unreleased
+- Network requests: `fossa-cli` retries network requests, if it experiences timeout error. ([#1203](https://github.com/fossas/fossa-cli/pull/1203))
 - Monorepo is no longer a supported feature of FOSSA. ([#1202](https://github.com/fossas/fossa-cli/pull/1202))
 - `experimental-enable-binary-discovery`, `detect-vendored`: Redact file contents in debug bundles. ([#1201](https://github.com/fossas/fossa-cli/pull/1201))
 - `setup.cfg`: Adds support for setup.cfg, in conjuction with `setup.py`. ([#1195](https://github.com/fossas/fossa-cli/pull/1195))

--- a/src/Network/HTTP/Req/Extra.hs
+++ b/src/Network/HTTP/Req/Extra.hs
@@ -3,9 +3,17 @@ module Network.HTTP.Req.Extra (
 ) where
 
 import Control.Exception (SomeException, fromException)
-import Control.Retry (RetryPolicy, constantDelay, limitRetriesByCumulativeDelay)
-import Network.HTTP.Client (HttpException (HttpExceptionRequest), HttpExceptionContent (ResponseTimeout))
-import Network.HTTP.Req (HttpConfig, HttpException (VanillaHttpException), defaultHttpConfig, httpConfigRetryJudgeException, httpConfigRetryPolicy)
+import Control.Retry (RetryPolicy, RetryStatus, constantDelay, limitRetriesByCumulativeDelay)
+import Network.HTTP.Client (HttpException (HttpExceptionRequest), HttpExceptionContent (ConnectionTimeout, ResponseTimeout), Response (responseStatus))
+import Network.HTTP.Req (
+  HttpConfig (
+    httpConfigRetryJudge,
+    httpConfigRetryJudgeException,
+    httpConfigRetryPolicy
+  ),
+  defaultHttpConfig,
+ )
+import Network.HTTP.Types (statusCode)
 
 -- | An HttpConfig that adds a retry handler for ResponseTimeout
 --
@@ -14,34 +22,60 @@ import Network.HTTP.Req (HttpConfig, HttpException (VanillaHttpException), defau
 --
 -- Some examples of behavior to expect:
 --
--- 408 - Request Timeout - Retried
--- 504 - Gateway Timeout - Retried
--- 500 - Internal Server Failure - Immediate failure
--- 502 - Bad Gateway - Immediate failure
--- 503 - Service Unavailable - Immediate failure
--- No internet - Immedate failure
+-- | Status Code | Description                   | Result  |
+-- |-------------|-------------------------------|---------|
+-- | 500         | Internal Server Failure       | Fails   |
+-- | 502         | Bad Gateway                   | Fails   |
+-- | 503         | Service Unavailable           | Fails   |
+-- | 408         | Request Timeout               | Retries |
+-- | 504         | Gateway Timeout               | Retries |
+-- | 524         | A Timeout Occurred            | Retries |
+-- | 598         | Network read timeout error    | Retries |
+-- | 599         | Network connect timeout error | Retries |
+-- | No Network  | N/A                           | Fails   |
+-- -
 httpConfigRetryTimeouts :: HttpConfig
 httpConfigRetryTimeouts =
   defaultHttpConfig
-    { httpConfigRetryJudgeException = const isResponseTimeout
-    , httpConfigRetryPolicy = retryPolicy
+    { httpConfigRetryPolicy = retryPolicy
+    , -- Determines if we should retry a request,
+      -- when exception is encountered
+      httpConfigRetryJudgeException = isTimeout
+    , -- Determines when we should retry a request,
+      -- in which did we did not encounter an exception.
+      httpConfigRetryJudge = \_ response ->
+        statusCodeOf response
+          `elem` [
+                   -- https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+                   408 -- request timeout
+                 , 504 -- gateway timeout
+                 , 524 -- a timeout occurred
+                 , 598 -- network read timeout error
+                 , 599 -- network connect timeout error
+                 ]
     }
-
--- | Retry every 5 seconds for up to 5 minutes
-retryPolicy :: RetryPolicy
-retryPolicy = limitRetriesByCumulativeDelay fiveMinutes (constantDelay fiveSeconds)
   where
-    -- five minutes
-    fiveMinutes :: Int
-    fiveMinutes = 5 * 60 * 1_000_000
+    statusCodeOf = statusCode . responseStatus
+
+-- | Retry every 5 seconds for up to 10 minutes
+retryPolicy :: RetryPolicy
+retryPolicy = limitRetriesByCumulativeDelay tenMinutes (constantDelay fiveSeconds)
+  where
+    -- ten minutes
+    tenMinutes :: Int
+    tenMinutes = 10 * 60 * 1_000_000
 
     -- five seconds
     fiveSeconds :: Int
     fiveSeconds = 5 * 1_000_000
 
--- | Is the Exception a ResponseTimeout?
-isResponseTimeout :: SomeException -> Bool
-isResponseTimeout exc =
-  case fromException exc of
-    Just (VanillaHttpException (HttpExceptionRequest _ ResponseTimeout)) -> True
+-- | True if the exception represnts timeout, otherwise False.
+isTimeout :: RetryStatus -> SomeException -> Bool
+isTimeout _ e =
+  case fromException e of
+    Just (HttpExceptionRequest _ c) ->
+      case c of
+        ResponseTimeout -> True
+        ConnectionTimeout -> True
+        _ -> False
     _ -> False


### PR DESCRIPTION
# Overview

This PR, modifies retry policy, and http config, so we retry network request if we receive timeout error. 

Looking at [telemetry](https://app.datadoghq.com/event/analytics?query=source%3Amy_apps%20A%20connection%20to%20the%20FOSSA%20endpoint%20was%20established%2C%20but%20the%20service%20took%20too%20long%20to%20respond.&cols=&messageDisplay=expanded-lg&options=&sort=DESC&from_ts=1672556400000&to_ts=1685469120000&live=false), we see: 
<img width="2059" alt="image" src="https://github.com/fossas/fossa-cli/assets/86321858/1c52e596-8705-4c10-a807-df52f8ee24cd">


## Acceptance criteria

- We retry network request, that failed due to timeouts.


## Testing plan

0. `git checkout master && git pull origin && git checkout feat/should-retry-network-calls`
1. `make install-dev`

**Run server (terminal 1)**
```bash
while true; do nc -l 8001; done
```

**(current) Run cli (terminal 2)**
```bash
>> fossa test --fossa-api-key somekey -e http://localhost:8001

GET /api/cli/organization HTTP/1.1
Host: localhost:8001
Accept-Encoding: gzip
Authorization: Bearer somekey
Accept: application/json

GET /api/cli/organization HTTP/1.1
Host: localhost:8001
Accept-Encoding: gzip
Authorization: Bearer somekey
Accept: application/json

<<-- FAILS HERE
```

**(with change) Run cli (terminal 2)**
```
fossa-dev test --fossa-api-key somekey -e http://localhost:8001

GET /api/cli/organization HTTP/1.1
Host: localhost:8001
Accept-Encoding: gzip
Authorization: Bearer somekey
Accept: application/json

GET /api/cli/organization HTTP/1.1
Host: localhost:8001
Accept-Encoding: gzip
Authorization: Bearer somekey
Accept: application/json

.... Keeps going until 10mins and fails
```

## Risks

Is 10 min too much - should we revert to 5mins?

## References

https://fossa.atlassian.net/browse/ANE-912

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
