### PR TITLE
Don't rebuild if we only change the changelog, readme, docs, etc.

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,10 @@
 name: Benchmarks
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - Changelog.md
+      - README.md
+      - docs/**
 
 jobs:
   benchmarks:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -2,7 +2,12 @@
 #
 # Binaries on each platform are stripped. This removes debug symbols.
 name: Build
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - Changelog.md
+      - README.md
+      - docs/**
 
 jobs:
   build-all:

--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -4,6 +4,10 @@ name: Integration Tests
 # Refer to https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_dispatch
 on:
   push:
+    paths-ignore:
+      - Changelog.md
+      - README.md
+      - docs/**
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * *" # At 05:00 on every day.


### PR DESCRIPTION
# Overview

It's frustrating to have to wait for a full build when only changing the changelog, readme, etc. 

## Acceptance criteria

* Pushing changes to the ignored files in a branch should not trigger a rebuild of everything

## Testing plan

TBD

## Risks

* [Chris to investigate] Are there risks of not having the right version/hash output in our binaries?
* [Chris to investigate] Does pushing a tag still always trigger a build? If so I think that prevents the problems I talked about in the first question.

## Metrics

None

## References

No ticket.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
