### PR TITLE
fix failing Gradle integration test

### DIFF
--- a/integration-test/Analysis/GradleSpec.hs
+++ b/integration-test/Analysis/GradleSpec.hs
@@ -28,7 +28,7 @@ springBoot =
     gradleEnv
     Nothing
     $ FixtureArtifact
-    "https://github.com/spring-projects/spring-boot/archive/refs/tags/v3.1.0-M1.tar.gz"
+      "https://github.com/spring-projects/spring-boot/archive/refs/tags/v3.1.0-M1.tar.gz"
       [reldir|gradle/sample/|]
       [reldir|spring-boot-3.1.0-M1|]
 

--- a/integration-test/Analysis/GradleSpec.hs
+++ b/integration-test/Analysis/GradleSpec.hs
@@ -28,9 +28,9 @@ springBoot =
     gradleEnv
     Nothing
     $ FixtureArtifact
-      "https://github.com/spring-projects/spring-boot/archive/refs/tags/v3.0.0-M1.tar.gz"
+    "https://github.com/spring-projects/spring-boot/archive/refs/tags/v3.1.0-M1.tar.gz"
       [reldir|gradle/sample/|]
-      [reldir|spring-boot-3.0.0-M1|]
+      [reldir|spring-boot-3.1.0-M1|]
 
 gradleSettingsOnly :: AnalysisTestFixture (Gradle.GradleProject)
 gradleSettingsOnly =
@@ -47,7 +47,7 @@ gradleSettingsOnly =
 testSpringBoot :: Spec
 testSpringBoot =
   aroundAll (withAnalysisOf springBoot) $ do
-    describe "gradle-java" $ do
+    describe "gradle-java springboot" $ do
       it "should find targets" $ \(result, extractedDir) -> do
         expectProject (GradleProjectType, extractedDir) result
         length result `shouldBe` 1
@@ -55,7 +55,7 @@ testSpringBoot =
 testGradleSettingsOnly :: Spec
 testGradleSettingsOnly =
   aroundAll (withAnalysisOf gradleSettingsOnly) $ do
-    describe "gradle-java" $ do
+    describe "gradle-java gradle settings only" $ do
       it "should find targets" $ \(result, extractedDir) -> do
         expectProject (GradleProjectType, extractedDir) result
         length result `shouldBe` 1


### PR DESCRIPTION
# Overview

Spring boot was using a plugin that Gradle couldn't find anymore. I've upgraded the version of springboot to a version that doesn't have that problem in its settings.Gradle.

## Acceptance criteria

Integration tests should pass now.

## Testing plan

I verified that integration tests completed successfully. 

## References

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
