### PR TITLE
Clarify Python setuptools documentation

### DIFF
--- a/docs/references/strategies/languages/python/setuptools.md
+++ b/docs/references/strategies/languages/python/setuptools.md
@@ -48,11 +48,11 @@ from both files.
 synchronization between them.
 * Since we don't actually run `setup.py` or do our own interpretation of the Python code therein, `install_requires` not defined as a literal array of string literals done in the `setup.py` file will hide the
 true `install_requires` list from our view. For example, we don't have a way to find `install_requires` set up this way:
-```python
-a = ['package1==1.0.0']
-b = ['package2==2.0.0']
-install_requires = a + b
-```
+    ```python
+    a = ['package1==1.0.0']
+    b = ['package2==2.0.0']
+    install_requires = a + b
+    ```
 However, we do catch *variables* named `install_requires`, as long as they are declared earlier in the file than the `install_requires` keyword argument to `setup`.
 * Often, the `requirements.txt` file entirely overlaps the `setup.py` file.  This is almost always by design.
 

--- a/docs/references/strategies/languages/python/setuptools.md
+++ b/docs/references/strategies/languages/python/setuptools.md
@@ -46,9 +46,14 @@ from both files.
 * Python requirements files and setup.py files do not provide any data about edges between dependencies.
 * Requirements files can be completely different than an existing setup.py specification, as there is no built-in
 synchronization between them.
-* Since we don't completely parse the python files, any programmability done in the `setup.py` file will hide the
-true `install_requires` list from our view.  However, we do catch *variables* named `install_requires` as well, as
-long as they are declared earlier in the file than the `install_requires` keyword argument to `setup`.
+* Since we don't actually run `setup.py` or do our own interpretation of the Python code therein, `install_requires` not defined as a literal array of string literals done in the `setup.py` file will hide the
+true `install_requires` list from our view. For example, we don't have a way to find `install_requires` set up this way:
+```python
+a = ['package1==1.0.0']
+b = ['package2==2.0.0']
+install_requires = a + b
+```
+However, we do catch *variables* named `install_requires`, as long as they are declared earlier in the file than the `install_requires` keyword argument to `setup`.
 * Often, the `requirements.txt` file entirely overlaps the `setup.py` file.  This is almost always by design.
 
 ## Examples

--- a/docs/references/strategies/languages/python/setuptools.md
+++ b/docs/references/strategies/languages/python/setuptools.md
@@ -46,14 +46,14 @@ from both files.
 * Python requirements files and setup.py files do not provide any data about edges between dependencies.
 * Requirements files can be completely different than an existing setup.py specification, as there is no built-in
 synchronization between them.
-* Since we don't actually run `setup.py` or do our own interpretation of the Python code therein, `install_requires` not defined as a literal array of string literals done in the `setup.py` file will hide the
-true `install_requires` list from our view. For example, we don't have a way to find `install_requires` set up this way:
+* The CLI will catch *variables* named `install_requires`, as long as they are declared earlier in the file than the `install_requires` keyword argument to `setup`.
+* Because the CLI doesn't actually run `setup.py` or do its own interpretation of the Python code therein, `install_requires` not defined as a literal array of string literals done in the `setup.py` file will hide the
+true `install_requires` list from the CLI's view. For example, FOSSA CLI does not have a general way to find `install_requires` set up this way:
     ```python
     a = ['package1==1.0.0']
     b = ['package2==2.0.0']
     install_requires = a + b
     ```
-However, we do catch *variables* named `install_requires`, as long as they are declared earlier in the file than the `install_requires` keyword argument to `setup`.
 * Often, the `requirements.txt` file entirely overlaps the `setup.py` file.  This is almost always by design.
 
 ## Examples


### PR DESCRIPTION
#Overview

I found some language that implied that getting python deep deps for setuptools is a matter of parsing, when I think that calling it a parsing issue undersells the the actual complexity of getting an accurate list of deps from setup.py.

## Acceptance criteria

* Should describe why we can't currently get deep deps easily for Python with setuptools jusing `setup.py`

## Testing plan

This is purely a doc change.

## Risks

## Metrics


## References

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
