### PR TITLE
[ANE-1009] golang retract statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ vendor-bins/
 /fossa-?dev
 /release
 /fourmolu
+/hlint
 
 # Debug output
 fossa.debug.json

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## Unreleased
 - Setup.py: Fixes an defect with `setup.py` parser, caused by failing to account for line comments or backslash. ([#1191](https://github.com/fossas/fossa-cli/pull/1191))
 - Installation: `install-latest.sh` now directs `curl` and `wget` to pass `Cache-Control: no-cache` headers to the server. ([#1206](https://github.com/fossas/fossa-cli/pull/1206))
-- `Go.mod`: Anaysis does not fail if it includes `retract` block.
+- `Go.mod`: Anaysis does not fail if `go.mod` includes `retract` block. ([#1213](https://github.com/fossas/fossa-cli/pull/1213))
 
 ## v3.8.0
 - License Scanning: You can license scan your first-party code with the `--experimental-force-first-party-scans` flag ([#1187](https://github.com/fossas/fossa-cli/pull/1187))

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Setup.py: Fixes an defect with `setup.py` parser, caused by failing to account for line comments or backslash. ([#1191](https://github.com/fossas/fossa-cli/pull/1191))
 - Installation: `install-latest.sh` now directs `curl` and `wget` to pass `Cache-Control: no-cache` headers to the server. ([#1206](https://github.com/fossas/fossa-cli/pull/1206))
+- `Go.mod`: Anaysis does not fail if it includes `retract` block.
 
 ## v3.8.0
 - License Scanning: You can license scan your first-party code with the `--experimental-force-first-party-scans` flag ([#1187](https://github.com/fossas/fossa-cli/pull/1187))

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -274,7 +274,7 @@ gomodParser = do
     singleExclude :: Parser Statement
     singleExclude = ExcludeStatement <$> packageName <*> version
 
-    -- top-level retract statment
+    -- top-level retract statements
     -- e.g.:
     --  retract v1.0.0
     --  retract [v1.0.0, v1.9.9]

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -20,7 +20,7 @@ import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, context, recover, warnOnErr)
 import Data.Char (isSpace)
 import Data.Foldable (traverse_)
-import Data.Functor (void)
+import Data.Functor (void, ($>))
 import Data.Hashable (Hashable)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -58,6 +58,7 @@ import Text.Megaparsec (
   oneOf,
   optional,
   parse,
+  sepBy,
   some,
   (<|>),
  )
@@ -66,8 +67,6 @@ import Text.Megaparsec.Char.Lexer qualified as L
 import Types (GraphBreadth (..))
 
 -- For the file's grammar, see https://golang.org/ref/mod#go-mod-file-grammar.
---
--- TODO: handle retract statements
 data Statement
   = -- | package, version
     RequireStatement PackageName PackageVersion
@@ -77,6 +76,11 @@ data Statement
     LocalReplaceStatement PackageName Text
   | -- | package, version
     ExcludeStatement PackageName PackageVersion
+  | -- | we do not care about values
+    -- associated with retract block for dependency graphing,
+    -- as they do not signify any relationship with dependencies
+    -- of go.mod, refer to: https://go.dev/ref/mod#go-mod-file-retract
+    RetractStatement
   | GoVersionStatement Text
   deriving (Eq, Ord, Show)
 
@@ -217,6 +221,7 @@ gomodParser = do
         <|> requireStatements
         <|> replaceStatements
         <|> excludeStatements
+        <|> retractStatements
 
     -- top-level go version statement
     -- e.g., go 1.12
@@ -269,6 +274,23 @@ gomodParser = do
     singleExclude :: Parser Statement
     singleExclude = ExcludeStatement <$> packageName <*> version
 
+    -- top-level retract statment
+    -- e.g.:
+    --  retract v1.0.0
+    --  retract [v1.0.0, v1.9.9]
+    --  retract (
+    --    v1.0.0
+    --    [v1.0.0, v1.9.9]
+    --  )
+    retractStatements :: Parser [Statement]
+    retractStatements = block "retract" (singleRetract <|> multipleRetract)
+
+    singleRetract :: Parser Statement
+    singleRetract = version $> RetractStatement
+
+    multipleRetract :: Parser Statement
+    multipleRetract = squareBrackets (version `sepBy` (symbol ",")) $> RetractStatement
+
     version :: Parser PackageVersion
     version = parsePackageVersion lexeme
 
@@ -308,6 +330,7 @@ gomodParser = do
 
     -- lexer combinators
     parens = between (symbol "(") (symbol ")")
+    squareBrackets = between (symbol "[") (symbol "]")
     symbol = L.symbol scn
     lexeme = L.lexeme sc
 


### PR DESCRIPTION
# Overview

This PR, 
- updates `go.mod` parser so, we don't fail when `retract` block exists

## Acceptance criteria

- `go.mod` parser does not fail when, `retract` block exists

## Testing plan

**Prereq**
```
git checkout master && git pull origin && git checkout go-lang-parser
make install-dev
mkdir sandbox && cd sandbox && wget https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/d1bda6802bc94c9c6980e9d47265801b4c62458f/internal/aws/xray/go.mod
```

**Current**
```
fossa analyze --output # fails
```

**With Change**
```
fossa-dev analyze --output # passes
```

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-1009

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
