### PR TITLE
Prevent failures when PNPM-lock.yaml has a lockfileVersion string

### DIFF
--- a/src/Strategy/Node/Pnpm/PnpmLock.hs
+++ b/src/Strategy/Node/Pnpm/PnpmLock.hs
@@ -80,15 +80,13 @@ import Path (Abs, File, Path)
 --    - [pnpm](https://pnpm.io/)
 --    - [pnpm-lockfile](https://github.com/pnpm/pnpm/blob/5cfd6d01946edcce86f62580bddc788d02f93ed6/packages/lockfile-types/src/index.ts)
 data PnpmLockfile = PnpmLockfile
-  { lockFileVersion :: Float
-  , importers :: Map Text ProjectMap
+  { importers :: Map Text ProjectMap
   , packages :: Map Text PackageData
   }
   deriving (Show, Eq, Ord)
 
 instance FromJSON PnpmLockfile where
   parseJSON = Yaml.withObject "pnpm-lock content" $ \obj -> do
-    lockFileVersion <- obj .: "lockfileVersion"
     importers <- obj .:? "importers" .!= mempty
     packages <- obj .:? "packages" .!= mempty
 
@@ -109,7 +107,7 @@ instance FromJSON PnpmLockfile where
             then Map.insert "." virtualRootWs importers
             else importers
 
-    pure $ PnpmLockfile lockFileVersion refinedImporters packages
+    pure $ PnpmLockfile refinedImporters packages
 
 data ProjectMap = ProjectMap
   { directDependencies :: Map Text Text


### PR DESCRIPTION
# Overview

This PR aims to prevent failures when analyzing PNPM projects in which the `pnpm-lock.yaml` file has a `lockfileVersion` attribute which is a string. Per [the spec](https://github.com/pnpm/pnpm/blob/main/lockfile/lockfile-types/src/index.ts#L12), this is a valid configuration in the lockfile, but the parser would fail when it was unable to read the value as a Float. Since the `lockfileVersion` field is not used, the decision was made to ignore the field entirely.

Prior to the changes, when encountering a string in the `lockfileVersion` field, the following error would occur:
```
 >>> Relevant errors

    Error

      Error parsing file: /Users/sara/FOSSA/scratch/mypnpmproj/pnpm-lock.yaml.

          Aeson exception:
          Error in $.lockfileVersion: parsing Float failed, unexpected String
```

## Acceptance criteria

Analyses should not fail when `pnpm-lock.yaml` has a `lockfileVersion` field that is a string

## Testing plan

I ran the following commands:
```
pnpm init
pnpm install --save react
```
I then went into `pnpm-lock.yaml` and ensured the `lockfileVersion` field was a string by wrapping the version in quotation marks, before running `fossa analyze` (using the CLI built from this checked-out branch).

The error listed in the overview should not occur.

## Risks

This does remove a field, but I wasn't able to locate any usage of the field elsewhere in the code, and it didn't cause any errors, thus I believe this is low risk.

## Checklist

- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
