### PR TITLE
Fix broken yarnpkg link

### DIFF
--- a/docs/references/strategies/languages/nodejs/yarn.md
+++ b/docs/references/strategies/languages/nodejs/yarn.md
@@ -44,6 +44,6 @@ the full graph of dependencies.
 
 ### What Yarn Protocols are supported
 
-There are many default [Yarn protocols](https://yarnpkg.com/features/protocols) that Yarn allows users to fetch dependencies. The FOSSA CLI currently supports the `npm` and `git` protocols.
+There are many default [Yarn protocols](https://yarnpkg.com/protocols) that Yarn allows users to fetch dependencies. The FOSSA CLI currently supports the `npm` and `git` protocols.
 
 <!-- We also support a tar protocol resolver, but this must be related to npm or a custom protocol because I can't find an example. -->


### PR DESCRIPTION
# Overview

Link check failed after I merged a PR to master. It looks like a link to yarn docs was broken. I found a link that I think shows equivalent information to what is implied to have been there.

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
