### PR TITLE
Ane 1164 show lernie results in scan results

### DIFF
--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -286,8 +286,8 @@ analyze cfg = Diag.context "fossa-analyze" $ do
     Diag.errorBoundaryIO
       . diagToDebug
       . runReader filters
-      $ Diag.context "discover-dynamic-linking" . doAnalyzeDynamicLinkedBinary basedir . Config.dynamicLinkingTarget $
-        Config.vsiOptions cfg
+      $ Diag.context "discover-dynamic-linking" . doAnalyzeDynamicLinkedBinary basedir . Config.dynamicLinkingTarget 
+      $ Config.vsiOptions cfg
   binarySearchResults <-
     Diag.errorBoundaryIO . diagToDebug $
       Diag.context "discover-binaries" $
@@ -409,6 +409,7 @@ fatalWithKeywordSearchExplanation lernieMatchesFound analyzeError = do
           ]
     else pure ()
   Diag.fatal analyzeError
+
 toProjectResult :: DiscoveredProjectScan -> Maybe ProjectResult
 toProjectResult (SkippedDueToProvidedFilter _) = Nothing
 toProjectResult (SkippedDueToDefaultProductionFilter _) = Nothing

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -94,7 +94,7 @@ import Data.ByteString.Lazy qualified as BL
 import Data.Flag (Flag, fromFlag)
 import Data.Foldable (traverse_)
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text.Extra (showT)
 import Diag.Result (resultToMaybe)

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -373,9 +373,10 @@ analyze cfg = Diag.context "fossa-analyze" $ do
           (Nothing, Just lernie) -> Just lernie
           (Just firstParty, Nothing) -> Just firstParty
   let result = buildResult includeAll additionalSourceUnits filteredProjects licenseSourceUnits
-  case checkForEmptyUpload includeAll projectResults filteredProjects additionalSourceUnits licenseSourceUnits of
+  case checkForEmptyUpload includeAll projectResults filteredProjects additionalSourceUnits licenseSourceUnits (lernieResultsKeywordSearches <$> lernieResults) of
     NoneDiscovered -> Diag.fatal ErrNoProjectsDiscovered
     FilteredAll -> Diag.fatal ErrFilteredAllProjects
+    KeywordSearchOnly -> pure ()
     CountedScanUnits scanUnits -> doUpload result iatAssertion destination basedir jsonOutput revision scanUnits
   pure result
   where

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.Analyze (

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -319,6 +319,8 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   traverse_ (Diag.flushLogs SevError SevDebug) [manualSrcUnits, binarySearchResults, dynamicLinkedResults]
   -- Flush logs using the original Result from VSI.
   traverse_ (Diag.flushLogs SevError SevDebug) [vsiResults]
+  -- Flush logs from lernie
+  traverse_ (Diag.flushLogs SevError SevDebug) [maybeLernieResults]
 
   maybeFirstPartyScanResults <-
     Diag.errorBoundaryIO . diagToDebug $

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -391,6 +391,9 @@ analyze cfg = Diag.context "fossa-analyze" $ do
               locator <- uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnits
               doAssertRevisionBinaries iatAssertion locator
 
+-- | If we find nothing but keyword search, we exit with a "No projects discovered" or "All projects filtered" error.
+-- | We do not want to succeed, because nothing gets uploaded to the API for keyword searches, so `fossa test` will fail.
+-- | So the solution is to still fail, but give a hopefully useful explanation that the error can be ignored if all you were expecting is keyword search results.
 fatalWithKeywordSearchExplanation ::
   ( Has Diag.Diagnostics sig m
   , Has Logger sig m

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -284,8 +284,8 @@ analyze cfg = Diag.context "fossa-analyze" $ do
     Diag.errorBoundaryIO
       . diagToDebug
       . runReader filters
-      $ Diag.context "discover-dynamic-linking" . doAnalyzeDynamicLinkedBinary basedir . Config.dynamicLinkingTarget $
-        Config.vsiOptions cfg
+      $ Diag.context "discover-dynamic-linking" . doAnalyzeDynamicLinkedBinary basedir . Config.dynamicLinkingTarget
+      $ Config.vsiOptions cfg
   binarySearchResults <-
     Diag.errorBoundaryIO . diagToDebug $
       Diag.context "discover-binaries" $

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -373,10 +373,9 @@ analyze cfg = Diag.context "fossa-analyze" $ do
           (Nothing, Just lernie) -> Just lernie
           (Just firstParty, Nothing) -> Just firstParty
   let result = buildResult includeAll additionalSourceUnits filteredProjects licenseSourceUnits
-  case checkForEmptyUpload includeAll projectResults filteredProjects additionalSourceUnits licenseSourceUnits (lernieResultsKeywordSearches <$> lernieResults) of
+  case checkForEmptyUpload includeAll projectResults filteredProjects additionalSourceUnits licenseSourceUnits of
     NoneDiscovered -> Diag.fatal ErrNoProjectsDiscovered
     FilteredAll -> Diag.fatal ErrFilteredAllProjects
-    KeywordSearchOnly -> pure ()
     CountedScanUnits scanUnits -> doUpload result iatAssertion destination basedir jsonOutput revision scanUnits
   pure result
   where

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -375,7 +375,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
           (Just firstParty, Nothing) -> Just firstParty
   let result = buildResult includeAll additionalSourceUnits filteredProjects licenseSourceUnits
   case checkForEmptyUpload includeAll projectResults filteredProjects additionalSourceUnits licenseSourceUnits of
-    NoneDiscovered -> fatalWithKeywordSearchExplanation (isJust $ lernieResultsKeywordSearches <$> lernieResults) ErrNoProjectsDiscovered
+    NoneDiscovered -> fatalWithKeywordSearchExplanation (maybe False (not . null . lernieResultsKeywordSearches) lernieResults) ErrNoProjectsDiscovered
     FilteredAll -> fatalWithKeywordSearchExplanation (maybe False (not . null . lernieResultsKeywordSearches) lernieResults) ErrFilteredAllProjects
     CountedScanUnits scanUnits -> doUpload result iatAssertion destination basedir jsonOutput revision scanUnits
   pure result

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -285,7 +285,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
     Diag.errorBoundaryIO
       . diagToDebug
       . runReader filters
-      $ Diag.context "discover-dynamic-linking" . doAnalyzeDynamicLinkedBinary basedir . Config.dynamicLinkingTarget 
+      $ Diag.context "discover-dynamic-linking" . doAnalyzeDynamicLinkedBinary basedir . Config.dynamicLinkingTarget
       $ Config.vsiOptions cfg
   binarySearchResults <-
     Diag.errorBoundaryIO . diagToDebug $
@@ -376,7 +376,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   let result = buildResult includeAll additionalSourceUnits filteredProjects licenseSourceUnits
   case checkForEmptyUpload includeAll projectResults filteredProjects additionalSourceUnits licenseSourceUnits of
     NoneDiscovered -> fatalWithKeywordSearchExplanation (isJust $ lernieResultsKeywordSearches <$> lernieResults) ErrNoProjectsDiscovered
-    FilteredAll -> fatalWithKeywordSearchExplanation (isJust $ lernieResultsKeywordSearches <$> lernieResults) ErrFilteredAllProjects
+    FilteredAll -> fatalWithKeywordSearchExplanation (maybe False (not . null . lernieResultsKeywordSearches) lernieResults) ErrFilteredAllProjects
     CountedScanUnits scanUnits -> doUpload result iatAssertion destination basedir jsonOutput revision scanUnits
   pure result
   where
@@ -401,15 +401,13 @@ fatalWithKeywordSearchExplanation ::
   AnalyzeError ->
   m b
 fatalWithKeywordSearchExplanation lernieMatchesFound analyzeError = do
-  if lernieMatchesFound
-    then
-      logWarn $
-        vsep
-          [ "Matches to your keyword searches were found, but no other analysis targets were found."
-          , "This will result in exiting with an error."
-          , "This error can be safely ignored if you are only expecting keyword search results."
-          ]
-    else pure ()
+  when lernieMatchesFound $
+    logWarn $
+      vsep
+        [ "Matches to your keyword searches were found, but no other analysis targets were found."
+        , "This will result in exiting with an error."
+        , "This error can be safely ignored if you are only expecting keyword search results."
+        ]
   Diag.fatal analyzeError
 
 toProjectResult :: DiscoveredProjectScan -> Maybe ProjectResult

--- a/src/App/Fossa/Analyze/Filter.hs
+++ b/src/App/Fossa/Analyze/Filter.hs
@@ -6,8 +6,10 @@ module App.Fossa.Analyze.Filter (
 import App.Fossa.Analyze.Project (ProjectResult)
 import App.Fossa.Analyze.Upload (ScanUnits (..))
 import App.Fossa.Config.Analyze (IncludeAll (..))
+import App.Fossa.Lernie.Types (LernieMatch)
 import Data.Flag (Flag, fromFlag)
 import Data.List.NonEmpty (fromList)
+import Data.List.NonEmpty qualified as NE
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (LicenseSourceUnit (licenseSourceUnitLicenseUnits), LicenseUnit (licenseUnitName), SourceUnit)
 
@@ -15,34 +17,38 @@ data CountedResult
   = NoneDiscovered
   | FilteredAll
   | CountedScanUnits ScanUnits
+  | KeywordSearchOnly
 
 -- | Return some state of the projects found, since we can't upload empty result arrays.
 -- Takes a list of all projects analyzed, and the list after filtering.  We assume
 -- that the smaller list is the latter, and return that list.  Starting with user-defined deps,
 -- we also include a check for an additional source unit from fossa-deps.yml
 -- and a check for any licenses found during the firstPartyScan
-checkForEmptyUpload :: Flag IncludeAll -> [ProjectResult] -> [ProjectResult] -> [SourceUnit] -> Maybe LicenseSourceUnit -> CountedResult
-checkForEmptyUpload includeAll xs ys additionalUnits firstPartyScanResults = do
+checkForEmptyUpload :: Flag IncludeAll -> [ProjectResult] -> [ProjectResult] -> [SourceUnit] -> Maybe LicenseSourceUnit -> Maybe [LernieMatch] -> CountedResult
+checkForEmptyUpload includeAll xs ys additionalUnits firstPartyScanResults lernieMatches = do
   if null additionalUnits
-    then case (xlen, ylen, licensesMaybeFound) of
+    then case (xlen, ylen, licensesMaybeFound, lernieMatchesMaybeFound) of
       -- We didn't discover, so we also didn't filter
-      (0, 0, Nothing) ->
+      (0, 0, Nothing, Nothing) ->
         NoneDiscovered
-      (0, 0, Just licenseSourceUnit) ->
+      (0, 0, Just licenseSourceUnit, _) ->
         CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
+      -- only return KeywordSearchOnly if nothing else works
+      (0, 0, Nothing, Just _) -> KeywordSearchOnly
       -- If either list is empty, we have nothing to upload
-      (0, _, Nothing) -> FilteredAll
-      (_, 0, Nothing) -> FilteredAll
+      (0, _, Nothing, Nothing) -> FilteredAll
+      (_, 0, Nothing, Nothing) -> FilteredAll
       -- NE.fromList is a partial, but is safe since we confirm the length is > 0.
-      (0, _, Just licenseSourceUnit) -> CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
-      (_, 0, Just licenseSourceUnit) -> CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
-      (_, _, Just licenseSourceUnit) -> CountedScanUnits $ SourceAndLicenseUnits (fromList discoveredUnits) licenseSourceUnit
-      (_, _, Nothing) -> CountedScanUnits . SourceUnitOnly $ fromList discoveredUnits
+      (0, _, Just licenseSourceUnit, _) -> CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
+      (_, 0, Just licenseSourceUnit, _) -> CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
+      (_, _, Just licenseSourceUnit, _) -> CountedScanUnits $ SourceAndLicenseUnits (fromList discoveredUnits) licenseSourceUnit
+      (_, _, Nothing, _) -> CountedScanUnits . SourceUnitOnly $ fromList discoveredUnits
     else -- If we have a additional source units, then there's always something to upload.
     case licensesMaybeFound of
       Nothing -> CountedScanUnits . SourceUnitOnly $ fromList (additionalUnits ++ discoveredUnits)
       Just licenseSourceUnit -> CountedScanUnits $ SourceAndLicenseUnits (fromList (additionalUnits ++ discoveredUnits)) licenseSourceUnit
   where
+    lernieMatchesMaybeFound = NE.nonEmpty =<< lernieMatches
     xlen = length xs
     ylen = length ys
     licensesMaybeFound = case firstPartyScanResults of

--- a/src/App/Fossa/Analyze/Filter.hs
+++ b/src/App/Fossa/Analyze/Filter.hs
@@ -6,10 +6,8 @@ module App.Fossa.Analyze.Filter (
 import App.Fossa.Analyze.Project (ProjectResult)
 import App.Fossa.Analyze.Upload (ScanUnits (..))
 import App.Fossa.Config.Analyze (IncludeAll (..))
-import App.Fossa.Lernie.Types (LernieMatch)
 import Data.Flag (Flag, fromFlag)
 import Data.List.NonEmpty (fromList)
-import Data.List.NonEmpty qualified as NE
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (LicenseSourceUnit (licenseSourceUnitLicenseUnits), LicenseUnit (licenseUnitName), SourceUnit)
 
@@ -17,38 +15,34 @@ data CountedResult
   = NoneDiscovered
   | FilteredAll
   | CountedScanUnits ScanUnits
-  | KeywordSearchOnly
 
 -- | Return some state of the projects found, since we can't upload empty result arrays.
 -- Takes a list of all projects analyzed, and the list after filtering.  We assume
 -- that the smaller list is the latter, and return that list.  Starting with user-defined deps,
 -- we also include a check for an additional source unit from fossa-deps.yml
 -- and a check for any licenses found during the firstPartyScan
-checkForEmptyUpload :: Flag IncludeAll -> [ProjectResult] -> [ProjectResult] -> [SourceUnit] -> Maybe LicenseSourceUnit -> Maybe [LernieMatch] -> CountedResult
-checkForEmptyUpload includeAll xs ys additionalUnits firstPartyScanResults lernieMatches = do
+checkForEmptyUpload :: Flag IncludeAll -> [ProjectResult] -> [ProjectResult] -> [SourceUnit] -> Maybe LicenseSourceUnit -> CountedResult
+checkForEmptyUpload includeAll xs ys additionalUnits firstPartyScanResults = do
   if null additionalUnits
-    then case (xlen, ylen, licensesMaybeFound, lernieMatchesMaybeFound) of
+    then case (xlen, ylen, licensesMaybeFound) of
       -- We didn't discover, so we also didn't filter
-      (0, 0, Nothing, Nothing) ->
+      (0, 0, Nothing) ->
         NoneDiscovered
-      (0, 0, Just licenseSourceUnit, _) ->
+      (0, 0, Just licenseSourceUnit) ->
         CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
-      -- only return KeywordSearchOnly if nothing else works
-      (0, 0, Nothing, Just _) -> KeywordSearchOnly
       -- If either list is empty, we have nothing to upload
-      (0, _, Nothing, Nothing) -> FilteredAll
-      (_, 0, Nothing, Nothing) -> FilteredAll
+      (0, _, Nothing) -> FilteredAll
+      (_, 0, Nothing) -> FilteredAll
       -- NE.fromList is a partial, but is safe since we confirm the length is > 0.
-      (0, _, Just licenseSourceUnit, _) -> CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
-      (_, 0, Just licenseSourceUnit, _) -> CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
-      (_, _, Just licenseSourceUnit, _) -> CountedScanUnits $ SourceAndLicenseUnits (fromList discoveredUnits) licenseSourceUnit
-      (_, _, Nothing, _) -> CountedScanUnits . SourceUnitOnly $ fromList discoveredUnits
+      (0, _, Just licenseSourceUnit) -> CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
+      (_, 0, Just licenseSourceUnit) -> CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
+      (_, _, Just licenseSourceUnit) -> CountedScanUnits $ SourceAndLicenseUnits (fromList discoveredUnits) licenseSourceUnit
+      (_, _, Nothing) -> CountedScanUnits . SourceUnitOnly $ fromList discoveredUnits
     else -- If we have a additional source units, then there's always something to upload.
     case licensesMaybeFound of
       Nothing -> CountedScanUnits . SourceUnitOnly $ fromList (additionalUnits ++ discoveredUnits)
       Just licenseSourceUnit -> CountedScanUnits $ SourceAndLicenseUnits (fromList (additionalUnits ++ discoveredUnits)) licenseSourceUnit
   where
-    lernieMatchesMaybeFound = NE.nonEmpty =<< lernieMatches
     xlen = length xs
     ylen = length ys
     licensesMaybeFound = case firstPartyScanResults of

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -220,7 +220,8 @@ getBinaryIdentifier srcUnit = maybe [] (srcUserDepName <$>) (userDefinedDeps =<<
 -- Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 1-1)
 -- <name of regex from config> - <path to file> (lines <startLine>-<endLine>)
 getLernieIdentifier :: [LernieMatch] -> [Text]
-getLernieIdentifier = concatMap renderLernieMatch
+getLernieIdentifier [] = ["No results found"]
+getLernieIdentifier matches = concatMap renderLernieMatch matches
   where
     renderLernieMatch :: LernieMatch -> [Text]
     renderLernieMatch LernieMatch{..} = map (renderLernieMatchData lernieMatchPath) lernieMatchMatches

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -24,7 +24,7 @@ import Data.Functor.Extra ((<$$>))
 import Data.List (sort)
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe, maybeToList)
 import Data.Monoid.Extra (isMempty)
-import Data.String.Conversion (toText)
+import Data.String.Conversion (showText, toText)
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
 import Diag.Result (EmittedWarn (IgnoredErrGroup), Result (Failure, Success), renderFailure, renderSuccess)
@@ -227,7 +227,7 @@ getLernieIdentifier matches = concatMap renderLernieMatch matches
     renderLernieMatch LernieMatch{..} = map (renderLernieMatchData lernieMatchPath) lernieMatchMatches
 
     renderLernieMatchData :: Text -> LernieMatchData -> Text
-    renderLernieMatchData path LernieMatchData{..} = lernieMatchDataName <> " - " <> path <> " (lines " <> toText (show lernieMatchDataStartLine) <> "-" <> toText (show lernieMatchDataEndLine) <> ")"
+    renderLernieMatchData path LernieMatchData{..} = lernieMatchDataName <> " - " <> path <> " (lines " <> showText lernieMatchDataStartLine <> "-" <> showText lernieMatchDataEndLine <> ")"
 
 getManualVendorDepsIdentifier :: SourceUnit -> [Text]
 getManualVendorDepsIdentifier srcUnit = refDeps ++ foundRemoteDeps ++ customDeps ++ vendorDeps

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -353,7 +353,7 @@ countWarnings ws =
     isIgnoredErrGroup _ = False
 
 dumpResultLogsToTempFile :: (Has (Lift IO) sig m) => Text -> AnalysisScanResult -> m (Path Abs File)
-dumpResultLogsToTempFile endpointVersion (AnalysisScanResult projects vsi binary manualDeps dynamicLinkingDeps lernie) = do
+dumpResultLogsToTempFile endpointVersion (AnalysisScanResult projects vsi binary manualDeps dynamicLinkingDeps lernieResults) = do
   let doc =
         renderStrict
           . layoutPretty defaultLayoutOptions
@@ -366,7 +366,7 @@ dumpResultLogsToTempFile endpointVersion (AnalysisScanResult projects vsi binary
               , renderSourceUnit "binary-deps analysis" binary
               , renderSourceUnit "dynamic linked dependency analysis" dynamicLinkingDeps
               , renderSourceUnit "fossa-deps analysis" manualDeps
-              , renderSourceUnit "Custom-license scan & Keyword Search" lernie
+              , renderSourceUnit "Custom-license scan & Keyword Search" lernieResults
               ]
 
   tmpDir <- sendIO getTempDir
@@ -374,7 +374,7 @@ dumpResultLogsToTempFile endpointVersion (AnalysisScanResult projects vsi binary
   pure (tmpDir </> scanSummaryFileName)
   where
     scanSummary :: [Doc AnsiStyle]
-    scanSummary = maybeToList (vsep <$> summarize endpointVersion (AnalysisScanResult projects vsi binary manualDeps dynamicLinkingDeps lernie))
+    scanSummary = maybeToList (vsep <$> summarize endpointVersion (AnalysisScanResult projects vsi binary manualDeps dynamicLinkingDeps lernieResults))
 
     renderSourceUnit :: Doc AnsiStyle -> Result (Maybe a) -> Maybe (Doc AnsiStyle)
     renderSourceUnit header (Failure ws eg) = Just $ renderFailure ws eg $ vsep $ summarizeSrcUnit header Nothing (Failure ws eg)

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -188,7 +188,7 @@ summarize endpointVersion (AnalysisScanResult dps vsi binary manualDeps dynamicL
         , srcUnitToScanCount binary
         , srcUnitToScanCount manualDeps
         , srcUnitToScanCount dynamicLinkingDeps
-        -- , lernieResultToScanCount lernie
+        , srcUnitToScanCount lernie
         ]
 
     -- This function relies on the fact that there is only ever one package in a vsi source unit dep graph.
@@ -255,8 +255,8 @@ getManualVendorDepsIdentifier srcUnit = refDeps ++ foundRemoteDeps ++ customDeps
       withPostfix "remote" $
         maybe [] (srcRemoteDepName <$>) (remoteDeps =<< additionalData srcUnit)
 
-withPostfix :: Text -> [Text] -> [Text]
-withPostfix bracketText = map (<> " (" <> bracketText <> ")")
+    withPostfix :: Text -> [Text] -> [Text]
+    withPostfix bracketText = map (<> " (" <> bracketText <> ")")
 
 vsiSrcUnitsToScanCount :: Result (Maybe [SourceUnit]) -> ScanCount
 vsiSrcUnitsToScanCount (Failure _ _) = ScanCount 0 0 0 0 0
@@ -265,7 +265,7 @@ vsiSrcUnitsToScanCount (Success wg (Just units)) =
    in ScanCount unitLen 0 unitLen 0 (length wg)
 vsiSrcUnitsToScanCount (Success _ Nothing) = ScanCount 0 0 0 0 0
 
-srcUnitToScanCount :: Result (Maybe SourceUnit) -> ScanCount
+srcUnitToScanCount :: Result (Maybe a) -> ScanCount
 srcUnitToScanCount (Failure _ _) = ScanCount 1 0 0 1 0
 srcUnitToScanCount (Success _ Nothing) = ScanCount 0 0 0 0 0
 srcUnitToScanCount (Success wg (Just _)) = ScanCount 1 0 1 0 (countWarnings wg)

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -361,6 +361,7 @@ dumpResultLogsToTempFile endpointVersion (AnalysisScanResult projects vsi binary
               , renderSourceUnit "binary-deps analysis" binary
               , renderSourceUnit "dynamic linked dependency analysis" dynamicLinkingDeps
               , renderSourceUnit "fossa-deps analysis" manualDeps
+              , renderSourceUnit "Custom-license scan & Keyword Search" lernie
               ]
 
   tmpDir <- sendIO getTempDir

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -215,6 +215,10 @@ itemize symbol f = map ((symbol <>) . f)
 getBinaryIdentifier :: SourceUnit -> [Text]
 getBinaryIdentifier srcUnit = maybe [] (srcUserDepName <$>) (userDefinedDeps =<< additionalData srcUnit)
 
+-- A LernieMatch has many LernieMatchData. getLernieIdentifier creates one line of output per LernieMatchData.
+-- Example output:
+-- Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 1-1)
+-- <name of regex from config> - <path to file> (lines <startLine>-<endLine>)
 getLernieIdentifier :: [LernieMatch] -> [Text]
 getLernieIdentifier = concatMap renderLernieMatch
   where

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -11,7 +11,7 @@ module App.Fossa.Analyze.Types (
 
 import App.Fossa.Analyze.Project (ProjectResult)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig)
-import App.Fossa.Lernie.Types (LernieResults (..))
+import App.Fossa.Lernie.Types (LernieResults)
 import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics, Has)
 import Control.Effect.Lift (Lift)

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -11,6 +11,7 @@ module App.Fossa.Analyze.Types (
 
 import App.Fossa.Analyze.Project (ProjectResult)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig)
+import App.Fossa.Lernie.Types (LernieResults (..))
 import Control.Effect.Debug (Debug)
 import Control.Effect.Diagnostics (Diagnostics, Has)
 import Control.Effect.Lift (Lift)
@@ -74,6 +75,7 @@ data AnalysisScanResult = AnalysisScanResult
   , binaryDepsScanResult :: Result (Maybe SourceUnit)
   , fossaDepsScanResult :: Result (Maybe SourceUnit)
   , dynamicLinkingResult :: Result (Maybe SourceUnit)
+  , lernieResult :: Result (Maybe LernieResults)
   }
 
 data DiscoveredProjectScan

--- a/src/App/Fossa/Lernie/Analyze.hs
+++ b/src/App/Fossa/Lernie/Analyze.hs
@@ -2,6 +2,7 @@
 
 module App.Fossa.Lernie.Analyze (
   analyzeWithLernie,
+  -- Exported for testing
   singletonLernieMessage,
   lernieMessagesToLernieResults,
   grepOptionsToLernieConfig,

--- a/src/App/Fossa/Lernie/Types.hs
+++ b/src/App/Fossa/Lernie/Types.hs
@@ -144,9 +144,7 @@ instance FromJSON LernieMatchData where
 instance ToJSON LernieMatchData
 
 data LernieResults = LernieResults
-  { lernieResultsWarnings :: [LernieWarning]
-  , lernieResultsErrors :: [LernieError]
-  , lernieResultsSourceUnit :: Maybe LicenseSourceUnit
+  { lernieResultsSourceUnit :: Maybe LicenseSourceUnit
   , lernieResultsKeywordSearches :: [LernieMatch]
   , lernieResultsCustomLicenses :: [LernieMatch]
   }

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -128,9 +128,7 @@ doubleMessages = singletonLernieMessage (LernieMessageLernieMatch secondCustomLi
 expectedLernieResults :: LernieResults
 expectedLernieResults =
   LernieResults
-    { lernieResultsWarnings = [warningMessage]
-    , lernieResultsErrors = [errorMessage]
-    , lernieResultsKeywordSearches = [keywordSearchMatchMessage]
+    { lernieResultsKeywordSearches = [keywordSearchMatchMessage]
     , lernieResultsCustomLicenses = [customLicenseMatchMessage]
     , lernieResultsSourceUnit = Just expectedSourceUnit
     }
@@ -328,8 +326,6 @@ spec = do
         case maybeRes of
           Nothing -> expectationFailure "analyzeWithLernie should not return Nothing"
           Just res -> do
-            (lernieResultsWarnings res) `shouldBe` []
-            (lernieResultsErrors res) `shouldBe` []
             (lernieResultsKeywordSearches res) `shouldBe` [keywordSearchMatchMessage{lernieMatchPath = fixedSomethingPath}]
             (lernieResultsCustomLicenses res)
               `shouldBe` [ customLicenseMatchMessage


### PR DESCRIPTION
# Overview

[Delivers ANE-1164](https://fossa.atlassian.net/browse/ANE-1164)

Output results of keyword searches and custom license searches to stderr and the scan-summary file.

Note to reviewer: As far as I can see, there are no tests for ScanResult. I left it untested, but the test plan is pretty thorough.

## Acceptance criteria

- the results of custom-license searches are output to stderr and the scan-summary file
- The results of keyword searchs are output to stderr and the scan-summary file
- If Lernie outputs an error or warning, the error or warning should be displayed in stderr and in the scan-summary file
- If no targets are found but keyword search results are found, we should still exit with the standard "no targets found" error, but there should be an explanation that this might be okay if all you were expecting was keyword search results

## Testing plan

Scan a project with both keyword and custom-license results. Here's an example: 

[grepper.zip](https://github.com/fossas/fossa-cli/files/12528124/grepper.zip)

This project has a broken symlink in it, so we expect to see a warning emitted near the top when Lernie reports its results, and also it should say that it succeeded with 1 warning: 

```
cabal run fossa -- analyze -e http://localhost:9578 /Users/scott/fossa/license-scan-dirs/grepper --output --debug > /dev/null 
[DEBUG] Loading configuration file from "/Users/scott/fossa/license-scan-dirs/grepper/"
[DEBUG] ----------
  A task succeeded with warnings

  Warning

    walk file system: IO error for operation on /Users/scott/fossa/license-scan-dirs/grepper/s/bar: No such file or directory (os error 2): WalkFile

... lots of standard output...

* Keyword Search: succeeded with 1 warning
  ** Proprietary and Confidential match - /Users/scott/fossa/license-scan-dirs/grepper/.fossa.yml (lines 11-11)
* Custom LicenseSearch: succeeded with 1 warning
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/.fossa.yml (lines 5-5)
  ** Confidential - /Users/scott/fossa/license-scan-dirs/grepper/.fossa.yml (lines 7-7)
  ** Confidential - /Users/scott/fossa/license-scan-dirs/grepper/.fossa.yml (lines 11-11)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/three.txt (lines 1-1)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 1-1)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 3-3)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 5-5)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 7-7)

  Some projects may not appear in the summary if they were filtered during discovery.
  You can run `fossa list-targets` to see all discoverable projects.

You can also view analysis summary with warning and error messages at: "/private/var/folders/45/k76d2pgj6mlb1vpx_2gyl7z80000gn/T/fossa-analyze-scan-summary.txt"
```

The scan summary should contain the same results and the warning:

```
Scan Summary
------------
fossa-cli branch ANE-1164-show-lernie-results-in-scan-results (revision 4e237182e21d compiled with ghc-9.0)
fossa endpoint server version: N/A

2 projects scanned;  0 skipped,  2 succeeded,  0 failed,  1 analysis warning

* npm project in "/Users/scott/fossa/license-scan-dirs/grepper/": succeeded
-
* Keyword Search: succeeded with 1 warning
  ** Proprietary and Confidential match - /Users/scott/fossa/license-scan-dirs/grepper/.fossa.yml (lines 11-11)
* Custom LicenseSearch: succeeded with 1 warning
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/.fossa.yml (lines 5-5)
  ** Confidential - /Users/scott/fossa/license-scan-dirs/grepper/.fossa.yml (lines 7-7)
  ** Confidential - /Users/scott/fossa/license-scan-dirs/grepper/.fossa.yml (lines 11-11)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/three.txt (lines 1-1)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 1-1)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 3-3)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 5-5)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 7-7)
----------
* Custom-license scan & Keyword Search: succeeded with 1 warning

Warning

  walk file system: IO error for operation on /Users/scott/fossa/license-scan-dirs/grepper/s/bar: No such file or directory (os error 2): WalkFile
```

Edit the .fossa.yml so that the keyword search regex finds nothing:

```yaml
version: 3

customLicenseSearch:
  - matchCriteria: "[Pp]roprietary [Ll]icense"
    name: "Proprietary License"
  - matchCriteria: "[Cc]onfidential"
    name: "Confidential"

experimentalKeywordSearch:
  - matchCriteria: "[Pp]roprietary and [Cc]onfidential will never be found"
    name: "Proprietary and Confidential match"
```

Analyze again. The summary should explicitly say that no keyword search results were found. While we're in there, delete the empty symlink (it's the s/bar file in the directory we're scanning) so that you can see what the results look like when there are no warnings:

```
cabal run fossa -- analyze -e http://localhost:9578 /Users/scott/fossa/license-scan-dirs/grepper --output --debug > /dev/null 

* Keyword Search: succeeded
  ** No results found
* Custom LicenseSearch: succeeded
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/.fossa.yml (lines 5-5)
  ** Confidential - /Users/scott/fossa/license-scan-dirs/grepper/.fossa.yml (lines 7-7)
  ** Confidential - /Users/scott/fossa/license-scan-dirs/grepper/.fossa.yml (lines 11-11)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/three.txt (lines 1-1)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 1-1)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 3-3)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 5-5)
  ** Proprietary License - /Users/scott/fossa/license-scan-dirs/grepper/one.txt (lines 7-7)
```

Analyze a project with a bad config. For example, you can add an unclosed escape on a regex like this:

```yaml
version: 3

customLicenseSearch:
  - matchCriteria: "[Pp]roprietary [Ll]icense"
    name: "Proprietary License"
  - matchCriteria: "[Cc]onfidential\\"
    name: "Confidential"
```

When you run `fossa analyze` with that config:
- `fossa analyze` should still complete
- There should be an error saying that we failed while running Lernie, and that error should give you information on why things failed

```
cabal run fossa -- analyze -e http://localhost:9578 /Users/scott/fossa/license-scan-dirs/grepper-bad-config --output --debug > /dev/null
[DEBUG] Loading configuration file from "/Users/scott/fossa/license-scan-dirs/grepper-bad-config/"
[ERROR] ----------
  An issue occurred

  >>> Relevant errors

    Error

      Command execution failed: 

          Attempted to run the command '/private/var/folders/45/k76d2pgj6mlb1vpx_2gyl7z80000gn/T/fossa-vendor/1693946174882306/lernie --config -'
          inside the working directory '/Users/scott/fossa/fossa-cli/',
          but failed, because the command exited with code '1'.

          Often, this kind of error is caused by the project not being ready to build;
          please ensure that the project at '/Users/scott/fossa/fossa-cli/'
          builds successfully before running fossa.

          The logs for the command are listed below.
          They will likely provide guidance on how to resolve this error.

          Command standard log:
            {"type":"Error","data":{"message":"create regular expression set: '[Pp]roprietary [Ll]icense -- [Cc]onfidential\\ -- [Pp]roprietary and [Cc]onfidential': regex parse error:\n    [Cc]onfidential\\\n                   ^\nerror: incomplete escape sequence, reached end of pattern prematurely","type":"CreateRegexSet"}}


          Command error log:
            Error: create regular expression set: '[Pp]roprietary [Ll]icense -- [Cc]onfidential\ -- [Pp]roprietary and [Cc]onfidential'
            ├╴at src/config.rs:97:14
            │
            ╰─▶ regex parse error:
                    [Cc]onfidential\
                                   ^
                error: incomplete escape sequence, reached end of pattern prematurely
                ╰╴at src/config.rs:96:14


      If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com

      Traceback:
        - custom-license & keyword search
        - fossa-analyze


... lots of standard analysis output ...

Scan Summary
------------
fossa-cli branch ANE-1164-show-lernie-results-in-scan-results (revision 4e237182e21d compiled with ghc-9.0)
fossa endpoint server version: N/A

2 projects scanned;  0 skipped,  1 succeeded,  1 failed,  0 analysis warnings

* npm project in "/Users/scott/fossa/license-scan-dirs/grepper-bad-config/": succeeded
-
* Keyword Search: failed
* Custom LicenseSearch: failed

  Some projects may not appear in the summary if they were filtered during discovery.
  You can run `fossa list-targets` to see all discoverable projects.

You can also view analysis summary with warning and error messages at: "/private/var/folders/45/k76d2pgj6mlb1vpx_2gyl7z80000gn/T/fossa-analyze-scan-summary.txt"
```

The scan summary should also show the error:

```
Scan Summary
------------
fossa-cli branch ANE-1164-show-lernie-results-in-scan-results (revision 4e237182e21d compiled with ghc-9.0)
fossa endpoint server version: N/A

2 projects scanned;  0 skipped,  1 succeeded,  1 failed,  0 analysis warnings

* npm project in "/Users/scott/fossa/license-scan-dirs/grepper-bad-config/": succeeded
-
* Keyword Search: failed
* Custom LicenseSearch: failed
----------
* Custom-license scan & Keyword Search: failed

>>> Relevant errors

  Error

    Command execution failed: 

        Attempted to run the command '/private/var/folders/45/k76d2pgj6mlb1vpx_2gyl7z80000gn/T/fossa-vendor/1693946174882306/lernie --config -'
        inside the working directory '/Users/scott/fossa/fossa-cli/',
        but failed, because the command exited with code '1'.

        Often, this kind of error is caused by the project not being ready to build;
        please ensure that the project at '/Users/scott/fossa/fossa-cli/'
        builds successfully before running fossa.

        The logs for the command are listed below.
        They will likely provide guidance on how to resolve this error.

        Command standard log:
          {"type":"Error","data":{"message":"create regular expression set: '[Pp]roprietary [Ll]icense -- [Cc]onfidential\\ -- [Pp]roprietary and [Cc]onfidential': regex parse error:\n    [Cc]onfidential\\\n                   ^\nerror: incomplete escape sequence, reached end of pattern prematurely","type":"CreateRegexSet"}}


        Command error log:
          Error: create regular expression set: '[Pp]roprietary [Ll]icense -- [Cc]onfidential\ -- [Pp]roprietary and [Cc]onfidential'
          ├╴at src/config.rs:97:14
          │
          ╰─▶ regex parse error:
                  [Cc]onfidential\
                                 ^
              error: incomplete escape sequence, reached end of pattern prematurely
              ╰╴at src/config.rs:96:14


    If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com

    Traceback:
      - custom-license & keyword search
      - fossa-analyze
```

Finally, run an analysis where no targets are found, but we still find keyword search results. In this case, we should exit with a "no targets found" error, but also display helpful message that we found keyword search results and that if that's all you were expecting to find the error can be ignored.

[grepper-keyword-search-only.zip](https://github.com/fossas/fossa-cli/files/12528180/grepper-keyword-search-only.zip)


```
cabal run fossa -- analyze -e http://localhost:9578 /Users/scott/fossa/license-scan-dirs/grepper-keyword-search-only --output --debug > /dev/null
[DEBUG] Loading configuration file from "/Users/scott/fossa/license-scan-dirs/grepper-keyword-search-only/"

... lots of standard analysis output ...

Scan Summary
------------
fossa-cli branch ANE-1164-show-lernie-results-in-scan-results (revision 4e237182e21d compiled with ghc-9.0)
fossa endpoint server version: N/A

1 projects scanned;  0 skipped,  1 succeeded,  0 failed,  0 analysis warnings

-
* Keyword Search: succeeded
  ** Proprietary match - /Users/scott/fossa/license-scan-dirs/grepper-keyword-search-only/.fossa.yml (lines 5-5)
  ** Proprietary match - /Users/scott/fossa/license-scan-dirs/grepper-keyword-search-only/three.txt (lines 1-1)
  ** Proprietary match - /Users/scott/fossa/license-scan-dirs/grepper-keyword-search-only/one.txt (lines 1-1)
  ** Proprietary match - /Users/scott/fossa/license-scan-dirs/grepper-keyword-search-only/one.txt (lines 3-3)
  ** Proprietary match - /Users/scott/fossa/license-scan-dirs/grepper-keyword-search-only/one.txt (lines 5-5)
  ** Proprietary match - /Users/scott/fossa/license-scan-dirs/grepper-keyword-search-only/one.txt (lines 7-7)
* Custom LicenseSearch: succeeded
  ** No results found

  Some projects may not appear in the summary if they were filtered during discovery.
  You can run `fossa list-targets` to see all discoverable projects.

You can also view analysis summary with warning and error messages at: "/private/var/folders/45/k76d2pgj6mlb1vpx_2gyl7z80000gn/T/fossa-analyze-scan-summary.txt"
------------
[WARN] Matches to your keyword searches were found, but no other analysis targets were found.
  This will result in exiting with an error.
  This error can be safely ignored if you are only expecting keyword search results.
[ERROR] ----------
  An issue occurred

  >>> Relevant errors

    Error

      No analysis targets found in directory.

      Make sure your project is supported. See the user guide for details:
          https://github.com/fossas/fossa-cli/blob/ANE-1164-show-lernie-results-in-scan-results/docs/README.md


      Traceback:
        - fossa-analyze

  >>> Possibly-related warnings

    Warning

      >>> Relevant errors

        Error

          Could not find .git directory in the current or any parent directory

          Traceback:
            - Inferring project from git
            - Validating configuration

        Error

          Could not find executable: `svn`.
          Please ensure `svn` exists in PATH prior to running fossa.

          If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com

          Traceback:
            - Running command 'svn'
            - Inferring project from SVN
            - Validating configuration
```

## Risks

None that I can think of

## Metrics

Coming soon in another PR

## References


[ANE-1164](https://fossa.atlassian.net/browse/ANE-1164)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
~- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.~
~- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.~
~- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).~


[ANE-1164]: https://fossa.atlassian.net/browse/ANE-1164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ