### PR TITLE
[ANE-1018] Fails for `remote-dep` when it goes above length of 255

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Installation: `install-latest.sh` now directs `curl` and `wget` to pass `Cache-Control: no-cache` headers to the server. ([#1206](https://github.com/fossas/fossa-cli/pull/1206))
 - `Go.mod`: Anaysis does not fail if `go.mod` includes `retract` block. ([#1213](https://github.com/fossas/fossa-cli/pull/1213))
 - `.aar`: Supports `.aar` archive files with native license scanning, and with `--unpack-archives` option. ([#1217](https://github.com/fossas/fossa-cli/pull/1217))
+- `remote-dependencies`: Analysis of `fossa-deps` fails, if remote-dependencies's character length is greater than maximum. It only applies during non-output mode.
 
 ## v3.8.0
 - License Scanning: You can license scan your first-party code with the `--experimental-force-first-party-scans` flag ([#1187](https://github.com/fossas/fossa-cli/pull/1187))

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 - Installation: `install-latest.sh` now directs `curl` and `wget` to pass `Cache-Control: no-cache` headers to the server. ([#1206](https://github.com/fossas/fossa-cli/pull/1206))
 - `Go.mod`: Anaysis does not fail if `go.mod` includes `retract` block. ([#1213](https://github.com/fossas/fossa-cli/pull/1213))
 - `.aar`: Supports `.aar` archive files with native license scanning, and with `--unpack-archives` option. ([#1217](https://github.com/fossas/fossa-cli/pull/1217))
-- `remote-dependencies`: Analysis of `fossa-deps` fails, if remote-dependencies's character length is greater than maximum. It only applies during non-output mode. ([#1216][https://github.com/fossas/fossa-cli/pull/1216])
+- `remote-dependencies`: Analysis of `fossa-deps` fails, if remote-dependencies's character length is greater than maximum. It only applies during non-output mode. ([#1216](https://github.com/fossas/fossa-cli/pull/1216))
 
 ## v3.8.0
 - License Scanning: You can license scan your first-party code with the `--experimental-force-first-party-scans` flag ([#1187](https://github.com/fossas/fossa-cli/pull/1187))

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 - Installation: `install-latest.sh` now directs `curl` and `wget` to pass `Cache-Control: no-cache` headers to the server. ([#1206](https://github.com/fossas/fossa-cli/pull/1206))
 - `Go.mod`: Anaysis does not fail if `go.mod` includes `retract` block. ([#1213](https://github.com/fossas/fossa-cli/pull/1213))
 - `.aar`: Supports `.aar` archive files with native license scanning, and with `--unpack-archives` option. ([#1217](https://github.com/fossas/fossa-cli/pull/1217))
-- `remote-dependencies`: Analysis of `fossa-deps` fails, if remote-dependencies's character length is greater than maximum. It only applies during non-output mode.
+- `remote-dependencies`: Analysis of `fossa-deps` fails, if remote-dependencies's character length is greater than maximum. It only applies during non-output mode. ([#1216][https://github.com/fossas/fossa-cli/pull/1216])
 
 ## v3.8.0
 - License Scanning: You can license scan your first-party code with the `--experimental-force-first-party-scans` flag ([#1187](https://github.com/fossas/fossa-cli/pull/1187))

--- a/docs/references/files/fossa-deps.md
+++ b/docs/references/files/fossa-deps.md
@@ -55,6 +55,13 @@ Denotes listing of dependencies, whose source code is to be downloaded from prov
 - `metadata.homepage`: Homepage of the dependency. This metadata is used to enrich reporting provided in FOSSA's web interface.
 - `metadata.description`: Description of the dependency. This metadata is used to enrich reporting provided in FOSSA's web interface.
 
+> Combined length of url and version has upper bound. It depends on your organization identifier. You can
+find your organization identifier in FOSSA Webapp, by going to any project's "settings" page, and retrieving
+numeric value from project's locator. For example, project locator of `custom+123/some-project-id`, means
+`123` is your organization identifier. 
+
+> Combined length of `url`, `version`, and your `organizaion id` must be less than `241`.
+
 For more details, please refer to the [feature](../../features/manual-dependencies.md) walk through. 
 
 ### `vendored-dependencies:`

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -31,7 +31,7 @@ import App.Fossa.VendoredDependency (
  )
 import App.Types (FullFileUploads (..))
 import Control.Carrier.FossaApiClient (runFossaApiClient)
-import Control.Effect.Diagnostics (Diagnostics, context, fatalText)
+import Control.Effect.Diagnostics (Diagnostics, context, fatalText, fatal)
 import Control.Effect.FossaApiClient (FossaApiClient, getOrganization)
 import Control.Effect.Lift (Has, Lift)
 import Control.Effect.StickyLogger (StickyLogger)
@@ -53,8 +53,9 @@ import Data.String.Conversion (toString, toText)
 import Data.Text (Text, toLower)
 import Data.Text qualified as Text
 import DepTypes (DepType (..))
+import Diag.Diagnostic (ToDiagnostic (renderDiagnostic))
 import Effect.Exec (Exec)
-import Effect.Logger (Logger)
+import Effect.Logger (Logger, vsep, pretty, indent)
 import Effect.ReadFS (ReadFS, doesFileExist, readContentsJson, readContentsYaml)
 import Fossa.API.Types (ApiOpts, Organization (..))
 import Path (Abs, Dir, File, Path, mkRelFile, (</>))
@@ -148,9 +149,16 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendor
     -- Don't do anything if there are no vendored deps.
     (_, Nothing) -> pure []
 
+    -- Some manual deps, such as remote dependencies in source unit cannot be
+    -- validated without endpoint interactions.
+  rdeps <- case maybeApiOpts of
+    Just apiOpts -> runFossaApiClient apiOpts $ do
+      traverse (\r -> validateRemoteDep r =<< getOrganization) remoteDependencies
+    Nothing -> pure remoteDependencies
+
   let renderedPath = toText root
       referenceLocators = refToLocator <$> referencedDependencies
-      additional = toAdditionalData (NE.nonEmpty customDependencies) (NE.nonEmpty remoteDependencies)
+      additional = toAdditionalData (NE.nonEmpty customDependencies) (NE.nonEmpty rdeps)
       build = toBuildData <$> NE.nonEmpty (referenceLocators <> archiveLocators)
       originPath = case depsFile of
         (ManualJSON path) -> tryMakeRelative root path
@@ -475,6 +483,47 @@ instance FromJSON RemoteDependency where
       <*> (obj `neText` "url")
       <*> obj .:? "metadata"
       <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
+
+validateRemoteDep :: (Has Diagnostics sig m) => RemoteDependency -> Organization -> m RemoteDependency
+validateRemoteDep r org = if locatorLen > maxLocatorLength
+      then fatal $ RemoteDepLengthIsGtThanAllowed (r, maxUrlRevLength)
+      else pure r
+  where
+    orgId :: Text
+    orgId = toText . show . organizationId $ org
+
+    maxLocatorLength :: Int
+    maxLocatorLength = 255
+
+    locatorLen :: Int
+    locatorLen = Text.length $ Text.intercalate "" [requiredChars, urlRevChars]
+
+    requiredChars :: Text
+    requiredChars = Text.intercalate "" ["url-private+", orgId, "/", "$"]
+
+    urlRevChars :: Text
+    urlRevChars = Text.intercalate "" [remoteUrl r, remoteVersion r]
+
+    maxUrlRevLength :: Int
+    maxUrlRevLength = maxLocatorLength - Text.length requiredChars
+
+newtype RemoteDepLengthIsGtThanAllowed = RemoteDepLengthIsGtThanAllowed (RemoteDependency, Int)
+instance ToDiagnostic RemoteDepLengthIsGtThanAllowed where
+  renderDiagnostic (RemoteDepLengthIsGtThanAllowed (r, maxLen)) = vsep [
+      "You provided remote-dependency: ",
+      "",
+      indent 2 $ pretty $ "Name: " <> remoteName r,
+      indent 2 $ pretty $ "Url: " <> remoteUrl r,
+      indent 2 $ pretty $ "Version: " <> remoteVersion r,
+      "",
+      pretty $ "The combined length of url and version is: "
+        <> show urlRevLength
+        <> ". It must be below: " <> show maxLen <> "."
+    ]
+    where
+      urlRevLength :: Int
+      urlRevLength = Text.length $ Text.intercalate "" [remoteUrl r, remoteVersion r]
+
 
 -- Dependency "metadata" section for both Remote and Custom Dependencies
 instance FromJSON DependencyMetadata where

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -154,7 +154,7 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendor
   rdeps <- case maybeApiOpts of
     Just apiOpts -> runFossaApiClient apiOpts $ do
       org <- getOrganization
-      traverse (\r -> validateRemoteDep r org) remoteDependencies
+      traverse (`validateRemoteDep` org) remoteDependencies
     Nothing -> pure remoteDependencies
 
   let renderedPath = toText root

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -153,7 +153,8 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendor
   -- validated without endpoint interactions.
   rdeps <- case maybeApiOpts of
     Just apiOpts -> runFossaApiClient apiOpts $ do
-      traverse (\r -> validateRemoteDep r =<< getOrganization) remoteDependencies
+      org <- getOrganization
+      traverse (\r -> validateRemoteDep r org) remoteDependencies
     Nothing -> pure remoteDependencies
 
   let renderedPath = toText root


### PR DESCRIPTION
# Overview

This PR, 
- Adds remote dep constraint on character length (only in upload mode)

## Acceptance criteria

- Fatally fails, when `remote-dep`'s length is greater than allowed length.

## Testing plan

**Prereq:**

```bash
git checkout master && git pull origin && git checkout fix/limit-chars-remote-dep && make install-dev
```

**Test Happy Path:**
```yaml
# > cat fossa-deps.yml
remote-dependencies:
  - name: fossa-cli
    url: https://github.com/fossas/fossa-cli/archive/refs/heads/master.zip
    version: "latest"
```

Run: `fossa analyze -p ane1018 -r happy --fossa-api-key some-key` (should succeed)

**Test not so Happy Path:**
```yaml
# > cat fossa-deps.yml
remote-dependencies:
  - name: fossa-cli
    url: https://github.com/fossas/fossa-cli/archive/refs/heads/master.zip
    version: "latest"

  - name: long-dep
    url: https://ohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurlohsuchalongurl.com/asset.zip
    version: "0.0.1"
```
Run: `fossa analyze -p ane1018 -r not-happy --fossa-api-key some-key` (should fail for `fossa-deps.yml`)

![ane1018-ex](https://github.com/fossas/fossa-cli/assets/86321858/e18998c8-e5fe-4e95-a085-706c7ea51711)

## Risks

We only fail when we are not in `--output` mode, since we don't know the organization Id at output only mode.

Endpoint Code:
- https://github.com/fossas/FOSSA/blob/develop/modules/BuildMetadataManager/additionalDependencyData.ts#L72
- https://github.com/fossas/FOSSA/blob/develop/modules/UrlPrivateDependencyManager.ts#L67

Long term, we should have have more holistic validation approach, ideally done at endpoint for things that requires some interaction w endpoint. 

## Metrics

N/A

## References

https://fossa.atlassian.net/browse/ANE-1018

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
