### PR TITLE
Always download the latest themis release

### DIFF
--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -22,7 +22,6 @@ module App.Fossa.Analyze.Debug (
 
 import App.Fossa.EmbeddedBinary (withThemisAndIndex)
 import App.Fossa.RunThemis (getThemisVersion)
-import Control.Carrier.Diagnostics qualified as Diag
 import App.Version (fullVersionDescription)
 import Control.Carrier.Debug (
   Algebra (..),
@@ -38,6 +37,7 @@ import Control.Carrier.Debug (
   runDebug,
   type (:+:) (..),
  )
+import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Lift (sendIO)
 import Control.Carrier.Simple (SimpleC, interpret, sendSimple)
 import Control.Effect.Diagnostics (Diag (Fatal), Diagnostics)
@@ -125,7 +125,7 @@ collectDebugBundle cfg act = do
   themisVersionUnsafe <- Diag.errorBoundaryIO $ withThemisAndIndex getThemisVersion
   let themisVersion = case themisVersionUnsafe of
         Success _ t -> t
-        _ -> "versionunavailable"
+        _ -> ""
 
   let output :: Aeson.Value = case res of
         Failure _ _ -> "scan was not successful, no output"

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -49,7 +49,7 @@ import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor (bimap)
 import Data.Map qualified as Map
-import Data.String.Conversion (decodeUtf8, toText)
+import Data.String.Conversion (toText)
 import Data.Text (Text, toLower)
 import Data.Word (Word64)
 import Diag.Result (Result (..))
@@ -122,7 +122,6 @@ collectDebugBundle cfg act = do
   args <- sendIO getCommandArgs
   envVars <- collectEnvVariables
   themisVersion <- withThemisAndIndex getThemisVersion
-  let themisVersionText = decodeUtf8 themisVersion
 
   let output :: Aeson.Value = case res of
         Failure _ _ -> "scan was not successful, no output"
@@ -132,7 +131,7 @@ collectDebugBundle cfg act = do
         DebugBundle
           { bundleSystem = sysInfo
           , bundleCLIVersion = fullVersionDescription
-          , bundleThemisVersion = themisVersionText
+          , bundleThemisVersion = themisVersion
           , bundleArgs = args
           , bundleConfig = cfg
           , bundleEnvVariables = envVars

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -22,6 +22,7 @@ module App.Fossa.Analyze.Debug (
 
 import App.Fossa.EmbeddedBinary (withThemisAndIndex)
 import App.Fossa.RunThemis (getThemisVersion)
+import Control.Carrier.Diagnostics qualified as Diag
 import App.Version (fullVersionDescription)
 import Control.Carrier.Debug (
   Algebra (..),
@@ -121,7 +122,10 @@ collectDebugBundle cfg act = do
   sysInfo <- sendIO collectSystemInfo
   args <- sendIO getCommandArgs
   envVars <- collectEnvVariables
-  themisVersion <- withThemisAndIndex getThemisVersion
+  themisVersionUnsafe <- Diag.errorBoundaryIO $ withThemisAndIndex getThemisVersion
+  let themisVersion = case themisVersionUnsafe of
+        Success _ t -> t
+        _ -> "versionunavailable"
 
   let output :: Aeson.Value = case res of
         Failure _ _ -> "scan was not successful, no output"

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -20,8 +20,7 @@ module App.Fossa.Analyze.Debug (
   debugEverything,
 ) where
 
-import App.Fossa.EmbeddedBinary (withThemisAndIndex)
-import App.Fossa.RunThemis (getThemisVersion)
+import App.Fossa.EmbeddedBinary (themisVersion)
 import App.Version (fullVersionDescription)
 import Control.Carrier.Debug (
   Algebra (..),
@@ -37,7 +36,6 @@ import Control.Carrier.Debug (
   runDebug,
   type (:+:) (..),
  )
-import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.Lift (sendIO)
 import Control.Carrier.Simple (SimpleC, interpret, sendSimple)
 import Control.Effect.Diagnostics (Diag (Fatal), Diagnostics)
@@ -122,10 +120,6 @@ collectDebugBundle cfg act = do
   sysInfo <- sendIO collectSystemInfo
   args <- sendIO getCommandArgs
   envVars <- collectEnvVariables
-  themisVersionUnsafe <- Diag.errorBoundaryIO $ withThemisAndIndex getThemisVersion
-  let themisVersion = case themisVersionUnsafe of
-        Success _ t -> t
-        _ -> ""
 
   let output :: Aeson.Value = case res of
         Failure _ _ -> "scan was not successful, no output"

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -11,6 +11,7 @@ module App.Fossa.EmbeddedBinary (
   withBerkeleyBinary,
   allBins,
   dumpEmbeddedBinary,
+  themisVersion,
 ) where
 
 import Codec.Compression.Lzma qualified as Lzma
@@ -20,7 +21,7 @@ import Data.ByteString (ByteString, writeFile)
 import Data.ByteString.Lazy qualified as BL
 import Data.FileEmbed.Extra (embedFileIfExists)
 import Data.Foldable (traverse_)
-import Data.String.Conversion (toLazy, toString)
+import Data.String.Conversion (toLazy, toString, ToText (toText))
 import Data.Tagged (Tagged, applyTag, unTag)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Path (
@@ -45,6 +46,9 @@ import Path.IO (
   setPermissions,
  )
 import Prelude hiding (writeFile)
+import App.Version.TH (themisVersionQ)
+import Data.Text (Text)
+import qualified Data.Text as T
 
 data PackagedBinary
   = Themis
@@ -180,10 +184,13 @@ embeddedBinaryThemis = $(embedFileIfExists "vendor-bins/themis-cli")
 embeddedBinaryThemisIndex :: ByteString
 embeddedBinaryThemisIndex = $(embedFileIfExists "vendor-bins/index.gob.xz")
 
+themisVersion :: Text
+themisVersion =  T.takeWhileEnd (/= ' ') $ T.strip $ toText $$themisVersionQ
+
 -- To build this, run `make build` or `cargo build --release`.
 #ifdef mingw32_HOST_OS
 embeddedBinaryBerkeleyDB :: ByteString
-embeddedBinaryBerkeleyDB = $(embedFileIfExists "target/release/berkeleydb.exe")
+embeddedBinaryBerkeleyDB = $embedFileIfExists "target/release/berkeleydb.exe"
 #else
 embeddedBinaryBerkeleyDB :: ByteString
 embeddedBinaryBerkeleyDB = $(embedFileIfExists "target/release/berkeleydb")

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -189,7 +189,7 @@ themisVersion = $$themisVersionQ
 -- To build this, run `make build` or `cargo build --release`.
 #ifdef mingw32_HOST_OS
 embeddedBinaryBerkeleyDB :: ByteString
-embeddedBinaryBerkeleyDB = $embedFileIfExists "target/release/berkeleydb.exe"
+embeddedBinaryBerkeleyDB = $(embedFileIfExists "target/release/berkeleydb.exe")
 #else
 embeddedBinaryBerkeleyDB :: ByteString
 embeddedBinaryBerkeleyDB = $(embedFileIfExists "target/release/berkeleydb")

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -14,6 +14,7 @@ module App.Fossa.EmbeddedBinary (
   themisVersion,
 ) where
 
+import App.Version.TH (themisVersionQ)
 import Codec.Compression.Lzma qualified as Lzma
 import Control.Effect.Exception (bracket)
 import Control.Effect.Lift (Has, Lift, sendIO)
@@ -21,8 +22,9 @@ import Data.ByteString (ByteString, writeFile)
 import Data.ByteString.Lazy qualified as BL
 import Data.FileEmbed.Extra (embedFileIfExists)
 import Data.Foldable (traverse_)
-import Data.String.Conversion (toLazy, toString, ToText (toText))
+import Data.String.Conversion (toLazy, toString)
 import Data.Tagged (Tagged, applyTag, unTag)
+import Data.Text (Text)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Path (
   Abs,
@@ -46,9 +48,6 @@ import Path.IO (
   setPermissions,
  )
 import Prelude hiding (writeFile)
-import App.Version.TH (themisVersionQ)
-import Data.Text (Text)
-import qualified Data.Text as T
 
 data PackagedBinary
   = Themis
@@ -185,7 +184,7 @@ embeddedBinaryThemisIndex :: ByteString
 embeddedBinaryThemisIndex = $(embedFileIfExists "vendor-bins/index.gob.xz")
 
 themisVersion :: Text
-themisVersion =  T.takeWhileEnd (/= ' ') $ T.strip $ toText $$themisVersionQ
+themisVersion = $$themisVersionQ
 
 -- To build this, run `make build` or `cargo build --release`.
 #ifdef mingw32_HOST_OS

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -21,7 +21,7 @@ import Data.ByteString.Lazy qualified as BL
 import Data.String.Conversion (ConvertUtf8 (decodeUtf8), toText)
 import Data.Tagged (Tagged, unTag)
 import Data.Text (Text)
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Effect.Exec (
   AllowErr (Never),
   Command (..),
@@ -46,7 +46,7 @@ getThemisVersion :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) =>
 getThemisVersion themisBins = do
   bytes <- execThrow' $ themisCommand themisBins "" ["--version"]
   let versionText = decodeUtf8 bytes
-  let version = T.takeWhileEnd (/= ' ') $ T.strip versionText
+  let version = Text.takeWhileEnd (/= ' ') $ Text.strip versionText
   pure version
 
 execThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Path Abs Dir -> [Text] -> m [LicenseUnit]

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -6,6 +6,7 @@ module App.Fossa.RunThemis (
   -- `themisCommand` is used by Hubble.
   themisCommand,
   themisFlags,
+  getThemisVersion,
 ) where
 
 import App.Fossa.EmbeddedBinary (
@@ -26,7 +27,9 @@ import Effect.Exec (
   Exec,
   execJson,
   execThrow,
+  execThrow',
  )
+import Effect.ReadFS (ReadFS)
 import Path (Abs, Dir, Path, parent)
 import Srclib.Types (LicenseUnit)
 import Types (GlobFilter (unGlobFilter), LicenseScanPathFilters (..))
@@ -34,7 +37,10 @@ import Types (GlobFilter (unGlobFilter), LicenseScanPathFilters (..))
 execRawThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> [Text] -> m BL.ByteString
 execRawThemis themisBins scanDir flags = execThrow scanDir $ themisCommand themisBins "" flags
 
--- TODO: We should log the themis version and index version
+-- get the themis version without requiring a directory to run in
+getThemisVersion :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => ThemisBins -> m BL.ByteString
+getThemisVersion themisBins = execThrow' $ themisCommand themisBins "" ["--version"]
+
 execThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Path Abs Dir -> [Text] -> m [LicenseUnit]
 execThemis themisBins pathPrefix scanDir flags = do
   execJson @[LicenseUnit] scanDir $ themisCommand themisBins pathPrefix flags

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -6,7 +6,6 @@ module App.Fossa.RunThemis (
   -- `themisCommand` is used by Hubble.
   themisCommand,
   themisFlags,
-  getThemisVersion,
 ) where
 
 import App.Fossa.EmbeddedBinary (
@@ -18,33 +17,22 @@ import App.Fossa.EmbeddedBinary (
 import App.Types (FullFileUploads (unFullFileUploads))
 import Control.Effect.Diagnostics (Diagnostics, Has)
 import Data.ByteString.Lazy qualified as BL
-import Data.String.Conversion (ConvertUtf8 (decodeUtf8), toText)
+import Data.String.Conversion (toText)
 import Data.Tagged (Tagged, unTag)
 import Data.Text (Text)
-import Data.Text qualified as Text
 import Effect.Exec (
   AllowErr (Never),
   Command (..),
   Exec,
   execJson,
   execThrow,
-  execThrow',
  )
-import Effect.ReadFS (ReadFS)
 import Path (Abs, Dir, Path, parent)
 import Srclib.Types (LicenseUnit)
 import Types (GlobFilter (unGlobFilter), LicenseScanPathFilters (..))
 
 execRawThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Path Abs Dir -> [Text] -> m BL.ByteString
 execRawThemis themisBins scanDir flags = execThrow scanDir $ themisCommand themisBins "" flags
-
--- get the themis version without requiring a directory to run in
--- The output will look something like
--- Version: ee69aa92245697a5f6d32a27129ec2b4d77dc423
-getThemisVersion :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => ThemisBins -> m Text
-getThemisVersion themisBins = do
-  bytes <- execThrow' $ themisCommand themisBins "" ["--version"]
-  pure $ Text.takeWhileEnd (/= ' ') (Text.strip $ decodeUtf8 bytes)
 
 execThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Path Abs Dir -> [Text] -> m [LicenseUnit]
 execThemis themisBins pathPrefix scanDir flags = do

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -40,14 +40,11 @@ execRawThemis themisBins scanDir flags = execThrow scanDir $ themisCommand themi
 
 -- get the themis version without requiring a directory to run in
 -- The output will look something like
--- 2023/06/26 14:37:54 Version: ee69aa92245697a5f6d32a27129ec2b4d77dc423
--- So we just split on the first space, counting from the end of the string
+-- Version: ee69aa92245697a5f6d32a27129ec2b4d77dc423
 getThemisVersion :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => ThemisBins -> m Text
 getThemisVersion themisBins = do
   bytes <- execThrow' $ themisCommand themisBins "" ["--version"]
-  let versionText = decodeUtf8 bytes
-  let version = Text.takeWhileEnd (/= ' ') $ Text.strip versionText
-  pure version
+  pure $ Text.takeWhileEnd (/= ' ') (Text.strip $ decodeUtf8 bytes)
 
 execThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Path Abs Dir -> [Text] -> m [LicenseUnit]
 execThemis themisBins pathPrefix scanDir flags = do

--- a/src/App/Fossa/RunThemis.hs
+++ b/src/App/Fossa/RunThemis.hs
@@ -16,14 +16,12 @@ import App.Fossa.EmbeddedBinary (
   toPath,
  )
 import App.Types (FullFileUploads (unFullFileUploads))
-import Control.Carrier.Diagnostics qualified as Diag
-import Control.Effect.Diagnostics (Diagnostics, Has, (<||>))
+import Control.Effect.Diagnostics (Diagnostics, Has)
 import Data.ByteString.Lazy qualified as BL
 import Data.String.Conversion (ConvertUtf8 (decodeUtf8), toText)
 import Data.Tagged (Tagged, unTag)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Diag.Result
 import Effect.Exec (
   AllowErr (Never),
   Command (..),
@@ -46,13 +44,10 @@ execRawThemis themisBins scanDir flags = execThrow scanDir $ themisCommand themi
 -- So we just split on the first space, counting from the end of the string
 getThemisVersion :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => ThemisBins -> m Text
 getThemisVersion themisBins = do
-  bytes <- Diag.runDiagnostics (execThrow' (themisCommand themisBins "" ["--version"]) <||> pure BL.empty)
-  case bytes of
-    Success _ bs -> do
-      let versionText = decodeUtf8 bs
-      let version = T.takeWhileEnd (/= ' ') $ T.strip versionText
-      pure version
-    _ -> pure ""
+  bytes <- execThrow' $ themisCommand themisBins "" ["--version"]
+  let versionText = decodeUtf8 bytes
+  let version = T.takeWhileEnd (/= ' ') $ T.strip versionText
+  pure version
 
 execThemis :: (Has Exec sig m, Has Diagnostics sig m) => ThemisBins -> Text -> Path Abs Dir -> [Text] -> m [LicenseUnit]
 execThemis themisBins pathPrefix scanDir flags = do

--- a/src/App/Version/TH.hs
+++ b/src/App/Version/TH.hs
@@ -14,6 +14,10 @@ module App.Version.TH (
 import Control.Carrier.Diagnostics (runDiagnostics)
 import Control.Carrier.Stack (runStack)
 import Control.Effect.Diagnostics (Diagnostics, fromEitherShow)
+import Control.Effect.Exception (Exception (displayException), SomeException)
+import Control.Exception.Safe (catchAny)
+import Control.Monad (when)
+import Data.ByteString.Lazy qualified as BL
 import Data.ByteString.Lazy qualified as BSL
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (decodeUtf8, toString, toText)
@@ -21,10 +25,6 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Versions (errorBundlePretty, semver)
 import Diag.Result (Result (Success))
-import Language.Haskell.TH.Syntax
-    ( runIO, Quasi(qAddDependentFile), reportWarning, runIO )
-import Language.Haskell.TH
-    ( bindCode, Code, Q, bindCode_, joinCode )
 import Effect.Exec (
   AllowErr (Always),
   Command (..),
@@ -36,7 +36,21 @@ import Effect.Exec (
 import Effect.ReadFS (ReadFS, getCurrentDir, runReadFSIO)
 import GitHash (giHash, tGitInfoCwdTry)
 import Instances.TH.Lift ()
-import System.Process.Typed (readProcess)
+import Language.Haskell.TH (
+  Code,
+  Q,
+  bindCode,
+  bindCode_,
+  joinCode,
+ )
+import Language.Haskell.TH.Syntax (
+  Quasi (qAddDependentFile),
+  reportWarning,
+  runIO,
+ )
+import Path (parseRelFile)
+import Path.IO (doesFileExist)
+import System.Process.Typed (ExitCode (ExitFailure, ExitSuccess), readProcess)
 
 gitTagPointCommand :: Text -> Command
 gitTagPointCommand commit =
@@ -92,12 +106,31 @@ validateSingleTag tag = do
     Left err -> reportWarning (errorBundlePretty err) `bindCode_` [||Nothing||]
     Right _ -> [||Just normalized||]
 
-themisVersionQ :: Code Q String
-themisVersionQ =
-  (do qAddDependentFile "vendor-bins/themis-cli"
-      runIO (readProcess "vendor-bins/themis-cli --version"))
-  `bindCode` spliceVersion
-  where spliceVersion (_exitCode, stdOut, _stdErr) = do
-          let versionStr = decodeUtf8 stdOut
-          [||versionStr||]
+themisVersionQ :: Code Q Text
+themisVersionQ = do
+  -- qAddDependentFile is meant to signal that when this file changes we should rebuild, but it doesn't seem to actually do that
+  ( do
+      case parseRelFile "vendor-bins/themis-cli" of
+        Just path' -> do
+          fileExists <- runIO $ doesFileExist path'
+          when fileExists (qAddDependentFile "vendor-bins/themis-cli")
+        Nothing -> pure ()
+      runIO (catchAny readProcess' exceptionToText)
+    )
+    `bindCode` spliceVersion
+  where
+    spliceVersion output = do
+      case output of
+        Left _ -> [||""||]
+        Right t ->
+          let t' = Text.takeWhileEnd (/= ' ') $ Text.strip t in [||t'||]
+    readProcess' :: (IO (Either String Text))
+    readProcess' = do
+      processOutput <$> readProcess "vendor-bins/themis-cli --version"
 
+processOutput :: (ExitCode, BL.ByteString, BL.ByteString) -> (Either String Text)
+processOutput (ExitFailure _, _, _) = Left ""
+processOutput (ExitSuccess, stdout, _) = Right $ decodeUtf8 stdout
+
+exceptionToText :: SomeException -> IO (Either String a)
+exceptionToText = (pure . Left . displayException)

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -6,9 +6,8 @@
 # Requires binary dependencies in $PATH:
 #   jq              Parse and manipulate json structures.
 #   curl            Download data over HTTP(s)
-#   sed             Modify syft tag
+#   sed             Modify executable names
 #   xz              compress the license index
-#   upx             Compress binaries (optional)
 #
 
 set -e
@@ -56,16 +55,15 @@ esac
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-THEMIS_TAG="2023-06-14-ee69aa9-1686783828"
-echo "Downloading themis binary"
-echo "Using themis release: $THEMIS_TAG"
+echo "Downloading themis binary from latest release"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json
 curl -sSL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
-    https://api.github.com/repos/fossas/basis/releases/tags/$THEMIS_TAG > $THEMIS_RELEASE_JSON
+    https://api.github.com/repos/fossas/basis/releases/latest > $THEMIS_RELEASE_JSON
 
 THEMIS_TAG=$(jq -cr ".name" $THEMIS_RELEASE_JSON)
+echo "Using themis release: $THEMIS_TAG"
 FILTER=".name == \"themis-cli-$BASIS_ASSET_POSTFIX\""
 jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $THEMIS_RELEASE_JSON | while read ASSET; do
   URL="$(echo $ASSET | jq -c -r '.url')"


### PR DESCRIPTION
# Overview

No ticket.

Always download the themis from the latest Basis release, https://github.com/fossas/basis/releases/latest

## Acceptance criteria

- `vendor_download.sh` will always download Themis from the latest basis release
- we do not have to make PRs to update Themis
- We include the themis version in debug bundles
- The debug bundle will still generate if Themis blows up

## Testing plan

Test that `vendor_download.sh` still downloads Themis properly, and that it downloads the latest release:

```
./vendor_download.sh

# verify that the version is correct. 
# The output of vendor_download.sh should say that it is downloading the release from 2023-06-27
# The version should (and does) match the current commit on Basis's master branch: https://github.com/fossas/basis/tree/master
./vendor-bins/themis-cli --version
2023/06/27 12:58:07 maxprocs: Leaving GOMAXPROCS=10: CPU quota undefined
Version: 80094c046f68f43ecfe578ee3ac252479ebe59d2

# verify that it scans licenses
xz --decompress --keep vendor-bins/index.gob.xz
./vendor-bins/themis-cli --license-data-dir ./vendor-bins .
```

Generate a debug bundle and make sure it contains the themis version:

```
cabal clean
make install-dev
fossa-dev analyze --debug 
gunzip fossa.debug.json.gz
jq '.bundleThemisVersion' fossa.debug.json
"80094c046f68f43ecfe578ee3ac252479ebe59d2"
```

Try deleting Themis and then generating a debug bundle. You should see an empty themis version in the debug bundle, but things should still run and the debug bundle should still be generated:

```
rm -rf vendor-bins/*
cabal clean
make install-dev
fossa-dev analyze --debug
gunzip fossa.debug.json.gz
jq '.bundleThemisVersion' fossa.debug.json
""
```

## Risks


## Metrics

## References


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
