### PR TITLE
Fix windows build in CI

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -23,19 +23,16 @@ jobs:
             container: fossa/haskell-static-alpine:ghc-9.0.2
             project-file: cabal.project.ci.linux
             ghc: '9.0.2'
-            cabal: '3.6'
 
           - os: macos-latest
             os-name: macOS
             project-file: cabal.project.ci.macos
             ghc: '9.0.2'
-            cabal: '3.6'
 
           - os: windows-latest
             os-name: Windows
             project-file: cabal.project.ci.windows
             ghc: '9.0.2'
-            cabal: '3.6'
 
     steps:
 
@@ -55,7 +52,6 @@ jobs:
       if: ${{ !contains(matrix.os, 'ubuntu') }}
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: ${{ matrix.cabal }}
 
     # Set up Rust.
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -49,7 +49,7 @@ jobs:
         brew install jq
 
     # Set up Haskell.
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v2
       id: setup-haskell
       name: Setup ghc/cabal (non-alpine)
       if: ${{ !contains(matrix.os, 'ubuntu') }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -23,16 +23,19 @@ jobs:
             container: fossa/haskell-static-alpine:ghc-9.0.2
             project-file: cabal.project.ci.linux
             ghc: '9.0.2'
+            cabal: '3.6'
 
           - os: macos-latest
             os-name: macOS
             project-file: cabal.project.ci.macos
             ghc: '9.0.2'
+            cabal: '3.6'
 
           - os: windows-latest
             os-name: Windows
             project-file: cabal.project.ci.windows
             ghc: '9.0.2'
+            cabal: '3.6'
 
     steps:
 
@@ -52,6 +55,7 @@ jobs:
       if: ${{ !contains(matrix.os, 'ubuntu') }}
       with:
         ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
 
     # Set up Rust.
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
# Overview

We were getting an error on installing cabal in some CI jobs. I noticed that we are on an older version of the action. This PR upgrades it and fixes the problem. Example [failing job](https://github.com/fossas/fossa-cli/actions/runs/5225443835/jobs/9434910055#step:4:108). 

## Acceptance criteria

CI should for windows should get past the "install cabal" step. 

## Testing plan

I waited to see if CI would get past the "install cabal" step. 

## Risks

## Metrics

## References


## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
