### PR TITLE
[No Ticket] Get os-release info/uname output in telemetry.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## Unreleased
-- Telemetry: Collect GNU/Linux distribution information and `uname -a` output. ([#1222](https://github.com/fossas/fossa-cli/pull/1222))
+- Telemetry: Collect GNU/Linux distribution information and `uname` output. ([#1222](https://github.com/fossas/fossa-cli/pull/1222))
 
 ## v3.8.2
 - Poetry: Defaults `category` to `main` if not present in lockfile. ([#1211](https://github.com/fossas/fossa-cli/pull/1211))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- Telemetry: Collect GNU/Linux distribution information and `uname -a` output. ([#1222](https://github.com/fossas/fossa-cli/pull/1222))
+
 ## v3.8.2
 - Poetry: Defaults `category` to `main` if not present in lockfile. ([#1211](https://github.com/fossas/fossa-cli/pull/1211))
 - Maven: Revert ([#1218](https://github.com/fossas/fossa-cli/pull/1218)) from v3.8.2 due to performance impacts.

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -102,6 +102,7 @@ common deps
     , network                      ^>=3.1.2.0
     , network-uri                  ^>=2.6.4.0
     , optparse-applicative         ^>=0.17.0.0
+    , os-release                   ^>=1.0.2
     , parser-combinators           ^>=1.3
     , path                         ^>=0.9.0
     , path-io                      ^>=1.8.0

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -113,6 +113,7 @@ common deps
     , raw-strings-qq               ^>=1.1
     , req                          ^>=3.13.0
     , retry                        ^>=0.9.0.0
+    , safe-exceptions              ^>=0.1.7
     , semver                       ^>=0.4.0.1
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0

--- a/src/Container/OsRelease.hs
+++ b/src/Container/OsRelease.hs
@@ -155,6 +155,9 @@ osInfoParser =
 initComments :: Parser ()
 initComments = void $ many $ (symbol "#") *> takeWhileP (Just "character") (/= '\n') <* "\n"
 
+-- NOTE: For telemetry purposes we use a pre-existing library to do this.
+-- If we find issues in this parser in the future, consider using that.
+
 -- | Parses os-release file for OS release information.
 osReleaseParser :: Parser OsInfo
 osReleaseParser = do

--- a/src/Control/Carrier/Telemetry/Types.hs
+++ b/src/Control/Carrier/Telemetry/Types.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE DerivingStrategies #-}
+
 module Control.Carrier.Telemetry.Types (
   CliEnvironment (..),
+  LddVersionErr (..),
   SystemInfo (..),
   TelemetryRecord (..),
   TimedLogRecord (..),
@@ -108,6 +111,12 @@ instance Show CliEnvironment where
 instance ToJSON CliEnvironment where
   toJSON = String . showT
 
+newtype LddVersionErr = LddVersionErr Text
+  deriving (Eq, Ord, Generic)
+  deriving newtype (Show)
+
+instance ToJSON LddVersionErr
+
 data SystemInfo = SystemInfo
   { systemInfoOs :: String
   , systemInfoArch :: String
@@ -115,6 +124,7 @@ data SystemInfo = SystemInfo
   , systemProcessors :: Int
   , systemDistroInfo :: Maybe String
   , systemUnameString :: Maybe Text
+  , systemLddVersion :: Maybe (Either LddVersionErr Text)
   }
   deriving (Eq, Ord, Show, Generic)
 

--- a/src/Control/Carrier/Telemetry/Types.hs
+++ b/src/Control/Carrier/Telemetry/Types.hs
@@ -113,6 +113,7 @@ data SystemInfo = SystemInfo
   , systemInfoArch :: String
   , systemCapabilities :: Int
   , systemProcessors :: Int
+  , systemInfoUname :: Maybe Text
   }
   deriving (Eq, Ord, Show, Generic)
 

--- a/src/Control/Carrier/Telemetry/Types.hs
+++ b/src/Control/Carrier/Telemetry/Types.hs
@@ -113,7 +113,8 @@ data SystemInfo = SystemInfo
   , systemInfoArch :: String
   , systemCapabilities :: Int
   , systemProcessors :: Int
-  , systemDistroInfo :: Maybe Text
+  , systemDistroInfo :: Maybe String
+  , systemUnameString :: Maybe Text
   }
   deriving (Eq, Ord, Show, Generic)
 

--- a/src/Control/Carrier/Telemetry/Types.hs
+++ b/src/Control/Carrier/Telemetry/Types.hs
@@ -10,6 +10,7 @@ module Control.Carrier.Telemetry.Types (
   TelemetryCtx (..),
   TelemetryTimeSpent (..),
   TelemetryCmdConfig (..),
+  UnameExecErr (..),
   CountableCliFeature (..),
   CIEnvironment (..),
 ) where
@@ -117,13 +118,19 @@ newtype LddVersionErr = LddVersionErr Text
 
 instance ToJSON LddVersionErr
 
+newtype UnameExecErr = UnameExecErr Text
+  deriving (Eq, Ord, Generic)
+  deriving newtype (Show)
+
+instance ToJSON UnameExecErr
+
 data SystemInfo = SystemInfo
   { systemInfoOs :: String
   , systemInfoArch :: String
   , systemCapabilities :: Int
   , systemProcessors :: Int
   , systemDistroInfo :: Maybe String
-  , systemUnameString :: Maybe Text
+  , systemUname :: Maybe (Either UnameExecErr Text)
   , systemLddVersion :: Maybe (Either LddVersionErr Text)
   }
   deriving (Eq, Ord, Show, Generic)

--- a/src/Control/Carrier/Telemetry/Types.hs
+++ b/src/Control/Carrier/Telemetry/Types.hs
@@ -113,7 +113,7 @@ data SystemInfo = SystemInfo
   , systemInfoArch :: String
   , systemCapabilities :: Int
   , systemProcessors :: Int
-  , systemInfoUname :: Maybe Text
+  , systemDistroInfo :: Maybe Text
   }
   deriving (Eq, Ord, Show, Generic)
 

--- a/src/Control/Carrier/Telemetry/Utils.hs
+++ b/src/Control/Carrier/Telemetry/Utils.hs
@@ -114,7 +114,7 @@ getSystemInfo = do
 
     readUname :: IO (Maybe Text)
     readUname = do
-      (exitCode, out) <- readProcessStdout "uname -a"
+      (exitCode, out) <- readProcessStdout "uname -mrsv"
       pure $ case exitCode of
         ExitFailure _ -> Nothing
         ExitSuccess -> Just (decodeUtf8 out) -- utf8 isn't a given, but seems likely.

--- a/src/Control/Carrier/Telemetry/Utils.hs
+++ b/src/Control/Carrier/Telemetry/Utils.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ViewPatterns #-}
+
 module Control.Carrier.Telemetry.Utils (
   getCurrentCliEnvironment,
   getCurrentCliVersion,
@@ -127,11 +128,10 @@ getSystemInfo = do
 -- If the parse fails for some reason, there is no warning.
 -- This is intended for telemetry, if we fail to find a value it isn't supposed to be reported or recovered from.
 parseOsRelease :: Text -> Map.Map Text Text
-parseOsRelease = Map.fromList . map splitOnEqual . Text.lines 
-  where splitOnEqual :: Text -> (Text, Text)
-        splitOnEqual (Text.span (== '=') -> (pre, post)) = (pre, Text.dropWhile (== '=') post)
-
-
+parseOsRelease = Map.fromList . map splitOnEqual . Text.lines
+  where
+    splitOnEqual :: Text -> (Text, Text)
+    splitOnEqual (Text.span (== '=') -> (pre, post)) = (pre, Text.dropWhile (== '=') post)
 
 lookupCIEnvironment :: IO (Maybe CIEnvironment)
 lookupCIEnvironment = do


### PR DESCRIPTION
# Overview

Currently we only collect `System.Info`'s `os` field. This doesn't tell us much, and in the case of Linux doesn't tell us anything about distribution. That information could be useful for making production decisions in the future. 

This PR adds support to the CLI for collecting more system info. I think additional work may be needed in order to actually store this on our back-end. 

## Acceptance criteria

* If the OS is linux, attempt to read the OS name/pretty name out of [os-release](https://www.freedesktop.org/software/systemd/man/os-release.html)
* If the system is not windows, attempt to read and report the output of `uname -mrsv`. This leaves out the system name that would be included with `uname -a` in case there is organization info in it. 

## Testing plan

I tested manually on my mac and also tested in a linux container. 

## Risks

* We are collecting more information from users. In particular `uname` has a lot of system information in its output, but I don't think it's generally sensitive.

## Metrics

We should do follow-up work to make sure this data is stored. After that we can add metrics to our dashboards as needed.

## References


## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
