### PR TITLE
ANE-895: full origin path for unpack archives

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,11 @@
 # FOSSA CLI Changelog
 
-## Unreleased
-- Telemetry: Collect GNU/Linux distribution information and `uname` output. ([#1222](https://github.com/fossas/fossa-cli/pull/1222))
+## v3.8.3
 - Logging: Don't output the `[INFO]` prefix for regular CLI messages. ([#1226](https://github.com/fossas/fossa-cli/pull/1226))
 - License Scanning: Fix a bug where we were identifying the "GPL with autoconf macro exception" license as "GPL with autoconf exception" in a few cases ([#1225](https://github.com/fossas/fossa-cli/pull/1225))
 - Container Scanning: More resiliant os-release parser, accounting initial line comments in the file ([#1230](https://github.com/fossas/fossa-cli/pull/1230))
+- Analysis: full paths to the files in archives are shown when running `fossa analyze --unpack-archives` ([#1231](https://github.com/fossas/fossa-cli/pull/1231))
+- Telemetry: Collect GNU/Linux distribution information and `uname` output. ([#1222](https://github.com/fossas/fossa-cli/pull/1222))
 
 ## v3.8.2
 - Poetry: Defaults `category` to `main` if not present in lockfile. ([#1211](https://github.com/fossas/fossa-cli/pull/1211))

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -3,6 +3,7 @@
 module App.Fossa.Analyze (
   analyzeMain,
   updateProgress,
+  runAnalyzers,
   runDependencyAnalysis,
   analyzeSubCommand,
 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -60,7 +60,7 @@ import App.Types (
   OverrideDynamicAnalysisBinary,
   ProjectRevision (..),
  )
-import App.Util (ancestryDirect)
+import App.Util (ancestryDirect, FileAncestry)
 import Codec.Compression.GZip qualified as GZip
 import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
 import Control.Carrier.Debug (Debug, debugMetadata, ignoreDebug)
@@ -107,7 +107,7 @@ import Effect.Logger (
   logStdout,
  )
 import Effect.ReadFS (ReadFS)
-import Path (Abs, Dir, Path, Rel, toFilePath)
+import Path (Abs, Dir, Path, toFilePath)
 import Path.IO (makeRelative)
 import Prettyprinter (
   Doc,
@@ -184,7 +184,7 @@ runDependencyAnalysis ::
   -- | Filters
   AllFilters ->
   -- | An optional path prefix to prepend to paths of discovered manifestFiles
-  Maybe (Path Rel Dir) ->
+  Maybe FileAncestry ->
   -- | The project to analyze
   DiscoveredProject proj ->
   m ()
@@ -227,7 +227,7 @@ runAnalyzers ::
   ) =>
   AllFilters ->
   Path Abs Dir ->
-  Maybe (Path Rel Dir) ->
+  Maybe FileAncestry ->
   m ()
 runAnalyzers filters basedir pathPrefix = do
   if filterIsVSIOnly filters

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -59,6 +59,7 @@ import App.Types (
   OverrideDynamicAnalysisBinary,
   ProjectRevision (..),
  )
+import App.Util (ancestryDirect)
 import Codec.Compression.GZip qualified as GZip
 import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
 import Control.Carrier.Debug (Debug, debugMetadata, ignoreDebug)
@@ -94,7 +95,6 @@ import Data.Maybe (mapMaybe)
 import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text.Extra (showT)
 import Diag.Result (resultToMaybe)
-import Discovery.Archive (ancestryDirect)
 import Discovery.Archive qualified as Archive
 import Discovery.Filters (AllFilters, applyFilters, filterIsVSIOnly, ignoredPaths, isDefaultNonProductionPath)
 import Discovery.Projects (withDiscoveredProjects)

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -181,8 +181,11 @@ runDependencyAnalysis ::
   ) =>
   -- | Analysis base directory
   Path Abs Dir ->
+  -- | Filters
   AllFilters ->
+  -- | An optional path prefix to prepend to paths of discovered manifestFiles
   Maybe (Path Rel Dir) ->
+  -- | The project to analyze
   DiscoveredProject proj ->
   m ()
 runDependencyAnalysis basedir filters pathPrefix project@DiscoveredProject{..} = do

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -60,7 +60,7 @@ import App.Types (
   OverrideDynamicAnalysisBinary,
   ProjectRevision (..),
  )
-import App.Util (ancestryDirect, FileAncestry)
+import App.Util (FileAncestry, ancestryDirect)
 import Codec.Compression.GZip qualified as GZip
 import Control.Carrier.AtomicCounter (AtomicCounter, runAtomicCounter)
 import Control.Carrier.Debug (Debug, debugMetadata, ignoreDebug)

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -94,6 +94,7 @@ import Data.Maybe (mapMaybe)
 import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text.Extra (showT)
 import Diag.Result (resultToMaybe)
+import Discovery.Archive (ancestryDirect)
 import Discovery.Archive qualified as Archive
 import Discovery.Filters (AllFilters, applyFilters, filterIsVSIOnly, ignoredPaths, isDefaultNonProductionPath)
 import Discovery.Projects (withDiscoveredProjects)
@@ -105,7 +106,7 @@ import Effect.Logger (
   logStdout,
  )
 import Effect.ReadFS (ReadFS)
-import Path (Abs, Dir, Path, toFilePath, Rel)
+import Path (Abs, Dir, Path, Rel, toFilePath)
 import Path.IO (makeRelative)
 import Prettyprinter (
   Doc,
@@ -121,7 +122,6 @@ import Prettyprinter.Render.Terminal (
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (LicenseSourceUnit, Locator, SourceUnit, sourceUnitToFullSourceUnit)
 import Types (DiscoveredProject (..), FoundTargets)
-import Discovery.Archive (ancestryDirect)
 
 debugBundlePath :: FilePath
 debugBundlePath = "fossa.debug.json.gz"

--- a/src/App/Fossa/Analyze/Log4jReport.hs
+++ b/src/App/Fossa/Analyze/Log4jReport.hs
@@ -193,7 +193,7 @@ runDependencyAnalysisForLog4j basedir filters project = do
       graphResult <- Diag.runDiagnosticsIO . diagToDebug . stickyLogStack . withEmptyStack . Diag.context "Project Analysis" $ do
         debugMetadata "DiscoveredProject" project
         analyzeProject targets (projectData project)
-      Diag.withResult SevWarn SevWarn graphResult (output . mkResult basedir project)
+      Diag.withResult SevWarn SevWarn graphResult (output . mkResult basedir project Nothing)
 
 data VulnerableDependency = VulnerableDependency
   { vdName :: Text

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -3,13 +3,13 @@ module App.Fossa.Analyze.Project (
   mkResult,
 ) where
 
+import App.Util (FileAncestry (..))
 import DepTypes
 import Graphing (Graphing)
 import Graphing qualified
 import Path
 import Path.Extra (tryMakeRelative)
 import Types
-import App.Util (FileAncestry (..))
 
 mkResult :: Path Abs Dir -> DiscoveredProject n -> Maybe FileAncestry -> (DependencyResults) -> ProjectResult
 mkResult basedir project pathPrefix dependencyResults =

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -9,8 +9,9 @@ import Graphing qualified
 import Path
 import Path.Extra (tryMakeRelative)
 import Types
+import App.Util (FileAncestry (..))
 
-mkResult :: Path Abs Dir -> DiscoveredProject n -> Maybe (Path Rel Dir) -> (DependencyResults) -> ProjectResult
+mkResult :: Path Abs Dir -> DiscoveredProject n -> Maybe FileAncestry -> (DependencyResults) -> ProjectResult
 mkResult basedir project pathPrefix dependencyResults =
   ProjectResult
     { projectResultType = projectType project
@@ -30,7 +31,7 @@ mkResult basedir project pathPrefix dependencyResults =
   where
     graph = dependencyGraph dependencyResults
     relativeManifestFiles = map (tryMakeRelative basedir) $ dependencyManifestFiles dependencyResults
-    prefixedManifestFiles = map (addPrefix pathPrefix) relativeManifestFiles
+    prefixedManifestFiles = map (addPrefix $ fileAncestryPath <$> pathPrefix) relativeManifestFiles
     addPrefix :: Maybe (Path Rel Dir) -> SomeBase File -> SomeBase File
     addPrefix maybePrefix relativeFile =
       case (maybePrefix, relativeFile) of

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -32,7 +32,7 @@ mkResult basedir project pathPrefix dependencyResults =
     relativeManifestFiles = map (tryMakeRelative basedir) $ dependencyManifestFiles dependencyResults
     prefixedManifestFiles = map (addPrefix pathPrefix) relativeManifestFiles
     addPrefix :: Maybe (Path Rel Dir) -> SomeBase File -> SomeBase File
-    addPrefix maybePrefix relativeFile  =
+    addPrefix maybePrefix relativeFile =
       case (maybePrefix, relativeFile) of
         (Nothing, relFile) -> relFile
         (Just prefix, Rel relFile) -> Rel $ prefix </> relFile

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -10,8 +10,8 @@ import Path
 import Path.Extra (tryMakeRelative)
 import Types
 
-mkResult :: Path Abs Dir -> DiscoveredProject n -> (DependencyResults) -> ProjectResult
-mkResult basedir project dependencyResults =
+mkResult :: Path Abs Dir -> DiscoveredProject n -> Maybe (Path Rel Dir) -> (DependencyResults) -> ProjectResult
+mkResult basedir project pathPrefix dependencyResults =
   ProjectResult
     { projectResultType = projectType project
     , projectResultPath = projectPath project
@@ -25,11 +25,18 @@ mkResult basedir project dependencyResults =
           then graph
           else Graphing.pruneUnreachable graph
     , projectResultGraphBreadth = dependencyGraphBreadth dependencyResults
-    , projectResultManifestFiles = relativeManifestFiles
+    , projectResultManifestFiles = prefixedManifestFiles
     }
   where
     graph = dependencyGraph dependencyResults
     relativeManifestFiles = map (tryMakeRelative basedir) $ dependencyManifestFiles dependencyResults
+    prefixedManifestFiles = map (addPrefix pathPrefix) relativeManifestFiles
+    addPrefix :: Maybe (Path Rel Dir) -> SomeBase File -> SomeBase File
+    addPrefix maybePrefix relativeFile  =
+      case (maybePrefix, relativeFile) of
+        (Nothing, relFile) -> relFile
+        (Just prefix, Rel relFile) -> Rel $ prefix </> relFile
+        (Just _, Abs absFile) -> Abs absFile
 
 data ProjectResult = ProjectResult
   { projectResultType :: DiscoveredProjectType

--- a/src/App/Fossa/Container/Sources/DockerArchive.hs
+++ b/src/App/Fossa/Container/Sources/DockerArchive.hs
@@ -238,7 +238,7 @@ runDependencyAnalysis basedir filters project@DiscoveredProject{..} = do
         Diag.context ctxMessage $ do
           analyzeProject' targets projectData
       Diag.flushLogs SevError SevDebug graphResult
-      output $ Scanned dpi (mkResult basedir project <$> graphResult)
+      output $ Scanned dpi (mkResult basedir project Nothing <$> graphResult)
 
 -- | Extracts Repository Name.
 --

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -10,7 +10,7 @@ import App.Fossa.VSI.IAT.Types qualified as IAT
 import App.Fossa.VSI.Types (ScanID (..))
 import App.Fossa.VSI.Types qualified as VSI
 import App.Types (ProjectRevision)
-import App.Util (ancestryDerived, ancestryDirect, FileAncestry (..))
+import App.Util (FileAncestry (..), ancestryDerived, ancestryDirect)
 import Control.Algebra (Has)
 import Control.Carrier.AtomicCounter (runAtomicCounter)
 import Control.Carrier.Diagnostics (runDiagnosticsIO, withResult)

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -10,7 +10,7 @@ import App.Fossa.VSI.IAT.Types qualified as IAT
 import App.Fossa.VSI.Types (ScanID (..))
 import App.Fossa.VSI.Types qualified as VSI
 import App.Types (ProjectRevision)
-import App.Util (ancestryDerived, ancestryDirect)
+import App.Util (ancestryDerived, ancestryDirect, FileAncestry (..))
 import Control.Algebra (Has)
 import Control.Carrier.AtomicCounter (runAtomicCounter)
 import Control.Carrier.Diagnostics (runDiagnosticsIO, withResult)
@@ -264,7 +264,7 @@ discover output filters root renderAncestry =
       forkTask . recover . fatalOnSomeException "extract archive" . withArchive' file $ \archiveRoot -> context "walking into child archive" $ do
         logDebug . pretty $ "walking into " <> toText file <> " as archive"
         logicalParent <- convertArchiveSuffix logicalPath
-        discover output filters archiveRoot $ ancestryDerived logicalParent
+        discover output filters archiveRoot $ ancestryDerived $ FileAncestry logicalParent
 
       -- Report the fingerprint and logical path for computing this chunk.
       logDebug . pretty $ "report logical path: " <> toText logicalPath

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -10,6 +10,7 @@ import App.Fossa.VSI.IAT.Types qualified as IAT
 import App.Fossa.VSI.Types (ScanID (..))
 import App.Fossa.VSI.Types qualified as VSI
 import App.Types (ProjectRevision)
+import App.Util (ancestryDerived, ancestryDirect)
 import Control.Algebra (Has)
 import Control.Carrier.AtomicCounter (runAtomicCounter)
 import Control.Carrier.Diagnostics (runDiagnosticsIO, withResult)
@@ -36,9 +37,8 @@ import Discovery.Filters (AllFilters, combinedPaths, excludeFilters, includeFilt
 import Discovery.Walk (WalkStep (WalkContinue, WalkSkipAll), walk)
 import Effect.Logger (Color (..), Logger, Severity (SevError, SevInfo, SevWarn), annotate, color, hsep, logDebug, logInfo, plural, pretty)
 import Effect.ReadFS (ReadFS)
-import Path (Dir, File, Path, isProperPrefixOf, (</>), Rel, Abs)
+import Path (Abs, Dir, File, Path, Rel, isProperPrefixOf, (</>))
 import Path qualified as P
-import App.Util (ancestryDirect, ancestryDerived)
 
 runVsiAnalysis ::
   ( Has (Lift IO) sig m

--- a/src/App/Util.hs
+++ b/src/App/Util.hs
@@ -13,11 +13,11 @@ import Control.Algebra (Has)
 import Control.Carrier.Diagnostics (Diagnostics, fatalText)
 import Control.Monad (unless)
 import Data.String.Conversion (ToText (..))
+import GHC.Generics (Generic)
 import Path (Abs, Dir, File, Path, Rel, SomeBase (..), toFilePath, (</>))
 import Path.Extra (tryMakeRelative)
 import Path.IO qualified as P
 import System.Exit (die)
-import GHC.Generics (Generic)
 
 -- | Validate that a filepath points to a directory and the directory exists
 validateDir :: FilePath -> IO BaseDir
@@ -43,7 +43,7 @@ ancestryDirect dir file = case tryMakeRelative dir file of
   Abs _ -> fatalText $ "failed to make " <> toText (toFilePath file) <> " relative to " <> toText (toFilePath dir)
   Rel rel -> pure rel
 
-newtype FileAncestry = FileAncestry { fileAncestryPath :: Path Rel Dir } deriving (Eq, Ord, Show, Generic)
+newtype FileAncestry = FileAncestry {fileAncestryPath :: Path Rel Dir} deriving (Eq, Ord, Show, Generic)
 
 -- | Renders the relative path from the provided directory to the file, prepended with the provided relative directory as a parent.
 -- If the path cannot be made relative, fatally exits through the diagnostic effect.

--- a/src/App/Util.hs
+++ b/src/App/Util.hs
@@ -1,15 +1,21 @@
 {-# LANGUAGE DataKinds #-}
 
 module App.Util (
+  ancestryDerived,
+  ancestryDirect,
   validateDir,
   validateFile,
 ) where
 
 import App.Types
 import Control.Monad (unless)
-import Path (Abs, File, Path)
+import Path (Abs, File, Path, Dir, Rel, SomeBase (..), toFilePath, (</>))
 import Path.IO qualified as P
 import System.Exit (die)
+import Control.Algebra (Has)
+import Control.Carrier.Diagnostics (Diagnostics, fatalText)
+import Path.Extra (tryMakeRelative)
+import Data.String.Conversion (ToText(..))
 
 -- | Validate that a filepath points to a directory and the directory exists
 validateDir :: FilePath -> IO BaseDir
@@ -27,3 +33,18 @@ validateFile file = do
   exists <- P.doesFileExist absolute
   unless exists (die $ "ERROR: File " <> show absolute <> " does not exist")
   pure absolute
+
+-- | Renders the relative path from the provided directory to the file.
+-- If the path cannot be made relative, fatally exits through the diagnostic effect.
+ancestryDirect :: Has Diagnostics sig m => Path Abs Dir -> Path Abs File -> m (Path Rel File)
+ancestryDirect dir file = case tryMakeRelative dir file of
+  Abs _ -> fatalText $ "failed to make " <> toText (toFilePath file) <> " relative to " <> toText (toFilePath dir)
+  Rel rel -> pure rel
+
+-- | Renders the relative path from the provided directory to the file, prepended with the provided relative directory as a parent.
+-- If the path cannot be made relative, fatally exits through the diagnostic effect.
+ancestryDerived :: Has Diagnostics sig m => Path Rel Dir -> Path Abs Dir -> Path Abs File -> m (Path Rel File)
+ancestryDerived parent dir file = do
+  rel <- ancestryDirect dir file
+  pure $ parent </> rel
+

--- a/src/App/Util.hs
+++ b/src/App/Util.hs
@@ -8,14 +8,14 @@ module App.Util (
 ) where
 
 import App.Types
-import Control.Monad (unless)
-import Path (Abs, File, Path, Dir, Rel, SomeBase (..), toFilePath, (</>))
-import Path.IO qualified as P
-import System.Exit (die)
 import Control.Algebra (Has)
 import Control.Carrier.Diagnostics (Diagnostics, fatalText)
+import Control.Monad (unless)
+import Data.String.Conversion (ToText (..))
+import Path (Abs, Dir, File, Path, Rel, SomeBase (..), toFilePath, (</>))
 import Path.Extra (tryMakeRelative)
-import Data.String.Conversion (ToText(..))
+import Path.IO qualified as P
+import System.Exit (die)
 
 -- | Validate that a filepath points to a directory and the directory exists
 validateDir :: FilePath -> IO BaseDir
@@ -47,4 +47,3 @@ ancestryDerived :: Has Diagnostics sig m => Path Rel Dir -> Path Abs Dir -> Path
 ancestryDerived parent dir file = do
   rel <- ancestryDirect dir file
   pure $ parent </> rel
-

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -91,7 +91,6 @@ discover go dir renderAncestry = context "Finding archives" $ do
     let process file unpackedDir = context (toText (fileName file)) $ do
           logicalPath <- renderAncestry dir file
           logicalParent <- convertArchiveToDir logicalPath
-          sendIO . print $ "calling 'go' on " <> toText file <> " with dir = " <> toText dir <> " and logicalParent = " <> toText logicalParent
           go unpackedDir (Just logicalParent)
           discover go unpackedDir $ ancestryDerived logicalParent
 

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -18,7 +18,8 @@ import Codec.Archive.Zip qualified as Zip
 import Codec.Compression.BZip qualified as BZip
 import Codec.Compression.GZip qualified as GZip
 import Conduit (runConduit, runResourceT, sourceFileBS, (.|))
-import Control.Effect.Diagnostics (Diagnostics, Has, ToDiagnostic (renderDiagnostic), context, warnOnSomeException, fatalText)
+import Control.Carrier.Diagnostics (fromEither)
+import Control.Effect.Diagnostics (Diagnostics, Has, ToDiagnostic (renderDiagnostic), context, fatalText, warnOnSomeException)
 import Control.Effect.Exception (SomeException)
 import Control.Effect.Finally (Finally, onExit)
 import Control.Effect.Lift (Lift, sendIO)
@@ -41,13 +42,12 @@ import Path (
   fromAbsFile,
   toFilePath,
  )
+import Path.Extra (tryMakeRelative)
 import Path.IO qualified as PIO
+import Path.Posix (Rel, SomeBase (..), (</>))
+import Path.Posix qualified as P
 import Prettyprinter (Pretty (pretty), hsep, viaShow, vsep)
 import Prelude hiding (zip)
-import Path.Posix (SomeBase(..), Rel, (</>))
-import Path.Extra (tryMakeRelative)
-import qualified Path.Posix as P
-import Control.Carrier.Diagnostics (fromEither)
 
 data ArchiveUnpackFailure = ArchiveUnpackFailure (Path Abs File) SomeException
 

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -12,7 +12,7 @@ module Discovery.Archive (
   unpackFailurePath,
 ) where
 
-import App.Util (ancestryDerived, FileAncestry (..))
+import App.Util (FileAncestry (..), ancestryDerived)
 import Codec.Archive.Tar qualified as Tar
 import Codec.Archive.Zip qualified as Zip
 import Codec.Compression.BZip qualified as BZip

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -41,10 +41,11 @@ import Path (
   fromAbsDir,
   fromAbsFile,
   toFilePath,
+  Rel,
+  (</>),
  )
 import Path.IO qualified as PIO
-import Path.Posix (Rel, (</>))
-import Path.Posix qualified as P
+import Path qualified as P
 import Prettyprinter (Pretty (pretty), hsep, viaShow, vsep)
 import Prelude hiding (zip)
 

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -38,14 +38,14 @@ import Path (
   Dir,
   File,
   Path,
+  Rel,
   fromAbsDir,
   fromAbsFile,
   toFilePath,
-  Rel,
   (</>),
  )
-import Path.IO qualified as PIO
 import Path qualified as P
+import Path.IO qualified as PIO
 import Prettyprinter (Pretty (pretty), hsep, viaShow, vsep)
 import Prelude hiding (zip)
 

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -93,7 +93,7 @@ convertArchiveToDir file = do
 discover ::
   (Has (Lift IO) sig m, Has ReadFS sig m, Has Diagnostics sig m, Has Finally sig m, Has TaskPool sig m) =>
   -- | Callback to run on the discovered file
-  (Path Abs Dir -> m ()) ->
+  (Path Abs Dir -> Maybe (Path Rel Dir) -> m ()) ->
   -- | Path to the archive
   Path Abs Dir ->
   -- | Path rendering
@@ -107,7 +107,7 @@ discover go dir renderAncestry = context "Finding archives" $ do
           logicalPath <- renderAncestry dir file
           logicalParent <- convertArchiveToDir logicalPath
           sendIO . print $ "calling 'go' on " <> toText file <> " with dir = " <> toText dir <> " and logicalParent = " <> toText logicalParent
-          go unpackedDir
+          go unpackedDir (Just logicalParent)
           discover go unpackedDir $ ancestryDerived logicalParent
 
     traverse_ (\file -> forkTask $ withArchive' file (process file)) files


### PR DESCRIPTION
# Overview

[Fixes ANE-895](https://fossa.atlassian.net/browse/ANE-895)

When you run `fossa analyze --unpack-archives`, we want to provide the full origin path, including the path to the archive.

This PR makes that happen.

## Acceptance criteria

- When you run `fossa analyze --unpack-archives` we provide the full origin path to the contents inside of the archive.

## Testing plan

I don't think there's an easy way to create automated tests for this PR, so this manual test plan will have to do :(.

Test with a nested archive.

One example is from the ticket: https://github.com/qos-ch/slf4j

```
make install-dev
```

```
git clone https://github.com/qos-ch/slf4j
cd slf4j
fossa-dev analyze --unpack-archives --output | jq
```

Look at the `OriginPaths` field. When the file being analyzed is from an archive, it should include the path to the archive.

Another, simpler, example is the `recursive-archive` example from github.com/fossas/example-projects

```
git clone https://github.com/fossas/example-projects
cd example-projects/recursive-archive-generator
./generate --include-targets
cd recursive-archive
fossa-dev analyze --unpack-archives --output | jq
```

With a jq filter to show just the `OriginPaths`, you see:

```
fossa-dev analyze --unpack-archives --output | jq '.sourceUnits[] | { Manifest, OriginPaths }'
```

With this PR: 

```ndjson
{
  "Manifest": "/Users/scott/fossa/example-projects/recursive-archive-generator/recursive-archive/",
  "OriginPaths": [
    "fossa-deps.yml"
  ]
}
{
  "Manifest": "/private/var/folders/45/k76d2pgj6mlb1vpx_2gyl7z80000gn/T/quux.tar.gz-0e183b7b1cc3e7e0/quux/",
  "OriginPaths": [
    "vendor/foo.tar.gz/foo/bar.tar.gz/bar/baz.tar.gz/baz/quux.tar.gz/quux/yarn.lock",
    "vendor/foo.tar.gz/foo/bar.tar.gz/bar/baz.tar.gz/baz/quux.tar.gz/quux/package.json"
  ]
}
{
  "Manifest": "/private/var/folders/45/k76d2pgj6mlb1vpx_2gyl7z80000gn/T/bar.tar.gz-38c1298545cc1dd9/bar/",
  "OriginPaths": [
    "vendor/foo.tar.gz/foo/bar.tar.gz/bar/pom.xml"
  ]
}

```

Without this PR:

```ndjson
{
  "Manifest": "/Users/scott/fossa/example-projects/recursive-archive-generator/recursive-archive/",
  "OriginPaths": [
    "fossa-deps.yml"
  ]
}
{
  "Manifest": "/private/var/folders/45/k76d2pgj6mlb1vpx_2gyl7z80000gn/T/quux.tar.gz-1de80f195eb8e179/quux/",
  "OriginPaths": [
    "quux/yarn.lock",
    "quux/package.json"
  ]
}
{
  "Manifest": "/private/var/folders/45/k76d2pgj6mlb1vpx_2gyl7z80000gn/T/bar.tar.gz-4681916e1cd2f07d/bar/",
  "OriginPaths": [
    "bar/pom.xml"
  ]
}
```

## Risks

I think this is low risk.

## Metrics

N/A

## References

[ANE-895](https://fossa.atlassian.net/browse/ANE-895)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-895]: https://fossa.atlassian.net/browse/ANE-895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ