### PR TITLE
Prevent infinite pom file recursion

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,12 @@
 # FOSSA CLI Changelog
 
-## v3.8.10
+## v3.8.12
+- Maven analysis: Address another case not solved by 1268 ([#1271](https://github.com/fossas/fossa-cli/pull/1271))
 
+## v3.8.11
+- Maven analysis: Prevent maven analysis from infinitely recursing when it encounters a recursive property ([#1268](https://github.com/fossas/fossa-cli/pull/1268))
+
+## v3.8.10
 - Reports: Can now export reports formatted as CycloneDX (json/xml), CSV, HTML, and JSON SPDX. ([#1266](https://github.com/fossas/fossa-cli/pull/1266))
 - Containers: RPM packages installed in containers that use the NDB format for their RPM database are now parsed much faster. ([#1262](https://github.com/fossas/fossa-cli/pull/1262))
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,13 @@
 # FOSSA CLI Changelog
 
 ## v3.8.13
-- Maven: Prevent infinite recursion from Pom file property interpolation. ([#1268](https://github.com/fossas/fossa-cli/pull/1268))
+- Maven: Prevent infinite recursion from Pom file property interpolation. ([#1271](https://github.com/fossas/fossa-cli/pull/1271))
 
 ## v3.8.12
-- Maven analysis: Address another case not solved by 1268 ([#1271](https://github.com/fossas/fossa-cli/pull/1271))
+- Conda: Support simple Pip packages in `environment.yml`. ([#1275](https://github.com/fossas/fossa-cli/pull/1275))
 
 ## v3.8.11
 - Maven analysis: Prevent maven analysis from infinitely recursing when it encounters a recursive property ([#1268](https://github.com/fossas/fossa-cli/pull/1268))
-- Conda: Support simple Pip packages in `environment.yml`. ([#1275](https://github.com/fossas/fossa-cli/pull/1275))
 
 ## v3.8.10
 - Reports: Can now export reports formatted as CycloneDX (json/xml), CSV, HTML, and JSON SPDX. ([#1266](https://github.com/fossas/fossa-cli/pull/1266))

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -71,6 +71,7 @@ getDeps ::
   m DependencyResults
 getDeps (MavenProject closure) = do
   (graph, graphBreadth) <- context "Maven" $ getDepsDynamicAnalysis closure <||> getStaticAnalysis closure
+  -- (graph, graphBreadth) <- context "Maven" $ getStaticAnalysis closure
   pure $
     DependencyResults
       { dependencyGraph = graph

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -71,7 +71,6 @@ getDeps ::
   m DependencyResults
 getDeps (MavenProject closure) = do
   (graph, graphBreadth) <- context "Maven" $ getDepsDynamicAnalysis closure <||> getStaticAnalysis closure
-  -- (graph, graphBreadth) <- context "Maven" $ getStaticAnalysis closure
   pure $
     DependencyResults
       { dependencyGraph = graph

--- a/src/Strategy/Maven/Pom.hs
+++ b/src/Strategy/Maven/Pom.hs
@@ -25,7 +25,6 @@ import Path.IO qualified as Path
 import Strategy.Maven.Pom.Closure
 import Strategy.Maven.Pom.PomFile
 import Types
-import Debug.Trace (traceM)
 
 data MavenStrategyOpts = MavenStrategyOpts
   { strategyPath :: Path Rel File
@@ -198,8 +197,6 @@ interpolate properties initialProperty =
 -- before the property, the property, and the text after the property
 splitMavenProperty :: Text -> Maybe (Text, Text, Text)
 splitMavenProperty text = do
-  traceM $ show text
   (beforeBegin, afterBegin) <- breakOnAndRemove "${" text
   (property, afterEnd) <- breakOnAndRemove "}" afterBegin
-  traceM $ show property
   pure (beforeBegin, property, afterEnd)

--- a/src/Strategy/Maven/Pom.hs
+++ b/src/Strategy/Maven/Pom.hs
@@ -25,9 +25,6 @@ import Path.IO qualified as Path
 import Strategy.Maven.Pom.Closure
 import Strategy.Maven.Pom.PomFile
 import Types
-import Debug.Trace
-import Data.SemVer (initial)
-import Language.Haskell.TH (prefixPatSyn)
 
 data MavenStrategyOpts = MavenStrategyOpts
   { strategyPath :: Path Rel File
@@ -198,8 +195,9 @@ interpolate properties initialProperty =
         Just foundProperty -> case splitMavenProperty $ prefix <> foundProperty <> suffix of
           Nothing -> property
           Just (_, property2, _) -> if property2 == property then property else interpolate properties $ prefix <> foundProperty <> suffix
-        -- where
-        --   fullProperty = prefix <> foundProperty <> suffix
+
+-- where
+--   fullProperty = prefix <> foundProperty <> suffix
 -- find the first maven property in the string, e.g., `${foo}`, returning text
 -- before the property, the property, and the text after the property
 splitMavenProperty :: Text -> Maybe (Text, Text, Text)

--- a/src/Strategy/Maven/Pom.hs
+++ b/src/Strategy/Maven/Pom.hs
@@ -169,7 +169,7 @@ reifyDeps pom = Map.mapWithKey overlayDepManagement (pomDependencies pom)
 -- interpolates both computed/built-in properties and user-specified properties,
 -- preferring user-specified properties
 interpolateProperties :: Pom -> Text -> Text
-interpolateProperties pom = interpolate (pomProperties pom <> computeBuiltinProperties pom)
+interpolateProperties pom = interpolate (pomProperties pom <> computeBuiltinProperties pom) Set.empty
 
 -- | Compute the most-commonly-used builtin properties for package resolution
 computeBuiltinProperties :: Pom -> Map Text Text
@@ -180,24 +180,25 @@ computeBuiltinProperties pom =
     , ("project.version", coordVersion (pomCoord pom))
     ]
 
-interpolate :: Map Text Text -> Text -> Text
-interpolate properties initialProperty =
+interpolate :: Map Text Text -> Set Text -> Text -> Text
+interpolate properties recursionCheck initialProperty =
   case splitMavenProperty initialProperty of
     Nothing -> initialProperty
     Just (prefix, property, suffix) ->
-      case (Map.lookup property properties) of
-        Nothing -> interpolate properties $ prefix <> "PROPERTY NOT FOUND: " <> property <> suffix
-        -- This block catches an infinite loop with interpolate
-        -- For the example of: <junit5.version>${junit5.version}</junit5.version>
-        -- The map will have ("junit5.version","${junit5.version}")
-        -- splitMavenProperty will remove the "${}" from the value and return the same key which causes infinite recursion.
-        -- Just foundProperty -> if fullProperty == initialProperty then property else interpolate properties fullProperty
-        Just foundProperty -> case splitMavenProperty $ prefix <> foundProperty <> suffix of
-          Nothing -> prefix <> foundProperty <> suffix
-          Just (_, property2, _) -> if property2 == property then property else interpolate properties $ prefix <> foundProperty <> suffix
+      -- This block catches an infinite loop with interpolate
+      -- For the example of: <junit5.version>${junit5.version}</junit5.version>
+      -- The map will have ("junit5.version","${junit5.version}")
+      -- splitMavenProperty will remove the "${}" from the value and return the same key which causes infinite recursion.
+      if Set.member property recursionCheck
+        then prefix <> property <> suffix
+        else
+          ( case (Map.lookup property properties) of
+              Nothing -> interpolate properties Set.empty $ prefix <> "PROPERTY NOT FOUND: " <> property <> suffix
+              Just foundProperty -> interpolate properties (Set.insert property recursionCheck) finalProperty
+                where
+                  finalProperty = prefix <> foundProperty <> suffix
+          )
 
--- where
---   fullProperty = prefix <> foundProperty <> suffix
 -- find the first maven property in the string, e.g., `${foo}`, returning text
 -- before the property, the property, and the text after the property
 splitMavenProperty :: Text -> Maybe (Text, Text, Text)

--- a/src/Strategy/Maven/Pom.hs
+++ b/src/Strategy/Maven/Pom.hs
@@ -193,7 +193,7 @@ interpolate properties initialProperty =
         -- splitMavenProperty will remove the "${}" from the value and return the same key which causes infinite recursion.
         -- Just foundProperty -> if fullProperty == initialProperty then property else interpolate properties fullProperty
         Just foundProperty -> case splitMavenProperty $ prefix <> foundProperty <> suffix of
-          Nothing -> property
+          Nothing -> prefix <> foundProperty <> suffix
           Just (_, property2, _) -> if property2 == property then property else interpolate properties $ prefix <> foundProperty <> suffix
 
 -- where

--- a/src/Strategy/Maven/Pom.hs
+++ b/src/Strategy/Maven/Pom.hs
@@ -25,6 +25,7 @@ import Path.IO qualified as Path
 import Strategy.Maven.Pom.Closure
 import Strategy.Maven.Pom.PomFile
 import Types
+import Debug.Trace (traceM)
 
 data MavenStrategyOpts = MavenStrategyOpts
   { strategyPath :: Path Rel File
@@ -191,12 +192,14 @@ interpolate properties initialProperty =
         -- For the example of: <junit5.version>${junit5.version}</junit5.version>
         -- The map will have ("junit5.version","${junit5.version}")
         -- splitMavenProperty will remove the "${}" from the value and return the same key which causes infinite recursion.
-        Just foundProperty -> if foundProperty == initialProperty then property else interpolate properties $ prefix <> foundProperty <> suffix
+        Just foundProperty -> if prefix <> foundProperty <> suffix == initialProperty then property else interpolate properties $ prefix <> foundProperty <> suffix
 
 -- find the first maven property in the string, e.g., `${foo}`, returning text
 -- before the property, the property, and the text after the property
 splitMavenProperty :: Text -> Maybe (Text, Text, Text)
 splitMavenProperty text = do
+  traceM $ show text
   (beforeBegin, afterBegin) <- breakOnAndRemove "${" text
   (property, afterEnd) <- breakOnAndRemove "}" afterBegin
+  traceM $ show property
   pure (beforeBegin, property, afterEnd)

--- a/test/Maven/PomStrategySpec.hs
+++ b/test/Maven/PomStrategySpec.hs
@@ -29,7 +29,7 @@ spec = do
     it "should not infinitely recurse when interpolating a property that is interpolated to itself" $ do
       let pom' = pom{pomProperties = Map.singleton "project.groupId" "${project.groupId}"}
       interpolateProperties pom' "${project.groupId}" `shouldBe` "project.groupId"
-    
+
     it "should not infinitely recurse when interpolating a property that is interpolated to itself" $ do
       let pom' = pom{pomProperties = Map.singleton "project.groupId" "//${project.groupId}"}
       interpolateProperties pom' "${project.groupId}" `shouldBe` "project.groupId"

--- a/test/Maven/PomStrategySpec.hs
+++ b/test/Maven/PomStrategySpec.hs
@@ -32,7 +32,7 @@ spec = do
 
     it "should not infinitely recurse when interpolating a property that is interpolated to itself" $ do
       let pom' = pom{pomProperties = Map.singleton "project.groupId" "\\${project.groupId}"}
-      interpolateProperties pom' "${project.groupId}" `shouldBe` "project.groupId"
+      interpolateProperties pom' "${project.groupId}" `shouldBe` "\\project.groupId"
 
   describe "buildMavenPackage" $ do
     let pom = Pom (MavenCoordinate "MYGROUP" "MYARTIFACT" "MYVERSION") Nothing Map.empty Map.empty Map.empty []

--- a/test/Maven/PomStrategySpec.hs
+++ b/test/Maven/PomStrategySpec.hs
@@ -31,7 +31,7 @@ spec = do
       interpolateProperties pom' "${project.groupId}" `shouldBe` "project.groupId"
 
     it "should not infinitely recurse when interpolating a property that is interpolated to itself" $ do
-      let pom' = pom{pomProperties = Map.singleton "project.groupId" "//${project.groupId}"}
+      let pom' = pom{pomProperties = Map.singleton "project.groupId" "\\${project.groupId}"}
       interpolateProperties pom' "${project.groupId}" `shouldBe` "project.groupId"
 
   describe "buildMavenPackage" $ do

--- a/test/Maven/PomStrategySpec.hs
+++ b/test/Maven/PomStrategySpec.hs
@@ -29,6 +29,10 @@ spec = do
     it "should not infinitely recurse when interpolating a property that is interpolated to itself" $ do
       let pom' = pom{pomProperties = Map.singleton "project.groupId" "${project.groupId}"}
       interpolateProperties pom' "${project.groupId}" `shouldBe` "project.groupId"
+    
+    it "should not infinitely recurse when interpolating a property that is interpolated to itself" $ do
+      let pom' = pom{pomProperties = Map.singleton "project.groupId" "//${project.groupId}"}
+      interpolateProperties pom' "${project.groupId}" `shouldBe` "project.groupId"
 
   describe "buildMavenPackage" $ do
     let pom = Pom (MavenCoordinate "MYGROUP" "MYARTIFACT" "MYVERSION") Nothing Map.empty Map.empty Map.empty []


### PR DESCRIPTION
# Overview

This is a followup PR to https://github.com/fossas/fossa-cli/pull/1268 with the same goal.

When deploying this PR in a user's environment we found an additional case where infinite Pom file recursion could happen. I missed accounting for the `prefix` and `suffix` and the test I wrote unfortunately didn't require this to be present. The specific case is when there is a leading escaped forward slash `//`. I added another test and the additional case is now accounted for.

## Acceptance criteria

- Maven static analysis no longer infinitely recurses

## Testing plan

- Testing on the user repository that was sent to us.
- Testing on 

## References

https://fossa.zendesk.com/agent/tickets/6791

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
