### PR TITLE
Ane 862 notarize mac binaries

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -175,7 +175,7 @@ jobs:
         codesign --options runtime -s 'Fossa, Inc.' release/diagnose
 
         # Perform notarization
-        zip notarization-archive.zip release
+        zip -rj notarization-archive.zip release
         xcrun notarytool submit notarization-archive.zip --apple-id "$APPLE_NOTARIZATION_DEV_ID" --password "$APPLE_NOTARIZATION_DEV_PASS" --team-id "$APPLE_TEAM_ID" --wait
         rm notarization-archive.zip
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -150,6 +150,9 @@ jobs:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
         MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}
         MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        APPLE_NOTARIZATION_DEV_PASS: ${{ secrets.APPLE_NOTARIZATION_DEV_PASS }}
+        APPLE_NOTARIZATION_DEV_ID: ${{ secrets.APPLE_NOTARIZATION_DEV_ID }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: |
         # create variables
         CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -170,6 +170,7 @@ jobs:
         security import $CERTIFICATE_PATH -P "$MACOS_BUILD_CERT_P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
         security list-keychain -d user -s $KEYCHAIN_PATH
 
+        chmod +x release/*
         # '--options runtime' enables the hardened runtime: https://developer.apple.com/documentation/security/hardened_runtime
         # The hardened runtime is required for notarization.
         codesign --options runtime -s 'FOSSA, Inc.' release/fossa

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -145,7 +145,7 @@ jobs:
         strip release/*
 
     - name: Sign Binaries (Mac OS)
-      if: ${{ contains(matrix.os, 'macos') && github.ref_type == 'tag' }}
+      if: ${{ contains(matrix.os, 'macos') }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
         MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -180,7 +180,7 @@ jobs:
         echo "$NOTARY_RESULTS"
         # The notarization tool doesn't set $?
         rm notarization-archive.zip
-        if ! grep "status: Accepted" "$NOTARY_RESULTS"; then
+        if ! grep "status: Accepted" ""; then
            exit 1
         fi
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -167,9 +167,14 @@ jobs:
         security import $CERTIFICATE_PATH -P "$MACOS_BUILD_CERT_P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
         security list-keychain -d user -s $KEYCHAIN_PATH
 
-        codesign -s 'Fossa, Inc.' release/fossa
-        codesign -s 'Fossa, Inc.' release/pathfinder
-        codesign -s 'Fossa, Inc.' release/diagnose
+        codesign --options runtime -s 'Fossa, Inc.' release/fossa
+        codesign --options runtime -s 'Fossa, Inc.' release/pathfinder
+        codesign --options runtime -s 'Fossa, Inc.' release/diagnose
+
+        # Perform notarization
+        zip notarization-archive.zip release
+        xcrun notarytool submit notarization-archive.zip --apple-id "$NOTARIZATION_DEV_ID" --password "$NOTARIZATION_APP_PASS" --team-id "$APPLE_TEAM_ID" --wait
+        rm notarization-archive.zip
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -144,7 +144,7 @@ jobs:
       run: |
         strip release/*
 
-    - name: Sign and notarize Binaries (Mac OS)
+    - name: Sign and Notarize Binaries (Mac OS)
       if: ${{ contains(matrix.os, 'macos') && startsWith(github.ref, 'refs/tags/v') }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
@@ -170,6 +170,8 @@ jobs:
         security import $CERTIFICATE_PATH -P "$MACOS_BUILD_CERT_P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
         security list-keychain -d user -s $KEYCHAIN_PATH
 
+        # '--options runtime' enables the hardened runtime: https://developer.apple.com/documentation/security/hardened_runtime
+        # The hardened runtime is required for notarization.
         codesign --options runtime -s 'Fossa, Inc.' release/fossa
         codesign --options runtime -s 'Fossa, Inc.' release/pathfinder
         codesign --options runtime -s 'Fossa, Inc.' release/diagnose
@@ -178,8 +180,8 @@ jobs:
         zip -rj notarization-archive.zip release
         NOTARY_RESULTS=$(xcrun notarytool submit notarization-archive.zip --apple-id "$APPLE_NOTARIZATION_DEV_ID" --password "$APPLE_NOTARIZATION_DEV_PASS" --team-id "$APPLE_TEAM_ID" --wait)
         echo "$NOTARY_RESULTS"
-        # The notarization tool doesn't set $?
         rm notarization-archive.zip
+        # The notarization tool doesn't set $?, so examine the output.
         if ! echo "$NOTARY_RESULTS" | grep -q "status: Accepted"; then
            exit 1
         fi

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -176,8 +176,13 @@ jobs:
 
         # Perform notarization
         zip -rj notarization-archive.zip release
-        xcrun notarytool submit notarization-archive.zip --apple-id "$APPLE_NOTARIZATION_DEV_ID" --password "$APPLE_NOTARIZATION_DEV_PASS" --team-id "$APPLE_TEAM_ID" --wait
+        NOTARY_RESULTS=$(xcrun notarytool submit notarization-archive.zip --apple-id "$APPLE_NOTARIZATION_DEV_ID" --password "$APPLE_NOTARIZATION_DEV_PASS" --team-id "$APPLE_TEAM_ID" --wait)
+        echo "$NOTARY_RESULTS"
+        # The notarization tool doesn't set $?
         rm notarization-archive.zip
+        if ! grep "status: Accepted" "$NOTARY_RESULTS"; then
+           exit 1
+        fi
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -180,7 +180,7 @@ jobs:
         echo "$NOTARY_RESULTS"
         # The notarization tool doesn't set $?
         rm notarization-archive.zip
-        if ! grep "status: Accepted" ""; then
+        if ! echo "$NOTARY_RESULTS" | grep -q "status: Accepted"; then
            exit 1
         fi
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -145,7 +145,7 @@ jobs:
         strip release/*
 
     - name: Sign and Notarize Binaries (Mac OS)
-      if: ${{ contains(matrix.os, 'macos') && startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ contains(matrix.os, 'macos') }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
         MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -145,7 +145,7 @@ jobs:
         strip release/*
 
     - name: Sign and notarize Binaries (Mac OS)
-      if: ${{ contains(matrix.os, 'macos') && github.ref_type == 'tag' }}
+      if: ${{ contains(matrix.os, 'macos') && startsWith(github.ref, 'refs/tags/v') }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
         MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -145,7 +145,7 @@ jobs:
         strip release/*
 
     - name: Sign and notarize Binaries (Mac OS)
-      if: ${{ contains(matrix.os, 'macos') }}
+      if: ${{ contains(matrix.os, 'macos') && github.ref_type == 'tag' }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
         MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -144,7 +144,7 @@ jobs:
       run: |
         strip release/*
 
-    - name: Sign Binaries (Mac OS)
+    - name: Sign and notarize Binaries (Mac OS)
       if: ${{ contains(matrix.os, 'macos') }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
@@ -173,7 +173,7 @@ jobs:
 
         # Perform notarization
         zip notarization-archive.zip release
-        xcrun notarytool submit notarization-archive.zip --apple-id "$NOTARIZATION_DEV_ID" --password "$NOTARIZATION_APP_PASS" --team-id "$APPLE_TEAM_ID" --wait
+        xcrun notarytool submit notarization-archive.zip --apple-id "$APPLE_NOTARIZATION_DEV_ID" --password "$APPLE_NOTARIZATION_DEV_PASS" --team-id "$APPLE_TEAM_ID" --wait
         rm notarization-archive.zip
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -145,7 +145,7 @@ jobs:
         strip release/*
 
     - name: Sign and Notarize Binaries (Mac OS)
-      if: ${{ contains(matrix.os, 'macos') }}
+      if: ${{ contains(matrix.os, 'macos') && startsWith(github.ref, 'refs/tags/v') }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
         MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -172,9 +172,9 @@ jobs:
 
         # '--options runtime' enables the hardened runtime: https://developer.apple.com/documentation/security/hardened_runtime
         # The hardened runtime is required for notarization.
-        codesign --options runtime -s 'Fossa, Inc.' release/fossa
-        codesign --options runtime -s 'Fossa, Inc.' release/pathfinder
-        codesign --options runtime -s 'Fossa, Inc.' release/diagnose
+        codesign --options runtime -s 'FOSSA, Inc.' release/fossa
+        codesign --options runtime -s 'FOSSA, Inc.' release/pathfinder
+        codesign --options runtime -s 'FOSSA, Inc.' release/diagnose
 
         # Perform notarization
         zip -rj notarization-archive.zip release

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.8.9
+- CLI Binaries: Notarize Mac OS binaries. ([#1261](https://github.com/fossas/fossa-cli/pull/1261))
+
 ## v3.8.8
 - CLI Binaries: Sign Mac OS builds using codesign. ([#1251](https://github.com/fossas/fossa-cli/pull/1251))
 - CLI Binaries: Sign Linux builds using cosign. ([#1243](https://github.com/fossas/fossa-cli/pull/1243))


### PR DESCRIPTION
# Overview

To make it so that customers can run `fossa` on Macs without getting a warning this PR notarizes the binaries. [Notarization](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution) involves uploading the executable(s) to Apple and them scanning them. This creates a record in their database that Mac's can fetch on their first run to verify that they've been scanned.

## Acceptance criteria

Users should not get a message like the following when first running `fossa` or any of the other binaries:

![Screenshot 2023-08-14 at 11 05 53 AM](https://github.com/fossas/fossa-cli/assets/190980/2bee522b-1fe2-4fc5-8ee5-200f8a89d5bc)

## Testing plan

I downloaded versions of the binaries from our build action and tried to run them. I used this build for testing: https://github.com/fossas/fossa-cli/actions/runs/5837966561

When I run `fossa` from that archive I get the following message now:
![Screenshot 2023-08-14 at 11 04 07 AM](https://github.com/fossas/fossa-cli/assets/190980/dd3920c4-ab8f-498f-8773-a2a870fd6479)

The current release version will output a message about the binary not having been scanned for malware the first time it is run.

## Risks

## Metrics

## References

[ANE-862](https://fossa.atlassian.net/browse/ANE-862)
[Slack](https://teamfossa.slack.com/archives/C0155DTGWB1/p1691616686713359?thread_ts=1684275181.104099&cid=C0155DTGWB1)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-862]: https://fossa.atlassian.net/browse/ANE-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ