### PR TITLE
[ANE-1082] Telemetry for custom license and keyword scans

### DIFF
--- a/src/App/Fossa/Lernie/Analyze.hs
+++ b/src/App/Fossa/Lernie/Analyze.hs
@@ -31,6 +31,7 @@ import Control.Carrier.Telemetry.Types
 import Control.Effect.FossaApiClient (FossaApiClient, getOrganization)
 import Control.Effect.Lift (Has, Lift)
 import Control.Effect.Telemetry (Telemetry, trackUsage)
+import Control.Monad (unless)
 import Data.Aeson (decode)
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BL
@@ -102,14 +103,8 @@ analyzeWithLernieMain rootDir grepOptions = do
   let maybeLernieConfig = grepOptionsToLernieConfig rootDir grepOptions
   case maybeLernieConfig of
     Just lernieConfig -> do
-      _ <-
-        if (not . null $ customLicenseSearch grepOptions)
-          then trackUsage CustomLicenseSearchUsage
-          else pure ()
-      _ <-
-        if (not . null $ keywordSearch grepOptions)
-          then trackUsage ExperimentalKeywordSearchUsage
-          else pure ()
+      unless (null $ customLicenseSearch grepOptions) $ trackUsage CustomLicenseSearchUsage
+      unless (null $ keywordSearch grepOptions) $ trackUsage ExperimentalKeywordSearchUsage
       messages <- runLernie lernieConfig (configFilePath grepOptions)
       let lernieResults = lernieMessagesToLernieResults messages rootDir
       pure $ Just lernieResults

--- a/src/Control/Carrier/Telemetry/Types.hs
+++ b/src/Control/Carrier/Telemetry/Types.hs
@@ -53,6 +53,8 @@ data TelemetryCtx = TelemetryCtx
 
 data CountableCliFeature
   = ExperimentalGradleSingleConfigurationUsage
+  | ExperimentalKeywordSearchUsage
+  | CustomLicenseSearchUsage
   deriving (Show, Eq, Ord, Generic)
 
 instance ToJSONKey CountableCliFeature where


### PR DESCRIPTION
# Overview

[Delivers ANE-1082](https://fossa.atlassian.net/browse/ANE-1082)

This PR just adds a counter for Custom License Searches and a counter for Keyword Searches. 

## Acceptance criteria

- We know when a customer used custom license searches or keyword searches in a run of `fossa analyze`

## Testing plan

I did a full test by running against core and verifying that it actually counted, but I had to get workers running and override some checks on the core side (it checks that the version of the CLI is valid, and the CLI version being passed up from a dev build is the branch name).

So that's overkill. For a quick sanity check, you can check that the counts are included in the telemetry file created when you generate a debug bundle.

So, grab this zip file and run `fossa-dev analyze --debug` on it: 

[grepper.zip](https://github.com/fossas/fossa-cli/files/12623885/grepper.zip)

```
cd ~/fossa/license-scan-dirs/grepper
fossa-dev analyze --debug
jq '.cliUsageCounter' fossa.telemetry.json 
{
  "CustomLicenseSearchUsage": 1,
  "ExperimentalKeywordSearchUsage": 1
}
```

## Risks
None that I can think of

## Metrics

Yep!

## References

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
