### PR TITLE
Allow create-release to make a draft release.

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -200,20 +200,20 @@ jobs:
             ;;
         esac
 
-    - name: Check that version info was embedded correctly
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      run: |
-        chmod +x Linux-binaries/fossa
+    # - name: Check that version info was embedded correctly
+    #   if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    #   run: |
+    #     chmod +x Linux-binaries/fossa
 
-        echo $GITHUB_REF_NAME
-        echo $GITHUB_REF_TYPE
-        echo $GITHUB_SHA
-        echo ${GITHUB_SHA:0:12}
-        echo $(Linux-binaries/fossa --version)
-        echo "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)"
+    #     echo $GITHUB_REF_NAME
+    #     echo $GITHUB_REF_TYPE
+    #     echo $GITHUB_SHA
+    #     echo ${GITHUB_SHA:0:12}
+    #     echo $(Linux-binaries/fossa --version)
+    #     echo "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)"
 
-        [ "$GITHUB_REF_TYPE" = "tag" ] && echo "Ref type OK"
-        [ "$(Linux-binaries/fossa --version)" = "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
+    #     [ "$GITHUB_REF_TYPE" = "tag" ] && echo "Ref type OK"
+    #     [ "$(Linux-binaries/fossa --version)" = "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
 
     - name: Install Cosign
       if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -200,20 +200,20 @@ jobs:
             ;;
         esac
 
-    # - name: Check that version info was embedded correctly
-    #   if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    #   run: |
-    #     chmod +x Linux-binaries/fossa
+    - name: Check that version info was embedded correctly
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: |
+        chmod +x Linux-binaries/fossa
 
-    #     echo $GITHUB_REF_NAME
-    #     echo $GITHUB_REF_TYPE
-    #     echo $GITHUB_SHA
-    #     echo ${GITHUB_SHA:0:12}
-    #     echo $(Linux-binaries/fossa --version)
-    #     echo "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)"
+        echo $GITHUB_REF_NAME
+        echo $GITHUB_REF_TYPE
+        echo $GITHUB_SHA
+        echo ${GITHUB_SHA:0:12}
+        echo $(Linux-binaries/fossa --version)
+        echo "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)"
 
-    #     [ "$GITHUB_REF_TYPE" = "tag" ] && echo "Ref type OK"
-    #     [ "$(Linux-binaries/fossa --version)" = "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
+        [ "$GITHUB_REF_TYPE" = "tag" ] && echo "Ref type OK"
+        [ "$(Linux-binaries/fossa --version)" = "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"
 
     - name: Install Cosign
       if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -182,6 +182,7 @@ jobs:
     needs: ['build-all']
     permissions:
         id-token: write
+        contents: write
 
     steps:
     - uses: actions/download-artifact@v2

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 - CLI Binaries: Sign Linux builds using cosign. ([#1243](https://github.com/fossas/fossa-cli/pull/1243))
 
 ## v3.8.7
-- Due to an issue with our release process [#1254](https://github.com/fossas/fossa-cli/pull/1254), this tag exists but was not released. Those changes were released with v3.8.8.
+- Due to an issue with our release process [#1254](https://github.com/fossas/fossa-cli/pull/1254), this tag exists but was not released. The changes that would have been in 3.8.7 were released as v3.8.8.
 
 ## v3.8.6
 - VSI: Fix a bug where root dependencies would cause analysis to fail. ([#1240](https://github.com/fossas/fossa-cli/pull/1240))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,11 @@
 # FOSSA CLI Changelog
 
-## v3.8.7
+## v3.8.8
 - CLI Binaries: Sign Mac OS builds using codesign. ([#1251](https://github.com/fossas/fossa-cli/pull/1251))
 - CLI Binaries: Sign Linux builds using cosign. ([#1243](https://github.com/fossas/fossa-cli/pull/1243))
+
+## v3.8.7
+- Due to an issue with our release process [#1254](https://github.com/fossas/fossa-cli/pull/1254), this tag exists but was not released. Those changes were released with v3.8.8.
 
 ## v3.8.6
 - VSI: Fix a bug where root dependencies would cause analysis to fail. ([#1240](https://github.com/fossas/fossa-cli/pull/1240))

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -8,6 +8,7 @@ module App.Version (
   versionOrBranch,
 ) where
 
+import App.Version.TH (getCurrentTag)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -16,9 +17,7 @@ import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwdTry)
 import System.Info (compilerName, compilerVersion)
 
 versionNumber :: Maybe Text
--- THIS IS TEMPORARY REVER BEFORE MERGE
--- I only a real version because our link checks will fail otherwise.
-versionNumber = Just "3.8.5" -- \$$(getCurrentTag)
+versionNumber = $$(getCurrentTag)
 
 info :: Either String GitInfo
 info = $$(tGitInfoCwdTry)

--- a/src/App/Version.hs
+++ b/src/App/Version.hs
@@ -8,7 +8,6 @@ module App.Version (
   versionOrBranch,
 ) where
 
-import App.Version.TH (getCurrentTag)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -17,7 +16,9 @@ import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwdTry)
 import System.Info (compilerName, compilerVersion)
 
 versionNumber :: Maybe Text
-versionNumber = $$(getCurrentTag)
+-- THIS IS TEMPORARY REVER BEFORE MERGE
+-- I only a real version because our link checks will fail otherwise.
+versionNumber = Just "3.8.5" -- \$$(getCurrentTag)
 
 info :: Either String GitInfo
 info = $$(tGitInfoCwdTry)


### PR DESCRIPTION
# Overview

I didn't realize that when I set permissions for `id-token` in our create release job it would [turn off](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) any other the other permissions that weren't explicitly set. According to the gh release action the one I've added in this PR should be enough: https://github.com/softprops/action-gh-release#permissions

I didn't test the actual release in those PRs by making a fake version tag because I did not want to have confusing tags that looked like versions around.

## Acceptance criteria

We should be able to release again.

## Testing plan

I made a tag called vfake-version-tag-delete-me which I've since deleted. But If you look at the [draft releases](https://github.com/fossas/fossa-cli/releases) page there is one. 

## Risks

I changed the 3.8.7 release to 3.8.8 in the changelog to avoid deleting the 3.8.7 tag. Even if it's probably safe, I'd rather not have release version tags that have pointed at different commits at different times. If you disagree that that's necessary, let me know.

## Metrics

## References

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
