### PR TITLE
ANE-1023 README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,14 +157,3 @@ We'll try to respond to issues opened in this repository on a best-effort basis,
 ## Contributing
 
 If you're interested in contributing, check out our [contributor documentation](./docs/contributing/README.md). PRs are welcome!
-
-## Licensing Data
-
-Some of the data used for CLI-side license scanning is provided by nexB under a [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/legalcode) license. This data can be found here: https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data.
-
-The licensing data is Copyright (c) nexB Inc. and others. All rights reserved.
-    ScanCode is a trademark of nexB Inc.
-    SPDX-License-Identifier: CC-BY-4.0
-    See https://creativecommons.org/licenses/by/4.0/legalcode for the license text.
-    See https://github.com/nexB/scancode-toolkit for support or download.
-    See https://aboutcode.org for more information about nexB OSS projects.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 [![FOSSA Downloads](https://img.shields.io/badge/downloads-5.8M-brightgreen)](https://github.com/fossas/fossa-cli/releases)
 [![Build](https://img.shields.io/github/actions/workflow/status/fossas/fossa-cli/build.yml)](https://github.com/fossas/fossa-cli/actions/workflows/build.yml)
 [![Dependency scan](https://img.shields.io/github/actions/workflow/status/fossas/fossa-cli/dependency-scan.yml?label=dependency%20scan)](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml)
-[![FOSSA License Status](https://app.fossa.com/api/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli.svg?type=shield)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield)
 [![FOSSA Security Status](https://app.fossa.com/api/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli.svg?type=shield&issueType=security)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield)
+
+[![FOSSA License Status](https://app.fossa.com/api/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli.svg?type=large)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_large)
 <!-- markdown-link-check-enable-->
 
 `fossa-cli` is a zero-configuration polyglot dependency analysis tool. You can point fossa CLI at any codebase or build, and it will automatically detect dependencies being used by your project.

--- a/attribution.md
+++ b/attribution.md
@@ -1,0 +1,10 @@
+## Licensing Data
+
+Some of the data used for CLI-side license scanning is provided by nexB under a [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/legalcode) license. This data can be found here: https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data.
+
+The licensing data is Copyright (c) nexB Inc. and others. All rights reserved.
+    ScanCode is a trademark of nexB Inc.
+    SPDX-License-Identifier: CC-BY-4.0
+    See https://creativecommons.org/licenses/by/4.0/legalcode for the license text.
+    See https://github.com/nexB/scancode-toolkit for support or download.
+    See https://aboutcode.org for more information about nexB OSS projects.


### PR DESCRIPTION
# Overview

Makes two updates to the README:

1) Change the FOSSA licensing badge to use the large version
2) Move the attribution of licensing data into its own file

## Acceptance criteria

- The badge still works

## Testing plan

This is a doc-only change

Here's a link to the rendered README: https://github.com/fossas/fossa-cli/blob/16af4b43a3834be5d5c373a17447c4be892be7f7/README.md

## Risks

None

## Metrics


## References

[ANE-1023](https://fossa.atlassian.net/browse/ANE-1023)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-1023]: https://fossa.atlassian.net/browse/ANE-1023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ