### PR TITLE
Ane 967 additional report fmts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## v3.8.10
 
+- Reports: Can now export reports formatted as CycloneDX (json/xml), CSV, HTML, and JSON SPDX. ([#1266](https://github.com/fossas/fossa-cli/pull/1266))
 - Containers: RPM packages installed in containers that use the NDB format for their RPM database are now parsed much faster. ([#1262](https://github.com/fossas/fossa-cli/pull/1262))
 
 ## v3.8.9

--- a/cabal.project
+++ b/cabal.project
@@ -59,7 +59,7 @@ source-repository-package
   location: https://github.com/fossas/tar
   tag: 6bd13acc541ae60b5c831823243040e18bd1d957
 
-index-state: hackage.haskell.org 2023-01-11T00:56:49Z
+index-state: hackage.haskell.org 2023-08-28T22:23:10Z
 
 package *
   extra-include-dirs: /opt/homebrew/include

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -66,4 +66,4 @@ source-repository-package
   location: https://github.com/fossas/tar
   tag: 6bd13acc541ae60b5c831823243040e18bd1d957
 
-index-state: hackage.haskell.org 2023-01-11T00:56:49Z
+index-state: hackage.haskell.org 2023-08-28T22:23:10Z

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -64,4 +64,4 @@ source-repository-package
   location: https://github.com/fossas/tar
   tag: 6bd13acc541ae60b5c831823243040e18bd1d957
 
-index-state: hackage.haskell.org 2023-01-11T00:56:49Z
+index-state: hackage.haskell.org 2023-08-28T22:23:10Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -66,4 +66,4 @@ source-repository-package
   location: https://github.com/fossas/tar
   tag: 6bd13acc541ae60b5c831823243040e18bd1d957
 
-index-state: hackage.haskell.org 2023-01-11T00:56:49Z
+index-state: hackage.haskell.org 2023-08-28T22:23:10Z

--- a/docs/references/subcommands/report.md
+++ b/docs/references/subcommands/report.md
@@ -28,9 +28,14 @@ Where `60` is the maximum number of seconds to wait for the report to be downloa
 
 `fossa report` supports customizing the format used to render a report via the `--format` flag.
 Available options are:
+- `csv`
+- `cyclonedx-json`
+- `cyclonedx-xml`
+- `html`
 - `json`
 - `markdown`
 - `spdx`
+- `spdx-json`
 - `text`
 
 For example, to render the report in JSON format, use `fossa report attribution --format json`.

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -59,7 +59,7 @@ common lang
 -- TODO: Switch `semver` back to `versions` since https://github.com/fosskers/versions/issues/47 is fixed. This package maintainer seems much more responsive. Contrast https://github.com/brendanhay/semver/issues/12.
 common deps
   build-depends:
-    , aeson                        ^>=2.1.0.0
+    , aeson                        ^>=2.1.2.0
     , aeson-pretty                 ^>=0.8.9
     , algebraic-graphs             ^>=0.7
     , ansi-terminal                ^>=0.11
@@ -101,7 +101,7 @@ common deps
     , mtl                          ^>=2.2.2
     , network                      ^>=3.1.2.0
     , network-uri                  ^>=2.6.4.0
-    , optparse-applicative         ^>=0.17.0.0
+    , optparse-applicative         ^>=0.18.0.0
     , os-release                   ^>=1.0.2
     , parser-combinators           ^>=1.3
     , path                         ^>=0.9.0

--- a/src/App/Fossa/Config/Report.hs
+++ b/src/App/Fossa/Config/Report.hs
@@ -46,10 +46,11 @@ import Options.Applicative (
   metavar,
   option,
   optional,
+  progDescDoc,
   strOption,
-  switch, progDescDoc,
+  switch,
  )
-import Prettyprinter (punctuate, comma, pretty, Doc, hardline, viaShow, softline)
+import Prettyprinter (Doc, comma, hardline, pretty, punctuate, softline, viaShow)
 import Prettyprinter.Render.Terminal (AnsiStyle)
 
 data ReportType = Attribution deriving (Eq, Ord, Enum, Bounded, Generic)
@@ -62,9 +63,9 @@ instance Show ReportType where
 
 data ReportOutputFormat
   = ReportCSV
-  -- Core will return the cyclonedx report with license data encoded in base64.
-  -- This is specified in the bom schema: https://github.com/CycloneDX/specification/blob/1.4/schema/bom-1.4.schema.json#L529
-  | ReportCycloneDXJSON
+  | -- Core will return the cyclonedx report with license data encoded in base64.
+    -- This is specified in the bom schema: https://github.com/CycloneDX/specification/blob/1.4/schema/bom-1.4.schema.json#L529
+    ReportCycloneDXJSON
   | ReportCycloneDXXML
   | ReportHTML
   | ReportJson
@@ -118,11 +119,14 @@ reportInfo = progDescDoc (Just desc)
     desc :: Doc AnsiStyle
     desc =
       "Access various reports from FOSSA and print to stdout."
-      <> softline <> "Currently available reports: (" <> mconcat (punctuate comma (map viaShow allReports)) <> ")"
-      <> hardline
-      <> "Examples: "
-      <> hardline
-      <> "fossa report --format html attribution"
+        <> softline
+        <> "Currently available reports: ("
+        <> mconcat (punctuate comma (map viaShow allReports))
+        <> ")"
+        <> hardline
+        <> "Examples: "
+        <> hardline
+        <> "fossa report --format html attribution"
 
 mkSubCommand :: (ReportConfig -> EffStack ()) -> SubCommand ReportCliOptions ReportConfig
 mkSubCommand = SubCommand "report" reportInfo parser loadConfig mergeOpts

--- a/src/App/Fossa/Config/Report.hs
+++ b/src/App/Fossa/Config/Report.hs
@@ -6,6 +6,8 @@ module App.Fossa.Config.Report (
   ReportOutputFormat (..),
   ReportType (..),
   mkSubCommand,
+  -- Exported for testing
+  parseReportOutputFormat,
 ) where
 
 import App.Fossa.Config.Common (
@@ -58,10 +60,17 @@ instance Show ReportType where
   show Attribution = "attribution"
 
 data ReportOutputFormat
-  = ReportJson
+  = ReportCSV
+  -- Core will return the cyclonedx report with license data encoded in base64.
+  -- This is specified in the bom schema: https://github.com/CycloneDX/specification/blob/1.4/schema/bom-1.4.schema.json#L529
+  | ReportCycloneDXJSON
+  | ReportCycloneDXXML
+  | ReportHTML
+  | ReportJson
   | ReportMarkdown
-  | ReportSpdx
   | ReportPlainText
+  | ReportSpdx
+  | ReportSpdxJSON
   deriving (Eq, Ord, Enum, Bounded, Generic)
 
 parseReportOutputFormat :: String -> Maybe ReportOutputFormat
@@ -69,6 +78,11 @@ parseReportOutputFormat s | s == show ReportJson = Just ReportJson
 parseReportOutputFormat s | s == show ReportSpdx = Just ReportSpdx
 parseReportOutputFormat s | s == show ReportMarkdown = Just ReportMarkdown
 parseReportOutputFormat s | s == show ReportPlainText = Just ReportPlainText
+parseReportOutputFormat s | s == show ReportSpdxJSON = Just ReportSpdxJSON
+parseReportOutputFormat s | s == show ReportCycloneDXJSON = Just ReportCycloneDXJSON
+parseReportOutputFormat s | s == show ReportCycloneDXXML = Just ReportCycloneDXXML
+parseReportOutputFormat s | s == show ReportHTML = Just ReportHTML
+parseReportOutputFormat s | s == show ReportCSV = Just ReportCSV
 parseReportOutputFormat _ = Nothing
 
 instance ToText ReportOutputFormat where
@@ -79,6 +93,11 @@ instance Show ReportOutputFormat where
   show ReportMarkdown = "markdown"
   show ReportSpdx = "spdx"
   show ReportPlainText = "text"
+  show ReportSpdxJSON = "spdx-json"
+  show ReportCycloneDXJSON = "cyclonedx-json"
+  show ReportCycloneDXXML = "cyclonedx-xml"
+  show ReportHTML = "html"
+  show ReportCSV = "csv"
 
 reportOutputFormatList :: String
 reportOutputFormatList = intercalate ", " $ map show allFormats

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -1097,10 +1097,17 @@ attributionEndpoint :: Url 'Https -> OrgId -> Locator -> ReportOutputFormat -> U
 attributionEndpoint baseurl orgId locator format = appendSegment format $ baseurl /: "api" /: "revisions" /: renderLocatorUrl orgId locator /: "attribution"
   where
     appendSegment :: ReportOutputFormat -> Url a -> Url a
-    appendSegment ReportJson input = input /: "json"
-    appendSegment ReportMarkdown input = input /: "full" /: "MD"
-    appendSegment ReportSpdx input = input /: "full" /: "spdx"
-    appendSegment ReportPlainText input = input /: "full" /: "TXT"
+    appendSegment fmt input =
+      case fmt of
+        ReportJson -> input /: "json"
+        ReportMarkdown -> input /: "full" /: "MD"
+        ReportSpdx -> input /: "full" /: "spdx"
+        ReportSpdxJSON -> input /: "full" /: "SPDX_JSON"
+        ReportCycloneDXJSON -> input /: "full" /: "CYCLONEDX_JSON"
+        ReportCycloneDXXML -> input /: "full" /: "CYCLONEDX_XML"
+        ReportPlainText -> input /: "full" /: "TXT"
+        ReportHTML -> input /: "full" /: "HTML"
+        ReportCSV -> input /: "full" /: "CSV"
 
 getAttributionJson ::
   (Has (Lift IO) sig m, Has Debug sig m, Has Diagnostics sig m) =>

--- a/src/Strategy/Go/GoListPackages.hs
+++ b/src/Strategy/Go/GoListPackages.hs
@@ -22,7 +22,7 @@ import Control.Effect.State (gets)
 import Control.Monad (unless, void, when, (>=>))
 import Data.Aeson (FromJSON (parseJSON), Value, withObject, (.!=), (.:), (.:?))
 import Data.Aeson.Encode.Pretty (encodePretty)
-import Data.Aeson.Internal (formatError)
+import Data.Aeson.Types (formatError)
 import Data.Foldable (traverse_)
 import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet qualified as HashSet

--- a/src/Strategy/Go/Transitive.hs
+++ b/src/Strategy/Go/Transitive.hs
@@ -29,7 +29,7 @@ import Data.Aeson (
   (.:),
   (.:?),
  )
-import Data.Aeson.Internal (formatError, iparse)
+import Data.Aeson.Types (formatError, iparse)
 import Data.Aeson.Parser (eitherDecodeWith)
 import Data.Attoparsec.ByteString qualified as A
 import Data.ByteString.Lazy qualified as BL

--- a/src/Strategy/Go/Transitive.hs
+++ b/src/Strategy/Go/Transitive.hs
@@ -29,8 +29,8 @@ import Data.Aeson (
   (.:),
   (.:?),
  )
-import Data.Aeson.Types (formatError, iparse)
 import Data.Aeson.Parser (eitherDecodeWith)
+import Data.Aeson.Types (formatError, iparse)
 import Data.Attoparsec.ByteString qualified as A
 import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (traverse_)

--- a/test/App/Fossa/ReportSpec.hs
+++ b/test/App/Fossa/ReportSpec.hs
@@ -1,6 +1,6 @@
 module App.Fossa.ReportSpec (spec) where
 
-import App.Fossa.Config.Report (ReportConfig (..), ReportOutputFormat (ReportJson), ReportType (..))
+import App.Fossa.Config.Report (ReportConfig (..), ReportOutputFormat (ReportJson), ReportType (..), parseReportOutputFormat)
 import App.Fossa.Report (fetchReport)
 import Control.Algebra (Has)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
@@ -8,8 +8,9 @@ import Control.Timeout (Duration (MilliSeconds))
 import Fossa.API.Types (RevisionDependencyCache (RevisionDependencyCache), RevisionDependencyCacheStatus (Ready))
 import Test.Effect (expectFatal', it')
 import Test.Fixtures qualified as Fixtures
-import Test.Hspec (Spec, describe, runIO)
+import Test.Hspec (Spec, describe, runIO, shouldBe, it)
 import Test.MockApi (MockApi, alwaysReturns, fails, returnsOnce)
+import Data.Foldable (for_)
 
 reportConfig :: IO ReportConfig
 reportConfig = do
@@ -60,6 +61,15 @@ spec =
       expectFetchRevisionDependencyCacheSuccess
       expectFetchReportError
       expectFatal' $ fetchReport config
+
+    parseReportOutputSpec
+
+parseReportOutputSpec :: Spec
+parseReportOutputSpec =
+  describe "Every value of ReportOutputJson can be parsed from a string matching its Show instance" $
+  for_ (enumFromTo minBound maxBound) $
+  \reportFmt -> let fmt = show reportFmt in
+                  it ("Parses \"" <> fmt <> "\"") $ (parseReportOutputFormat fmt) `shouldBe` Just reportFmt
 
 expectBuildSuccess :: (Has MockApi sig m) => m ()
 expectBuildSuccess = do

--- a/test/App/Fossa/ReportSpec.hs
+++ b/test/App/Fossa/ReportSpec.hs
@@ -5,12 +5,12 @@ import App.Fossa.Report (fetchReport)
 import Control.Algebra (Has)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
 import Control.Timeout (Duration (MilliSeconds))
+import Data.Foldable (for_)
 import Fossa.API.Types (RevisionDependencyCache (RevisionDependencyCache), RevisionDependencyCacheStatus (Ready))
 import Test.Effect (expectFatal', it')
 import Test.Fixtures qualified as Fixtures
-import Test.Hspec (Spec, describe, runIO, shouldBe, it)
+import Test.Hspec (Spec, describe, it, runIO, shouldBe)
 import Test.MockApi (MockApi, alwaysReturns, fails, returnsOnce)
-import Data.Foldable (for_)
 
 reportConfig :: IO ReportConfig
 reportConfig = do
@@ -67,9 +67,10 @@ spec =
 parseReportOutputSpec :: Spec
 parseReportOutputSpec =
   describe "Every value of ReportOutputJson can be parsed from a string matching its Show instance" $
-  for_ (enumFromTo minBound maxBound) $
-  \reportFmt -> let fmt = show reportFmt in
-                  it ("Parses \"" <> fmt <> "\"") $ (parseReportOutputFormat fmt) `shouldBe` Just reportFmt
+    for_ (enumFromTo minBound maxBound) $
+      \reportFmt ->
+        let fmt = show reportFmt
+         in it ("Parses \"" <> fmt <> "\"") $ (parseReportOutputFormat fmt) `shouldBe` Just reportFmt
 
 expectBuildSuccess :: (Has MockApi sig m) => m ()
 expectBuildSuccess = do


### PR DESCRIPTION
# Overview

This adds support in the CLI for some of the formats already supported by Core.

As part of this I tried to add a bit more documentation for the report command and in the process advanced the index-state in order to be able to use a feature in one of the newer versions of `optparse-applicative`.

## Acceptance criteria

* The CLI can fetch attribution reports in every format currently supported by FOSSA. Except PDF.

PDFs aren't included in this because you can't download them directly from FOSSA.

## Testing plan

I added one test which is meant to break if we ever add a format to the format data structure and don't support it fully in our output format parser. 

I then did manual tests by fetching each report format for a project.

## Risks


## Metrics


## References

- [ANE-957](https://fossa.atlassian.net/browse/ANE-957)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).


[ANE-957]: https://fossa.atlassian.net/browse/ANE-957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ