### PR TITLE
[No Ticket] Don't print "[INFO]" in output.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- Logging: Don't output the `[INFO]` prefix for regular CLI messages. ([#1226](https://github.com/fossas/fossa-cli/pull/1226))
+
 ## v3.8.2
 - Poetry: Defaults `category` to `main` if not present in lockfile. ([#1211](https://github.com/fossas/fossa-cli/pull/1211))
 - Maven: Revert ([#1218](https://github.com/fossas/fossa-cli/pull/1218)) from v3.8.2 due to performance impacts.

--- a/src/Effect/Logger.hs
+++ b/src/Effect/Logger.hs
@@ -190,12 +190,15 @@ termLoggerFormatter :: LogFormatter Text
 termLoggerFormatter sev msg = renderIt $ formatCommon sev msg <> line
 
 formatCommon :: Severity -> Doc AnsiStyle -> Doc AnsiStyle
-formatCommon sev msg = hang 2 (pretty '[' <> showSev sev <> pretty @String "] " <> msg)
+formatCommon sev msg = hang 2 (showSev sev <> msg)
   where
-    showSev SevError = annotate (color Red) (pretty @String "ERROR")
-    showSev SevWarn = annotate (color Yellow) (pretty @String " WARN")
-    showSev SevInfo = annotate (color Cyan) (pretty @String " INFO")
-    showSev SevDebug = annotate (color White) (pretty @String "DEBUG")
+    showSev SevError = withBrackets $ annotate (color Red) (pretty @String "ERROR")
+    showSev SevWarn = withBrackets $ annotate (color Yellow) (pretty @String "WARN")
+    showSev SevInfo = ""
+    showSev SevDebug = withBrackets $ annotate (color White) (pretty @String "DEBUG")
+
+    withBrackets :: Doc AnsiStyle -> Doc AnsiStyle
+    withBrackets s = pretty '[' <> s <> pretty @String "] "
 
 type LoggerC = SimpleC LoggerF
 


### PR DESCRIPTION
# Overview

During discussions in slack and in our last sizing we decided that the `[INFO]` designation printed at the front of log lines doesn't really add much value. This PR removes it. 

## Acceptance criteria

* In cli output we should no longer see `[INFO]` printed.
* Every other log level should appear as before.

## Testing plan

I tested manually. Using our currently released fossa:
<img width="895" alt="Screenshot 2023-06-15 at 4 13 20 PM" src="https://github.com/fossas/fossa-cli/assets/190980/0dba2cce-eeb1-4120-8d32-f6c4955e597a">

Using the version from this branch:
<img width="444" alt="Screenshot 2023-06-15 at 4 14 14 PM" src="https://github.com/fossas/fossa-cli/assets/190980/5302b1a5-c8f3-4162-a96c-2c8818e0b1f5">

## Risks

* Someone out in the universe might be grepping for `[INFO]`.

## Metrics

No.

## References

There were references to this in [Slack thread](https://teamfossa.slack.com/archives/C039KE5ERNE/p1680122504055729) but most discussion was verbal.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
