### PR TITLE
Embed lernie

### DIFF
--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -10,6 +10,7 @@ module App.Fossa.EmbeddedBinary (
   toPath,
   withThemisAndIndex,
   withBerkeleyBinary,
+  withLernieBinary,
   allBins,
   dumpEmbeddedBinary,
   themisVersion,
@@ -109,6 +110,13 @@ withBerkeleyBinary ::
   (BinaryPaths -> m c) ->
   m c
 withBerkeleyBinary = withEmbeddedBinary BerkeleyDB
+
+withLernieBinary ::
+  ( Has (Lift IO) sig m
+  ) =>
+  (BinaryPaths -> m c) ->
+  m c
+withLernieBinary = withEmbeddedBinary Lernie
 
 withEmbeddedBinary ::
   ( Has (Lift IO) sig m

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -207,7 +207,6 @@ embeddedBinaryLernie = $(embedFileIfExists "vendor-bins/lernie")
 #ifdef mingw32_HOST_OS
 embeddedBinaryBerkeleyDB :: ByteString
 embeddedBinaryBerkeleyDB = $(embedFileIfExists "target/release/berkeleydb.exe")
-
 #else
 embeddedBinaryBerkeleyDB :: ByteString
 embeddedBinaryBerkeleyDB = $(embedFileIfExists "target/release/berkeleydb")

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -4,6 +4,7 @@
 
 module App.Fossa.EmbeddedBinary (
   BinaryPaths,
+  Lernie,
   ThemisIndex,
   ThemisBins (..),
   toPath,
@@ -53,6 +54,7 @@ data PackagedBinary
   = Themis
   | ThemisIndex
   | BerkeleyDB
+  | Lernie
   deriving (Show, Eq, Enum, Bounded)
 
 allBins :: [PackagedBinary]
@@ -67,6 +69,8 @@ data BinaryPaths = BinaryPaths
 data ThemisBinary
 
 data ThemisIndex
+
+data Lernie
 
 data ThemisBins = ThemisBins
   { themisBinaryPaths :: Tagged ThemisBinary BinaryPaths
@@ -137,6 +141,7 @@ writeBinary dest bin = sendIO . writeExecutable dest $ case bin of
   Themis -> embeddedBinaryThemis
   ThemisIndex -> embeddedBinaryThemisIndex
   BerkeleyDB -> embeddedBinaryBerkeleyDB
+  Lernie -> embeddedBinaryLernie
 
 writeExecutable :: Path Abs File -> ByteString -> IO ()
 writeExecutable path content = do
@@ -149,6 +154,7 @@ extractedPath bin = case bin of
   Themis -> $(mkRelFile "themis-cli")
   ThemisIndex -> $(mkRelFile "index.gob.xz")
   BerkeleyDB -> $(mkRelFile "berkeleydb-plugin")
+  Lernie -> $(mkRelFile "lernie")
 
 -- | Extract to @$TMP/fossa-vendor/<timestamp>
 -- We used to extract everything to @$TMP/fossa-vendor@, but there's a subtle issue with that.
@@ -186,10 +192,14 @@ embeddedBinaryThemisIndex = $(embedFileIfExists "vendor-bins/index.gob.xz")
 themisVersion :: Text
 themisVersion = $$themisVersionQ
 
+embeddedBinaryLernie :: ByteString
+embeddedBinaryLernie = $(embedFileIfExists "vendor-bins/lernie")
+
 -- To build this, run `make build` or `cargo build --release`.
 #ifdef mingw32_HOST_OS
 embeddedBinaryBerkeleyDB :: ByteString
 embeddedBinaryBerkeleyDB = $(embedFileIfExists "target/release/berkeleydb.exe")
+
 #else
 embeddedBinaryBerkeleyDB :: ByteString
 embeddedBinaryBerkeleyDB = $(embedFileIfExists "target/release/berkeleydb")

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -116,7 +116,6 @@ LERNIE_TAG=$(jq -cr ".name" $LERNIE_RELEASE_JSON)
 # Strip the leading 'v' off of the tag
 LERNIE_VERSION=$(echo $LERNIE_TAG | sed -e 's/^v//')
 FILTER=".name == \"lernie-$LERNIE_VERSION-$LERNIE_ASSET_POSTFIX\""
-echo "looking for lernie with filter: $FILTER"
 jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $LERNIE_RELEASE_JSON | while read ASSET; do
   URL="$(echo $ASSET | jq -c -r '.url')"
   NAME="$(echo $ASSET | jq -c -r '.name')"

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -32,25 +32,39 @@ mkdir -p vendor-bins
 
 ASSET_POSTFIX=""
 BASIS_ASSET_POSTFIX=""
+LERNIE_ASSET_POSTFIX=""
 OS_WINDOWS=false
 case "$(uname -s)" in
   Darwin)
     ASSET_POSTFIX="darwin"
     BASIS_ASSET_POSTFIX="darwin-amd64"
+    case "$(uname -m)" in
+      arm64)
+        LERNIE_ASSET_POSTFIX="aarch64-macos"
+        ;;
+
+      *)
+        LERNIE_ASSET_POSTFIX="x86_64-macos"
+        ;;
+    esac
     ;;
 
   Linux)
     ASSET_POSTFIX="linux"
     BASIS_ASSET_POSTFIX="linux-amd64"
+    LERNIE_ASSET_POSTFIX="linux"
     ;;
 
   *)
     echo "Warn: Assuming $(uname -s) is Windows"
     ASSET_POSTFIX="windows.exe"
     BASIS_ASSET_POSTFIX="windows-amd64"
+    LERNIE_ASSET_POSTFIX="windows"
     OS_WINDOWS=true
     ;;
 esac
+
+# Download latest release of Themis and its index
 
 TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
@@ -89,6 +103,35 @@ echo "themis index downloaded"
 rm $THEMIS_RELEASE_JSON
 echo
 
+# Download latest release of Lernie
+
+echo "Downloading lernie binary from latest release"
+LERNIE_RELEASE_JSON=vendor-bins/lernie-release.json
+curl -sSL \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3.raw" \
+    https://api.github.com/repos/fossas/lernie/releases/latest > $LERNIE_RELEASE_JSON
+
+LERNIE_TAG=$(jq -cr ".name" $LERNIE_RELEASE_JSON)
+# Strip the leading 'v' off of the tag
+LERNIE_VERSION=$(echo $LERNIE_TAG | sed -e 's/^v//')
+FILTER=".name == \"lernie-$LERNIE_VERSION-$LERNIE_ASSET_POSTFIX\""
+echo "looking for lernie with filter: $FILTER"
+jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $LERNIE_RELEASE_JSON | while read ASSET; do
+  URL="$(echo $ASSET | jq -c -r '.url')"
+  NAME="$(echo $ASSET | jq -c -r '.name')"
+  OUTPUT="$(echo vendor-bins/$NAME | sed 's/-'$LERNIE_VERSION'-'$LERNIE_ASSET_POSTFIX'$//')"
+
+  echo "Downloading '$NAME' to '$OUTPUT'"
+  curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT
+done
+echo "Lernie download successful"
+
+rm $LERNIE_RELEASE_JSON
+
+# Finished downloading
+
+echo
 echo "Marking binaries executable"
 chmod +x vendor-bins/*
 

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -52,14 +52,14 @@ case "$(uname -s)" in
   Linux)
     ASSET_POSTFIX="linux"
     BASIS_ASSET_POSTFIX="linux-amd64"
-    LERNIE_ASSET_POSTFIX="linux"
+    LERNIE_ASSET_POSTFIX="x86_64-linux"
     ;;
 
   *)
     echo "Warn: Assuming $(uname -s) is Windows"
     ASSET_POSTFIX="windows.exe"
     BASIS_ASSET_POSTFIX="windows-amd64"
-    LERNIE_ASSET_POSTFIX="windows"
+    LERNIE_ASSET_POSTFIX="x86_64-windows.exe"
     OS_WINDOWS=true
     ;;
 esac


### PR DESCRIPTION
# Overview

[Delivers ANE-1066](https://fossa.atlassian.net/browse/ANE-1066)

Download the latest release of Lernie and embed it into the CLI

## Acceptance criteria

- `vendor_download.sh` should downlod the latest release of Lernie
- Lernie should be embedded in the CLI 
- We should download the correct architecture on MacOS

## Testing plan

This will be more fully tested in a future PR that actually uses the embedded binary, https://github.com/fossas/fossa-cli/pull/1248

## Risks

None

## Metrics


## References

[ANE-1066](https://fossa.atlassian.net/browse/ANE-1066)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-1066]: https://fossa.atlassian.net/browse/ANE-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ