### PR TITLE
increase the timeout in the link check linter

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,5 +1,6 @@
 {
   "retryOn429": true,
+  "timeout": "1m",
   "ignorePatterns": [
     {
       "pattern": "https://support.fossa.com"


### PR DESCRIPTION
# Overview

Our link check linter was pretty consistently failing when trying to load a link from web.archive.org

https://web.archive.org/web/20220926013308/https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_using-the-container-tools-api_building-running-and-managing-containers

I did some manual testing, and it was taking around 30 seconds to load in my browser. So I increased the timeout to 1 minute.

## Acceptance criteria

The link check linter succeeds more consistently

## Testing plan

The link check linter should pass. Run it a few times and make sure it passes.

## Risks

The linter will take longer, but that's probably fine.

## Metrics



## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
