### PR TITLE
Cosign signing

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -220,13 +220,28 @@ jobs:
 
         cat *.sha256 | sha256sum --check --status
 
-    - name: Install Cosign
-      uses: sigstore/cosign-installer@v3.1.1
-
     - name: Sign Binaries (Linux)
-      run: |
-        cosign version
-        cosign sign-blob --yes --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz
+      env:
+        Bundle_Path: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle"
+        Archive_Path: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
+      steps:
+        - name: Install Cosign
+          uses: sigstore/cosign-installer@v3.1.1
+        - name: Print Version
+          run: cosign version
+        - name: Sign Release
+          run: cosign sign-blob --yes --bundle "$Bundle_Path" "$Archive_Path"
+        - name: Get Id Token
+          id: get-id-token
+          with:
+            script: |
+              const coreObj = require('@actions/core');
+              let token = await coreObj.getIdToken();
+              core.setOutput('cert_identity', `https://github.com/${token.job_workflow_ref}`);
+              core.setOutput('odic_issuer', token.iss);
+        - name: Verify Signature
+          run:
+            cosign verify-blob --bundle "$Bundle_Path" --certificate-oidc-issuer "${{ steps.get-id-token.cert_identity}}" --certificate-identity '${{ steps.get-id-token.oidc_issuer }}' "$Archive_Path"
 
     # Uploads the generated archives (tar.gz/zip) as build artifacts to allow
     # verifying them without needing to do an actual release. This step does not

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -182,18 +182,18 @@ jobs:
         [ "$(Linux-binaries/fossa --version)" = "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
 
     - name: Install Cosign
-      # if: ${{ github.ref_type == 'tag' }}
+      if: ${{ github.ref_type == 'tag' }}
       uses: sigstore/cosign-installer@v3.1.1
 
     - name: Sign Release (Linux)
-      # if: ${{ github.ref_type == 'tag' }}
+      if: ${{ github.ref_type == 'tag' }}
       run: |
         cosign version
         cosign sign-blob --yes --bundle "Linux-binaries/fossa.bundle" "Linux-binaries/fossa"
         cosign sign-blob --yes --bundle "Linux-binaries/pathfinder.bundle" "Linux-binaries/pathfinder"
 
     - name: Verify Signatures
-      # if: ${{ github.ref_type == 'tag' }}
+      if: ${{ github.ref_type == 'tag' }}
       run: |
         cosign verify-blob --bundle "Linux-binaries/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/fossa"
         cosign verify-blob --bundle "Linux-binaries/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/pathfinder"
@@ -222,12 +222,12 @@ jobs:
         tar --create --verbose --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa
         tar --create --verbose --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder
 
-        #if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+        if [ "$GITHUB_REF_TYPE" = "tag" ]; then
         tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
         tar --append --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder.bundle
         zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
         zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder.bundle
-        # fi
+        fi
 
         gzip "$LINUX_PATHFINDER_TAR_PATH"
         gzip "$LINUX_FOSSA_TAR_PATH"

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -204,7 +204,7 @@ jobs:
       run: |
         cosign verify-blob --bundle "Linux-binaries/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/fossa"
         cosign verify-blob --bundle "Linux-binaries/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/pathfinder"
-        cosign verify-blob --bundle "Linux-binaries/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/diagnose"
+        cosign verify-blob --bundle "Linux-binaries/diagnose.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/diagnose"
 
     # This uses names compatible with our install script.
     #

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -217,16 +217,16 @@ jobs:
         ls -R
 
         chmod +x Linux-binaries/*
-        zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/fossa
-        zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/pathfinder
+        zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder
+        zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa
         tar --create --verbose --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa
         tar --create --verbose --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder
 
         if [ "$GITHUB_REF_TYPE" = "tag" ]; then
-        tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
-        tar --append --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder.bundle
-        zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
-        zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder.bundle
+          tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
+          tar --append --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder.bundle
+          zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
+          zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder.bundle
         fi
 
         gzip "$LINUX_PATHFINDER_TAR_PATH"

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -146,7 +146,7 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         cosign version
-        cosign sign-blob --yes release/fossa --bundle release/fossa_linux_amd64.bundle
+        cosign sign-blob --yes --oidc-issuer='https://token.actions.githubusercontent.com' --bundle release/fossa_linux_amd64.bundle release/fossa
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -228,6 +228,9 @@ jobs:
         cosign version
         cosign sign-blob --yes --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 
+    - name: Install OIDC Client from Core Package
+      run: npm install @actions/core@1.6.0 @actions/http-client
+
     - name: Get Id Token
       uses: actions/github-script@v6
       id: get-id-token

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -216,9 +216,10 @@ jobs:
     - name: Bundle binaries
       env:
         LINUX_PATHFINDER_TAR_PATH: "release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
-        LINUX_FOSSA_TAR_PATH: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
         LINUX_PATHFINDER_ZIP_PATH: "release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
+        LINUX_FOSSA_TAR_PATH: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
         LINUX_FOSSA_ZIP_PATH: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
+        LINUX_DIAGNOSE_TAR_PATH: "release/diagnose_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
         LINUX_DIAGNOSE_ZIP_PATH: "release/diagnose_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
       run: |
         mkdir release
@@ -228,6 +229,7 @@ jobs:
         chmod +x Linux-binaries/*
         zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder
         zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa
+        zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose
         tar --create --verbose --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa
         tar --create --verbose --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder
         tar --create --verbose --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose
@@ -235,6 +237,7 @@ jobs:
         # if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
           tar --append --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder.bundle
+          tar --append --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose.bundle
           zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
           zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder.bundle
           zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose.bundle

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -188,11 +188,11 @@ jobs:
         [ "$(Linux-binaries/fossa --version)" = "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
 
     - name: Install Cosign
-      # if: ${{ github.ref_type == 'tag' }}
+      if: ${{ github.ref_type == 'tag' }}
       uses: sigstore/cosign-installer@v3.1.1
 
     - name: Sign Release (Linux)
-      # if: ${{ github.ref_type == 'tag' }}
+      if: ${{ github.ref_type == 'tag' }}
       run: |
         cosign version
         cosign sign-blob --yes --bundle "Linux-binaries/fossa.bundle" "Linux-binaries/fossa"
@@ -200,7 +200,7 @@ jobs:
         cosign sign-blob --yes --bundle "Linux-binaries/diagnose.bundle" "Linux-binaries/diagnose"
 
     - name: Verify Signatures
-      # if: ${{ github.ref_type == 'tag' }}
+      if: ${{ github.ref_type == 'tag' }}
       run: |
         cosign verify-blob --bundle "Linux-binaries/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/fossa"
         cosign verify-blob --bundle "Linux-binaries/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/pathfinder"
@@ -234,14 +234,14 @@ jobs:
         tar --create --verbose --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder
         tar --create --verbose --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose
 
-        # if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+        if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
           tar --append --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder.bundle
           tar --append --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose.bundle
           zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
           zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder.bundle
           zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose.bundle
-        # fi
+        fi
 
         gzip "$LINUX_PATHFINDER_TAR_PATH"
         gzip "$LINUX_FOSSA_TAR_PATH"

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -238,8 +238,8 @@ jobs:
         script: |
           const coreObj = require('@actions/core');
           let token = await coreObj.getIDToken();
-          core.setOutput('cert_identity', `https://github.com/${token.job_workflow_ref}`);
-          core.setOutput('odic_issuer', token.iss);
+          coreObj.setOutput('cert_identity', `https://github.com/${token.job_workflow_ref}`);
+          coreObj.setOutput('odic_issuer', token.iss);
 
     - name: Verify Signature
       run:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -194,7 +194,7 @@ jobs:
 
     - name: Verify Signatures
       # if: ${{ github.ref_type == 'tag' }}
-      run:
+      run: |
         cosign verify-blob --bundle "release/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "release/fossa"
         cosign verify-blob --bundle "release/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "release/pathfinder"
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -236,14 +236,13 @@ jobs:
       id: get-id-token
       with:
         script: |
-          const coreObj = require('@actions/core');
-          let token = await coreObj.getIDToken();
-          coreObj.setOutput('cert_identity', `https://github.com/${token.job_workflow_ref}`);
-          coreObj.setOutput('odic_issuer', token.iss);
+          let token = await core.getIDToken();
+          return {'cert_identity': `https://github.com/${token.job_workflow_ref}`,
+                  'oidc_issuer': token.iss};
 
     - name: Verify Signature
       run:
-        cosign verify-blob --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" --certificate-oidc-issuer "${{ steps.get-id-token.cert_identity}}" --certificate-identity '${{ steps.get-id-token.oidc_issuer }}' "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
+        cosign verify-blob --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" --certificate-oidc-issuer "${{ steps.get-id-token.outputs.result.oidc_issuer}}" --certificate-identity "${{ steps.get-id-token.outputs.result.cert_identity }}" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 
     # Uploads the generated archives (tar.gz/zip) as build artifacts to allow
     # verifying them without needing to do an actual release. This step does not

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -149,9 +149,6 @@ jobs:
     permissions:
         id-token: write
 
-    env:
-      NEEDS_RELEASE_SIGNATURE: "${{ github.ref_type == 'tag' }}"
-
     steps:
     - uses: actions/download-artifact@v2
 
@@ -224,17 +221,17 @@ jobs:
         cat *.sha256 | sha256sum --check --status
 
     - name: Install Cosign
-      if: ${{ "$NEEDS_RELEASE_SIGNATURE" == 'true' }}
+      if: ${{ github.ref_type == 'tag' }}
       uses: sigstore/cosign-installer@v3.1.1
 
     - name: Sign Release
-      if: ${{ "$NEEDS_RELEASE_SIGNATURE" == 'true' }}
+      if: ${{ github.ref_type == 'tag' }}
       run: |
         cosign version
         cosign sign-blob --yes --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 
     - name: Verify Signature
-      if: ${{ "$NEEDS_RELEASE_SIGNATURE" == 'true' }}
+      if: ${{ github.ref_type == 'tag' }}
       run:
         cosign verify-blob --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -228,20 +228,9 @@ jobs:
         cosign version
         cosign sign-blob --yes --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 
-    - name: Get Id Token
-      uses: actions/github-script@v6
-      id: get-id-token
-      with:
-        script: |
-          let token = await core.getIDToken();
-          console.log(`https://github.com/${token.job_workflow_ref}`);
-          console.log(token.iss);
-          return {'cert_identity': `https://github.com/${token.job_workflow_ref}`,
-                  'oidc_issuer': token.iss};
-
     - name: Verify Signature
       run:
-        cosign verify-blob --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" --certificate-oidc-issuer "${{ steps.get-id-token.outputs.result.oidc_issuer}}" --certificate-identity "${{ steps.get-id-token.outputs.result.cert_identity }}" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
+        cosign verify-blob --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 
     # Uploads the generated archives (tar.gz/zip) as build artifacts to allow
     # verifying them without needing to do an actual release. This step does not

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -61,7 +61,7 @@ jobs:
         profile: minimal
         toolchain: stable
     - uses: taiki-e/install-action@nextest
-    
+
     - uses: Swatinem/rust-cache@v2
 
     - name: Debugging information
@@ -140,16 +140,6 @@ jobs:
       run: |
         strip release/*
 
-    - name: Install Cosign (Linux)
-      if: ${{ contains(matrix.os, 'ubuntu') }}
-      uses: sigstore/cosign-installer@v3.1.1
-
-    - name: Sign Binaries (Linux)
-      if: ${{ contains(matrix.os, 'ubuntu') }}
-      run: |
-        cosign version
-        cosign sign-blob --yes --output-certificate release/fossa_linux_amd64.pem --output-signature release/fossa_linux_amd64.sig release/fossa
-
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ runner.os }}-binaries
@@ -205,8 +195,7 @@ jobs:
         ls -R
 
         chmod +x Linux-binaries/*
-        cp Linux-binaries/fossa_linux_amd64.pem release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.pem
-        cp Linux-binaries/fossa_linux_amd64.sig release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.sig
+        cp Linux-binaries/fossa_linux_amd64.bundle release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/fossa
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/pathfinder
         tar --create --gzip --verbose --file release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz --directory Linux-binaries fossa
@@ -232,6 +221,14 @@ jobs:
         echo "Sanity-checking the checksums."
 
         cat *.sha256 | sha256sum --check --status
+
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3.1.1
+
+    - name: Sign Binaries (Linux)
+      run: |
+        cosign version
+        cosign sign-blob --yes --bundle "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz
 
     # Uploads the generated archives (tar.gz/zip) as build artifacts to allow
     # verifying them without needing to do an actual release. This step does not

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -149,6 +149,9 @@ jobs:
     permissions:
         id-token: write
 
+    env:
+      NEEDS_RELEASE_SIGNATURE: "${{ github.ref_type == 'tag') }}"
+
     steps:
     - uses: actions/download-artifact@v2
 
@@ -221,14 +224,17 @@ jobs:
         cat *.sha256 | sha256sum --check --status
 
     - name: Install Cosign
+      if: "$NEEDS_RELEASE_SIGNATURE" == 'true'
       uses: sigstore/cosign-installer@v3.1.1
 
     - name: Sign Release
+      if: "$NEEDS_RELEASE_SIGNATURE" == 'true'
       run: |
         cosign version
         cosign sign-blob --yes --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 
     - name: Verify Signature
+      if: "$NEEDS_RELEASE_SIGNATURE" == 'true'
       run:
         cosign verify-blob --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -219,6 +219,7 @@ jobs:
         LINUX_FOSSA_TAR_PATH: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
         LINUX_PATHFINDER_ZIP_PATH: "release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
         LINUX_FOSSA_ZIP_PATH: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
+        LINUX_DIAGNOSE_ZIP_PATH: "release/diagnose_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
       run: |
         mkdir release
 
@@ -229,24 +230,29 @@ jobs:
         zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa
         tar --create --verbose --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa
         tar --create --verbose --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder
+        tar --create --verbose --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose
 
         if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
           tar --append --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder.bundle
           zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
           zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder.bundle
+          zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose.bundle
         fi
 
         gzip "$LINUX_PATHFINDER_TAR_PATH"
         gzip "$LINUX_FOSSA_TAR_PATH"
+        gzip "$LINUX_DIAGNOSE_TAR_PATH"
 
         chmod +x macOS-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/fossa
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/pathfinder
+        zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/diagnose
 
         chmod +x Windows-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/fossa.exe
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/pathfinder.exe
+        zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/diagnose.exe
 
     - name: Create checksums
       # We have to run from within the release dir so that "release" isn't prepended to the relative path of the zip file.

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -139,7 +139,7 @@ jobs:
         strip release/*
 
     - name: Install Cosign (Linux)
-      if: ${{ contains(matrix.os, 'linux') }}
+      if: ${{ contains(matrix.os, 'ubuntu') }}
       uses: sigstore/cosign-installer@v3.1.1
 
     - name: Sign Binaries (Linux)

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -138,9 +138,12 @@ jobs:
       run: |
         strip release/*
 
-    - name: Sign Binaries (Linux)
+    - name: Install Cosign (Linux)
       if: ${{ contains(matrix.os, 'linux') }}
       uses: sigstore/cosign-installer@v3.1.1
+
+    - name: Sign Binaries (Linux)
+      if: ${{ contains(matrix.os, 'linux') }}
       run: |
         cosign version
         cosign sign-blob --yes release/fossa --bundle release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -195,8 +195,8 @@ jobs:
     - name: Verify Signatures
       # if: ${{ github.ref_type == 'tag' }}
       run: |
-        cosign verify-blob --bundle "release/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "release/fossa"
-        cosign verify-blob --bundle "release/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "release/pathfinder"
+        cosign verify-blob --bundle "Linux-binaries/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/fossa"
+        cosign verify-blob --bundle "Linux-binaries/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/pathfinder"
 
     # This uses names compatible with our install script.
     #

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -181,6 +181,23 @@ jobs:
         [ "$GITHUB_REF_TYPE" = "tag" ] && echo "Ref type OK"
         [ "$(Linux-binaries/fossa --version)" = "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
 
+    - name: Install Cosign
+      # if: ${{ github.ref_type == 'tag' }}
+      uses: sigstore/cosign-installer@v3.1.1
+
+    - name: Sign Release (Linux)
+      # if: ${{ github.ref_type == 'tag' }}
+      run: |
+        cosign version
+        cosign sign-blob --yes --bundle "Linux-binaries/fossa.bundle" "Linux-binaries/fossa"
+        cosign sign-blob --yes --bundle "Linux-binaries/pathfinder.bundle" "Linux-binaries/pathfinder"
+
+    - name: Verify Signatures
+      # if: ${{ github.ref_type == 'tag' }}
+      run:
+        cosign verify-blob --bundle "release/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "release/fossa"
+        cosign verify-blob --bundle "release/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "release/pathfinder"
+
     # This uses names compatible with our install script.
     #
     # Originally, CLI >=2.x Linux releases were only packaged as zip files, but
@@ -189,16 +206,31 @@ jobs:
     # default. To avoid breaking compatibility with older install scripts, we
     # release both formats but default to using tar.gz when installing.
     - name: Bundle binaries
+      env:
+        LINUX_PATHFINDER_TAR_PATH: "release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
+        LINUX_FOSSA_TAR_PATH: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
+        LINUX_PATHFINDER_ZIP_PATH: "release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
+        LINUX_FOSSA_ZIP_PATH: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
       run: |
         mkdir release
 
         ls -R
 
         chmod +x Linux-binaries/*
-        zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/fossa
-        zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/pathfinder
-        tar --create --gzip --verbose --file release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz --directory Linux-binaries fossa
-        tar --create --gzip --verbose --file release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz --directory Linux-binaries pathfinder
+        zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/fossa
+        zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/pathfinder
+        tar --create --verbose --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa
+        tar --create --verbose --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder
+
+        #if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+        tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
+        tar --append --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder.bundle
+        zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
+        zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder.bundle
+        # fi
+
+        gzip "$LINUX_PATHFINDER_TAR_PATH"
+        gzip "$LINUX_FOSSA_TAR_PATH"
 
         chmod +x macOS-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/fossa
@@ -220,21 +252,6 @@ jobs:
         echo "Sanity-checking the checksums."
 
         cat *.sha256 | sha256sum --check --status
-
-    - name: Install Cosign
-      if: ${{ github.ref_type == 'tag' }}
-      uses: sigstore/cosign-installer@v3.1.1
-
-    - name: Sign Release
-      if: ${{ github.ref_type == 'tag' }}
-      run: |
-        cosign version
-        cosign sign-blob --yes --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
-
-    - name: Verify Signature
-      if: ${{ github.ref_type == 'tag' }}
-      run:
-        cosign verify-blob --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 
     # Uploads the generated archives (tar.gz/zip) as build artifacts to allow
     # verifying them without needing to do an actual release. This step does not

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -237,7 +237,7 @@ jobs:
       with:
         script: |
           const coreObj = require('@actions/core');
-          let token = await coreObj.getIdToken();
+          let token = await coreObj.getIDToken();
           core.setOutput('cert_identity', `https://github.com/${token.job_workflow_ref}`);
           core.setOutput('odic_issuer', token.iss);
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -148,7 +148,7 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         cosign version
-        cosign sign-blob --yes --bundle release/fossa_linux_amd64.bundle release/fossa
+        cosign sign-blob --yes --output-certificate release/fossa_linux_amd64.pem --output-signature release/fossa_linux_amd64.sig release/fossa
 
     - uses: actions/upload-artifact@v2
       with:
@@ -205,7 +205,8 @@ jobs:
         ls -R
 
         chmod +x Linux-binaries/*
-        cp Linux-binaries/fossa_linux_amd64.bundle release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle
+        cp Linux-binaries/fossa_linux_amd64.pem release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.pem
+        cp Linux-binaries/fossa_linux_amd64.sig release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.sig
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/fossa
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/pathfinder
         tar --create --gzip --verbose --file release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz --directory Linux-binaries fossa

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -188,11 +188,11 @@ jobs:
         [ "$(Linux-binaries/fossa --version)" = "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
 
     - name: Install Cosign
-      if: ${{ github.ref_type == 'tag' }}
+      # if: ${{ github.ref_type == 'tag' }}
       uses: sigstore/cosign-installer@v3.1.1
 
     - name: Sign Release (Linux)
-      if: ${{ github.ref_type == 'tag' }}
+      # if: ${{ github.ref_type == 'tag' }}
       run: |
         cosign version
         cosign sign-blob --yes --bundle "Linux-binaries/fossa.bundle" "Linux-binaries/fossa"
@@ -200,7 +200,7 @@ jobs:
         cosign sign-blob --yes --bundle "Linux-binaries/diagnose.bundle" "Linux-binaries/diagnose"
 
     - name: Verify Signatures
-      if: ${{ github.ref_type == 'tag' }}
+      # if: ${{ github.ref_type == 'tag' }}
       run: |
         cosign verify-blob --bundle "Linux-binaries/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/fossa"
         cosign verify-blob --bundle "Linux-binaries/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/pathfinder"
@@ -232,13 +232,13 @@ jobs:
         tar --create --verbose --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder
         tar --create --verbose --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose
 
-        if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+        # if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
           tar --append --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder.bundle
           zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
           zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder.bundle
           zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose.bundle
-        fi
+        # fi
 
         gzip "$LINUX_PATHFINDER_TAR_PATH"
         gzip "$LINUX_FOSSA_TAR_PATH"

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -9,6 +9,7 @@ jobs:
     name: ${{ matrix.os-name }}-build
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
+
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -224,17 +224,17 @@ jobs:
         cat *.sha256 | sha256sum --check --status
 
     - name: Install Cosign
-      if: "$NEEDS_RELEASE_SIGNATURE" == 'true'
+      if: ${{ "$NEEDS_RELEASE_SIGNATURE" == 'true' }}
       uses: sigstore/cosign-installer@v3.1.1
 
     - name: Sign Release
-      if: "$NEEDS_RELEASE_SIGNATURE" == 'true'
+      if: ${{ "$NEEDS_RELEASE_SIGNATURE" == 'true' }}
       run: |
         cosign version
         cosign sign-blob --yes --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 
     - name: Verify Signature
-      if: "$NEEDS_RELEASE_SIGNATURE" == 'true'
+      if: ${{ "$NEEDS_RELEASE_SIGNATURE" == 'true' }}
       run:
         cosign verify-blob --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -150,7 +150,7 @@ jobs:
         id-token: write
 
     env:
-      NEEDS_RELEASE_SIGNATURE: "${{ github.ref_type == 'tag') }}"
+      NEEDS_RELEASE_SIGNATURE: "${{ github.ref_type == 'tag' }}"
 
     steps:
     - uses: actions/download-artifact@v2

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -197,12 +197,14 @@ jobs:
         cosign version
         cosign sign-blob --yes --bundle "Linux-binaries/fossa.bundle" "Linux-binaries/fossa"
         cosign sign-blob --yes --bundle "Linux-binaries/pathfinder.bundle" "Linux-binaries/pathfinder"
+        cosign sign-blob --yes --bundle "Linux-binaries/diagnose.bundle" "Linux-binaries/diagnose"
 
     - name: Verify Signatures
       if: ${{ github.ref_type == 'tag' }}
       run: |
         cosign verify-blob --bundle "Linux-binaries/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/fossa"
         cosign verify-blob --bundle "Linux-binaries/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/pathfinder"
+        cosign verify-blob --bundle "Linux-binaries/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/diagnose"
 
     # This uses names compatible with our install script.
     #

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -9,9 +9,6 @@ jobs:
     name: ${{ matrix.os-name }}-build
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    permissions:
-        id-token: write
-
     defaults:
       run:
         shell: bash
@@ -149,6 +146,8 @@ jobs:
     name: create-release
     runs-on: ubuntu-latest
     needs: ['build-all']
+    permissions:
+        id-token: write
 
     steps:
     - uses: actions/download-artifact@v2

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -143,10 +143,11 @@ jobs:
       uses: sigstore/cosign-installer@v3.1.1
 
     - name: Sign Binaries (Linux)
-      if: ${{ contains(matrix.os, 'linux') }}
+      if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         cosign version
-        cosign sign-blob --yes release/fossa --bundle release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle
+        cosign sign-blob --yes release/fossa --bundle release/fossa_linux_amd64.bundle
+
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ runner.os }}-binaries
@@ -202,7 +203,7 @@ jobs:
         ls -R
 
         chmod +x Linux-binaries/*
-        cp Linux-binaries/*.bundle release/
+        cp Linux-binaries/fossa_linux_amd64.bundle release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/fossa
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/pathfinder
         tar --create --gzip --verbose --file release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz --directory Linux-binaries fossa

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -9,6 +9,8 @@ jobs:
     name: ${{ matrix.os-name }}-build
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
+    permissions:
+        id-token: write
 
     defaults:
       run:
@@ -146,7 +148,7 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         cosign version
-        cosign sign-blob --yes --oidc-provider='github-actions' --bundle release/fossa_linux_amd64.bundle release/fossa
+        cosign sign-blob --yes --bundle release/fossa_linux_amd64.bundle release/fossa
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -195,7 +195,6 @@ jobs:
         ls -R
 
         chmod +x Linux-binaries/*
-        cp Linux-binaries/fossa_linux_amd64.bundle release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/fossa
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/pathfinder
         tar --create --gzip --verbose --file release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz --directory Linux-binaries fossa
@@ -228,7 +227,7 @@ jobs:
     - name: Sign Binaries (Linux)
       run: |
         cosign version
-        cosign sign-blob --yes --bundle "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz
+        cosign sign-blob --yes --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz
 
     # Uploads the generated archives (tar.gz/zip) as build artifacts to allow
     # verifying them without needing to do an actual release. This step does not

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -228,15 +228,14 @@ jobs:
         cosign version
         cosign sign-blob --yes --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 
-    - name: Install OIDC Client from Core Package
-      run: npm install @actions/core@1.6.0 @actions/http-client
-
     - name: Get Id Token
       uses: actions/github-script@v6
       id: get-id-token
       with:
         script: |
           let token = await core.getIDToken();
+          console.log(`https://github.com/${token.job_workflow_ref}`);
+          console.log(token.iss);
           return {'cert_identity': `https://github.com/${token.job_workflow_ref}`,
                   'oidc_issuer': token.iss};
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -138,6 +138,12 @@ jobs:
       run: |
         strip release/*
 
+    - name: Sign Binaries (Linux)
+      if: ${{ contains(matrix.os, 'linux') }}
+      uses: sigstore/cosign-installer@v3.1.1
+      run: |
+        cosign version
+        cosign sign-blob --yes release/fossa --bundle release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ runner.os }}-binaries
@@ -193,6 +199,7 @@ jobs:
         ls -R
 
         chmod +x Linux-binaries/*
+        cp Linux-binaries/*.bundle release/
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/fossa
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip Linux-binaries/pathfinder
         tar --create --gzip --verbose --file release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz --directory Linux-binaries fossa

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -146,7 +146,7 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         cosign version
-        cosign sign-blob --yes --oidc-issuer='https://token.actions.githubusercontent.com' --bundle release/fossa_linux_amd64.bundle release/fossa
+        cosign sign-blob --yes --oidc-provider='github-actions' --bundle release/fossa_linux_amd64.bundle release/fossa
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -220,28 +220,27 @@ jobs:
 
         cat *.sha256 | sha256sum --check --status
 
-    - name: Sign Binaries (Linux)
-      env:
-        Bundle_Path: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle"
-        Archive_Path: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
-      steps:
-        - name: Install Cosign
-          uses: sigstore/cosign-installer@v3.1.1
-        - name: Print Version
-          run: cosign version
-        - name: Sign Release
-          run: cosign sign-blob --yes --bundle "$Bundle_Path" "$Archive_Path"
-        - name: Get Id Token
-          id: get-id-token
-          with:
-            script: |
-              const coreObj = require('@actions/core');
-              let token = await coreObj.getIdToken();
-              core.setOutput('cert_identity', `https://github.com/${token.job_workflow_ref}`);
-              core.setOutput('odic_issuer', token.iss);
-        - name: Verify Signature
-          run:
-            cosign verify-blob --bundle "$Bundle_Path" --certificate-oidc-issuer "${{ steps.get-id-token.cert_identity}}" --certificate-identity '${{ steps.get-id-token.oidc_issuer }}' "$Archive_Path"
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3.1.1
+
+    - name: Sign Release
+      run: |
+        cosign version
+        cosign sign-blob --yes --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
+
+    - name: Get Id Token
+      uses: actions/github-script@v6
+      id: get-id-token
+      with:
+        script: |
+          const coreObj = require('@actions/core');
+          let token = await coreObj.getIdToken();
+          core.setOutput('cert_identity', `https://github.com/${token.job_workflow_ref}`);
+          core.setOutput('odic_issuer', token.iss);
+
+    - name: Verify Signature
+      run:
+        cosign verify-blob --bundle "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.bundle" --certificate-oidc-issuer "${{ steps.get-id-token.cert_identity}}" --certificate-identity '${{ steps.get-id-token.oidc_issuer }}' "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz"
 
     # Uploads the generated archives (tar.gz/zip) as build artifacts to allow
     # verifying them without needing to do an actual release. This step does not

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## 3.8.7
+- CLI Binaries: Sign Linux builds using cosign. ([#1243](https://github.com/fossas/fossa-cli/pull/1243))
+
 ## v3.8.6
 - VSI: Fix a bug where root dependencies would cause analysis to fail. ([#1240](https://github.com/fossas/fossa-cli/pull/1240))
 - Node (PNPM): Fixes a bug where analyses would fail when the `lockfileVersion` attribute was a string in `pnpm-lock.yaml`. ([1239](https://github.com/fossas/fossa-cli/pull/1239))

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -8,7 +8,6 @@ module App.Version (
   versionOrBranch,
 ) where
 
-import App.Version.TH (getCurrentTag)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -17,7 +16,8 @@ import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwdTry)
 import System.Info (compilerName, compilerVersion)
 
 versionNumber :: Maybe Text
-versionNumber = $$(getCurrentTag)
+-- This is just for testing, revert before merging
+versionNumber = Just "v0.0.0" -- $$(getCurrentTag)
 
 info :: Either String GitInfo
 info = $$(tGitInfoCwdTry)

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -8,6 +8,7 @@ module App.Version (
   versionOrBranch,
 ) where
 
+import App.Version.TH (getCurrentTag)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -16,7 +17,7 @@ import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwdTry)
 import System.Info (compilerName, compilerVersion)
 
 versionNumber :: Maybe Text
-versionNumber = Just "3.8.5" -- TAG TEST: Revert me $$(getCurrentTag)
+versionNumber = $$(getCurrentTag)
 
 info :: Either String GitInfo
 info = $$(tGitInfoCwdTry)

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -8,6 +8,7 @@ module App.Version (
   versionOrBranch,
 ) where
 
+import App.Version.TH (getCurrentTag)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -16,8 +17,7 @@ import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwdTry)
 import System.Info (compilerName, compilerVersion)
 
 versionNumber :: Maybe Text
--- This is just for testing, revert before merging
-versionNumber = Just "3.8.5" -- $$(getCurrentTag)
+versionNumber = $$(getCurrentTag)
 
 info :: Either String GitInfo
 info = $$(tGitInfoCwdTry)

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -8,7 +8,6 @@ module App.Version (
   versionOrBranch,
 ) where
 
-import App.Version.TH (getCurrentTag)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -17,7 +16,7 @@ import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwdTry)
 import System.Info (compilerName, compilerVersion)
 
 versionNumber :: Maybe Text
-versionNumber = $$(getCurrentTag)
+versionNumber = Just "3.8.5" -- TAG TEST: Revert me $$(getCurrentTag)
 
 info :: Either String GitInfo
 info = $$(tGitInfoCwdTry)

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -17,7 +17,7 @@ import System.Info (compilerName, compilerVersion)
 
 versionNumber :: Maybe Text
 -- This is just for testing, revert before merging
-versionNumber = Just "v0.0.0" -- $$(getCurrentTag)
+versionNumber = Just "3.8.5" -- $$(getCurrentTag)
 
 info :: Either String GitInfo
 info = $$(tGitInfoCwdTry)


### PR DESCRIPTION
# Overview

This generates signature information for linux builds using `cosign` which is developed by [sigstore](https://sigstore.dev).

## Acceptance criteria

There will now be a `.bundle` file included with our release artifacts that has signature information. The certificate/signature in there can be used to verify that the artifact was made by our build job.

## Testing plan

Given a signed artifact you can fetch information about its certificate from sigstore using the following script:
```sh
#!/bin/sh

# Given filename, try to fetch records for it from rekor.
# Then look up the certificate information.
# If filename has been signed multiple times, gets info for the first certificate returned from rekor.

FILENAME=$1
SHA=$(shasum -a 256 "$FILENAME" | awk '{print $1;}')
UUID=$(curl -X POST -H "Content-type: application/json" 'https://rekor.sigstore.dev/api/v1/index/retrieve' --data-raw "{\"hash\":\"sha256:$SHA\"}" | jq -r '.[0]')
CERT=$(curl -X GET "https://rekor.sigstore.dev/api/v1/log/entries/${UUID}" \
       | jq -r '.[] .body' \
       | base64 -d \
       | jq -r '.spec.signature.publicKey.content' \
       | base64 -d )

openssl x509 -noout -text <<EOF
$CERT
EOF
```
Usage is `./get_file_cert_info.sh <filename>`.

If you run it on a signed artifact, like the fossa tarball inside release archives from this run: https://github.com/fossas/fossa-cli/actions/runs/5694017560
You should see output like the following:
![Screenshot 2023-07-28 at 2 40 09 PM](https://github.com/fossas/fossa-cli/assets/190980/9be3088a-6472-4fd1-af2c-2ace785cb271)
Which shows that the identity of the signer was our workflow job. Cosign uses OpenId to link an identity to certificates that get stored in the transparent log, rekor. 

You can see the sign and verification steps for that build here: https://github.com/fossas/fossa-cli/actions/runs/5694017560/job/15435201048

I've made the signing conditional on the build job being triggered by a tag. I used a test tag on this [branch](https://github.com/fossas/fossa-cli/actions/runs/5696621293/job/15442620332). This is why the latest commit in the PR skips the signing step.

## Risks

Using the tag type to determine if we're releasing something or not is a bit unreliable. I'd like to make a separate release workflow that can be separate from build-all which can be triggered on release. If there's a better way to handle this I'd like to hear your suggestions.

Signing binaries in this way is new to me as well, so any critiques of this method or questions would help me.

## Metrics

I can't think of any that would be easy to get that we don't have already.

## References

[ANE-862](https://fossa.atlassian.net/browse/ANE-862)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-862]: https://fossa.atlassian.net/browse/ANE-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ