### PR TITLE
[No ticket] Add "Common Flags" to analyze.md

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- Doc only: Fixed an issue where a referenced table was missing from `analyze.md`
+
 ## v3.8.3
 - Logging: Don't output the `[INFO]` prefix for regular CLI messages. ([#1226](https://github.com/fossas/fossa-cli/pull/1226))
 - License Scanning: Fix a bug where we were identifying the "GPL with autoconf macro exception" license as "GPL with autoconf exception" in a few cases ([#1225](https://github.com/fossas/fossa-cli/pull/1225))

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -180,3 +180,15 @@ For a workaround, create an empty `reqs.txt` file before running `fossa analyze,
 ```bash
 touch reqs.txt && fossa analyze && rm reqs.txt && fossa test
 ```
+
+## Common FOSSA Project Flags
+
+All `fossa` commands support the following FOSSA-project-related flags:
+
+| Name                               | Short | Description                                                                                                                                            |
+| ---------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--project 'some project'`         | `-p`  | Override the detected project name                                                                                                                     |
+| `--revision 'some revision'`       | `-r`  | -Override the detected project revision                                                                                                                |
+| `--fossa-api-key 'my-api-key'`     |       | An alternative to using the `FOSSA_API_KEY` environment variable to specify a FOSSA API key                                                            |
+| `--endpoint 'https://example.com'` | `-e`  | Override the FOSSA API server base URL                                                                                                                 |
+| `--config /path/to/file`           | `-c`  | Path to a [configuration file](../files/fossa-yml.md) including filename. By default we look for `.fossa.yml` in base working directory. |


### PR DESCRIPTION
# Overview

This PR ports the existing "Common Flags" table to the analyze doc. There's a link for it, but it was apparently never added!

## Acceptance criteria

Nothing breaks, and the `usual FOSSA project flags` link now works.

## Testing plan

You can check this branch out and preview the file, or head to the file below and clicktest the link:
- https://github.com/fossas/fossa-cli/blob/palacio-add_common_flags/docs/references/subcommands/analyze.md

## Risks

No risk, doc only.

## References

None

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
