### PR TITLE
Codesign on Mac OS

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -145,7 +145,7 @@ jobs:
         strip release/*
 
     - name: Sign Binaries (Mac OS)
-      if: ${{ contains(matrix.os, 'macos') && github.ref_type == 'tag' }}
+      if: ${{ contains(matrix.os, 'macos') }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
         MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -36,6 +36,10 @@ jobs:
 
     steps:
 
+    - name: Check for codesign, remove me later (Mac OS)
+      if: ${{ contains(matrix.os, 'macos') }}
+      run: codesign --invalid
+
     - uses: actions/checkout@v3
       with:
         lfs: true
@@ -138,6 +142,41 @@ jobs:
       run: |
         strip release/*
 
+    - name: Sign Binaries (Mac OS)
+      if: ${{ contains(matrix.os, 'macos') }}
+      env:
+        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          # I'm not sure we need provisioning profiles since we aren't using xcode.
+          # BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          # PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          # import certificate and provisioning profile from secrets
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          # echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+
+          # create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          codesign -s 'Fossa, Inc.' release/fossa
+          # Maybe not necessary, who uses pathfinder?
+          codesign -s 'Fossa, Inc.' release/pathfinder
+
+          # apply provisioning profile
+          # mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          # cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+        
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ runner.os }}-binaries

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -139,22 +139,18 @@ jobs:
         strip release/*
 
     - name: Sign Binaries (Mac OS)
-      if: ${{ contains(matrix.os, 'macos') }}
+      if: ${{ contains(matrix.os, 'macos') && github.ref_type == 'tag' }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
         MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}
-          # I'm not sure we need provisioning profiles since we aren't using xcode.
-          # BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
         MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
       run: |
         # create variables
         CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-        # PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
         KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
         # import certificate and provisioning profile from secrets
         echo -n "$MACOS_BUILD_CERT_BASE64" | base64 --decode -o $CERTIFICATE_PATH
-        # echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
 
         # create temporary keychain
         security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
@@ -166,12 +162,7 @@ jobs:
         security list-keychain -d user -s $KEYCHAIN_PATH
 
         codesign -s 'Fossa, Inc.' release/fossa
-        # Maybe not necessary, who uses pathfinder?
         codesign -s 'Fossa, Inc.' release/pathfinder
-
-        # apply provisioning profile
-        # mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-        # cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -145,7 +145,7 @@ jobs:
         strip release/*
 
     - name: Sign Binaries (Mac OS)
-      if: ${{ contains(matrix.os, 'macos') }}
+      if: ${{ contains(matrix.os, 'macos') && github.ref_type == 'tag' }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
         MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -169,6 +169,7 @@ jobs:
 
         codesign -s 'Fossa, Inc.' release/fossa
         codesign -s 'Fossa, Inc.' release/pathfinder
+        codesign -s 'Fossa, Inc.' release/diagnose
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -36,10 +36,6 @@ jobs:
 
     steps:
 
-    - name: Check for codesign, remove me later (Mac OS)
-      if: ${{ contains(matrix.os, 'macos') }}
-      run: codesign --invalid
-
     - uses: actions/checkout@v3
       with:
         lfs: true

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -150,33 +150,33 @@ jobs:
           # I'm not sure we need provisioning profiles since we aren't using xcode.
           # BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
         KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        run: |
-          # create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          # PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+      run: |
+        # create variables
+        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+        # PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+        KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
-          # import certificate and provisioning profile from secrets
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
-          # echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+        # import certificate and provisioning profile from secrets
+        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+        # echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
 
-          # create temporary keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        # create temporary keychain
+        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
-          # import certificate to keychain
-          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
+        # import certificate to keychain
+        security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+        security list-keychain -d user -s $KEYCHAIN_PATH
 
-          codesign -s 'Fossa, Inc.' release/fossa
-          # Maybe not necessary, who uses pathfinder?
-          codesign -s 'Fossa, Inc.' release/pathfinder
+        codesign -s 'Fossa, Inc.' release/fossa
+        # Maybe not necessary, who uses pathfinder?
+        codesign -s 'Fossa, Inc.' release/pathfinder
 
-          # apply provisioning profile
-          # mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          # cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
-        
+        # apply provisioning profile
+        # mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+        # cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ runner.os }}-binaries

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -141,11 +141,11 @@ jobs:
     - name: Sign Binaries (Mac OS)
       if: ${{ contains(matrix.os, 'macos') }}
       env:
-        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
+        MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}
           # I'm not sure we need provisioning profiles since we aren't using xcode.
           # BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
-        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
       run: |
         # create variables
         CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
@@ -153,16 +153,16 @@ jobs:
         KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
         # import certificate and provisioning profile from secrets
-        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+        echo -n "$MACOS_BUILD_CERT_BASE64" | base64 --decode -o $CERTIFICATE_PATH
         # echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
 
         # create temporary keychain
-        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
         security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+        security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
         # import certificate to keychain
-        security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+        security import $CERTIFICATE_PATH -P "$MACOS_BUILD_CERT_P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
         security list-keychain -d user -s $KEYCHAIN_PATH
 
         codesign -s 'Fossa, Inc.' release/fossa

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.8.7
+- CLI Binaries: Sign Mac OS builds using codesign. ([#1251](https://github.com/fossas/fossa-cli/pull/1251))
+
 ## v3.8.6
 - VSI: Fix a bug where root dependencies would cause analysis to fail. ([#1240](https://github.com/fossas/fossa-cli/pull/1240))
 - Node (PNPM): Fixes a bug where analyses would fail when the `lockfileVersion` attribute was a string in `pnpm-lock.yaml`. ([1239](https://github.com/fossas/fossa-cli/pull/1239))

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -8,6 +8,7 @@ module App.Version (
   versionOrBranch,
 ) where
 
+import App.Version.TH (getCurrentTag)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -16,7 +17,7 @@ import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwdTry)
 import System.Info (compilerName, compilerVersion)
 
 versionNumber :: Maybe Text
-versionNumber = Just "3.8.5" -- TAG TEST: Revert me $$(getCurrentTag)
+versionNumber = $$(getCurrentTag)
 
 info :: Either String GitInfo
 info = $$(tGitInfoCwdTry)

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -8,7 +8,6 @@ module App.Version (
   versionOrBranch,
 ) where
 
-import App.Version.TH (getCurrentTag)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -17,7 +16,7 @@ import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwdTry)
 import System.Info (compilerName, compilerVersion)
 
 versionNumber :: Maybe Text
-versionNumber = $$(getCurrentTag)
+versionNumber = Just "3.8.5" -- TAG TEST: Revert me $$(getCurrentTag)
 
 info :: Either String GitInfo
 info = $$(tGitInfoCwdTry)


### PR DESCRIPTION
# Overview

This PR signs our Mac OS X binaries using `codesign`.

## Acceptance criteria

You should be able to download release binaries from a [build](https://github.com/fossas/fossa-cli/actions/runs/5732282982) that resulted in signed binaries and run `codesign -v` on them and receive no output.

Binaries should not be signed for untagged revisions.

## Testing plan

I tested by having the binaries be signed in CI and then downloaded and checking the above with `codesign -v`. 

Example:
```
codesign -v ./fossa
```

I also have builds in this PR which were untagged and weren't signed. The one I link above that was tagged and is signed.

## Risks

We have new secrets.

## Metrics

None.

## References



- [ANE-862](https://fossa.atlassian.net/browse/ANE-862)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-862]: https://fossa.atlassian.net/browse/ANE-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ