### PR TITLE
Add metrics tracking to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,12 @@ _Highlight any areas that you're unsure of, want feedback on, or want reviewers 
 
 _Example: I'm not sure I did X correctly, can reviewers please double-check that for me?_
 
+## Metrics
+
+_Optional at the moment_
+
+_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_
+
 ## References
 
 _Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,8 +29,6 @@ _Example: I'm not sure I did X correctly, can reviewers please double-check that
 
 ## Metrics
 
-_Optional at the moment_
-
 _Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_
 
 ## References


### PR DESCRIPTION
# Overview

We've talked a lot about tracking metrics as a team. This is an easy way to get people in the habit of thinking about it.

## Risks

We think too much about useless metrics

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
