### PR TITLE
[ANE-769] allow missing EXTERNAL SOURCES field in Podfile.lock

### DIFF
--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -11,7 +11,8 @@ on:
 jobs:
   integration-test:
     name: integration-test
-    runs-on: ubuntu-latest
+    runs-on:
+      group: "FOSSA CLI Runner"
     # Be sure to update the env below too
     container: fossa/haskell-static-alpine:ghc-9.0.2
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.8.13
+
+- Cocoapods: Allow Podfile.lock without EXTERNAL SOURCES field ([#1279](https://github.com/fossas/fossa-cli/pull/1279))
+
 ## v3.8.12
 
 - Conda: Support simple Pip packages in `environment.yml`. ([#1275](https://github.com/fossas/fossa-cli/pull/1275))

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -26,10 +26,10 @@ import Control.Effect.Diagnostics (
  )
 import Control.Effect.State (State, get, put)
 import Control.Monad (when)
-import Data.Aeson (FromJSON (parseJSON), (.!=))
+import Data.Aeson (FromJSON (parseJSON), (.!=), withObject, (.:?))
 import Data.Aeson qualified as JSON
 import Data.Aeson.KeyMap qualified as Object
-import Data.Aeson.Types (FromJSONKey)
+import Data.Aeson.Types (FromJSONKey, Parser)
 import Data.Bifunctor (first)
 import Data.Char qualified as C
 import Data.Foldable (asum, find, traverse_)
@@ -354,11 +354,12 @@ parseNameAndVersion :: Parser (Text, Text)
 parseNameAndVersion = (,) <$> parseName <*> parseVersion
 
 instance FromJSON PodLock where
-  parseJSON = Yaml.withObject "Podfile.lock content" $ \obj ->
+  parseJSON = withObject "Podfile.lock content" $ \obj ->
     PodLock
       <$> obj .: "PODS"
       <*> obj .: "DEPENDENCIES"
-      <*> obj .: "EXTERNAL SOURCES"
+      <*> obj .:? "EXTERNAL SOURCES" .!= Map.empty
+
 
 instance FromJSON Pod where
   parseJSON (Yaml.String p) = parserPod p Nothing

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -26,10 +26,10 @@ import Control.Effect.Diagnostics (
  )
 import Control.Effect.State (State, get, put)
 import Control.Monad (when)
-import Data.Aeson (FromJSON (parseJSON), (.!=), withObject, (.:?))
+import Data.Aeson (FromJSON (parseJSON), (.!=), (.:?))
 import Data.Aeson qualified as JSON
 import Data.Aeson.KeyMap qualified as Object
-import Data.Aeson.Types (FromJSONKey, Parser)
+import Data.Aeson.Types (FromJSONKey)
 import Data.Bifunctor (first)
 import Data.Char qualified as C
 import Data.Foldable (asum, find, traverse_)
@@ -354,7 +354,7 @@ parseNameAndVersion :: Parser (Text, Text)
 parseNameAndVersion = (,) <$> parseName <*> parseVersion
 
 instance FromJSON PodLock where
-  parseJSON = withObject "Podfile.lock content" $ \obj ->
+  parseJSON = Yaml.withObject "Podfile.lock content" $ \obj ->
     PodLock
       <$> obj .: "PODS"
       <*> obj .: "DEPENDENCIES"

--- a/src/Strategy/Cocoapods/PodfileLock.hs
+++ b/src/Strategy/Cocoapods/PodfileLock.hs
@@ -26,7 +26,7 @@ import Control.Effect.Diagnostics (
  )
 import Control.Effect.State (State, get, put)
 import Control.Monad (when)
-import Data.Aeson (FromJSON (parseJSON), (.!=), (.:?))
+import Data.Aeson (FromJSON (parseJSON), (.!=))
 import Data.Aeson qualified as JSON
 import Data.Aeson.KeyMap qualified as Object
 import Data.Aeson.Types (FromJSONKey)


### PR DESCRIPTION
# Overview

Per [ANE-769](https://fossa.atlassian.net/browse/ANE-769), `fossa analyze` fails when scanning a Podfile.lock that does not contain an `EXTERNAL SOURCES` element. This PR makes `EXTERNAL SOURCES` an optional field. 

## Acceptance criteria

When scanning a Podfile.lock with no `EXTERNAL SOURCES` specified, `fossa analyze` should still succeed.

## Testing plan

I think @zlav has tested this for me and fixed a couple of things I missed.

## Risks

We're unsure whether there's a spec that states that this field can be optional, or why it wasn't made optional in this code in the first place.

## Metrics

n/a

## References

https://fossa.atlassian.net/browse/ANE-769
https://fossa.zendesk.com/agent/tickets/5565
https://fossa.zendesk.com/agent/tickets/6926
https://fossa.zendesk.com/agent/tickets/5751
https://fossa.zendesk.com/agent/tickets/6588


## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-769]: https://fossa.atlassian.net/browse/ANE-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ