### PR TITLE
Conda pip support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Conda: Support simple Pip packages in `environment.yml`.
+
 ## v3.8.10
 
 - Reports: Can now export reports formatted as CycloneDX (json/xml), CSV, HTML, and JSON SPDX. ([#1266](https://github.com/fossas/fossa-cli/pull/1266))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,12 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## v3.8.12
 
-- Conda: Support simple Pip packages in `environment.yml`.
+- Conda: Support simple Pip packages in `environment.yml`. ([#1275](https://github.com/fossas/fossa-cli/pull/1275))
+
+## v3.8.11
+
+- Maven: Prevent infinite recursion from Pom file property interpolation. ([#1268](https://github.com/fossas/fossa-cli/pull/1268))
 
 ## v3.8.10
 

--- a/src/Strategy/Conda/EnvironmentYml.hs
+++ b/src/Strategy/Conda/EnvironmentYml.hs
@@ -31,7 +31,7 @@ import Debug.Trace (trace)
 import Data.String.Conversion (toString)
 
 buildGraph :: EnvironmentYmlFile -> Graphing Dependency
-buildGraph envYmlFile = Graphing.fromList (condaPkgToDependency =<< (dependencies envYmlFile))
+buildGraph envYmlFile = Graphing.fromList (condaPkgToDependency =<< dependencies envYmlFile)
   where
     condaPkgToDependency :: CondaPkg -> [Dependency]
     condaPkgToDependency (Pkg text) = [toDependency . getCondaDepFromText $ text]

--- a/src/Strategy/Python/ReqTxt.hs
+++ b/src/Strategy/Python/ReqTxt.hs
@@ -35,7 +35,7 @@ instance ToDiagnostic ReqsTxtFailed where
 
 type Parser = Parsec Void Text
 
--- https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+-- https://pip.pypa.io/en/stable/reference/requirements-file-format/
 requirementsTxtParser :: Parser [Req]
 requirementsTxtParser = concat <$> manyTill reqParser eof
 

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -29,14 +29,14 @@ import Toml qualified
 
 reqToDependency :: Req -> Dependency
 reqToDependency req =
-      Dependency
-        { dependencyType = PipType
-        , dependencyName = depName req
-        , dependencyVersion = depVersion req
-        , dependencyLocations = []
-        , dependencyEnvironments = mempty
-        , dependencyTags = maybe Map.empty toTags (depMarker req)
-        }
+  Dependency
+    { dependencyType = PipType
+    , dependencyName = depName req
+    , dependencyVersion = depVersion req
+    , dependencyLocations = []
+    , dependencyEnvironments = mempty
+    , dependencyTags = maybe Map.empty toTags (depMarker req)
+    }
   where
     depName (NameReq nm _ _ _) = nm
     depName (UrlReq nm _ _ _) = nm

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -6,6 +6,8 @@ module Strategy.Python.Util (
   MarkerOp (..),
   Operator (..),
   Req (..),
+  requirementParser,
+  reqToDependency,
   reqCodec,
   toConstraint,
 ) where
@@ -25,10 +27,8 @@ import Text.Megaparsec.Char
 import Text.URI qualified as URI
 import Toml qualified
 
-buildGraph :: [Req] -> Graphing Dependency
-buildGraph = Graphing.fromList . map toDependency
-  where
-    toDependency req =
+reqToDependency :: Req -> Dependency
+reqToDependency req =
       Dependency
         { dependencyType = PipType
         , dependencyName = depName req
@@ -37,7 +37,7 @@ buildGraph = Graphing.fromList . map toDependency
         , dependencyEnvironments = mempty
         , dependencyTags = maybe Map.empty toTags (depMarker req)
         }
-
+  where
     depName (NameReq nm _ _ _) = nm
     depName (UrlReq nm _ _ _) = nm
 
@@ -46,6 +46,9 @@ buildGraph = Graphing.fromList . map toDependency
 
     depMarker (NameReq _ _ _ marker) = marker
     depMarker (UrlReq _ _ _ marker) = marker
+
+buildGraph :: [Req] -> Graphing Dependency
+buildGraph = Graphing.fromList . map reqToDependency
 
 -- we pull out tags naively. we don't respect and/or semantics, and ignore operators
 -- FUTURE: more useful tagging? in particular: only pull out sys_platform?

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -1,5 +1,4 @@
 module Strategy.Python.Util (
-  requirementParser,
   buildGraph,
   Version (..),
   Marker (..),

--- a/test/Conda/EnvironmentYmlSpec.hs
+++ b/test/Conda/EnvironmentYmlSpec.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE QuasiQuotes #-}
+
 module Conda.EnvironmentYmlSpec (
   spec,
 ) where
 
 import Data.ByteString qualified as BS
 import Data.Map.Strict qualified as Map
-import Text.RawString.QQ (r)
 import Data.Yaml (decodeEither', prettyPrintParseException)
 import DepTypes (
   DepType (CondaType, PipType),
@@ -17,6 +17,7 @@ import Graphing (Graphing)
 import Strategy.Conda.EnvironmentYml (buildGraph)
 import Test.Hspec
 import Test.Hspec qualified as T
+import Text.RawString.QQ (r)
 
 dependencyOne :: Dependency
 dependencyOne =
@@ -82,8 +83,8 @@ expectedGraph = run . evalGrapher $ do
       , dependencyTags = Map.empty
       }
   direct $
-    Dependency {
-       dependencyType = PipType
+    Dependency
+      { dependencyType = PipType
       , dependencyName = "pytest-httpserver"
       , dependencyVersion = Just (CEq "1.0.6")
       , dependencyLocations = []

--- a/test/Conda/EnvironmentYmlSpec.hs
+++ b/test/Conda/EnvironmentYmlSpec.hs
@@ -19,20 +19,17 @@ import Test.Hspec
 import Test.Hspec qualified as T
 import Text.RawString.QQ (r)
 
-dependencyTwo :: Dependency
-dependencyTwo =
-  Dependency
-    { dependencyType = CondaType
-    , dependencyName = "name"
-    , dependencyVersion = Just (CEq "version2")
-    , dependencyLocations = []
-    , dependencyEnvironments = mempty
-    , dependencyTags = Map.empty
-    }
-
 expectedGraph :: Graphing Dependency
 expectedGraph = run . evalGrapher $ do
-  direct dependencyTwo
+  direct $
+    Dependency
+      { dependencyType = CondaType
+      , dependencyName = "name"
+      , dependencyVersion = Just (CEq "version2")
+      , dependencyLocations = []
+      , dependencyEnvironments = mempty
+      , dependencyTags = Map.empty
+      }
   direct $
     Dependency
       { dependencyType = CondaType

--- a/test/Conda/EnvironmentYmlSpec.hs
+++ b/test/Conda/EnvironmentYmlSpec.hs
@@ -19,34 +19,12 @@ import Test.Hspec
 import Test.Hspec qualified as T
 import Text.RawString.QQ (r)
 
-dependencyOne :: Dependency
-dependencyOne =
-  Dependency
-    { dependencyType = CondaType
-    , dependencyName = "name"
-    , dependencyVersion = Just (CEq "version1")
-    , dependencyLocations = []
-    , dependencyEnvironments = mempty
-    , dependencyTags = Map.empty
-    }
-
 dependencyTwo :: Dependency
 dependencyTwo =
   Dependency
     { dependencyType = CondaType
     , dependencyName = "name"
     , dependencyVersion = Just (CEq "version2")
-    , dependencyLocations = []
-    , dependencyEnvironments = mempty
-    , dependencyTags = Map.empty
-    }
-
-dependencyThree :: Dependency
-dependencyThree =
-  Dependency
-    { dependencyType = CondaType
-    , dependencyName = "name"
-    , dependencyVersion = Nothing
     , dependencyLocations = []
     , dependencyEnvironments = mempty
     , dependencyTags = Map.empty

--- a/test/Conda/testdata/environment.yml
+++ b/test/Conda/testdata/environment.yml
@@ -1,8 +1,0 @@
-name: testName
-channels:
-  - defaults
-dependencies:
-  - biopython=1.78=py38haf1e3a3_0
-  - blas=1.0=mkl
-  - ca-certificates=2021.1.19=hecd8cb5_1
-prefix: /path/to/env


### PR DESCRIPTION
# Overview

This PR provides partial support for pip package specifiers in `environment.yml`.

What it doesn't support are URLs like would be used in pip.

## Acceptance criteria

It is possible to analyze conda projects with an `environment.yml` like:
```
name: example-environment

dependencies:
  - click=8.1.3
  - pip:
    - pytest-httpserver==1.0.6 
```

## Testing plan

I tested manually. I also refactored the tests a little bit for EnvironmentYmlSpec and added this as a case.

## References

[Slack thread](https://teamfossa.slack.com/archives/C0155DTGWB1/p1694524113935939)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
