### PR TITLE
[WIP] Cabal: Improved multi-module project support

### DIFF
--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -223,7 +223,10 @@ doGraph plan = do
 -- | We're working on improving how we handle multi-module Cabal projects.
 --
 -- For now, just remove all the filters to get some baseline data.
--- I think basically right now the concrete effect of not having any filters is that test deps are reported.
+-- Consequences of this:
+-- 1. Test-only deps will likely be reported.
+-- 2. Standard lib deps (e.g. @base@) will likely be reported, and may not resolve in the FOSSA backend.
+-- 3. The project itself may be reported as a dep.
 shouldInclude :: InstallPlan -> Bool
 shouldInclude _ = True
 

--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -117,11 +117,11 @@ instance FromJSON InstallPlan where
     InstallPlan
       <$> (obj .: "type" >>= parsePlanType)
       <*> obj
-      .: "id"
+        .: "id"
       <*> obj
-      .: "pkg-name"
+        .: "pkg-name"
       <*> obj
-      .: "pkg-version"
+        .: "pkg-version"
       <*> (obj .:? "depends" .!= Set.empty)
       <*> (obj .:? "style" >>= traverse parsePlanStyle)
       <*> fmap mergeComponents (obj .:? "components" .!= Map.empty)

--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -220,9 +220,9 @@ doGraph plan = do
     edge parentId dep
     when (isDirectDep plan) (direct dep)
 
--- | Just include everything for now!
+-- | We're working on improving how we handle multi-module Cabal projects.
 --
--- We need to research the correct way to filter dependencies.
+-- For now, just remove all the filters to get some baseline data.
 -- I think basically right now the concrete effect of not having any filters is that test deps are reported.
 shouldInclude :: InstallPlan -> Bool
 shouldInclude _ = True

--- a/test/GraphUtil.hs
+++ b/test/GraphUtil.hs
@@ -48,7 +48,7 @@ expectDep' dep graph = sendIO $ expectDep dep graph
 -- | Expect only the given edges between @[(parent,child)]@ dependencies to be present in the graph
 expectEdges :: (Ord a, Show a) => [(a, a)] -> Graphing a -> Expectation
 expectEdges edges graph =
-  (length edges `shouldBe` AM.edgeCount (Graphing.toAdjacencyMap graph))
+  (AM.edgeCount (Graphing.toAdjacencyMap graph) `shouldBe` length edges)
     *> traverse_ (`shouldSatisfy` \(from, to) -> AM.hasEdge from to (Graphing.toAdjacencyMap graph)) edges
 
 -- This assertion is meant to give more detailed information when two graphs are not equal to each other.

--- a/test/Haskell/CabalSpec.hs
+++ b/test/Haskell/CabalSpec.hs
@@ -8,10 +8,12 @@ import Data.Aeson
 import Data.ByteString.Lazy qualified as BL
 import Data.Set qualified as Set
 import DepTypes
+import Effect.Logger (Severity (SevError), withDefaultLogger)
 import GraphUtil
 import Graphing
 import ResultUtil
 import Strategy.Haskell.Cabal
+import Test.Hspec (runIO)
 import Test.Hspec qualified as Test
 
 buildPlan :: [InstallPlan]
@@ -44,7 +46,7 @@ spec = do
         Left err -> Test.expectationFailure $ "failed to parse: " ++ err
         Right result -> installPlans result `Test.shouldMatchList` buildPlan
   Test.describe "cabal plan graph builder" $ do
-    let result = run . runStack . runDiagnostics . buildGraph $ BuildPlan buildPlan
+    result <- runIO . runStack . withDefaultLogger SevError . runDiagnostics . buildGraph $ BuildPlan buildPlan
 
     Test.it "should build a correct graph" $
       assertOnSuccess result $ \_ graph -> do


### PR DESCRIPTION
# Overview

To better support multi-module Cabal projects, we need to more accurately filter dependencies in the graph. The current state of this PR is a first step towards this, which just disables all the current filtering and adds more detailed debugging information.

This PR, in its current state, mostly exists as a way to get a sharable build. As such I'm ignoring the PR template for now.