### PR TITLE
Update themis to pull in fixes from themis-license-data

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,6 @@
 # FOSSA CLI Changelog
 
-## DONE Unreleased
-   CLOSED: [2023-6-15 12:58]
+## Unreleased
 - License Scanning: Fix a bug where we were identifying the "GPL with autoconf macro exception" license as "GPL with autoconf exception" in a few cases ([#1225](https://github.com/fossas/fossa-cli/pull/1225))
 
 ## v3.8.2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # FOSSA CLI Changelog
 
-## Unreleased
-- License Scanning: Fix a bug where we were identifying the "GPL with autoconf macro exception" license as "GPL with autoconf exception" in a few cases
+## DONE Unreleased
+   CLOSED: [2023-6-15 12:58]
+- License Scanning: Fix a bug where we were identifying the "GPL with autoconf macro exception" license as "GPL with autoconf exception" in a few cases ([#1225](https://github.com/fossas/fossa-cli/pull/1225))
 
 ## v3.8.2
 - Poetry: Defaults `category` to `main` if not present in lockfile. ([#1211](https://github.com/fossas/fossa-cli/pull/1211))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- License Scanning: Fix a bug where we were identifying the "GPL with autoconf macro exception" license as "GPL with autoconf exception" in a few cases
+
 ## v3.8.2
 - Poetry: Defaults `category` to `main` if not present in lockfile. ([#1211](https://github.com/fossas/fossa-cli/pull/1211))
 - Maven: Revert ([#1218](https://github.com/fossas/fossa-cli/pull/1218)) from v3.8.2 due to performance impacts.

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -56,7 +56,7 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-THEMIS_TAG="2023-04-25-95b18b6-1682456045"
+THEMIS_TAG="2023-06-14-ee69aa9-1686783828"
 echo "Downloading themis binary"
 echo "Using themis release: $THEMIS_TAG"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json


### PR DESCRIPTION
# Overview

Fixes [ZD-6452](https://fossa.zendesk.com/agent/tickets/6452).

Updates the themis release tag to pull in the changes from https://github.com/fossas/themis-license-data/pull/44

## Acceptance criteria

- as long as `vendor_download.sh` works, this is safe

## Testing plan

I ran vendor_download.sh and verified that it was able to download themis and its index.

## Risks

None

## Metrics

N/A

## References

[ZD-6452](https://fossa.zendesk.com/agent/tickets/6452).

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [X] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
