### PR TITLE
[No Ticket] Log basic HTTP request info in debug bundles.

### DIFF
--- a/src/App/Fossa/FirstPartyScan.hs
+++ b/src/App/Fossa/FirstPartyScan.hs
@@ -11,6 +11,7 @@ import App.Fossa.ManualDeps (ManualDependencies (vendoredDependencies), Vendored
 import App.Types (FirstPartyScansFlag (..), FullFileUploads (FullFileUploads))
 import Control.Carrier.Diagnostics qualified as Diag
 import Control.Carrier.FossaApiClient (runFossaApiClient)
+import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics, fatalText)
 import Control.Effect.FossaApiClient (FossaApiClient, getOrganization)
 import Control.Effect.Lift (Lift)
@@ -42,6 +43,7 @@ runFirstPartyScan ::
   , Has StickyLogger sig m
   , Has Logger sig m
   , Has Exec sig m
+  , Has Debug sig m
   , Has ReadFS sig m
   ) =>
   Path Abs Dir ->

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -31,6 +31,7 @@ import App.Fossa.VendoredDependency (
  )
 import App.Types (FullFileUploads (..))
 import Control.Carrier.FossaApiClient (runFossaApiClient)
+import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics, context, fatal, fatalText)
 import Control.Effect.FossaApiClient (FossaApiClient, getOrganization)
 import Control.Effect.Lift (Has, Lift)
@@ -74,6 +75,7 @@ analyzeFossaDepsFile ::
   , Has (Lift IO) sig m
   , Has StickyLogger sig m
   , Has Logger sig m
+  , Has Debug sig m
   , Has Exec sig m
   ) =>
   Path Abs Dir ->
@@ -131,6 +133,7 @@ toSourceUnit ::
   , Has StickyLogger sig m
   , Has Logger sig m
   , Has Exec sig m
+  , Has Debug sig m
   , Has ReadFS sig m
   ) =>
   Path Abs Dir ->

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -13,6 +13,7 @@ import App.Fossa.API.BuildWait (
 import App.Fossa.Config.Report (ReportCliOptions, ReportConfig (..), ReportOutputFormat (ReportJson), mkSubCommand)
 import App.Fossa.Subcommand (SubCommand)
 import App.Types (ProjectRevision (..))
+import Control.Carrier.Debug (ignoreDebug)
 import Control.Carrier.FossaApiClient (runFossaApiClient)
 import Control.Carrier.StickyLogger (StickyLogger, logSticky, runStickyLogger)
 import Control.Effect.Diagnostics (Diagnostics)
@@ -52,6 +53,7 @@ report config@ReportConfig{..} = do
     * Above includes errors, types, and scaffolding
   -}
   runStickyLogger SevInfo
+    . ignoreDebug
     . runFossaApiClient apiOpts
     $ fetchReport config
 

--- a/src/App/Fossa/VSI/IAT/AssertUserDefinedBinaries.hs
+++ b/src/App/Fossa/VSI/IAT/AssertUserDefinedBinaries.hs
@@ -13,6 +13,7 @@ import App.Fossa.Subcommand (SubCommand)
 import App.Fossa.VSI.Fingerprint (fingerprintContentsRaw)
 import App.Types (BaseDir (..))
 import Control.Algebra (Has)
+import Control.Carrier.Debug (ignoreDebug)
 import Control.Carrier.FossaApiClient (runFossaApiClient)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.FossaApiClient qualified as API
@@ -36,4 +37,4 @@ assertUserDefinedBinaries LinkUserBinsConfig{..} = do
   fingerprints <- fingerprintContentsRaw $ unBaseDir baseDir
 
   logInfo "Uploading assertion to FOSSA"
-  runFossaApiClient apiOpts $ API.assertUserDefinedBinaries binMetadata fingerprints
+  ignoreDebug . runFossaApiClient apiOpts $ API.assertUserDefinedBinaries binMetadata fingerprints

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -8,6 +8,7 @@ import Control.Carrier.FossaApiClient.Internal.LicenseScanning qualified as Lice
 import Control.Carrier.FossaApiClient.Internal.VSI qualified as VSI
 import Control.Carrier.Reader (ReaderC, runReader)
 import Control.Carrier.Simple (SimpleC, interpret)
+import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
 import Control.Effect.Lift (Lift)
@@ -19,6 +20,7 @@ type FossaApiClientC m = SimpleC FossaApiClientF (ReaderC ApiOpts m)
 -- | Runs FossaAPI effects as IO operations
 runFossaApiClient ::
   ( Has (Lift IO) sig m
+  , Has Debug sig m
   , Has Diagnostics sig m
   ) =>
   ApiOpts ->

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -25,6 +25,7 @@ import App.Types (FullFileUploads, ProjectMetadata, ProjectRevision (..))
 import Container.Types qualified as NativeContainer
 import Control.Algebra (Has)
 import Control.Carrier.FossaApiClient.Internal.FossaAPIV1 qualified as API
+import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.FossaApiClient (PackageRevision (..))
 import Control.Effect.Lift (Lift)
@@ -51,6 +52,7 @@ import Srclib.Types (Locator, SourceUnit, renderLocator)
 getOrganization ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   m Organization
@@ -63,6 +65,7 @@ getOrganization = do
 getProject ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   ProjectRevision ->
@@ -74,6 +77,7 @@ getProject revision = do
 getAnalyzedRevisions ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   NE.NonEmpty VendoredDependency ->
@@ -85,6 +89,7 @@ getAnalyzedRevisions vdeps = do
 uploadAnalysis ::
   ( Has (Lift IO) sig m
   , Has (Reader ApiOpts) sig m
+  , Has Debug sig m
   , Has Diagnostics sig m
   ) =>
   ProjectRevision ->
@@ -98,6 +103,7 @@ uploadAnalysis revision metadata units = do
 uploadAnalysisWithFirstPartyLicenses ::
   ( Has (Lift IO) sig m
   , Has (Reader ApiOpts) sig m
+  , Has Debug sig m
   , Has Diagnostics sig m
   ) =>
   ProjectRevision ->
@@ -111,6 +117,7 @@ uploadAnalysisWithFirstPartyLicenses revision metadata fullFileUploads = do
 uploadNativeContainerScan ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   ProjectRevision ->
@@ -124,6 +131,7 @@ uploadNativeContainerScan revision metadata scan = do
 uploadContributors ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   Locator ->
@@ -136,6 +144,7 @@ uploadContributors locator contributors = do
 getLatestBuild ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   ProjectRevision ->
@@ -147,6 +156,7 @@ getLatestBuild rev = do
 getIssues ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   ProjectRevision ->
@@ -159,6 +169,7 @@ getIssues rev diffRevision = do
 getAttribution ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   ProjectRevision ->
@@ -171,6 +182,7 @@ getAttribution revision format = do
 getRevisionDependencyCacheStatus ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   ProjectRevision ->
@@ -182,6 +194,7 @@ getRevisionDependencyCacheStatus rev = do
 getSignedUploadUrl ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   PackageRevision ->
@@ -193,6 +206,7 @@ getSignedUploadUrl PackageRevision{..} = do
 queueArchiveBuild ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   Archive ->
@@ -214,6 +228,7 @@ uploadArchive =
 getEndpointVersion ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   m Text

--- a/src/Control/Carrier/FossaApiClient/Internal/LicenseScanning.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/LicenseScanning.hs
@@ -10,6 +10,7 @@ module Control.Carrier.FossaApiClient.Internal.LicenseScanning (
 
 import Control.Algebra (Has)
 import Control.Carrier.FossaApiClient.Internal.FossaAPIV1 qualified as API
+import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.FossaApiClient (PackageRevision (..))
 import Control.Effect.Lift (Lift)
@@ -22,6 +23,7 @@ import Srclib.Types (FullSourceUnit, LicenseSourceUnit)
 getSignedFirstPartyScanUrl ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   PackageRevision ->
@@ -33,6 +35,7 @@ getSignedFirstPartyScanUrl PackageRevision{..} = do
 getSignedLicenseScanUrl ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   PackageRevision ->
@@ -44,6 +47,7 @@ getSignedLicenseScanUrl PackageRevision{..} = do
 finalizeLicenseScan ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   ArchiveComponents ->

--- a/src/Control/Carrier/FossaApiClient/Internal/VSI.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/VSI.hs
@@ -17,6 +17,7 @@ import App.Fossa.VSI.Types qualified as VSI
 import App.Types (ProjectRevision)
 import Control.Algebra (Has)
 import Control.Carrier.FossaApiClient.Internal.FossaAPIV1 qualified as API
+import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Lift)
 import Control.Effect.Reader (Reader, ask)
@@ -28,6 +29,7 @@ import Srclib.Types (Locator)
 assertRevisionBinaries ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   Locator ->
@@ -40,6 +42,7 @@ assertRevisionBinaries meta fingerprints = do
 assertUserDefinedBinaries ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   IAT.UserDefinedAssertionMeta ->
@@ -52,6 +55,7 @@ assertUserDefinedBinaries meta fingerprints = do
 resolveUserDefinedBinary ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   IAT.UserDep ->
@@ -63,6 +67,7 @@ resolveUserDefinedBinary dep = do
 resolveProjectDependencies ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   VSI.Locator ->
@@ -74,6 +79,7 @@ resolveProjectDependencies locator = do
 createVsiScan ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   ProjectRevision ->
@@ -85,6 +91,7 @@ createVsiScan revision = do
 addFilesToVsiScan ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   VSI.ScanID ->
@@ -97,6 +104,7 @@ addFilesToVsiScan scanId files = do
 completeVsiScan ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   VSI.ScanID ->
@@ -108,6 +116,7 @@ completeVsiScan scanId = do
 getVsiScanAnalysisStatus ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   VSI.ScanID ->
@@ -119,6 +128,7 @@ getVsiScanAnalysisStatus scanId = do
 getVsiInferences ::
   ( Has (Lift IO) sig m
   , Has Diagnostics sig m
+  , Has Debug sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   VSI.ScanID ->


### PR DESCRIPTION
# Overview

This provides basic support for outputting some tracing info for our HTTP requests. Output is only to the debug bundle. 

This PR itself is pretty minimal in terms of the info it outputs but it makes it much easier to add additional info in the future.

I discovered that several of our subcommands support `--debug` but don't output any debug bundle. They will not be able to benefit from this work. For those I had to add a call to `ignoreDebug` to make the types check. I think I did this correctly but if a reviewer can double-check it would be helpful.

## Acceptance criteria

* It should output the method and URL whenever an HTTP call is made through our api client effect to the debug bundle.
* It should not output this information to stderr/stdout.

## Testing plan

I ran `fossa analyze` and `fossa test`, etc. with the `--debug` flag and checked that it output some information in the debug bundle (where relevant) and didn't output anything to the console.

## Risks

None, in the worst case I think nothing will happen.

## Metrics

None.

## References

None.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
