### PR TITLE
[Review after ANE-956] Ane 958 src unit origin paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.8.4
+- VSI: Report VSI rules and display them in FOSSA's UI. ([#1237](https://github.com/fossas/fossa-cli/pull/1237), [#1235](https://github.com/fossas/fossa-cli/pull/1235))
+
 ## v3.8.3
 - Logging: Don't output the `[INFO]` prefix for regular CLI messages. ([#1226](https://github.com/fossas/fossa-cli/pull/1226))
 - License Scanning: Fix a bug where we were identifying the "GPL with autoconf macro exception" license as "GPL with autoconf exception" in a few cases ([#1225](https://github.com/fossas/fossa-cli/pull/1225))

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -92,10 +92,10 @@ import Data.ByteString.Lazy qualified as BL
 import Data.Flag (Flag, fromFlag)
 import Data.Foldable (traverse_)
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text.Extra (showT)
-import Diag.Result (resultToMaybe)
+import Diag.Result (Result, resultToMaybe)
 import Discovery.Archive qualified as Archive
 import Discovery.Filters (AllFilters, applyFilters, filterIsVSIOnly, ignoredPaths, isDefaultNonProductionPath)
 import Discovery.Projects (withDiscoveredProjects)
@@ -296,9 +296,18 @@ analyze cfg = Diag.context "fossa-analyze" $ do
           logInfo "Running in VSI only mode, skipping manual source units"
           pure Nothing
         else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir maybeApiOpts vendoredDepsOptions
-  let additionalSourceUnits :: [SourceUnit]
-      additionalSourceUnits = mapMaybe (join . resultToMaybe) [manualSrcUnits, vsiResults, binarySearchResults, dynamicLinkedResults]
-  traverse_ (Diag.flushLogs SevError SevDebug) [vsiResults, binarySearchResults, manualSrcUnits, dynamicLinkedResults]
+
+  let -- This makes nice with additionalSourceUnits below, but throws out additional Result data.
+      -- This is ok because 'resultToMaybe' would do that anyway.
+      -- We'll use the original results to output warnings/errors below.
+      vsiResults' :: [SourceUnit]
+      vsiResults' = fromMaybe [] $ join (resultToMaybe vsiResults)
+
+      additionalSourceUnits :: [SourceUnit]
+      additionalSourceUnits = vsiResults' <> mapMaybe (join . resultToMaybe) [manualSrcUnits, binarySearchResults, dynamicLinkedResults]
+  traverse_ (Diag.flushLogs SevError SevDebug) [manualSrcUnits, binarySearchResults, dynamicLinkedResults]
+  -- Flush logs using the original Result from VSI.
+  traverse_ (Diag.flushLogs SevError SevDebug) [vsiResults]
 
   maybeFirstPartyScanResults <-
     Diag.errorBoundaryIO . diagToDebug $
@@ -379,7 +388,7 @@ analyzeVSI ::
   ProjectRevision ->
   AllFilters ->
   VSI.SkipResolution ->
-  m (Maybe SourceUnit)
+  m (Maybe [SourceUnit])
 analyzeVSI dir revision filters skipResolving = do
   logInfo "Running VSI analysis"
 
@@ -389,8 +398,7 @@ analyzeVSI dir revision filters skipResolving = do
       logInfo "Skipping resolution of the following locators:"
       traverse_ (logInfo . pretty . VSI.renderLocator) skippedLocators
 
-  results <- analyzeVSIDeps dir revision filters skipResolving
-  pure $ Just results
+  analyzeVSIDeps dir revision filters skipResolving
 
 analyzeDiscoverBinaries ::
   ( Has Diag.Diagnostics sig m

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -95,7 +95,7 @@ import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text.Extra (showT)
-import Diag.Result (Result, resultToMaybe)
+import Diag.Result (resultToMaybe)
 import Discovery.Archive qualified as Archive
 import Discovery.Filters (AllFilters, applyFilters, filterIsVSIOnly, ignoredPaths, isDefaultNonProductionPath)
 import Discovery.Projects (withDiscoveredProjects)

--- a/src/App/Fossa/Analyze/Log4jReport.hs
+++ b/src/App/Fossa/Analyze/Log4jReport.hs
@@ -72,7 +72,7 @@ import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
 import Graphing (directList, getRootsOf, hasPredecessors, vertexList)
 import Options.Applicative (InfoMod, progDesc)
-import Path (Abs, Dir, File, Path, SomeBase, toFilePath)
+import Path (Abs, Dir, Path, toFilePath)
 import Prettyprinter (Doc, Pretty (pretty), annotate, vsep)
 import Prettyprinter.Render.Terminal (AnsiStyle, Color (Yellow), color)
 import Srclib.Converter (verConstraintToRevision)
@@ -236,7 +236,7 @@ data Log4jVulnerableReportItem = Log4jVulnerableReportItem
   deriving (Show, Eq, Ord)
 
 data VulnerableDependencyOrigin
-  = VulnerableDependencyManifestFiles [SomeBase File]
+  = VulnerableDependencyManifestFiles [Text]
   | VulnerableDependencyRootDependency [Dependency]
   deriving (Eq, Ord)
 

--- a/src/App/Fossa/Analyze/Log4jReport.hs
+++ b/src/App/Fossa/Analyze/Log4jReport.hs
@@ -73,6 +73,7 @@ import GHC.Generics (Generic)
 import Graphing (directList, getRootsOf, hasPredecessors, vertexList)
 import Options.Applicative (InfoMod, progDesc)
 import Path (Abs, Dir, Path, toFilePath)
+import Path.Extra (SomePath)
 import Prettyprinter (Doc, Pretty (pretty), annotate, vsep)
 import Prettyprinter.Render.Terminal (AnsiStyle, Color (Yellow), color)
 import Srclib.Converter (verConstraintToRevision)
@@ -236,7 +237,7 @@ data Log4jVulnerableReportItem = Log4jVulnerableReportItem
   deriving (Show, Eq, Ord)
 
 data VulnerableDependencyOrigin
-  = VulnerableDependencyManifestFiles [Text]
+  = VulnerableDependencyManifestFiles [SomePath]
   | VulnerableDependencyRootDependency [Dependency]
   deriving (Eq, Ord)
 

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -4,8 +4,6 @@ module App.Fossa.Analyze.Project (
 ) where
 
 import App.Util (FileAncestry (..))
-import Data.String.Conversion (toText)
-import Data.Text (Text)
 import DepTypes
 import Graphing (Graphing)
 import Graphing qualified

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -4,6 +4,8 @@ module App.Fossa.Analyze.Project (
 ) where
 
 import App.Util (FileAncestry (..))
+import Data.String.Conversion (toText)
+import Data.Text (Text)
 import DepTypes
 import Graphing (Graphing)
 import Graphing qualified
@@ -31,7 +33,7 @@ mkResult basedir project pathPrefix dependencyResults =
   where
     graph = dependencyGraph dependencyResults
     relativeManifestFiles = map (tryMakeRelative basedir) $ dependencyManifestFiles dependencyResults
-    prefixedManifestFiles = map (addPrefix $ fileAncestryPath <$> pathPrefix) relativeManifestFiles
+    prefixedManifestFiles = map (toText . addPrefix (fileAncestryPath <$> pathPrefix)) relativeManifestFiles
     addPrefix :: Maybe (Path Rel Dir) -> SomeBase File -> SomeBase File
     addPrefix maybePrefix relativeFile =
       case (maybePrefix, relativeFile) of
@@ -44,7 +46,7 @@ data ProjectResult = ProjectResult
   , projectResultPath :: Path Abs Dir
   , projectResultGraph :: Graphing Dependency
   , projectResultGraphBreadth :: GraphBreadth
-  , projectResultManifestFiles :: [SomeBase File]
+  , projectResultManifestFiles :: [Text]
   }
   deriving (Show)
 

--- a/src/App/Fossa/Analyze/Project.hs
+++ b/src/App/Fossa/Analyze/Project.hs
@@ -10,7 +10,7 @@ import DepTypes
 import Graphing (Graphing)
 import Graphing qualified
 import Path
-import Path.Extra (tryMakeRelative)
+import Path.Extra (SomePath (SomeFile), tryMakeRelative)
 import Types
 
 mkResult :: Path Abs Dir -> DiscoveredProject n -> Maybe FileAncestry -> (DependencyResults) -> ProjectResult
@@ -33,7 +33,7 @@ mkResult basedir project pathPrefix dependencyResults =
   where
     graph = dependencyGraph dependencyResults
     relativeManifestFiles = map (tryMakeRelative basedir) $ dependencyManifestFiles dependencyResults
-    prefixedManifestFiles = map (toText . addPrefix (fileAncestryPath <$> pathPrefix)) relativeManifestFiles
+    prefixedManifestFiles = map (SomeFile . addPrefix (fileAncestryPath <$> pathPrefix)) relativeManifestFiles
     addPrefix :: Maybe (Path Rel Dir) -> SomeBase File -> SomeBase File
     addPrefix maybePrefix relativeFile =
       case (maybePrefix, relativeFile) of
@@ -46,7 +46,7 @@ data ProjectResult = ProjectResult
   , projectResultPath :: Path Abs Dir
   , projectResultGraph :: Graphing Dependency
   , projectResultGraphBreadth :: GraphBreadth
-  , projectResultManifestFiles :: [Text]
+  , projectResultManifestFiles :: [SomePath]
   }
   deriving (Show)
 

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -70,7 +70,7 @@ type AnalyzeStaticTaskEffs sig m =
 
 data AnalysisScanResult = AnalysisScanResult
   { analyzersScanResult :: [DiscoveredProjectScan]
-  , vsiScanResult :: Result (Maybe SourceUnit)
+  , vsiScanResult :: Result (Maybe [SourceUnit])
   , binaryDepsScanResult :: Result (Maybe SourceUnit)
   , fossaDepsScanResult :: Result (Maybe SourceUnit)
   , dynamicLinkingResult :: Result (Maybe SourceUnit)

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -50,7 +50,7 @@ import Data.Functor.Extra ((<$$>))
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, isJust)
-import Data.String.Conversion (showText, toString, toText)
+import Data.String.Conversion (toString, toText)
 import Data.Text (Text, toLower)
 import Data.Text qualified as Text
 import DepTypes (DepType (..))

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -60,7 +60,7 @@ import Effect.Logger (Logger, indent, pretty, vsep)
 import Effect.ReadFS (ReadFS, doesFileExist, readContentsJson, readContentsYaml)
 import Fossa.API.Types (ApiOpts, Organization (..))
 import Path (Abs, Dir, File, Path, mkRelFile, (</>))
-import Path.Extra (tryMakeRelative)
+import Path.Extra (SomePath (SomeFile), tryMakeRelative)
 import Srclib.Converter (depTypeToFetcher)
 import Srclib.Types (AdditionalDepData (..), Locator (..), SourceRemoteDep (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (SourceUnitDependency), SourceUserDefDep (..))
 import Types (ArchiveUploadType (..), GraphBreadth (..))
@@ -174,7 +174,7 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendor
       , sourceUnitType = "user-specific-yaml"
       , sourceUnitBuild = build
       , sourceUnitGraphBreadth = Complete
-      , sourceUnitOriginPaths = [showText originPath]
+      , sourceUnitOriginPaths = [SomeFile originPath]
       , additionalData = additional
       }
 

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -50,7 +50,7 @@ import Data.Functor.Extra ((<$$>))
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, isJust)
-import Data.String.Conversion (toString, toText)
+import Data.String.Conversion (showText, toString, toText)
 import Data.Text (Text, toLower)
 import Data.Text qualified as Text
 import DepTypes (DepType (..))
@@ -174,7 +174,7 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendor
       , sourceUnitType = "user-specific-yaml"
       , sourceUnitBuild = build
       , sourceUnitGraphBreadth = Complete
-      , sourceUnitOriginPaths = [originPath]
+      , sourceUnitOriginPaths = [showText originPath]
       , additionalData = additional
       }
 

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -6,8 +6,7 @@ module App.Fossa.VSI.Analyze (
 ) where
 
 import App.Fossa.VSI.Fingerprint (Combined, fingerprint)
-import App.Fossa.VSI.IAT.Types qualified as IAT
-import App.Fossa.VSI.Types (ScanID (..), VsiRule (..), generateRules)
+import App.Fossa.VSI.Types (ScanID (..), generateRules)
 import App.Fossa.VSI.Types qualified as VSI
 import App.Types (ProjectRevision)
 import App.Util (FileAncestry (..), ancestryDerived, ancestryDirect)

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -53,7 +53,7 @@ runVsiAnalysis ::
   Path Abs Dir ->
   ProjectRevision ->
   AllFilters ->
-  m ([VSI.Locator], [IAT.UserDep])
+  m [VSI.VsiRule]
 runVsiAnalysis dir projectRevision filters = context "VSI" $ do
   -- If we try to run with fewer than 2 capabilities, STM will deadlock
   capabilities <- max 2 <$> sendIO getNumCapabilities
@@ -84,13 +84,10 @@ runVsiAnalysis dir projectRevision filters = context "VSI" $ do
     let rules = generateRules inferences
     logDebug . pretty $ "Generated Rules: " <> (decodeUtf8 @Text . encode $ rules)
     pure rules
-  --    pure . filter (/= "") . VSI.uniqueVsiLocators $ inferences
+
   when (null rules) $ fatalText "No dependencies discovered with VSI"
 
-  let allLocators = vsiRuleLocator <$> rules
-  let userDefinedDeps = map IAT.toUserDep $ filter VSI.isUserDefined allLocators
-  let allOtherDeps = filter (not . VSI.isUserDefined) allLocators
-  pure (allOtherDeps, userDefinedDeps)
+  pure rules
 
 uploadBufferSize :: Int
 uploadBufferSize = 1000

--- a/src/App/Fossa/VSI/Types.hs
+++ b/src/App/Fossa/VSI/Types.hs
@@ -32,7 +32,7 @@ import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String (IsString)
-import Data.String.Conversion (ToText, toText)
+import Data.String.Conversion (ToString, ToText, toText)
 import Data.Text (Text, isPrefixOf)
 import Data.Text qualified as Text
 import DepTypes (DepType (..), Dependency (..), VerConstraint (CEq))
@@ -165,7 +165,7 @@ newtype VsiFilePath = VsiFilePath {unVsiFilePath :: Text}
 -- |A path for a VSI rule.
 -- During processing we change a list of file paths to directory paths for inclusion in rules.
 newtype VsiRulePath = VsiRulePath {unVsiRulePath :: Text}
-  deriving newtype (Eq, Ord, Show, ToJSON, ToJSONKey)
+  deriving newtype (Eq, Ord, Show, ToJSON, ToJSONKey, ToString)
 
 newtype VsiInference = VsiInference
   {inferenceLocator :: Maybe Locator}

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -19,15 +19,15 @@ import Control.Effect.Lift (Lift)
 import Control.Effect.StickyLogger (StickyLogger)
 import Data.Bifunctor (first)
 import Data.List (partition)
-import Data.String.Conversion (toString, toText)
+import Data.String.Conversion (toString)
 import DepTypes (Dependency)
 import Discovery.Filters (AllFilters)
 import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
 import Graphing (Graphing)
 import Graphing qualified
-import Path (Abs, Dir, Path)
-import Path.Posix (parseAbsDir)
+import Path (Abs, Dir, Path, SomeBase (..), parseAbsDir)
+import Path.Extra (SomePath (SomeDir))
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
 import Types (DiscoveredProjectType (VsiProjectType), GraphBreadth (Complete))
@@ -75,7 +75,7 @@ analyzeVSIDeps dir projectRevision filters skipResolving = do
         Nothing -> fatal $ "Could not parse rule path: " <> show vsiRulePath
 
 toProject :: Path Abs Dir -> Graphing Dependency -> ProjectResult
-toProject dir graph = ProjectResult VsiProjectType dir graph Complete [toText dir]
+toProject dir graph = ProjectResult VsiProjectType dir graph Complete [SomeDir . Abs $ dir]
 
 toSourceUnit :: ProjectResult -> Maybe [SourceUserDefDep] -> SourceUnit
 toSourceUnit project deps = do

--- a/src/Data/String/Conversion.hs
+++ b/src/Data/String/Conversion.hs
@@ -9,6 +9,7 @@ module Data.String.Conversion (
   ToLText (..),
   ToString (..),
   LazyStrict (..),
+  showText,
 ) where
 
 import Data.Aeson.Key (Key)
@@ -87,6 +88,11 @@ instance ToText (SomeBase t) where
 
 instance ToText Key where
   toText = Key.toText
+
+-- |Avoid this function in favor of using 'toText' or some other direct conversion if possible.
+-- Unfortunately sometimes this is the best way to convert something to text.
+showText :: Show a => a -> Text.Text
+showText = toText . show
 
 ----- ToLText
 

--- a/src/Path/Extra.hs
+++ b/src/Path/Extra.hs
@@ -10,7 +10,7 @@ module Path.Extra (
 
 import Control.Effect.Record (RecordableValue)
 import Control.Effect.Replay (ReplayableValue)
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON, ToJSON (toJSON))
 import Data.String.Conversion (ToText, toText)
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -23,7 +23,10 @@ data SomePath
   | SomeDir (SomeBase Dir)
   deriving (Eq, Ord, Show, Generic)
 
-instance ToJSON SomePath
+instance ToJSON SomePath where
+  toJSON (SomeFile f) = toJSON f
+  toJSON (SomeDir d) = toJSON d
+  
 instance RecordableValue SomePath
 instance FromJSON SomePath
 instance ReplayableValue SomePath

--- a/src/Path/Extra.hs
+++ b/src/Path/Extra.hs
@@ -26,7 +26,7 @@ data SomePath
 instance ToJSON SomePath where
   toJSON (SomeFile f) = toJSON f
   toJSON (SomeDir d) = toJSON d
-  
+
 instance RecordableValue SomePath
 instance FromJSON SomePath
 instance ReplayableValue SomePath

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -84,7 +84,7 @@ data FullSourceUnit = FullSourceUnit
   , fullSourceUnitManifest :: Maybe Text
   , fullSourceUnitBuild :: Maybe SourceUnitBuild
   , fullSourceUnitGraphBreadth :: GraphBreadth
-  , fullSourceUnitOriginPaths :: [SomeBase File]
+  , fullSourceUnitOriginPaths :: [Text]
   , fullSourceUnitAdditionalData :: Maybe AdditionalDepData
   , fullSourceUnitFiles :: Maybe (NonEmpty Text)
   , fullSourceUnitData :: Maybe (NonEmpty LicenseUnitData)
@@ -290,7 +290,7 @@ data SourceUnit = SourceUnit
   -- ^ path to manifest file
   , sourceUnitBuild :: Maybe SourceUnitBuild
   , sourceUnitGraphBreadth :: GraphBreadth
-  , sourceUnitOriginPaths :: [SomeBase File]
+  , sourceUnitOriginPaths :: [Text]
   , additionalData :: Maybe AdditionalDepData
   }
   deriving (Eq, Ord, Show)

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -30,6 +30,7 @@ import Data.String.Conversion (ToText, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Path (File, SomeBase)
+import Path.Extra (SomePath)
 import Types (GraphBreadth (..))
 
 data LicenseScanType = CliLicenseScanned
@@ -84,7 +85,7 @@ data FullSourceUnit = FullSourceUnit
   , fullSourceUnitManifest :: Maybe Text
   , fullSourceUnitBuild :: Maybe SourceUnitBuild
   , fullSourceUnitGraphBreadth :: GraphBreadth
-  , fullSourceUnitOriginPaths :: [Text]
+  , fullSourceUnitOriginPaths :: [SomePath]
   , fullSourceUnitAdditionalData :: Maybe AdditionalDepData
   , fullSourceUnitFiles :: Maybe (NonEmpty Text)
   , fullSourceUnitData :: Maybe (NonEmpty LicenseUnitData)
@@ -290,7 +291,7 @@ data SourceUnit = SourceUnit
   -- ^ path to manifest file
   , sourceUnitBuild :: Maybe SourceUnitBuild
   , sourceUnitGraphBreadth :: GraphBreadth
-  , sourceUnitOriginPaths :: [Text]
+  , sourceUnitOriginPaths :: [SomePath]
   , additionalData :: Maybe AdditionalDepData
   }
   deriving (Eq, Ord, Show)

--- a/test/App/Fossa/VSI/TypesSpec.hs
+++ b/test/App/Fossa/VSI/TypesSpec.hs
@@ -136,6 +136,6 @@ generateRulesSpec = describe "generateRules" $ do
     generateRules' = generateRules . VsiExportedInferencesBody . Map.fromList
 
 spec :: Spec
-spec = focus $ do
+spec = do
   vsiTypesSpec
   generateRulesSpec

--- a/test/App/Fossa/VSI/TypesSpec.hs
+++ b/test/App/Fossa/VSI/TypesSpec.hs
@@ -8,7 +8,6 @@ import Data.ByteString.Lazy.Char8 qualified as BS
 import Data.Either (isLeft)
 import Data.Map qualified as Map
 import Test.Hspec (Spec, describe, it, shouldBe, shouldMatchList, shouldSatisfy)
-import Test.Hspec.Core.Spec (focus)
 import Text.RawString.QQ
 
 inferencesBody :: BS.ByteString


### PR DESCRIPTION
# Overview

In #1235 I change the CLI to download full rules for VSI. This PR changes the CLI to report each VSI dependency as a different source unit to FOSSA.

On our current releases when running with `--detect-vendored` you'll get output like this:
<img width="1457" alt="Screenshot 2023-06-30 at 2 17 01 PM" src="https://github.com/fossas/fossa-cli/assets/190980/6f9ed8a7-6a47-4918-8095-156916beccf3">
As you can see, there is just one result for VSI which actually finds multiple deps for this project. 

This PR changes it so we report a new source unit for every dep that VSI finds:
![Screenshot 2023-07-03 at 4 19 23 PM](https://github.com/fossas/fossa-cli/assets/190980/d957ef45-30cc-482e-b9e3-3b4de83fe28b)
Including one for the project overall (this will not be shown in FOSSA's UI).

In FOSSA, the deps are now reported with their proper origin paths from within the project. This is show on the right hand side of this screenshot:
<img width="1499" alt="Screenshot 2023-06-30 at 2 08 48 PM" src="https://github.com/fossas/fossa-cli/assets/190980/d71f973c-7d3c-4ac0-b8fc-a3307d9738cf">

Clicking on the dep will show the full path:
<img width="1188" alt="Screenshot 2023-06-30 at 2 21 52 PM" src="https://github.com/fossas/fossa-cli/assets/190980/25ac1de7-9b81-4ed5-afe0-6fa8a874e7e0">

## Acceptance criteria

* Each dependency is now its own source unit with an origin path showing where in the project it was found (the VSI Rule that found it)
* The CLI also reports each VSI dep independently.

## Testing plan

I manually tested scanning with VSI against staging and prod. I verified that the deps that were found were the same but the UI reflected the change in source unit reporting.

You can test this using the [demo](https://github.com/fossas/cpp-vsi-demo). 

## Risks

I removed some type safety around paths in the SourceUnit's structure. 

## References


- [ANE-958](https://fossa.atlassian.net/browse/ANE-958): Output rules as source units with origin paths

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-958]: https://fossa.atlassian.net/browse/ANE-958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ