### PR TITLE
[No Ticket] 502s are retried

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@
 - `Go.mod`: Anaysis does not fail if `go.mod` includes `retract` block. ([#1213](https://github.com/fossas/fossa-cli/pull/1213))
 - `.aar`: Supports `.aar` archive files with native license scanning, and with `--unpack-archives` option. ([#1217](https://github.com/fossas/fossa-cli/pull/1217))
 - `remote-dependencies`: Analysis of `fossa-deps` fails, if remote-dependencies's character length is greater than maximum. It only applies during non-output mode. ([#1216](https://github.com/fossas/fossa-cli/pull/1216))
-- Network requests: `fossa-cli` retries network requests which return response with status code of 502.
+- Network requests: `fossa-cli` retries network requests which return response with status code of 502. ([#1220](https://github.com/fossas/fossa-cli/pull/1220))
 
 ## v3.8.0
 - License Scanning: You can license scan your first-party code with the `--experimental-force-first-party-scans` flag ([#1187](https://github.com/fossas/fossa-cli/pull/1187))

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - `Go.mod`: Anaysis does not fail if `go.mod` includes `retract` block. ([#1213](https://github.com/fossas/fossa-cli/pull/1213))
 - `.aar`: Supports `.aar` archive files with native license scanning, and with `--unpack-archives` option. ([#1217](https://github.com/fossas/fossa-cli/pull/1217))
 - `remote-dependencies`: Analysis of `fossa-deps` fails, if remote-dependencies's character length is greater than maximum. It only applies during non-output mode. ([#1216](https://github.com/fossas/fossa-cli/pull/1216))
+- Network requests: `fossa-cli` retries network requests which return response with status code of 502.
 
 ## v3.8.0
 - License Scanning: You can license scan your first-party code with the `--experimental-force-first-party-scans` flag ([#1187](https://github.com/fossas/fossa-cli/pull/1187))

--- a/src/Network/HTTP/Req/Extra.hs
+++ b/src/Network/HTTP/Req/Extra.hs
@@ -25,7 +25,7 @@ import Network.HTTP.Types (statusCode)
 -- | Status Code | Description                   | Result  |
 -- |-------------|-------------------------------|---------|
 -- | 500         | Internal Server Failure       | Fails   |
--- | 502         | Bad Gateway                   | Fails   |
+-- | 502         | Bad Gateway                   | Retries |
 -- | 503         | Service Unavailable           | Fails   |
 -- | 408         | Request Timeout               | Retries |
 -- | 504         | Gateway Timeout               | Retries |
@@ -48,6 +48,7 @@ httpConfigRetryTimeouts =
           `elem` [
                    -- https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
                    408 -- request timeout
+                 , 502 -- bad gateway
                  , 504 -- gateway timeout
                  , 524 -- a timeout occurred
                  , 598 -- network read timeout error


### PR DESCRIPTION
# Overview

This PR retries, 502 status code requests.

## Acceptance criteria

- All api requests returning 502 response codes are retried!

## Testing plan

Terminal 1:
```python
# filename: main.py
from typing import Union
from fastapi import FastAPI
app = FastAPI()

@app.get("/api/cli/organization", status_code=502)
def read_root():
    return {}
```

```bash
>> uvicorn main:app
```

Terminal 2:
```
sudo make install-dev
fossa-dev analyze . --fossa-api-key -e http://127.0.0.1:8000
```

You should see that it does not fail ouright, while on terminal 1, you should be able to see the all retry attempts by fossa-cli!

## Risks

N/A

## Metrics

N/A

## References

Slack thread: https://teamfossa.slack.com/archives/C039KE5ERNE/p1686338403435209

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
