### PR TITLE
[ANE-504] Supports `.aar` file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 - Setup.py: Fixes an defect with `setup.py` parser, caused by failing to account for line comments or backslash. ([#1191](https://github.com/fossas/fossa-cli/pull/1191))
 - Installation: `install-latest.sh` now directs `curl` and `wget` to pass `Cache-Control: no-cache` headers to the server. ([#1206](https://github.com/fossas/fossa-cli/pull/1206))
 - `Go.mod`: Anaysis does not fail if `go.mod` includes `retract` block. ([#1213](https://github.com/fossas/fossa-cli/pull/1213))
-- `.aar`: Supports `.aar` file.
+- `.aar`: Supports `.aar` archive files with native license scanning, and with `--unpack-archives` option. ([#1213](https://github.com/fossas/fossa-cli/pull/1217))
 
 ## v3.8.0
 - License Scanning: You can license scan your first-party code with the `--experimental-force-first-party-scans` flag ([#1187](https://github.com/fossas/fossa-cli/pull/1187))

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 - Setup.py: Fixes an defect with `setup.py` parser, caused by failing to account for line comments or backslash. ([#1191](https://github.com/fossas/fossa-cli/pull/1191))
 - Installation: `install-latest.sh` now directs `curl` and `wget` to pass `Cache-Control: no-cache` headers to the server. ([#1206](https://github.com/fossas/fossa-cli/pull/1206))
 - `Go.mod`: Anaysis does not fail if `go.mod` includes `retract` block. ([#1213](https://github.com/fossas/fossa-cli/pull/1213))
+- `.aar`: Supports `.aar` file.
 
 ## v3.8.0
 - License Scanning: You can license scan your first-party code with the `--experimental-force-first-party-scans` flag ([#1187](https://github.com/fossas/fossa-cli/pull/1187))

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 - Setup.py: Fixes an defect with `setup.py` parser, caused by failing to account for line comments or backslash. ([#1191](https://github.com/fossas/fossa-cli/pull/1191))
 - Installation: `install-latest.sh` now directs `curl` and `wget` to pass `Cache-Control: no-cache` headers to the server. ([#1206](https://github.com/fossas/fossa-cli/pull/1206))
 - `Go.mod`: Anaysis does not fail if `go.mod` includes `retract` block. ([#1213](https://github.com/fossas/fossa-cli/pull/1213))
-- `.aar`: Supports `.aar` archive files with native license scanning, and with `--unpack-archives` option. ([#1213](https://github.com/fossas/fossa-cli/pull/1217))
+- `.aar`: Supports `.aar` archive files with native license scanning, and with `--unpack-archives` option. ([#1217](https://github.com/fossas/fossa-cli/pull/1217))
 
 ## v3.8.0
 - License Scanning: You can license scan your first-party code with the `--experimental-force-first-party-scans` flag ([#1187](https://github.com/fossas/fossa-cli/pull/1187))

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -66,6 +66,7 @@ We support the following archive formats:
 - `.tar.xz`
 - `.tar.bz2`
 - `.jar`
+- `.aar`
 - `.rpm`, with...
   - `gzip` compression
   - `lzma` compression

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -80,6 +80,7 @@ selectUnarchiver file
   | ".zip" `isSuffixOf` file = Just extractZip
   | ".jar" `isSuffixOf` file = Just extractZip
   | ".rpm" `isSuffixOf` file = Just extractRpm
+  | ".aar" `isSuffixOf` file = Just extractZip
   | otherwise = Nothing
 
 -- | Extract an archive to a temporary directory, and run the provided callback


### PR DESCRIPTION
# Overview

This PR adds support for `.aar` file.

## Acceptance criteria

As a user, I can:
- analyze `aar` file for native license scanning, when provided as vendor dep
- analyze `aar` file with `--unpack-archive` option

## Testing plan

Retrieve example file from: https://fossa.atlassian.net/browse/ANE-504

```bash
>> git checkout master && git pull origin && git checkout feat/can-scan-aar

# download vendor deps
>>  GITHUB_TOKEN=mytoken vendor_download.sh

# ensure cache is clean so vendor deps get picked up!
>> cabal clean
>> make install-dev
```

Or you can retrieve binaries from CI's artifact instead: https://github.com/fossas/fossa-cli/actions/runs/5200927462

**Before the change**

```bash
# fossa-deps.yml
vendored-dependencies:
  - name: ExampleAar
    path: facebook-core-4.35.0.aar
    version: "0.0.1"
```

Execute `./fossa license-scan fossa-deps`. You should see error message.

<img width="910" alt="image" src="https://github.com/fossas/fossa-cli/assets/86321858/ce0bde97-19c9-416d-83bb-e030ac924f63">

**After the change**

```bash
# fossa-deps.yml
vendored-dependencies:
  - name: ExampleAar
    path: facebook-core-4.35.0.aar
    version: "0.0.1"
```

Execute `./fossa-dev license-scan fossa-deps`. You should see findings. 

<img width="744" alt="image" src="https://github.com/fossas/fossa-cli/assets/86321858/7484e2a2-cc74-4fc4-a83c-591b056ed0bb">

Or execute: `./fossa-dev analyze -p aarsupport-1 -r 1` and see that it reports licenses and findings in webapp.

## Risks

N/A

## Metrics

N/A

## References

[ANE-504](https://fossa.atlassian.net/browse/ANE-504)

## Checklist

- [ ] ~I added tests for this PR's change (or explained in the PR description why tests don't make sense).~
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] ~If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).~


[ANE-504]: https://fossa.atlassian.net/browse/ANE-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ