### PR TITLE
Resiliant os-release parser

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Logging: Don't output the `[INFO]` prefix for regular CLI messages. ([#1226](https://github.com/fossas/fossa-cli/pull/1226))
 - License Scanning: Fix a bug where we were identifying the "GPL with autoconf macro exception" license as "GPL with autoconf exception" in a few cases ([#1225](https://github.com/fossas/fossa-cli/pull/1225))
+- Container Scanning: More resiliant os-release parser, accounting initial line comments in the file.
 
 ## v3.8.2
 - Poetry: Defaults `category` to `main` if not present in lockfile. ([#1211](https://github.com/fossas/fossa-cli/pull/1211))

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## Unreleased
 - Logging: Don't output the `[INFO]` prefix for regular CLI messages. ([#1226](https://github.com/fossas/fossa-cli/pull/1226))
 - License Scanning: Fix a bug where we were identifying the "GPL with autoconf macro exception" license as "GPL with autoconf exception" in a few cases ([#1225](https://github.com/fossas/fossa-cli/pull/1225))
-- Container Scanning: More resiliant os-release parser, accounting initial line comments in the file.
+- Container Scanning: More resiliant os-release parser, accounting initial line comments in the file ([#1230](https://github.com/fossas/fossa-cli/pull/1230))
 
 ## v3.8.2
 - Poetry: Defaults `category` to `main` if not present in lockfile. ([#1211](https://github.com/fossas/fossa-cli/pull/1211))

--- a/test/Container/OsReleaseSpec.hs
+++ b/test/Container/OsReleaseSpec.hs
@@ -48,6 +48,7 @@ spec = do
       alpineWithComment `shouldOsReleaseParseInto` OsInfo "alpine" "3.15.4"
       alpineWithComment2 `shouldOsReleaseParseInto` OsInfo "alpine" "3.15.4"
       alpineWithComment3 `shouldOsReleaseParseInto` OsInfo "alpine" "3.15.4"
+      alpineWithComment4 `shouldOsReleaseParseInto` OsInfo "alpine" "3.15.4"
 
     it "should parse busybox release info" $ do
       busyBoxContent `shouldBusyBoxParser` OsInfo "busybox" "1.34.1"
@@ -92,6 +93,17 @@ BUG_REPORT_URL="https://bugs.alpinelinux.org/"
 alpineWithComment3 :: Text
 alpineWithComment3 =
   [r|NAME="Alpine Linux"
+ID=alpine # it's alpine
+VERSION_ID=3.15.4
+PRETTY_NAME="Alpine Linux v3.15" # comments
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://bugs.alpinelinux.org/"
+|]
+
+alpineWithComment4 :: Text
+alpineWithComment4 =
+  [r| # comment with space as first char
+NAME="Alpine Linux"
 ID=alpine # it's alpine
 VERSION_ID=3.15.4
 PRETTY_NAME="Alpine Linux v3.15" # comments

--- a/test/Container/OsReleaseSpec.hs
+++ b/test/Container/OsReleaseSpec.hs
@@ -46,6 +46,8 @@ spec = do
 
     it "should not parse comments in release info " $ do
       alpineWithComment `shouldOsReleaseParseInto` OsInfo "alpine" "3.15.4"
+      alpineWithComment2 `shouldOsReleaseParseInto` OsInfo "alpine" "3.15.4"
+      alpineWithComment3 `shouldOsReleaseParseInto` OsInfo "alpine" "3.15.4"
 
     it "should parse busybox release info" $ do
       busyBoxContent `shouldBusyBoxParser` OsInfo "busybox" "1.34.1"
@@ -68,6 +70,31 @@ ID=alpine
 # VERSION_ID=0
 VERSION_ID=3.15.4
 PRETTY_NAME="Alpine Linux v3.15"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://bugs.alpinelinux.org/"
+|]
+
+alpineWithComment2 :: Text
+alpineWithComment2 =
+  [r|# /etc/space/nepture.conf
+NAME="Alpine Linux"
+ID=alpine
+# VERSION_ID=0
+VERSION_ID=3.15.4
+PRETTY_NAME="Alpine Linux v3.15"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://bugs.alpinelinux.org/"
+
+# some additional comments
+  # and some more!!
+|]
+
+alpineWithComment3 :: Text
+alpineWithComment3 =
+  [r|NAME="Alpine Linux"
+ID=alpine # it's alpine
+VERSION_ID=3.15.4
+PRETTY_NAME="Alpine Linux v3.15" # comments
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"
 |]


### PR DESCRIPTION
# Overview

This PR, addresses os-release parser. 

Previously, we did account for line comments, but only after atleast one valid parser was consumed. This led to the case, where we were not able to parse file, in which the very first line was a line comment. 

## Acceptance criteria

- As a user, I can use container which has /etc/os-release file starting with line comments

## Testing plan

Added unit test - I relied on automated testing.

## Risks

N/A

## Metrics

N/A

## References

ANE-1033

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
