### PR TITLE
Millhone CLI: output matches to disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,7 @@ dependencies = [
  "maplit",
  "once_cell",
  "pretty_assertions",
+ "rand",
  "retry",
  "secrecy",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_derive 3.2.25",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -439,16 +439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +545,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,12 +586,6 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fastrand"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "flagset"
@@ -674,6 +664,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,7 +713,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -842,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "millhone"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.21.4",
  "clap 4.4.4",
@@ -850,19 +856,19 @@ dependencies = [
  "getset",
  "itertools 0.11.0",
  "maplit",
- "once_cell",
  "pretty_assertions",
  "rand",
+ "rayon",
  "retry",
  "secrecy",
  "serde",
  "serde_json",
+ "serde_yaml",
  "snippets",
  "srclib",
  "stable-eyre",
  "strum 0.25.0",
  "tap",
- "tempfile",
  "thiserror",
  "tikv-jemallocator",
  "traceconf",
@@ -900,16 +906,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.2",
- "libc",
 ]
 
 [[package]]
@@ -1087,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -1097,23 +1093,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1366,6 +1351,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+dependencies = [
+ "indexmap 2.0.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,19 +1534,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempfile"
-version = "3.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys",
-]
 
 [[package]]
 name = "termcolor"
@@ -1830,6 +1815,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
 name = "flagset"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,15 +850,18 @@ dependencies = [
  "getset",
  "itertools 0.11.0",
  "maplit",
+ "once_cell",
  "pretty_assertions",
  "retry",
  "secrecy",
  "serde",
+ "serde_json",
  "snippets",
  "srclib",
  "stable-eyre",
  "strum 0.25.0",
  "tap",
+ "tempfile",
  "thiserror",
  "tikv-jemallocator",
  "traceconf",
@@ -1095,6 +1104,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1517,6 +1535,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "termcolor"

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -30,6 +30,9 @@ walkdir = "2.4.0"
 retry = "2.0.0"
 uuid = { version = "1.4.1", features = ["v4"] }
 secrecy = "0.8.0"
+tempfile = "3.8.0"
+once_cell = "1.18.0"
+serde_json = "1.0.107"
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -37,3 +37,4 @@ serde_json = "1.0.107"
 [dev-dependencies]
 maplit = "1.0.2"
 pretty_assertions = "1.4.0"
+rand = "0.8.5"

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "millhone"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 
 [features]
@@ -30,9 +30,9 @@ walkdir = "2.4.0"
 retry = "2.0.0"
 uuid = { version = "1.4.1", features = ["v4"] }
 secrecy = "0.8.0"
-tempfile = "3.8.0"
-once_cell = "1.18.0"
 serde_json = "1.0.107"
+serde_yaml = "0.9.25"
+rayon = "1.8.0"
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/extlib/millhone/README.md
+++ b/extlib/millhone/README.md
@@ -1,0 +1,15 @@
+# `millhone`
+
+This CLI is used for FOSSA snippet scanning,
+and will be accessible via `fossa snippets` in future FOSSA CLI releases.
+
+# Subcommands
+
+Subcommand                                 | Description
+-------------------------------------------|-------------------------------------------------------------------------------
+[`analyze`](./docs/subcommands/analyze.md) | Match snippets in a local project against snippets in the FOSSA knowledgebase.
+[`commit`](./docs/subcommands/commit.md)   | Collect matched snippet information into a `fossa-deps` file.
+[`ingest`](./docs/subcommands/ingest.md)   | Manually ingest a new library into the knowledgebase.
+[`ping`](./docs/subcommands/ping.md)       | Test connectivity to the FOSSA API.
+
+For more information on possible options, run `millhone --help`.

--- a/extlib/millhone/docs/subcommands/analyze.md
+++ b/extlib/millhone/docs/subcommands/analyze.md
@@ -1,0 +1,113 @@
+# `analyze`
+
+This subcommand analyzes a local project for snippets that match snippets in the FOSSA knowledgebase.
+For more information on possible options, run `millhone analyze --help`.
+
+# Output
+
+Matches are written to the location specified by the `--output` (or `-o`) argument.
+If this argument is not specified, `millhone` creates a temporary directory prefixed by "millhone_".
+
+> [!NOTE]
+> Millhone by default creates this directory in the system temporary directory.
+> If desired, this can be customized:
+> - On Linux and macOS: set the `TMPDIR` environment variable.
+> - On Windows, this uses the `GetTempPath` system call, which uses the first valid option of:
+>   - The path specified by the `TMP` environment variable.
+>   - The path specified by the `TEMP` environment variable.
+>   - The path specified by the `USERPROFILE` environment variable.
+>   - The Windows directory.
+
+The output directory consists of a set of flat files, each representing a file in the scan directory
+that had at least one matching snippet. These files are named with the path of the file relative to
+the scan directory, with any path separators replaced by underscores, and a `.json` extension appended.
+
+For example, the following project:
+```
+/Users/
+  me/
+    projects/
+      example-project/
+        lib/
+          lib.c
+          vendor/
+            openssh/
+              openssh.c
+        main.c
+```
+
+When scanned like `millhone analyze /Users/me/projects/example-project`,
+would be presented like the below if all files contained a snippet match:
+```
+/tmp/
+  millhone_abcd1234/
+    lib_lib.c.json
+    lib_vendor_openssh_openssh.c.json
+    main.c.json
+```
+
+The contents of each of these files are a JSON encoded array of matches,
+where each object in the array consists of the following keys:
+
+Key                 | Description
+--------------------|-------------------------------------------------------------------------------
+`found_in`          | The relative path of the local file in which the snippet match was found.
+`local_text`        | The text that matched the snippet in the local file.
+`local_snippet`     | Information about the snippet extracted from the local file.
+`matching_snippets` | A collection of snippets from the FOSSA knowledgebase that match this snippet.
+
+The `local_snippet` object has the following keys:
+
+Key           | Description
+--------------|---------------------------------------------------------------------------
+`fingerprint` | The base64 representation of the snippet fingerprint.
+`target`      | The kind of source code item that matched for this snippet.
+`kind`        | The kind of snippet that was matched.
+`method`      | The normalization method used on the matching snippet.
+`file_path`   | The path of the file containing the snippet, relative to the project root.
+`byte_start`  | The byte index in the file at which the snippet begins.
+`byte_end`    | The byte index in the file at which the snippet ends.
+`line_start`  | The line number in the file at which the snippet begins.
+`line_end`    | The line number in the file at which the snippet ends.
+`col_start`   | The column number on the `line_start` at which the snippet begins.
+`col_end`     | The column number on the `line_end` at which the snippet ends.
+`language`    | The language of the identified snippet.
+
+Each entry in the `matching_snippets` collection has the following keys:
+
+Key           | Description
+--------------|---------------------------------------------------------------------------
+`locator`     | The FOSSA identifier for the project to which this snippet belongs.
+`fingerprint` | The base64 representation of the snippet fingerprint.
+`target`      | The kind of source code item that matched for this snippet.
+`kind`        | The kind of snippet that was matched.
+`method`      | The normalization method used on the matching snippet.
+`file_path`   | The path of the file containing the snippet, relative to the project root.
+`byte_start`  | The byte index in the file at which the snippet begins.
+`byte_end`    | The byte index in the file at which the snippet ends.
+`line_start`  | The line number in the file at which the snippet begins.
+`line_end`    | The line number in the file at which the snippet ends.
+`col_start`   | The column number on the `line_start` at which the snippet begins.
+`col_end`     | The column number on the `line_end` at which the snippet ends.
+`language`    | The language of the identified snippet.
+`ingest_id`   | The ingestion run that discovered this snippet (not meaningful to users).
+
+# Correcting Matches
+
+In order to correct matches, users may manually edit the contents of this directory
+or files within the directory to alter or remove matches.
+
+For example, if a certain snippet is found in the local code that matches
+a snippet in the FOSSA knowledgebase, but it's known to be a false positive,
+users can script the removal of that snippet match from this directory prior to
+committing these results in a FOSSA scan.
+
+# Next Steps
+
+After running `millhone analyze`, the next step is to run `millhone commit`.
+
+These are separate steps to give users the ability to edit or review the matched data
+prior to submitting the results to FOSSA.
+
+If this separation is not desired, users can also run `millhone analyze --commit`,
+which merges the two operations into one step.

--- a/extlib/millhone/docs/subcommands/analyze.md
+++ b/extlib/millhone/docs/subcommands/analyze.md
@@ -108,6 +108,3 @@ After running `millhone analyze`, the next step is to run `millhone commit`.
 
 These are separate steps to give users the ability to edit or review the matched data
 prior to submitting the results to FOSSA.
-
-If this separation is not desired, users can also run `millhone analyze --commit`,
-which merges the two operations into one step.

--- a/extlib/millhone/docs/subcommands/commit.md
+++ b/extlib/millhone/docs/subcommands/commit.md
@@ -1,0 +1,3 @@
+# `commit`
+
+_This will be documented in a future PR_.

--- a/extlib/millhone/docs/subcommands/commit.md
+++ b/extlib/millhone/docs/subcommands/commit.md
@@ -1,3 +1,28 @@
 # `commit`
 
-_This will be documented in a future PR_.
+This subcommand commits the analysis performed in the `analyze` subcommand into a `fossa-deps` file.
+For more information on possible options, run `millhone commit --help`.
+
+# Input
+
+The primary thing this subcommand requires is the path to the directory in which the output of `analyze`
+was written. Users can also alter which kinds of matches to commit, and customize the output format
+of the created `fossa-deps` file.
+
+# Output
+
+The result of this subcommand is a `fossa-deps` file written to the root of the project directory.
+
+> [!NOTE]
+> This subcommand will not overwrite an existing `fossa-deps` file by default,
+> and currently does not merge its output into an existing `fossa-deps` file.
+>
+> However, users can customize the output format (via `--format`) and then
+> perform scripted merges themselves.
+
+# Next Steps
+
+After running `millhone commit`, the next step is to run `fossa analyze` on the project.
+
+FOSSA CLI will then pick up the dependencies reported in that `fossa-deps` file and report them
+as dependencies of the project.

--- a/extlib/millhone/docs/subcommands/ingest.md
+++ b/extlib/millhone/docs/subcommands/ingest.md
@@ -3,14 +3,14 @@
 This subcommand adds an open-source library to the FOSSA knowledge base.
 For more information on possible options, run `millhone ingest --help`.
 
-# Internal Users
+# FOSSA employees
 
 This subcommand is run by internal FOSSA employees;
 end users are not able to use this command to ingest matches.
 
 This is controlled by the permissions granted to the API keys for the service.
 
-# Ingesting a library
+## Ingesting a library
 
 First, download the library locally, and determine the locator that FOSSA would use
 to refer to this library in the future.
@@ -30,6 +30,6 @@ millhone ingest \
 
 For more information on possible options, run `millhone ingest --help`.
 
-# Next Steps
+## Next Steps
 
 Now that the library is ingested, you can discover matches via `millhone analyze`.

--- a/extlib/millhone/docs/subcommands/ingest.md
+++ b/extlib/millhone/docs/subcommands/ingest.md
@@ -1,0 +1,35 @@
+# `ingest`
+
+This subcommand adds an open-source library to the FOSSA knowledge base.
+For more information on possible options, run `millhone ingest --help`.
+
+# Internal Users
+
+This subcommand is run by internal FOSSA employees;
+end users are not able to use this command to ingest matches.
+
+This is controlled by the permissions granted to the API keys for the service.
+
+# Ingesting a library
+
+First, download the library locally, and determine the locator that FOSSA would use
+to refer to this library in the future.
+
+For example, if the library was at `https://github.com/openssh/libopenssh`,
+the locator would be something like `git+github.com/openssh/libopenssh$05dfdd5f54d9a1bae5544141a7ee65baa3313ecd`.
+
+Once these are both performed, run the program with the appropriate arguments to ingest:
+```shell
+millhone ingest \
+  --locator 'git+github.com/openssh/libopenssh$05dfdd5f54d9a1bae5544141a7ee65baa3313ecd' \
+  ~/projects/scratch/libopenssh
+```
+
+> [!IMPORTANT]
+> Make sure to fill in your own data for these arguments.
+
+For more information on possible options, run `millhone ingest --help`.
+
+# Next Steps
+
+Now that the library is ingested, you can discover matches via `millhone analyze`.

--- a/extlib/millhone/docs/subcommands/ping.md
+++ b/extlib/millhone/docs/subcommands/ping.md
@@ -1,0 +1,4 @@
+# `ping`
+
+This subcommand tests the ability of the CLI to connect to the FOSSA API.
+For more information on possible options, run `millhone ping --help`.

--- a/extlib/millhone/src/api/types.rs
+++ b/extlib/millhone/src/api/types.rs
@@ -90,7 +90,9 @@ pub enum State {
 /// An [`extract::Snippet`] augmented with ingestion metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, CopyGetters, Getters)]
 pub struct ApiSnippet {
+    /// The snippet represented.
     #[serde(flatten)]
+    #[getset(get = "pub")]
     snippet: extract::Snippet,
 
     /// The full locator of the project from which this locator was extracted.

--- a/extlib/millhone/src/api/v1/lookup.rs
+++ b/extlib/millhone/src/api/v1/lookup.rs
@@ -5,7 +5,7 @@ use retry::{
     retry_with_index,
 };
 use tap::{Pipe, TapFallible};
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 use ureq::Agent;
 use url::Url;
 
@@ -27,7 +27,7 @@ pub fn run(agent: &Agent, base: &BaseUrl, fp: &Fingerprint) -> Result<HashSet<Ap
         agent
             .get(target.as_str())
             .call()
-            .tap_ok(|_| info!(%retry, "fetched matching snippets"))
+            .tap_ok(|_| debug!(%retry, "fetched matching snippets"))
     });
 
     match response {

--- a/extlib/millhone/src/cmd.rs
+++ b/extlib/millhone/src/cmd.rs
@@ -97,7 +97,7 @@ pub fn latest_temp_dir() -> Result<Option<PathBuf>, std::io::Error> {
 #[cfg(test)]
 mod tests {
 
-    use std::path::Path;
+    use std::{path::Path, thread::sleep, time::Duration};
 
     use super::*;
 
@@ -115,6 +115,10 @@ mod tests {
     #[test]
     fn finds_latest_temp_dir() {
         let a = namespaced_temp_dir().expect("create 'a'");
+
+        // Windows, unfortunately, was flaky without this.
+        sleep(Duration::from_secs(1));
+
         let b = namespaced_temp_dir()
             .tap_err(|_| cleanup(&a))
             .expect("create 'b'");

--- a/extlib/millhone/src/cmd.rs
+++ b/extlib/millhone/src/cmd.rs
@@ -1,11 +1,35 @@
 use std::borrow::Cow;
 
+use clap::Parser;
+use getset::Getters;
+use millhone::api;
+use secrecy::Secret;
 use tracing::warn;
 use walkdir::DirEntry;
 
 pub mod analyze;
 pub mod ingest;
 pub mod ping;
+
+/// Arguments for API authentication.
+#[derive(Debug, Parser, Getters)]
+#[getset(get = "pub")]
+pub struct ApiAuthentication {
+    /// Provide the API Key ID for authentication.
+    #[clap(long)]
+    api_key_id: String,
+
+    /// Provide the API Secret for authentication.
+    #[clap(long)]
+    api_secret: Secret<String>,
+}
+
+impl ApiAuthentication {
+    /// Create credentials from these options.
+    fn as_credentials(&self) -> api::Credentials {
+        api::Credentials::new(self.api_key_id.clone(), self.api_secret.clone())
+    }
+}
 
 /// Unwrap a directory entry, warning on error.
 #[tracing::instrument]

--- a/extlib/millhone/src/cmd/analyze.rs
+++ b/extlib/millhone/src/cmd/analyze.rs
@@ -1,10 +1,15 @@
-use std::fs;
+use std::{collections::HashSet, fs, path::PathBuf};
 
 use clap::Parser;
 use getset::Getters;
-use millhone::{api::prelude::*, extract::Snippet};
+use millhone::{
+    api::{prelude::*, ApiSnippet},
+    extract::{ContentSnippet, Snippet},
+};
+use serde::{Deserialize, Serialize};
 use stable_eyre::{eyre::Context, Report};
 use tracing::{debug, info, warn};
+use typed_builder::TypedBuilder;
 use walkdir::WalkDir;
 
 /// Options for snippet ingestion.
@@ -12,6 +17,14 @@ use walkdir::WalkDir;
 #[getset(get = "pub")]
 #[clap(version)]
 pub struct Subcommand {
+    /// The directory to which matches are output.
+    ///
+    /// If not specified, matches are output to a temporary directory, which is not cleaned up on exit.
+    /// The path to this temporary directory is written to `stdout` follwed by a newline.
+    /// It is the responsibility of the user to clean up this directory after analysis.
+    #[clap(long, short)]
+    output: Option<PathBuf>,
+
     #[clap(flatten)]
     auth: super::ApiAuthentication,
 
@@ -41,6 +54,11 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
     let mut total_count_snippets = 0usize;
     let mut total_count_files = 0usize;
 
+    let output_dir = match opts.output() {
+        Some(dir) => dir.to_owned(),
+        None => super::namespaced_temp_dir()?,
+    };
+
     // Future enhancement: walk and analyze in parallel with rayon.
     let snippet_opts = opts.extract().into();
     for entry in walk.into_iter() {
@@ -65,23 +83,48 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
         total_count_files += 1;
         info!(path = %path.display(), "analyze");
 
-        let snippets = Snippet::from_file(root, &snippet_opts, &path)
+        let snippets = ContentSnippet::from_file(root, &snippet_opts, &path)
             .wrap_err_with(|| format!("process '{}'", path.display()))?;
 
         info!(snippet_count = %snippets.len(), "extracted snippets");
         total_count_snippets += snippets.len();
+        if snippets.is_empty() {
+            continue;
+        }
 
-        for snippet in snippets {
-            let fingerprint = snippet.fingerprint();
+        let mut records = Vec::new();
+        for found in snippets {
+            let fingerprint = found.snippet().fingerprint();
             let matching_snippets = client
                 .lookup_snippets(fingerprint)
                 .wrap_err_with(|| format!("lookup snippet for fingerprint '{fingerprint}'"))?;
 
-            // As of now just log matching snippets; functionality to write to disk is coming in another PR.
-            for matching_snippet in matching_snippets {
-                info!(%fingerprint, "matching snippet: {matching_snippet:#?}");
-            }
+            let record = MatchingSnippet::builder()
+                .found_in(found.snippet().file_path())
+                .local_snippet(found.snippet().clone())
+                .local_text(String::from_utf8_lossy(found.content()))
+                .matching_snippets(matching_snippets)
+                .build();
+
+            records.push(record);
         }
+
+        let record_name = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace(std::path::MAIN_SEPARATOR_STR, "_");
+
+        let record_path = output_dir.join(&record_name);
+        let encoded = serde_json::to_string_pretty(&records).context("encode record")?;
+        std::fs::write(&record_path, encoded).context("write records")?;
+
+        info!(
+            "wrote {} match record(s) for '{}' to '{}'",
+            records.len(),
+            record_name,
+            record_path.display()
+        );
     }
 
     info!(
@@ -90,5 +133,28 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
         %total_count_files,
         "Finished extracting snippets",
     );
+
+    println!("{}", output_dir.display());
     Ok(())
+}
+
+/// A snippet match found in a local file during analysis.
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
+pub struct MatchingSnippet {
+    /// The local path in which the match was found, rendered as a string.
+    /// Any invalid UTF8 content is replaced by `U+FFFD`.
+    #[builder(setter(into))]
+    found_in: String,
+
+    /// A copy of the file content indicated by `found_at`, rendered as a string.
+    /// Any invalid UTF8 content is replaced by `U+FFFD`.
+    #[builder(setter(into))]
+    local_text: String,
+
+    /// The snippet that was identified in the local project.
+    local_snippet: Snippet,
+
+    /// Snippets in the knowledgebase that match this snippet.
+    #[builder(setter(into))]
+    matching_snippets: HashSet<ApiSnippet>,
 }

--- a/extlib/millhone/src/cmd/analyze.rs
+++ b/extlib/millhone/src/cmd/analyze.rs
@@ -1,16 +1,21 @@
-use std::{collections::HashSet, fs, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 use clap::Parser;
 use getset::Getters;
-use millhone::{
-    api::{prelude::*, ApiSnippet},
-    extract::{ContentSnippet, Snippet},
+use millhone::{api::prelude::*, extract::ContentSnippet};
+use rayon::prelude::*;
+use stable_eyre::{
+    eyre::{bail, Context},
+    Report,
 };
-use serde::{Deserialize, Serialize};
-use stable_eyre::{eyre::Context, Report};
-use tracing::{debug, info, warn};
-use typed_builder::TypedBuilder;
+use tap::Pipe;
+use tracing::{debug, info, trace, warn};
 use walkdir::WalkDir;
+
+use crate::cmd::{AtomicCounter, MatchingSnippet};
 
 /// Options for snippet ingestion.
 #[derive(Debug, Parser, Getters)]
@@ -18,12 +23,12 @@ use walkdir::WalkDir;
 #[clap(version)]
 pub struct Subcommand {
     /// The directory to which matches are output.
-    ///
-    /// If not specified, matches are output to a temporary directory, which is not cleaned up on exit.
-    /// The path to this temporary directory is written to `stdout` follwed by a newline.
-    /// It is the responsibility of the user to clean up this directory after analysis.
     #[clap(long, short)]
-    output: Option<PathBuf>,
+    output: PathBuf,
+
+    /// If specified, overwrites the output directory if it exists.
+    #[clap(long)]
+    overwrite_output: bool,
 
     #[clap(flatten)]
     auth: super::ApiAuthentication,
@@ -36,129 +41,158 @@ pub struct Subcommand {
 pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
     info!(
         api_key_id = %opts.auth.api_key_id(),
-        "Analyzing local snippet matches",
+        output = %opts.output.display(),
+        overwrite_output = %opts.overwrite_output,
+        extract_opts = ?opts.extract,
+        "analyzing local snippet matches",
     );
+
+    if opts.output().exists() {
+        if opts.overwrite_output {
+            std::fs::remove_dir_all(opts.output()).context("remove existing output directory")?;
+            debug!("removed existing output dir: {}", opts.output().display());
+        } else {
+            bail!(
+                "the output directory '{}' already exists.",
+                opts.output().display(),
+            );
+        }
+    }
+    if !opts.output().exists() {
+        std::fs::create_dir_all(opts.output()).context("create output directory")?;
+        debug!("created output dir: {}", opts.output().display());
+    }
 
     let creds = opts.auth.as_credentials();
     let client = ApiClientV1::authenticated(endpoint, creds);
     let root = opts.extract().target();
-    let walk = WalkDir::new(root)
+    let snippet_opts = opts.extract().into();
+
+    let total_count_entries = AtomicCounter::default();
+    let total_count_snippets = AtomicCounter::default();
+    let total_count_files = AtomicCounter::default();
+
+    WalkDir::new(root)
         // Follow symlinks; loops are yielded as errors automatically.
         .follow_links(true)
         // Not chosen for a specific reason, just seems reasonable.
         .max_depth(1000)
         // Just make the walk deterministic (per directory anyway).
-        .sort_by_file_name();
+        .sort_by_file_name()
+        .into_iter()
+        .inspect(|_| total_count_entries.increment())
+        .filter_map(super::unwrap_dir_entry)
+        // Bridge into rayon for parallelization.
+        .par_bridge()
+        // Resolve symlinks into full paths and filter to only files.
+        .filter_map(|entry| -> Option<PathBuf> {
+            debug!(path = %entry.path().display(), "resolve path");
+            let path = super::resolve_path(&entry)
+                .map_err(|err| warn!(path = %entry.path().display(), "failed to resolve symlink to path: {err:#}"))
+                .ok()?;
 
-    let mut total_count_entries = 0usize;
-    let mut total_count_snippets = 0usize;
-    let mut total_count_files = 0usize;
+            if path.is_file() {
+                debug!(path = %path.display(), "enqueued for processing");
+                total_count_files.increment();
+                Some(path)
+            } else {
+                debug!(path = %path.display(), "skipped: not a file");
+                None
+            }
+        })
+        // Extract snippets from each file in parallel.
+        .filter_map(|path| -> Option<(PathBuf, HashSet<ContentSnippet>)> {
+            debug!(path = %path.display(), "extract snippets");
+            let snippets = ContentSnippet::from_file(root, &snippet_opts, &path)
+                .map_err(|err| warn!(path = %path.display(), "extract snippets: {err:#}"))
+                .ok()?;
 
-    let output_dir = match opts.output() {
-        Some(dir) => dir.to_owned(),
-        None => super::namespaced_temp_dir()?,
-    };
+            if snippets.is_empty() {
+                debug!(path = %path.display(), "no snippets extracted");
+                return None;
+            }
 
-    // Future enhancement: walk and analyze in parallel with rayon.
-    let snippet_opts = opts.extract().into();
-    for entry in walk.into_iter() {
-        total_count_entries += 1;
-        let Some(entry) = super::unwrap_dir_entry(entry) else {
-            continue;
-        };
+            let snippet_count = snippets.len();
+            debug!(path = %path.display(), %snippet_count, "extracted snippets");
+            total_count_snippets.increment_by(snippet_count);
 
-        let path = if entry.path_is_symlink() {
-            let path = entry.path();
-            fs::read_link(path)
-                .wrap_err_with(|| format!("resolve symlink of '{}'", path.display()))?
-        } else {
-            entry.path().to_path_buf()
-        };
-
-        if !path.is_file() {
-            debug!(path = %path.display(), "skipped: not a file");
-            continue;
-        }
-
-        total_count_files += 1;
-        info!(path = %path.display(), "analyze");
-
-        let snippets = ContentSnippet::from_file(root, &snippet_opts, &path)
-            .wrap_err_with(|| format!("process '{}'", path.display()))?;
-
-        info!(snippet_count = %snippets.len(), "extracted snippets");
-        total_count_snippets += snippets.len();
-        if snippets.is_empty() {
-            continue;
-        }
-
-        let mut records = Vec::new();
-        for found in snippets {
+            (path, snippets).pipe(Some)
+        })
+        // The goal is to then parallelize API calls, so flatten collections of snippets.
+        // Using the serial `flat_map_iter` because this inner iterator has no computation aside from a clone.
+        .flat_map_iter(|(path, snippets)| std::iter::repeat(path).zip(snippets))
+        // Now match snippets up with the API into collections of matches.
+        .filter_map(|(path, found)| -> Option<(PathBuf, MatchingSnippet)> {
             let fingerprint = found.snippet().fingerprint();
             let matching_snippets = client
                 .lookup_snippets(fingerprint)
-                .wrap_err_with(|| format!("lookup snippet for fingerprint '{fingerprint}'"))?;
+                .map_err(|err| warn!(path = %path.display(), %fingerprint, "lookup snippet: {err:#}"))
+                .ok()?;
+            if matching_snippets.is_empty() {
+                trace!(%fingerprint, "no matches in corpus");
+                return None;
+            }
+            for matched in matching_snippets.iter() {
+                trace!(%fingerprint, ?matched, "matched snippet");
+            }
 
-            let record = MatchingSnippet::builder()
+            MatchingSnippet::builder()
                 .found_in(found.snippet().file_path())
                 .local_snippet(found.snippet().clone())
                 .local_text(String::from_utf8_lossy(found.content()))
                 .matching_snippets(matching_snippets)
-                .build();
+                .build()
+                .pipe(|record| (path, record))
+                .pipe(Some)
+        })
+        // Snippet lookups were parallelized. Join them back together by path.
+        // Need both fold and reduce; see https://docs.rs/rayon/latest/rayon/iter/trait.ParallelIterator.html#method.fold
+        .fold(HashMap::new, |mut acc, (path, record)| {
+            acc.entry(path).or_insert_with(Vec::new).push(record);
+            acc
+        })
+        .reduce(HashMap::new, |mut acc, partial| {
+            for (k, v) in partial {
+                acc.entry(k).or_insert_with(Vec::new).extend(v);
+            }
+            acc
+        })
+        // Reduce handed back a hashmap. Spread it back out into an iterator,
+        // such that each path corresponds to a single set of records.
+        .into_par_iter()
+        .for_each(|(path, records)| {
+            let record_name = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR_STR, "_");
 
-            records.push(record);
-        }
+            let current_ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
+            let record_path = opts
+                .output()
+                .join(record_name)
+                .with_extension(format!("{current_ext}.json"));
 
-        let record_name = path
-            .strip_prefix(root)
-            .unwrap_or(&path)
-            .to_string_lossy()
-            .replace(std::path::MAIN_SEPARATOR_STR, "_");
-
-        let current_ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
-        let record_path = output_dir
-            .join(&record_name)
-            .with_extension(format!("{current_ext}.json"));
-
-        let encoded = serde_json::to_string_pretty(&records).context("encode record")?;
-        std::fs::write(&record_path, encoded).context("write records")?;
-
-        info!(
-            "wrote {} match record(s) for '{}' to '{}'",
-            records.len(),
-            record_name,
-            record_path.display()
-        );
-    }
+            let written = serde_json::to_string_pretty(&records)
+                .context("encode records")
+                .and_then(|encoded| std::fs::write(&record_path, encoded).context("write records"));
+            match written {
+                Ok(_) => info!(
+                    "wrote {} matches for '{}' to '{}'",
+                    records.len(),
+                    path.display(),
+                    record_path.display()
+                ),
+                Err(err) => warn!(record_path = %record_path.display(), "failed to write match records: {err:#}"),
+            }
+        });
 
     info!(
-        %total_count_entries,
-        %total_count_snippets,
-        %total_count_files,
-        "Finished extracting snippets",
+        total_count_entries = %total_count_entries.into_inner(),
+        total_count_snippets = %total_count_snippets.into_inner(),
+        total_count_files = %total_count_files.into_inner(),
+        "finished extracting snippets",
     );
 
-    println!("{}", output_dir.display());
     Ok(())
-}
-
-/// A snippet match found in a local file during analysis.
-#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
-pub struct MatchingSnippet {
-    /// The local path in which the match was found, rendered as a string.
-    /// Any invalid UTF8 content is replaced by `U+FFFD`.
-    #[builder(setter(into))]
-    found_in: String,
-
-    /// A copy of the file content indicated by `found_at`, rendered as a string.
-    /// Any invalid UTF8 content is replaced by `U+FFFD`.
-    #[builder(setter(into))]
-    local_text: String,
-
-    /// The snippet that was identified in the local project.
-    local_snippet: Snippet,
-
-    /// Snippets in the knowledgebase that match this snippet.
-    #[builder(setter(into))]
-    matching_snippets: HashSet<ApiSnippet>,
 }

--- a/extlib/millhone/src/cmd/analyze.rs
+++ b/extlib/millhone/src/cmd/analyze.rs
@@ -115,7 +115,7 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
             .to_string_lossy()
             .replace(std::path::MAIN_SEPARATOR_STR, "_");
 
-        let record_path = output_dir.join(&record_name);
+        let record_path = output_dir.join(&record_name).with_extension("json");
         let encoded = serde_json::to_string_pretty(&records).context("encode record")?;
         std::fs::write(&record_path, encoded).context("write records")?;
 

--- a/extlib/millhone/src/cmd/analyze.rs
+++ b/extlib/millhone/src/cmd/analyze.rs
@@ -115,7 +115,11 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
             .to_string_lossy()
             .replace(std::path::MAIN_SEPARATOR_STR, "_");
 
-        let record_path = output_dir.join(&record_name).with_extension("json");
+        let current_ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
+        let record_path = output_dir
+            .join(&record_name)
+            .with_extension(format!("{current_ext}.json"));
+
         let encoded = serde_json::to_string_pretty(&records).context("encode record")?;
         std::fs::write(&record_path, encoded).context("write records")?;
 

--- a/extlib/millhone/src/cmd/commit.rs
+++ b/extlib/millhone/src/cmd/commit.rs
@@ -1,0 +1,255 @@
+use std::{collections::HashSet, path::PathBuf};
+
+use clap::{Parser, ValueEnum};
+use getset::Getters;
+use itertools::Itertools;
+use millhone::extract::{Kind, Method, Target, Transform};
+use serde::{Deserialize, Serialize};
+use srclib::{Fetcher, Locator};
+use stable_eyre::{
+    eyre::{bail, eyre, Context},
+    Report,
+};
+use strum::{Display, IntoEnumIterator};
+use tap::{Pipe, Tap, TapFallible};
+use tracing::{debug, info, warn};
+
+use crate::cmd::MatchingSnippet;
+
+/// Options for snippet ingestion.
+#[derive(Debug, Parser, Getters)]
+#[getset(get = "pub")]
+#[clap(version)]
+pub struct Subcommand {
+    /// The path to the directory in which the `analyze` subcommand wrote its output.
+    #[clap(long)]
+    analyze_output_dir: PathBuf,
+
+    /// The output format for the generated `fossa-deps` file.
+    #[clap(long, default_value_t = OutputFormat::Json)]
+    format: OutputFormat,
+
+    /// If specified, overwrites the output file if it exists.
+    #[clap(long)]
+    overwrite_fossa_deps: bool,
+
+    /// Only commit matches with the specified targets.
+    ///
+    /// Defaults to all supported targets.
+    /// Specify the argument multiple times to indicate additional options.
+    #[clap(long = "target")]
+    targets: Vec<Target>,
+
+    /// Only commit matches with the specified kinds.
+    ///
+    /// Defaults to all supported kinds.
+    /// Specify the argument multiple times to indicate additional options.
+    #[clap(long = "kind")]
+    kinds: Vec<Kind>,
+
+    /// Only commit matches with the specified transforms.
+    ///
+    /// Defaults to all supported transforms. Raw matches (i.e. no transforms)
+    /// are always committed and cannot be disabled.
+    /// Specify the argument multiple times to indicate additional options.
+    #[clap(long = "transform")]
+    transforms: Vec<Transform>,
+
+    /// The directory being analyzed by FOSSA.
+    ///
+    /// The `fossa-deps` file is written into the root of this directory.
+    target: PathBuf,
+}
+
+/// The output format for the generated `fossa-deps` file.
+#[derive(Debug, Clone, Copy, ValueEnum, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum OutputFormat {
+    /// Commit as `fossa-deps.json`.
+    Json,
+
+    /// Commit as `fossa-deps.yml`.
+    Yml,
+}
+
+#[tracing::instrument(skip_all, fields(target = %opts.target().display()))]
+pub fn main(opts: Subcommand) -> Result<(), Report> {
+    info!(
+        analyze_output_dir = ?opts.analyze_output_dir,
+        format = %opts.format,
+        targets = ?opts.targets,
+        kinds = ?opts.kinds,
+        transforms = ?opts.transforms,
+        "Committing local snippet matches",
+    );
+
+    let output_file = opts
+        .target()
+        .join("fossa-deps")
+        .with_extension(opts.format().to_string());
+    if !opts.overwrite_fossa_deps() && output_file.exists() {
+        bail!(
+            "The output file '{}' already exists. This program does not currently merge `fossa-deps` files.",
+            output_file.display(),
+        );
+    }
+
+    if !opts.analyze_output_dir().exists() {
+        bail!(
+            "The directory specified for `analyze` output, '{}', does not exist.",
+            opts.analyze_output_dir().display()
+        );
+    }
+
+    let match_targets = default_if_empty(opts.targets(), Target::iter);
+    let match_kinds = default_if_empty(opts.kinds(), Kind::iter);
+    let match_methods = if opts.transforms().is_empty() {
+        Method::iter()
+            .map(|m| m.to_string())
+            .collect::<HashSet<_>>()
+    } else {
+        opts.transforms()
+            .iter()
+            .copied()
+            .pipe(Method::iter_constrained)
+            .map(|m| m.to_string())
+            .collect::<HashSet<_>>()
+    };
+
+    let deps = std::fs::read_dir(opts.analyze_output_dir())
+        .wrap_err_with(|| format!("list contents of '{}'", opts.analyze_output_dir().display()))?
+        .inspect(|entry| debug!(analyze_output_dir = %opts.analyze_output_dir().display(), ?entry, "walk contents"))
+        .filter_ok(|entry| {
+            let path = entry.path();
+            path.extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext == "json")
+                .unwrap_or_default()
+                .tap(|valid| debug!(path = %entry.path().display(), %valid, "filter to json"))
+        })
+        .map_ok(|entry| {
+            std::fs::read(entry.path())
+                .wrap_err_with(|| format!("read '{}'", entry.path().display()))
+                .tap_ok(|_| debug!(path = %entry.path().display(), "read entry"))
+        })
+        .flatten()
+        .map_ok(|content| serde_json::from_slice::<Vec<MatchingSnippet>>(&content))
+        .flatten()
+        .flatten_ok()
+        .map_ok(|m| {
+            m.matching_snippets
+                .iter()
+                .filter_map(|m| {
+                    let matches = match_kinds.contains(m.snippet().kind())
+                        || match_targets.contains(m.snippet().target())
+                        || match_methods.contains(m.snippet().method());
+                    debug!(
+                        ?match_kinds,
+                        ?match_targets,
+                        ?match_methods,
+                        "snippet {m:?} matches criteria: {matches}"
+                    );
+
+                    if matches {
+                        Some(m.locator().clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect_vec()
+        })
+        .flatten_ok()
+        .collect::<Result<HashSet<_>, _>>()
+        .context("find matching snippets")?
+        .into_iter()
+        .filter_map(|loc| {
+            ReferencedDependency::try_from(loc)
+                .tap_err(|(loc, err)| {
+                    warn!("unable to translate locator '{loc}' to referenced dependency: {err:#}")
+                })
+                .ok()
+        })
+        .collect_vec();
+
+    if deps.is_empty() {
+        info!("No dependencies committed");
+        return Ok(());
+    }
+
+    let deps_file = FossaDeps { referenced: deps };
+    let rendered = match opts.format {
+        OutputFormat::Json => {
+            serde_json::to_string_pretty(&deps_file).context("render fossa-deps")?
+        }
+        OutputFormat::Yml => serde_yaml::to_string(&deps_file).context("render fossa-deps")?,
+    };
+    std::fs::write(&output_file, rendered)
+        .wrap_err_with(|| format!("write fossa-deps at '{}'", output_file.display()))?;
+
+    info!(
+        "Wrote output to '{}' with dependency count: {}",
+        output_file.display(),
+        deps_file.referenced.len(),
+    );
+    Ok(())
+}
+
+fn default_if_empty<F, I, T>(items: &[T], or_default: F) -> HashSet<String>
+where
+    F: FnOnce() -> I,
+    I: IntoIterator<Item = T>,
+    T: ToString,
+{
+    if items.is_empty() {
+        or_default().into_iter().map(|s| s.to_string()).collect()
+    } else {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+}
+
+/// Serialize the entries of the `referenced-dependencies` type in `fossa-deps`:
+/// https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-deps.md#referenced-dependencies
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ReferencedDependency {
+    #[serde(rename = "type")]
+    kind: String,
+    name: String,
+    version: String,
+}
+
+impl ReferencedDependency {
+    fn kind_for_fetcher(fetcher: Fetcher) -> Result<String, Report> {
+        match fetcher {
+            Fetcher::Git => Ok("git".into()),
+            _ => Err(eyre!("unsupported fetcher: {fetcher}")),
+        }
+    }
+}
+
+impl TryFrom<Locator> for ReferencedDependency {
+    type Error = (Locator, Report);
+
+    fn try_from(loc: Locator) -> Result<Self, Self::Error> {
+        let kind = Self::kind_for_fetcher(loc.fetcher())
+            .context("translate fetcher to 'referenced-dependency'.type")
+            .map_err(|err| (loc.clone(), err))?;
+        let version = loc
+            .revision()
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| (loc.clone(), eyre!("version required for locator")))?;
+
+        Ok(Self {
+            kind,
+            version,
+            name: loc.project().to_string(),
+        })
+    }
+}
+
+/// Serialize a `fossa-deps` file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FossaDeps {
+    #[serde(rename = "referenced-dependencies")]
+    referenced: Vec<ReferencedDependency>,
+}

--- a/extlib/millhone/src/extract.rs
+++ b/extlib/millhone/src/extract.rs
@@ -399,6 +399,16 @@ impl<'de> serde::Deserialize<'de> for Fingerprint {
 
 /// The location, using textual "line, column" indicators, for a snippet.
 ///
+/// Byte locations are 0-based, while line and column indexes are 1-based:
+/// ```ignore
+/// // Remember that while `\n` is two columns as typed, it's 1 in actual text.
+/// let input = b"hello\nworld\nand beyond!";
+/// //            ^   ^  ^   ^  ^        ^
+/// //   bytes:   0   4  6   10 12       21
+/// // columns:   1   5  1   5  1        11
+/// //   lines:   1      2      3
+///```
+///
 /// Line end is inclusive: if a snippet starts on line 1 and ends before
 /// the end of the line, `line_end` is line 1 as well.
 ///

--- a/extlib/millhone/src/main.rs
+++ b/extlib/millhone/src/main.rs
@@ -52,10 +52,13 @@ enum Commands {
 
     /// Ingest snippets to the Millhone backend.
     // Boxed to reduce size difference between variants, a clippy lint.
-    Ingest(Box<cmd::ingest::Subcommand>),
+    Ingest(cmd::ingest::Subcommand),
 
     /// Analyze a local project for matches.
-    Analyze(Box<cmd::analyze::Subcommand>),
+    Analyze(cmd::analyze::Subcommand),
+
+    /// Commit matches discovered during analyze into a fossa-deps file.
+    Commit(cmd::commit::Subcommand),
 }
 
 fn main() -> stable_eyre::Result<()> {
@@ -70,7 +73,8 @@ fn main() -> stable_eyre::Result<()> {
     // And then dispatch to the subcommand.
     match app.commands {
         Commands::Ping => cmd::ping::main(&app.direct_endpoint),
-        Commands::Ingest(opts) => cmd::ingest::main(&app.direct_endpoint, *opts),
-        Commands::Analyze(opts) => cmd::analyze::main(&app.direct_endpoint, *opts),
+        Commands::Ingest(opts) => cmd::ingest::main(&app.direct_endpoint, opts),
+        Commands::Analyze(opts) => cmd::analyze::main(&app.direct_endpoint, opts),
+        Commands::Commit(opts) => cmd::commit::main(opts),
     }
 }


### PR DESCRIPTION
# Overview

Outputs matches found in `millhone analyze` to disk.
Also adds some documentation.

## Acceptance criteria

Match data is output to disk in a manner that is:
- usable to the future `millhone commit`, to generate a `fossa-deps` file.
- relatively easy to manually review, for users.
- relatively easy to parse, for user scripts.

## Testing plan

Automated tests cover the fiddly bits. I manually ran a smoke test:

In one terminal, run Millhone. I ran it with the in-memory DB for convenience:
```shell
foundation/millhone on ⑆ millhone/nits [$] is 📦 v0.2.0 via 🦀 v1.72.0
❯ cargo run -- --db-in-memory
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `/Users/jessica/projects/foundation/target/debug/millhone --db-in-memory`
  2023-09-21T23:42:11.659337Z  INFO millhone: creating server, options: Application { port: 3000, tracing: TracingConfig { trace_level: Info, trace_spans: Off, trace_format: Text, trace_colors: Auto }, app_db: AppDbConfig { app_db_host: NonEmptyString("localhost"), app_db_port: 5432, app_db_name: NonEmptyString("millhone"), app_db_user: NonEmptyString("fossa"), app_db_password: Secret([REDACTED alloc::string::String]), app_db_max_pool: 10, app_db_min_pool: 10, app_db_connection_timeout_seconds: 30 }, corpus_db: CorpusDbConfig { corpus_db_nodes: ["localhost:9042"], corpus_db_keyspace: "millhone", corpus_db_username: None, corpus_db_password: None }, db_in_memory: true }
    at millhone/src/main.rs:198

  2023-09-21T23:42:11.669588Z  INFO millhone: booting server, addr: 0.0.0.0:3000
    at millhone/src/main.rs:202
```

I then ingested the `cpp-vsi-demo` project with all currently implemented kinds & methods:
```shell
fossa-cli/extlib/millhone on ⑆ millhone-cli/output-to-disk [$] is 📦 v0.1.0 via 🦀 v1.72.0
❯ cargo run -- ingest --direct-endpoint http://localhost:3000 --api-key-id 0ee7fb68-d368-4ee1-8a81-9bb77a722067 --api-secret cf7a2814-f9f6-4d15-9828-5bd750ee4246 --locator 'git+github.com/fossas/cpp-vsi-demo-src$v0.1.0' ~/projects/cpp-vsi-demo/example-internal-project --kind signature --kind body --kind full --transform space --trace-level off
   Compiling millhone v0.1.0 (/Users/jessica/projects/fossa-cli/extlib/millhone)
    Finished dev [unoptimized + debuginfo] target(s) in 0.51s
     Running `/Users/jessica/projects/fossa-cli/target/debug/millhone ingest --direct-endpoint 'http://localhost:3000' --api-key-id 0ee7fb68-d368-4ee1-8a81-9bb77a722067 --api-secret cf7a2814-f9f6-4d15-9828-5bd750ee4246 --locator 'git+github.com/fossas/cpp-vsi-demo-src$v0.1.0' /Users/jessica/projects/cpp-vsi-demo/example-internal-project --kind signature --kind body --kind full --transform space --trace-level off
```

I then ran `analyze`:
```shell
fossa-cli/extlib/millhone on ⑆ millhone-cli/output-to-disk [$] is 📦 v0.1.0 via 🦀 v1.72.0
❯ mkdir testdata && cargo run -- analyze --direct-endpoint http://localhost:3000 --api-key-id 0ee7fb68-d368-4ee1-8a81-9bb77a722067 --api-secret cf7a2814-f9f6-4d15-9828-5bd750ee4246 ~/projects/cpp-vsi-demo/example-internal-project --kind signature --kind body --kind full --transform space -o testdata
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `/Users/jessica/projects/fossa-cli/target/debug/millhone analyze --direct-endpoint 'http://localhost:3000' --api-key-id 0ee7fb68-d368-4ee1-8a81-9bb77a722067 --api-secret cf7a2814-f9f6-4d15-9828-5bd750ee4246 /Users/jessica/projects/cpp-vsi-demo/example-internal-project --kind signature --kind body --kind full --transform space -o testdata`
```

I observed the output looks reasonable:
```shell
fossa-cli/extlib/millhone on ⑆ millhone-cli/output-to-disk [$?] is 📦 v0.1.0 via 🦀 v1.72.0
❯ ll testdata | head
.rw-r--r-- 6.3k 21 Sep 16:44 -N src_main.json
.rw-r--r--  54k 21 Sep 16:44 -N vendor_libssh2_example_direct_tcpip.c.json
.rw-r--r--  36k 21 Sep 16:44 -N vendor_libssh2_example_scp.c.json
.rw-r--r--  83k 21 Sep 16:44 -N vendor_libssh2_example_scp_nonblock.c.json
.rw-r--r--  41k 21 Sep 16:44 -N vendor_libssh2_example_scp_write.c.json
.rw-r--r--  75k 21 Sep 16:44 -N vendor_libssh2_example_scp_write_nonblock.c.json
.rw-r--r--  58k 21 Sep 16:44 -N vendor_libssh2_example_sftp.c.json
.rw-r--r--  42k 21 Sep 16:44 -N vendor_libssh2_example_sftp_append.c.json
.rw-r--r--  35k 21 Sep 16:44 -N vendor_libssh2_example_sftp_mkdir.c.json
.rw-r--r--  35k 21 Sep 16:44 -N vendor_libssh2_example_sftp_mkdir_nonblock.c.json
```

And the output of the matches looks reasonable (keep in mind that the exact same files were ingested and then matched):
```json
[
  {
    "found_in": "src/main.c",
    "local_text": "{\n  printf(\"hello world\\n\");\n  return 0;\n}",
    "local_snippet": {
      "fingerprint": "w0vrr3TVihD2TvpYQGJxK2RUirEvTUGFF3+yxThtEFw=",
      "target": "function",
      "kind": "body",
      "method": "normalized(space)",
      "file_path": "src/main.c",
      "byte_start": 32,
      "byte_end": 74,
      "line_start": 4,
      "line_end": 7,
      "col_start": 12,
      "col_end": 2,
      "language": "c99_tc3/static"
    },
    "matching_snippets": [
      {
        "fingerprint": "w0vrr3TVihD2TvpYQGJxK2RUirEvTUGFF3+yxThtEFw=",
        "target": "function",
        "kind": "body",
        "method": "normalized(space)",
        "file_path": "src/main.c",
        "byte_start": 32,
        "byte_end": 74,
        "line_start": 4,
        "line_end": 7,
        "col_start": 12,
        "col_end": 2,
        "language": "c99_tc3/static",
        "locator": "git+github.com/fossas/cpp-vsi-demo-src$v0.1.0",
        "ingest_id": "7d556086-6317-45b1-a63c-cbab4fb67370"
      }
    ]
  },
  {
    "found_in": "src/main.c",
    "local_text": "{\n  printf(\"hello world\\n\");\n  return 0;\n}",
    "local_snippet": {
      "fingerprint": "v2x9rdvIqjoxVU+cnxMjxitPtGNWm83OR+GxsI/AiE4=",
      "target": "function",
      "kind": "body",
      "method": "raw",
      "file_path": "src/main.c",
      "byte_start": 32,
      "byte_end": 74,
      "line_start": 4,
      "line_end": 7,
      "col_start": 12,
      "col_end": 2,
      "language": "c99_tc3/static"
    },
    "matching_snippets": [
      {
        "fingerprint": "v2x9rdvIqjoxVU+cnxMjxitPtGNWm83OR+GxsI/AiE4=",
        "target": "function",
        "kind": "body",
        "method": "raw",
        "file_path": "src/main.c",
        "byte_start": 32,
        "byte_end": 74,
        "line_start": 4,
        "line_end": 7,
        "col_start": 12,
        "col_end": 2,
        "language": "c99_tc3/static",
        "locator": "git+github.com/fossas/cpp-vsi-demo-src$v0.1.0",
        "ingest_id": "7d556086-6317-45b1-a63c-cbab4fb67370"
      }
    ]
  },
  {
    "found_in": "src/main.c",
    "local_text": "int main()",
    "local_snippet": {
      "fingerprint": "OFxpLQXYGQzLjWud7D9ZLoq6Agzu9eaH/38i58yqZJs=",
      "target": "function",
      "kind": "signature",
      "method": "raw",
      "file_path": "src/main.c",
      "byte_start": 21,
      "byte_end": 31,
      "line_start": 4,
      "line_end": 4,
      "col_start": 1,
      "col_end": 11,
      "language": "c99_tc3/static"
    },
    "matching_snippets": [
      {
        "fingerprint": "OFxpLQXYGQzLjWud7D9ZLoq6Agzu9eaH/38i58yqZJs=",
        "target": "function",
        "kind": "signature",
        "method": "raw",
        "file_path": "vendor/libssh2/tests/runner.c",
        "byte_start": 1685,
        "byte_end": 1695,
        "line_start": 42,
        "line_end": 42,
        "col_start": 1,
        "col_end": 11,
        "language": "c99_tc3/static",
        "locator": "git+github.com/fossas/cpp-vsi-demo-src$v0.1.0",
        "ingest_id": "7d556086-6317-45b1-a63c-cbab4fb67370"
      },
      {
        "fingerprint": "OFxpLQXYGQzLjWud7D9ZLoq6Agzu9eaH/38i58yqZJs=",
        "target": "function",
        "kind": "signature",
        "method": "raw",
        "file_path": "vendor/libssh2/tests/test_keyboard_interactive_auth_info_request.c",
        "byte_start": 8065,
        "byte_end": 8075,
        "line_start": 294,
        "line_end": 294,
        "col_start": 1,
        "col_end": 11,
        "language": "c99_tc3/static",
        "locator": "git+github.com/fossas/cpp-vsi-demo-src$v0.1.0",
        "ingest_id": "7d556086-6317-45b1-a63c-cbab4fb67370"
      },
      {
        "fingerprint": "OFxpLQXYGQzLjWud7D9ZLoq6Agzu9eaH/38i58yqZJs=",
        "target": "function",
        "kind": "signature",
        "method": "raw",
        "file_path": "src/main.c",
        "byte_start": 21,
        "byte_end": 31,
        "line_start": 4,
        "line_end": 4,
        "col_start": 1,
        "col_end": 11,
        "language": "c99_tc3/static",
        "locator": "git+github.com/fossas/cpp-vsi-demo-src$v0.1.0",
        "ingest_id": "7d556086-6317-45b1-a63c-cbab4fb67370"
      }
    ]
  },
  {
    "found_in": "src/main.c",
    "local_text": "int main() {\n  printf(\"hello world\\n\");\n  return 0;\n}",
    "local_snippet": {
      "fingerprint": "5UQ3uNX6t+hneAlNXo7l94uxtf+fZx/lcFppooYi2dA=",
      "target": "function",
      "kind": "full",
      "method": "normalized(space)",
      "file_path": "src/main.c",
      "byte_start": 21,
      "byte_end": 74,
      "line_start": 4,
      "line_end": 7,
      "col_start": 1,
      "col_end": 2,
      "language": "c99_tc3/static"
    },
    "matching_snippets": [
      {
        "fingerprint": "5UQ3uNX6t+hneAlNXo7l94uxtf+fZx/lcFppooYi2dA=",
        "target": "function",
        "kind": "full",
        "method": "normalized(space)",
        "file_path": "src/main.c",
        "byte_start": 21,
        "byte_end": 74,
        "line_start": 4,
        "line_end": 7,
        "col_start": 1,
        "col_end": 2,
        "language": "c99_tc3/static",
        "locator": "git+github.com/fossas/cpp-vsi-demo-src$v0.1.0",
        "ingest_id": "7d556086-6317-45b1-a63c-cbab4fb67370"
      }
    ]
  },
  {
    "found_in": "src/main.c",
    "local_text": "int main() {\n  printf(\"hello world\\n\");\n  return 0;\n}",
    "local_snippet": {
      "fingerprint": "RjpGXHcd2yCz04Q+BXBT3w65hnLBbXZE+zcmBW4OPw0=",
      "target": "function",
      "kind": "full",
      "method": "raw",
      "file_path": "src/main.c",
      "byte_start": 21,
      "byte_end": 74,
      "line_start": 4,
      "line_end": 7,
      "col_start": 1,
      "col_end": 2,
      "language": "c99_tc3/static"
    },
    "matching_snippets": [
      {
        "fingerprint": "RjpGXHcd2yCz04Q+BXBT3w65hnLBbXZE+zcmBW4OPw0=",
        "target": "function",
        "kind": "full",
        "method": "raw",
        "file_path": "src/main.c",
        "byte_start": 21,
        "byte_end": 74,
        "line_start": 4,
        "line_end": 7,
        "col_start": 1,
        "col_end": 2,
        "language": "c99_tc3/static",
        "locator": "git+github.com/fossas/cpp-vsi-demo-src$v0.1.0",
        "ingest_id": "7d556086-6317-45b1-a63c-cbab4fb67370"
      }
    ]
  }
]
```

## Risks

None

## Metrics

None

## References

Completes https://fossa.atlassian.net/browse/ANE-1137

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
