### PR TITLE
fix(docs): Minor typos

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -22,12 +22,12 @@ parsers correctly, and links to a few tutorials.
 
 If a top-level component of a graph of dependencies is a test dependency, then its direct children are also test
 dependencies, as are their direct children, and so on.  In some cases, the build tool/manifest files/lock files will
-tell us this information, but sometimes, we have to propogate these environments downwards ourselves.  This is called
+tell us this information, but sometimes, we have to propagate these environments downwards ourselves.  This is called
 [`graph hydration`](graph-hydration.md), and is handled by the `Graphing.Hydrate` module.
 
 ## Testing with effects
 
-Testing with `hspec` provides several useful assertion/organization methods.  Wrtiting business logic with
+Testing with `hspec` provides several useful assertion/organization methods.  Writing business logic with
 `fused-effects` allows us to write expressive, convenient, and safe code.  Testing those `fused-effects`-based
 functions with `hspec` is a nightmare.  In short, `hspec` is `IO`-only, and `fused-effects` operates on free-ish
 monads (not really, but it does work similarly).  To make this easier for us, we created the `Test.Effect` module,

--- a/docs/contributing/filtering.md
+++ b/docs/contributing/filtering.md
@@ -114,7 +114,7 @@ We construct these string representations like so:
 Given the analysis target tuple `(type, path, [list, of, subtargets])`,
 we emit one target per subtarget, plus a target with no subtargets.  The target
 without a subtarget component is ALWAYS present, even when no subtargets are
-found.  This is the most commmon scenario, since most analyzers do not make use
+found.  This is the most common scenario, since most analyzers do not make use
 of subtargets.  For example, the tuple `(cargo, foo/bar, [])` would emit the
 single target `cargo@foo/bar`.  The tuple of `(gradle, foo/baz, [subA, subB])`
 would emit three targets:
@@ -148,7 +148,7 @@ exclude a/b AND include a/b/c
 -- rewritten:
 Do not include a/b (or its children)
 AND
-Do not incluse anything that is not a/b/c (or its children)
+Do not include anything that is not a/b/c (or its children)
 ```
 
 In this wording, it is clear that we must not include `a/b/c`, because it has

--- a/docs/contributing/graph-hydration.md
+++ b/docs/contributing/graph-hydration.md
@@ -31,7 +31,7 @@ both flow downwards, creating purple when they join.
 - In the yellow isolated graph, we have no trace of blue or red anywhere, meaning that graph hydration
 allows for isolation of subgraphs.
 - In the cyclic graph, we ended up with all nodes being the same color.  This is again due to combining
-the colors, but if we defined the behvior to overwrite existing colors (or to reject all colors after
+the colors, but if we defined the behavior to overwrite existing colors (or to reject all colors after
 the first), we could end up with VERY different graphs.
 
 Graph hydration is handled through the `Hydrateable` typeclass, in the `Graphing.Hydrate` module.

--- a/docs/differences-from-v1.md
+++ b/docs/differences-from-v1.md
@@ -75,7 +75,7 @@ With [`fossa-deps.{yml,json}` file](features/manual-dependencies.md), 3.x suppor
 - License scanning vendor dependencies 
 <!-- markdown-link-check-disable-next-line -->
 - Analyzing archives that are located at a specific web address (e.g. https://my-deps-source/v1.zip)
-- Manually specifying dependency by it's name and license (e.g. my-custom-dep with MIT licence)
+- Manually specifying dependency by it's name and license (e.g. my-custom-dep with MIT license)
 - Manually specifying dependency for analysis by its name and dependency type (e.g. pip dependency: request)
 
 This is very useful when working with a package manager that is not supported, or when you have a custom and nonstandard dependency management solution. The FOSSA CLI will automatically read a fossa-deps.yml or a fossa-deps.json file in the root directory (usually the current working directory) when fossa analyze is run and parse dependencies from it. These dependencies will be added to the dependencies that are normally found when fossa analysis is run in the directory.

--- a/docs/walkthroughs/analysis-target-configuration.md
+++ b/docs/walkthroughs/analysis-target-configuration.md
@@ -4,7 +4,7 @@ FOSSA CLI can be configured to discover and analyze, based on the target type (e
 
 To do so, we will use the following:
 
-- [fossa list-target](./../references/subcommands/list-targets.md) command
+- [fossa list-targets](./../references/subcommands/list-targets.md) command
 - [.fossa.yml](./../references/files/fossa-yml.md) configuration file
 
 ## Example
@@ -69,7 +69,7 @@ When command is executed, it would produce a list of target and their path:
 [ INFO] Found target: gradle@test-suite/integration/:
 ```
 
-So, 
+So,
 
 1. Let's select any targets under `src/back-end` and `src/front-end/v2/` directory using [`paths.only`](./../references/files/fossa-yml.md#`paths.only:`) directive:
 
@@ -93,7 +93,6 @@ paths:
         - src/front-end/v2/
         - utils/
 ```
-
 
 3. We want to exclude any targets in `utils/migration-tests/` directory, to do so, use [`paths.exclude`](./../references/files/fossa-yml.md#`paths.exclude:`) directive. This will ensure cli does not scan `utils/migrations/` directory for analysis.
 


### PR DESCRIPTION
# Overview

Initially opened this PR because I noticed the `fossa list-targets` command was referred to as `list-target` and when I tried it, it didn't work. While there, I found a few other small typos so this PR is entirely an editorial fix to fix a few minor typos in a few different docs pages.

## Acceptance criteria

Improved docs!

## Testing plan

Read the docs.

## Risks

Low; revert any docs issues.

## Metrics

None.

## References

None.

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
