### PR TITLE
Go v3 resolver doc tweaks

### DIFF
--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -40,10 +40,10 @@ FOSSA CLI runs `go list -json -e -deps all` which produces something like:
 }
 ```
 
-We generate a graph of *packages* and then resolve these back to their parent modules.
-Every `Main` module we find in this graph will have its dependencies promoted to be a direct dependency.
+FOSSA CLI generates a graph of *packages* and then resolves these back to their parent modules.
+Every `Main` module it finds in this graph will have its dependencies promoted to be a direct dependency of the project.
 
-The reason that we started with a graph of packages is because a Go module distributes source code for one or more packages.
+The reason that FOSSA CLI starts with a graph of packages is because a Go module distributes source code for one or more packages.
 However, only packages are `import`ed in Go source code.
 An implication of this is that the graph of module dependencies does not necessarily correspond to how different packages in a Go project depend on each other.
 By looking at how packages import one another, FOSSA CLI can get more information about what packages and modules are actually used in a final build product than by looking at modules alone.
@@ -56,7 +56,7 @@ For more information about this transition please see this [document](./v3-go-re
 
 ## Strategy: gomod
 
-We parse the go.mod file, which looks something like:
+FOSSA CLI parses the go.mod file, which looks something like:
 
 ```
 module our/package/path
@@ -78,7 +78,7 @@ where:
 
 ### Why do I see a dependency in `go.mod`, but it is not reflected in FOSSA?
 
-To explain how this can be the case, it's important to note that just because a package is in `go.mod`` doesn't mean that it's actually used in the project;
+To explain how this can be the case, it's important to note that just because a package is in `go.mod` doesn't mean that it's actually used in the project;
 and just because it's in `go.mod` without an `// indirect` comment doesn't mean it's actually direct.
 Instead, Go defines direct dependencies as:
 
@@ -203,5 +203,5 @@ require github.com/cenkalti/backoff/v4 v4.2.1
 not using backoff!
 ```
 
-As a concrete next step, we recommend running `go mod tidy` on the project,
-which should remove any dependencies that are not used and update the `//indirect` comments for any that are used.
+As a concrete step towards resolving this sort of discrepancy, we recommend running `go mod tidy` on the project;
+this command should synchronize the `go.mod` file with the actual state of the project.

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -82,7 +82,7 @@ where:
 
 To explain how this can be the case, it's important to note that just because a package is in `go.mod` doesn't mean that it's actually used in the project;
 and just because it's in `go.mod` without an `// indirect` comment doesn't mean it's actually direct.
-Instead, Go defines direct dependencies as:
+Instead, [the Go language defines direct dependencies as](https://go.dev/ref/mod#glos-direct-dependency):
 
 > A package whose path appears in an `import` declaration in a `.go` source file for a package or test in the main module, 
 > or the module containing such a package.

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -47,7 +47,8 @@ The reason that FOSSA CLI starts with a graph of packages is because Go modules 
 However, only _packages_, not _modules_, are `import`ed in Go source code.
 An implication of this is that the graph of _module_ dependencies does not necessarily correspond to the graph of _package_ dependencies,
 which are the real deciding factor in whether a given module is actually used in the end program.
-By looking at how packages import one another, FOSSA CLI can get more information about what packages and modules are actually used in a final build product than by looking at modules alone.
+By looking at how packages import one another, FOSSA CLI can get more information about what packages
+(and therefore modules) are actually used in a final build product than by looking at modules alone.
 This should eliminate some false positives found by tactics in older versions of FOSSA CLI that use `go list -m`.
 
 Currently, this strategy does not yet include path dependencies or their transitive deps from Go `replace` directives.

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -205,5 +205,5 @@ require github.com/cenkalti/backoff/v4 v4.2.1
 not using backoff!
 ```
 
-As a concrete step towards resolving this sort of discrepancy, we recommend running `go mod tidy` on the project;
+As a concrete step towards resolving this sort of discrepancy, we recommend running `go mod tidy` on projects regularly;
 this command should synchronize the `go.mod` file with the actual state of the project.

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -43,9 +43,10 @@ FOSSA CLI runs `go list -json -e -deps all` which produces something like:
 FOSSA CLI generates a graph of *packages* and then resolves these back to their parent modules.
 Every `Main` module it finds in this graph will have its dependencies promoted to be a direct dependency of the project.
 
-The reason that FOSSA CLI starts with a graph of packages is because a Go module distributes source code for one or more packages.
-However, only packages are `import`ed in Go source code.
-An implication of this is that the graph of module dependencies does not necessarily correspond to how different packages in a Go project depend on each other.
+The reason that FOSSA CLI starts with a graph of packages is because Go modules distribute source code for one or more packages.
+However, only _packages_, not _modules_, are `import`ed in Go source code.
+An implication of this is that the graph of _module_ dependencies does not necessarily correspond to the graph of _package_ dependencies,
+which are the real deciding factor in whether a given module is actually used in the end program.
 By looking at how packages import one another, FOSSA CLI can get more information about what packages and modules are actually used in a final build product than by looking at modules alone.
 This should eliminate some false positives found by tactics in older versions of FOSSA CLI that use `go list -m`.
 

--- a/docs/references/strategies/languages/golang/v3-go-resolver-transition-qa.md
+++ b/docs/references/strategies/languages/golang/v3-go-resolver-transition-qa.md
@@ -15,9 +15,12 @@ Several of our users noticed with the old strategy that they were getting depend
 This was increasing the burden on their compliance and engineering teams by requiring them to fix policy or vulnerability issues reported by FOSSA for packages that weren’t actually being used by the built software. 
 
 # What differences can I expect to see in my results from the new package-based Go module analysis?
-The main difference you can expect to see is a reduced number of dependencies and their associated issues. 
-For example, if a module includes a package that depends on another module, but that package isn’t actually used by the software under analysis then technically that other module is not a dependency of the final build product. 
-The old go modules strategy could not detect this case while the new one will correctly exclude the extra module. 
+The main difference you can expect to see is a reduced number of dependencies and their associated issues.
+
+For example, if a module includes a package that depends on another module, but that package isn’t actually used by the software under analysis then technically that other module is not a dependency of the final build product.
+The old go modules strategy could not detect this case while the new one will correctly exclude the extra module.
+This also can apply to seemingly direct dependencies; for more information see the [Go strategy FAQ](./gomodules.md#why-do-i-see-a-dependency-in-gomod-but-it-is-not-reflected-in-fossa).
+
 Additionally, this new strategy should be able to detect test dependencies better than the previous one which results in a further reduction in packages.
         
 You may also notice different results if previously your scans were falling back to a static analysis strategy where now with the new Go modules strategy it is able to complete dynamic analysis successfully.

--- a/docs/references/strategies/languages/golang/v3-go-resolver-transition-qa.md
+++ b/docs/references/strategies/languages/golang/v3-go-resolver-transition-qa.md
@@ -16,9 +16,12 @@ This was increasing the burden on their compliance and engineering teams by requ
 
 # What differences can I expect to see in my results from the new package-based Go module analysis?
 The main difference you can expect to see is a reduced number of dependencies and their associated issues.
+However the strategy is overall more accurate so it is possible, just less common, to see an increased number of dependencies as well.
 
 Results may also be different if scans of a project were previously falling back to a less preferred analysis strategy;
 the new strategy is more resilient to errors in the project so should be forced to fall back less often.
+In such cases, it's common to see an increased number of dependencies due to more accurate analysis, but they could be reduced as well.
+
 For more information about different strategies used to analyze Go modules projects,
 see the [Go modules strategy documentation](./gomodules.md).
 

--- a/docs/references/strategies/languages/golang/v3-go-resolver-transition-qa.md
+++ b/docs/references/strategies/languages/golang/v3-go-resolver-transition-qa.md
@@ -17,16 +17,35 @@ This was increasing the burden on their compliance and engineering teams by requ
 # What differences can I expect to see in my results from the new package-based Go module analysis?
 The main difference you can expect to see is a reduced number of dependencies and their associated issues.
 
-For example, if a module includes a package that depends on another module, but that package isn’t actually used by the software under analysis then technically that other module is not a dependency of the final build product.
-The old go modules strategy could not detect this case while the new one will correctly exclude the extra module.
-This also can apply to seemingly direct dependencies; for more information see the [Go strategy FAQ](./gomodules.md#why-do-i-see-a-dependency-in-gomod-but-it-is-not-reflected-in-fossa).
+Results may also be different if scans of a project were previously falling back to a less preferred analysis strategy;
+the new strategy is more resilient to errors in the project so should be forced to fall back less often.
+For more information about different strategies used to analyze Go modules projects,
+see the [Go modules strategy documentation](./gomodules.md).
 
-Additionally, this new strategy should be able to detect test dependencies better than the previous one which results in a further reduction in packages.
-        
-You may also notice different results if previously your scans were falling back to a static analysis strategy where now with the new Go modules strategy it is able to complete dynamic analysis successfully.
+## Direct dependencies
+It is possible to see a different (usually reduced) set of direct dependencies.
 
-# Should I expect to see test dependencies in the results?
-No, test dependencies should be excluded from the results using the new strategy. If they are included, it is likely a bug. Please file a report at https://support.fossa.com.
+We expect a reduced set of dependencies to occur especially in situations where
+a dependency is implied by `go.mod` to be a direct dependency, but is not actually used.
+
+For more information see the [Go strategy FAQ](./gomodules.md#why-do-i-see-a-dependency-in-gomod-but-it-is-not-reflected-in-fossa).
+
+## Transitive dependencies
+It is possible to see a different (usually reduced) set of transitive dependencies.
+
+We expect a reduced set of dependencies to occur especially in situations where
+a transitive dependency is implied by the module imports, but the package(s) the transitive dependency provides
+are not actually used in the final build product of the project.
+
+For more information see ["how could a module be referenced by a Go project and not be a dependency?"](#how-could-a-module-be-referenced-by-a-go-project-and-not-be-a-dependency).
+
+## Test dependencies
+It is possible to see a different (usually reduced) set of test dependencies.
+
+We expect a reduced set of dependencies to occur in some cases where the previous analyzer had issues
+telling whether a given module was only used for tests.
+
+If test dependencies are reported, it is likely a bug. Please file a report at https://support.fossa.com.
 
 # How do I use the new package-based Go modules analysis?
 This new form of dynamic analysis should be available if you use a version of fossa-cli >= v3.8.5.


### PR DESCRIPTION
# Overview

Tweaks the v3 Go resolver docs, as well as adding a new explanation of why a dependency may not be reported.

## Acceptance criteria

The docs make sense and are accurate.
Rendered views: 

- https://github.com/fossas/fossa-cli/blob/go-v3-doc-direct-deps/docs/references/strategies/languages/golang/gomodules.md
- https://github.com/fossas/fossa-cli/blob/go-v3-doc-direct-deps/docs/references/strategies/languages/golang/v3-go-resolver-transition-qa.md
