### PR TITLE
Use larger runner for integration tests

### DIFF
--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -11,7 +11,8 @@ on:
 jobs:
   integration-test:
     name: integration-test
-    runs-on: ubuntu-latest
+    runs-on:
+      group: fossa-cli-runner
     # Be sure to update the env below too
     container: fossa/haskell-static-alpine:ghc-9.0.2
 

--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -12,7 +12,7 @@ jobs:
   integration-test:
     name: integration-test
     runs-on:
-      group: fossa-cli-runner
+      group: "FOSSA CLI Runner"
     # Be sure to update the env below too
     container: fossa/haskell-static-alpine:ghc-9.0.2
 


### PR DESCRIPTION
# Overview

Our integration tests are [failing](https://github.com/fossas/fossa-cli/actions/runs/6244205498) due to running out of disk space when running the integration tests. The real fix is to investigate why, but in the meantime this PR configures integration tests to run on a runner with more disk space.

## Acceptance criteria

* Integration Tests succeed

## Testing plan

I checked the integration tests succeeded.

## Risks

There is a cost based on time used for the more powerful runner. More information can be seen in the organization config for github.

## Metrics


## References

[slack thread 1](https://teamfossa.slack.com/archives/C039KE5ERNE/p1694727166486499)
[slack thread 2](https://teamfossa.slack.com/archives/C039KE5ERNE/p1694727207423039)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
