### PR TITLE
Use a newtype for originpaths

### DIFF
--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -193,7 +193,7 @@ summarize endpointVersion (AnalysisScanResult dps vsi binary manualDeps dynamicL
     vsiSourceUnits sUnit =
       let renderOriginPath =
             case vsiSrcUnitLocator sUnit of
-              Just loc -> \originPath -> toText originPath <> " (locator: " <> renderLocator loc <> ")"
+              Just loc -> \originPath -> (toText originPath) <> " (locator: " <> renderLocator loc <> ")"
               _ -> toText
        in map renderOriginPath (sourceUnitOriginPaths sUnit)
 

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -60,9 +60,9 @@ import Effect.Logger (Logger, indent, pretty, vsep)
 import Effect.ReadFS (ReadFS, doesFileExist, readContentsJson, readContentsYaml)
 import Fossa.API.Types (ApiOpts, Organization (..))
 import Path (Abs, Dir, File, Path, mkRelFile, (</>))
-import Path.Extra (SomePath (SomeFile), tryMakeRelative)
+import Path.Extra (tryMakeRelative)
 import Srclib.Converter (depTypeToFetcher)
-import Srclib.Types (AdditionalDepData (..), Locator (..), SourceRemoteDep (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (SourceUnitDependency), SourceUserDefDep (..))
+import Srclib.Types (AdditionalDepData (..), Locator (..), SourceRemoteDep (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (SourceUnitDependency), SourceUserDefDep (..), someBaseToOriginPath)
 import Types (ArchiveUploadType (..), GraphBreadth (..))
 
 data FoundDepsFile
@@ -174,7 +174,7 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendor
       , sourceUnitType = "user-specific-yaml"
       , sourceUnitBuild = build
       , sourceUnitGraphBreadth = Complete
-      , sourceUnitOriginPaths = [SomeFile originPath]
+      , sourceUnitOriginPaths = [someBaseToOriginPath originPath]
       , additionalData = additional
       }
 

--- a/src/Path/Extra.hs
+++ b/src/Path/Extra.hs
@@ -10,7 +10,7 @@ module Path.Extra (
 
 import Control.Effect.Record (RecordableValue)
 import Control.Effect.Replay (ReplayableValue)
-import Data.Aeson (FromJSON, ToJSON (toJSON))
+import Data.Aeson (FromJSON, ToJSON)
 import Data.String.Conversion (ToText, toText)
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -23,10 +23,7 @@ data SomePath
   | SomeDir (SomeBase Dir)
   deriving (Eq, Ord, Show, Generic)
 
-instance ToJSON SomePath where
-  toJSON (SomeFile f) = toJSON f
-  toJSON (SomeDir d) = toJSON d
-
+instance ToJSON SomePath
 instance RecordableValue SomePath
 instance FromJSON SomePath
 instance ReplayableValue SomePath

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -42,6 +42,7 @@ import Srclib.Types (
     buildSucceeded
   ),
   SourceUnitDependency (..),
+  somePathToOriginPath,
  )
 
 toSourceUnit :: Bool -> ProjectResult -> SourceUnit
@@ -59,7 +60,7 @@ toSourceUnit leaveUnfiltered ProjectResult{..} =
             , buildDependencies = deps
             }
     , sourceUnitGraphBreadth = projectResultGraphBreadth
-    , sourceUnitOriginPaths = projectResultManifestFiles
+    , sourceUnitOriginPaths = map somePathToOriginPath projectResultManifestFiles
     , additionalData = Nothing
     }
   where

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -47,6 +47,13 @@ instance ToText LicenseScanType where
 instance ToJSON LicenseScanType where
   toJSON = toJSON . toText
 
+-- |This type is meant to represent the paths in a project where a particular set of dependencies were discovered.
+-- For example, in a project directory that has a @go.mod@ the OriginPath might be 'foo/bar/go.mod'.
+-- In a project with VSI dependencies the OriginPath would be the directory the dep was found in, such as 'vendored/zlib/'
+--
+-- OriginPaths were previously `SomeBase File`, however with support for VSI OriginPaths can now be a directory in addition to a file path.
+-- The reason we cannot use `SomePath` for this is that outputting an `OriginPath` to JSON in a form like @/foo/bar/path_end@ doesn't say whether the path is a file or directory which is required for parsing to a `SomePath` in `FromJSON`.
+-- This type and its exported smart constructors describe that OriginPath is a path, but has no information about whether the path is a file or directory.
 newtype OriginPath = OriginPath FilePath
   deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, ToText)
 


### PR DESCRIPTION
# Overview

This change makes it possible for source unit origin paths to have instances of from/to json which are inverses of each other.

## Acceptance criteria

* The CLI has a `SourceUnit` type with From/To Json instances that and produce/consume for each other.

## Testing plan

I tested the CLI output and verified that the outputted paths are paths like we expect. Since this uses the generated From/To json instances I did not think it was worth adding a test for them being inversions of each other.

## Risks

This is less type safe. I think it's clear that the intention is for an OriginPath to be a path, but nothing really enforces it. Particularly when using `FromJSON`. 

One potential option is to make a `FromJSON` instance which tries to parse an origin path as a file, then as a directory and fails if neither of them work, but otherwise just wraps the string it got. Let me know if you think this is worthwhile.

## Metrics



## References

- _[ANE-1159](https://fossa.atlassian.net/browse/ANE-1159)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-1159]: https://fossa.atlassian.net/browse/ANE-1159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ