### PR TITLE
Handle the case where a VSI dep appears in a root directory.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # FOSSA CLI Changelog
 
 ## Unreleased
+- VSI: Fix a bug where root dependencies would cause analysis to fail. ([#1240](https://github.com/fossas/fossa-cli/pull/1240))
 - Node (PNPM): Fixes a bug where analyses would fail when the `lockfileVersion` attribute was a string in `pnpm-lock.yaml`. ([1239](https://github.com/fossas/fossa-cli/pull/1239))
 
 ## v3.8.5

--- a/src/App/Fossa/VSI/Types.hs
+++ b/src/App/Fossa/VSI/Types.hs
@@ -245,7 +245,7 @@ getPrefixes paths = snd . foldr accumPrefixes startVal $ (NE.tail sorted)
            in (parent, parent <| acc)
 
     parentDir :: VsiFilePath -> VsiRulePath
-    parentDir = VsiRulePath . Text.dropEnd 1 . Text.dropWhileEnd (/= '/') . unVsiFilePath
+    parentDir = VsiRulePath . Text.dropWhileEnd (/= '/') . unVsiFilePath
 
     prefixesFilePath :: VsiRulePath -> VsiFilePath -> Bool
     prefixesFilePath rp fp = unVsiRulePath rp `isPrefixOf` unVsiFilePath fp

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -49,7 +49,6 @@ analyzeVSIDeps ::
   VSI.SkipResolution ->
   m (Maybe [SourceUnit])
 analyzeVSIDeps dir projectRevision filters skipResolving = do
-  -- (direct, userDeps) <- runVsiAnalysis dir projectRevision filters
   rules <- runVsiAnalysis dir projectRevision filters
 
   let (userDeps, directRules) =

--- a/test/App/Fossa/VSI/TypesSpec.hs
+++ b/test/App/Fossa/VSI/TypesSpec.hs
@@ -78,7 +78,7 @@ singleInference =
   ]
 
 singleRuleExpected :: [VsiRule]
-singleRuleExpected = [VsiRule (VsiRulePath "/foo") (Locator "git" "github.com/facebook/folly" "v2016.08.08.00")]
+singleRuleExpected = [VsiRule (VsiRulePath "/foo/") (Locator "git" "github.com/facebook/folly" "v2016.08.08.00")]
 
 commonPrefixInferences :: [(VsiFilePath, VsiInference)]
 commonPrefixInferences =
@@ -92,8 +92,8 @@ multipleInferences =
 
 multipleRulesExpected :: [VsiRule]
 multipleRulesExpected =
-  VsiRule (VsiRulePath "/otherProject") (Locator "git" "github.com/otherProject" "2.0.0")
-    : VsiRule (VsiRulePath "/baz") (Locator "git" "github.com/someProject" "1.0.0")
+  VsiRule (VsiRulePath "/otherProject/") (Locator "git" "github.com/otherProject" "2.0.0")
+    : VsiRule (VsiRulePath "/baz/") (Locator "git" "github.com/someProject" "1.0.0")
     : singleRuleExpected
 
 nestedProjectInferences :: [(VsiFilePath, VsiInference)]
@@ -105,8 +105,19 @@ nestedProjectInferences =
 
 nestedProjectRulesExpected :: [VsiRule]
 nestedProjectRulesExpected =
-  VsiRule (VsiRulePath "/foo/bar") (Locator "git" "github.com/facebook/follyNested" "1.0.0")
+  VsiRule (VsiRulePath "/foo/bar/") (Locator "git" "github.com/facebook/follyNested" "1.0.0")
     : singleRuleExpected
+
+rootRuleInferences :: [(VsiFilePath, VsiInference)]
+rootRuleInferences =
+  [
+    ( VsiFilePath "/"
+    , VsiInference . Just $ Locator "git" "github.com/foo" "1.0"
+    )
+  ]
+
+rootRuleExpected :: [VsiRule]
+rootRuleExpected = [VsiRule (VsiRulePath "/") (Locator "git" "github.com/foo" "1.0")]
 
 vsiTypesSpec :: Spec
 vsiTypesSpec = describe "VSI Types" $ do
@@ -130,6 +141,8 @@ generateRulesSpec = describe "generateRules" $ do
     generateRules' multipleInferences `shouldMatchList` multipleRulesExpected
   it "Reports distinct locators for nested projects" $
     generateRules' nestedProjectInferences `shouldMatchList` nestedProjectRulesExpected
+  it "Reports root rules correctly" $
+    generateRules' rootRuleInferences `shouldMatchList` rootRuleExpected
   where
     generateRules' :: [(VsiFilePath, VsiInference)] -> [VsiRule]
     generateRules' = generateRules . VsiExportedInferencesBody . Map.fromList


### PR DESCRIPTION
# Overview

There was a bug in how I output VSI rules where I would turn root dependencies with file paths like `/foo.c` into a rule of `""` and then try to parse them as a path, which wouldn't work correctly. This changes the code to handle those properly.

## Acceptance criteria

* We should be able to run VSI on projects where VSI defines a rule for the project root.

## Testing plan

I tested manually by downloading [make](https://ftp.gnu.org/gnu/make/) and running `fossa analyze --detect-vendored` at its root. The output included the path correctly:
![Screenshot 2023-07-13 at 5 29 51 PM](https://github.com/fossas/fossa-cli/assets/190980/57939760-269e-4fe5-8843-7b18383317ba)

![Screenshot 2023-07-13 at 5 56 07 PM](https://github.com/fossas/fossa-cli/assets/190980/4a6187f5-5e2f-4a64-91aa-9773b0ed1225)


## Risks

None.

## Metrics


## References

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
