### PR TITLE
Millhone CLI: commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_derive 3.2.25",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -555,6 +555,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +680,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,7 +729,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -857,6 +879,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "serde_yaml",
  "snippets",
  "srclib",
  "stable-eyre",
@@ -1366,6 +1389,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+dependencies = [
+ "indexmap 2.0.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +1866,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "millhone"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.21.4",
  "clap 4.4.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,16 +439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "millhone"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.21.4",
  "clap 4.4.4",
@@ -868,6 +858,7 @@ dependencies = [
  "maplit",
  "pretty_assertions",
  "rand",
+ "rayon",
  "retry",
  "secrecy",
  "serde",
@@ -915,16 +906,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.2",
- "libc",
 ]
 
 [[package]]
@@ -1102,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -1112,14 +1093,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,12 +598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
-name = "fastrand"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
-
-[[package]]
 name = "flagset"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,7 +866,6 @@ dependencies = [
  "getset",
  "itertools 0.11.0",
  "maplit",
- "once_cell",
  "pretty_assertions",
  "rand",
  "retry",
@@ -885,7 +878,6 @@ dependencies = [
  "stable-eyre",
  "strum 0.25.0",
  "tap",
- "tempfile",
  "thiserror",
  "tikv-jemallocator",
  "traceconf",
@@ -1128,15 +1120,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1572,19 +1555,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempfile"
-version = "3.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys",
-]
 
 [[package]]
 name = "termcolor"

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "millhone"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [features]

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -33,6 +33,7 @@ secrecy = "0.8.0"
 tempfile = "3.8.0"
 once_cell = "1.18.0"
 serde_json = "1.0.107"
+serde_yaml = "0.9.25"
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -30,8 +30,6 @@ walkdir = "2.4.0"
 retry = "2.0.0"
 uuid = { version = "1.4.1", features = ["v4"] }
 secrecy = "0.8.0"
-tempfile = "3.8.0"
-once_cell = "1.18.0"
 serde_json = "1.0.107"
 serde_yaml = "0.9.25"
 

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "millhone"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [features]
@@ -32,6 +32,7 @@ uuid = { version = "1.4.1", features = ["v4"] }
 secrecy = "0.8.0"
 serde_json = "1.0.107"
 serde_yaml = "0.9.25"
+rayon = "1.8.0"
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/extlib/millhone/docs/subcommands/analyze.md
+++ b/extlib/millhone/docs/subcommands/analyze.md
@@ -108,6 +108,3 @@ After running `millhone analyze`, the next step is to run `millhone commit`.
 
 These are separate steps to give users the ability to edit or review the matched data
 prior to submitting the results to FOSSA.
-
-If this separation is not desired, users can also run `millhone analyze --commit`,
-which merges the two operations into one step.

--- a/extlib/millhone/docs/subcommands/commit.md
+++ b/extlib/millhone/docs/subcommands/commit.md
@@ -1,3 +1,28 @@
 # `commit`
 
-_This will be documented in a future PR_.
+This subcommand commits the analysis performed in the `analyze` subcommand into a `fossa-deps` file.
+For more information on possible options, run `millhone commit --help`.
+
+# Input
+
+The primary thing this subcommand requires is the path to the directory in which the output of `analyze`
+was written. Users can also alter which kinds of matches to commit, and customize the output format
+of the created `fossa-deps` file.
+
+# Output
+
+The result of this subcommand is a `fossa-deps` file written to the root of the project directory.
+
+> [!NOTE]
+> This subcommand will not overwrite an existing `fossa-deps` file by default,
+> and currently does not merge its output into an existing `fossa-deps` file.
+>
+> However, users can customize the output format (via `--format`) and then
+> perform scripted merges themselves.
+
+# Next Steps
+
+After running `millhone commit`, the next step is to run `fossa analyze` on the project.
+
+FOSSA CLI will then pick up the dependencies reported in that `fossa-deps` file and report them
+as dependencies of the project.

--- a/extlib/millhone/docs/subcommands/ingest.md
+++ b/extlib/millhone/docs/subcommands/ingest.md
@@ -3,14 +3,14 @@
 This subcommand adds an open-source library to the FOSSA knowledge base.
 For more information on possible options, run `millhone ingest --help`.
 
-# Internal Users
+# FOSSA employees
 
 This subcommand is run by internal FOSSA employees;
 end users are not able to use this command to ingest matches.
 
 This is controlled by the permissions granted to the API keys for the service.
 
-# Ingesting a library
+## Ingesting a library
 
 First, download the library locally, and determine the locator that FOSSA would use
 to refer to this library in the future.
@@ -30,6 +30,6 @@ millhone ingest \
 
 For more information on possible options, run `millhone ingest --help`.
 
-# Next Steps
+## Next Steps
 
 Now that the library is ingested, you can discover matches via `millhone analyze`.

--- a/extlib/millhone/src/api/types.rs
+++ b/extlib/millhone/src/api/types.rs
@@ -90,7 +90,9 @@ pub enum State {
 /// An [`extract::Snippet`] augmented with ingestion metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, CopyGetters, Getters)]
 pub struct ApiSnippet {
+    /// The snippet represented.
     #[serde(flatten)]
+    #[getset(get = "pub")]
     snippet: extract::Snippet,
 
     /// The full locator of the project from which this locator was extracted.

--- a/extlib/millhone/src/api/v1/lookup.rs
+++ b/extlib/millhone/src/api/v1/lookup.rs
@@ -5,7 +5,7 @@ use retry::{
     retry_with_index,
 };
 use tap::{Pipe, TapFallible};
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 use ureq::Agent;
 use url::Url;
 
@@ -27,7 +27,7 @@ pub fn run(agent: &Agent, base: &BaseUrl, fp: &Fingerprint) -> Result<HashSet<Ap
         agent
             .get(target.as_str())
             .call()
-            .tap_ok(|_| info!(%retry, "fetched matching snippets"))
+            .tap_ok(|_| debug!(%retry, "fetched matching snippets"))
     });
 
     match response {

--- a/extlib/millhone/src/cmd.rs
+++ b/extlib/millhone/src/cmd.rs
@@ -1,16 +1,13 @@
-use std::{borrow::Cow, collections::HashSet, path::PathBuf};
+use std::{borrow::Cow, collections::HashSet};
 
 use clap::Parser;
 use getset::Getters;
-use itertools::Itertools;
 use millhone::{
     api::{self, ApiSnippet},
     extract::Snippet,
 };
-use once_cell::sync::Lazy;
 use secrecy::Secret;
 use serde::{Deserialize, Serialize};
-use tap::Pipe;
 use tracing::warn;
 use typed_builder::TypedBuilder;
 use walkdir::DirEntry;
@@ -82,74 +79,5 @@ fn unwrap_dir_entry(entry: Result<DirEntry, walkdir::Error>) -> Option<DirEntry>
             }
             None
         }
-    }
-}
-
-static TEMP_PREFIX: Lazy<String> = Lazy::new(|| {
-    let name = env!("CARGO_PKG_NAME");
-    format!("{name}_")
-});
-
-/// Create a temporary directory prefixed by the name of the current crate in the system temp directory.
-pub fn namespaced_temp_dir() -> Result<PathBuf, std::io::Error> {
-    tempfile::Builder::new()
-        .prefix(TEMP_PREFIX.as_str())
-        .tempdir()
-        .map(|tf| tf.into_path())
-}
-
-/// Find the latest temporary directory created by [`namespaced_temp_dir`].
-///
-/// Note: this is allowed as dead code for now but code that uses it (via the `commit` subcommand)
-/// is coming in another PR.
-#[allow(dead_code)]
-pub fn latest_temp_dir() -> Result<Option<PathBuf>, std::io::Error> {
-    let temp = std::env::temp_dir();
-    let mut files = std::fs::read_dir(temp)?
-        .filter_ok(|entry| {
-            entry
-                .file_name()
-                .to_str()
-                .map(|name| name.starts_with(TEMP_PREFIX.as_str()))
-                .unwrap_or_default()
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    // `sort_by_key` operates in ascending order; we want the first in descending order
-    // (which is equivalent to "the one created most recently").
-    files.sort_by_key(|entry| entry.metadata().and_then(|m| m.created()).ok());
-    files.last().map(|entry| entry.path()).pipe(Ok)
-}
-
-#[cfg(test)]
-mod tests {
-
-    use std::path::Path;
-
-    use super::*;
-
-    use tap::TapFallible;
-
-    fn cleanup(dir: &Path) {
-        if let Err(err) = std::fs::remove_dir_all(dir) {
-            eprintln!(
-                "[warn] failed to clean up directory '{}': {err:#}",
-                dir.display()
-            );
-        }
-    }
-
-    #[test]
-    fn finds_latest_temp_dir() {
-        let a = namespaced_temp_dir().expect("create 'a'");
-        let b = namespaced_temp_dir()
-            .tap_err(|_| cleanup(&a))
-            .expect("create 'b'");
-        let latest = latest_temp_dir()
-            .tap_err(|_| cleanup(&a))
-            .tap_err(|_| cleanup(&b))
-            .expect("find latest");
-
-        assert_eq!(latest, Some(b));
     }
 }

--- a/extlib/millhone/src/cmd/analyze.rs
+++ b/extlib/millhone/src/cmd/analyze.rs
@@ -95,6 +95,9 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
             let matching_snippets = client
                 .lookup_snippets(fingerprint)
                 .wrap_err_with(|| format!("lookup snippet for fingerprint '{fingerprint}'"))?;
+            if matching_snippets.is_empty() {
+                continue;
+            }
 
             let record = MatchingSnippet::builder()
                 .found_in(found.snippet().file_path())
@@ -104,6 +107,10 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
                 .build();
 
             records.push(record);
+        }
+
+        if records.is_empty() {
+            continue;
         }
 
         let record_name = path

--- a/extlib/millhone/src/cmd/analyze.rs
+++ b/extlib/millhone/src/cmd/analyze.rs
@@ -1,16 +1,13 @@
-use std::{collections::HashSet, fs, path::PathBuf};
+use std::{fs, path::PathBuf};
 
 use clap::Parser;
 use getset::Getters;
-use millhone::{
-    api::{prelude::*, ApiSnippet},
-    extract::{ContentSnippet, Snippet},
-};
-use serde::{Deserialize, Serialize};
+use millhone::{api::prelude::*, extract::ContentSnippet};
 use stable_eyre::{eyre::Context, Report};
 use tracing::{debug, info, warn};
-use typed_builder::TypedBuilder;
 use walkdir::WalkDir;
+
+use crate::cmd::MatchingSnippet;
 
 /// Options for snippet ingestion.
 #[derive(Debug, Parser, Getters)]
@@ -140,25 +137,4 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
 
     println!("{}", output_dir.display());
     Ok(())
-}
-
-/// A snippet match found in a local file during analysis.
-#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
-pub struct MatchingSnippet {
-    /// The local path in which the match was found, rendered as a string.
-    /// Any invalid UTF8 content is replaced by `U+FFFD`.
-    #[builder(setter(into))]
-    found_in: String,
-
-    /// A copy of the file content indicated by `found_at`, rendered as a string.
-    /// Any invalid UTF8 content is replaced by `U+FFFD`.
-    #[builder(setter(into))]
-    local_text: String,
-
-    /// The snippet that was identified in the local project.
-    local_snippet: Snippet,
-
-    /// Snippets in the knowledgebase that match this snippet.
-    #[builder(setter(into))]
-    matching_snippets: HashSet<ApiSnippet>,
 }

--- a/extlib/millhone/src/cmd/analyze.rs
+++ b/extlib/millhone/src/cmd/analyze.rs
@@ -1,16 +1,21 @@
-use std::{fs, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 use clap::Parser;
 use getset::Getters;
 use millhone::{api::prelude::*, extract::ContentSnippet};
+use rayon::prelude::*;
 use stable_eyre::{
     eyre::{bail, Context},
     Report,
 };
-use tracing::{debug, info, warn};
+use tap::Pipe;
+use tracing::{debug, info, trace, warn};
 use walkdir::WalkDir;
 
-use crate::cmd::MatchingSnippet;
+use crate::cmd::{AtomicCounter, MatchingSnippet};
 
 /// Options for snippet ingestion.
 #[derive(Debug, Parser, Getters)]
@@ -36,123 +41,157 @@ pub struct Subcommand {
 pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
     info!(
         api_key_id = %opts.auth.api_key_id(),
-        "Analyzing local snippet matches",
+        output = %opts.output.display(),
+        overwrite_output = %opts.overwrite_output,
+        extract_opts = ?opts.extract,
+        "analyzing local snippet matches",
     );
-
-    let creds = opts.auth.as_credentials();
-    let client = ApiClientV1::authenticated(endpoint, creds);
-    let root = opts.extract().target();
-    let walk = WalkDir::new(root)
-        // Follow symlinks; loops are yielded as errors automatically.
-        .follow_links(true)
-        // Not chosen for a specific reason, just seems reasonable.
-        .max_depth(1000)
-        // Just make the walk deterministic (per directory anyway).
-        .sort_by_file_name();
-
-    let mut total_count_entries = 0usize;
-    let mut total_count_snippets = 0usize;
-    let mut total_count_files = 0usize;
 
     if opts.output().exists() {
         if opts.overwrite_output {
             std::fs::remove_dir_all(opts.output()).context("remove existing output directory")?;
+            debug!("removed existing output dir: {}", opts.output().display());
         } else {
             bail!(
-                "The output directory '{}' already exists.",
+                "the output directory '{}' already exists.",
                 opts.output().display(),
             );
         }
     }
     if !opts.output().exists() {
         std::fs::create_dir_all(opts.output()).context("create output directory")?;
+        debug!("created output dir: {}", opts.output().display());
     }
 
-    // Future enhancement: walk and analyze in parallel with rayon.
+    let creds = opts.auth.as_credentials();
+    let client = ApiClientV1::authenticated(endpoint, creds);
+    let root = opts.extract().target();
     let snippet_opts = opts.extract().into();
-    for entry in walk.into_iter() {
-        total_count_entries += 1;
-        let Some(entry) = super::unwrap_dir_entry(entry) else {
-            continue;
-        };
 
-        let path = if entry.path_is_symlink() {
-            let path = entry.path();
-            fs::read_link(path)
-                .wrap_err_with(|| format!("resolve symlink of '{}'", path.display()))?
-        } else {
-            entry.path().to_path_buf()
-        };
+    let total_count_entries = AtomicCounter::default();
+    let total_count_snippets = AtomicCounter::default();
+    let total_count_files = AtomicCounter::default();
 
-        if !path.is_file() {
-            debug!(path = %path.display(), "skipped: not a file");
-            continue;
-        }
+    WalkDir::new(root)
+        // Follow symlinks; loops are yielded as errors automatically.
+        .follow_links(true)
+        // Not chosen for a specific reason, just seems reasonable.
+        .max_depth(1000)
+        // Just make the walk deterministic (per directory anyway).
+        .sort_by_file_name()
+        .into_iter()
+        .inspect(|_| total_count_entries.increment())
+        .filter_map(super::unwrap_dir_entry)
+        // Bridge into rayon for parallelization.
+        .par_bridge()
+        // Resolve symlinks into full paths and filter to only files.
+        .filter_map(|entry| -> Option<PathBuf> {
+            debug!(path = %entry.path().display(), "resolve path");
+            let path = super::resolve_path(&entry)
+                .map_err(|err| warn!(path = %entry.path().display(), "failed to resolve symlink to path: {err:#}"))
+                .ok()?;
 
-        total_count_files += 1;
-        info!(path = %path.display(), "analyze");
+            if path.is_file() {
+                debug!(path = %path.display(), "enqueued for processing");
+                total_count_files.increment();
+                Some(path)
+            } else {
+                debug!(path = %path.display(), "skipped: not a file");
+                None
+            }
+        })
+        // Extract snippets from each file in parallel.
+        .filter_map(|path| -> Option<(PathBuf, HashSet<ContentSnippet>)> {
+            debug!(path = %path.display(), "extract snippets");
+            let snippets = ContentSnippet::from_file(root, &snippet_opts, &path)
+                .map_err(|err| warn!(path = %path.display(), "extract snippets: {err:#}"))
+                .ok()?;
 
-        let snippets = ContentSnippet::from_file(root, &snippet_opts, &path)
-            .wrap_err_with(|| format!("process '{}'", path.display()))?;
+            if snippets.is_empty() {
+                debug!(path = %path.display(), "no snippets extracted");
+                return None;
+            }
 
-        info!(snippet_count = %snippets.len(), "extracted snippets");
-        total_count_snippets += snippets.len();
-        if snippets.is_empty() {
-            continue;
-        }
+            let snippet_count = snippets.len();
+            debug!(path = %path.display(), %snippet_count, "extracted snippets");
+            total_count_snippets.increment_by(snippet_count);
 
-        let mut records = Vec::new();
-        for found in snippets {
+            (path, snippets).pipe(Some)
+        })
+        // The goal is to then parallelize API calls, so flatten collections of snippets.
+        // Using the serial `flat_map_iter` because this inner iterator has no computation aside from a clone.
+        .flat_map_iter(|(path, snippets)| std::iter::repeat(path).zip(snippets))
+        // Now match snippets up with the API into collections of matches.
+        .filter_map(|(path, found)| -> Option<(PathBuf, MatchingSnippet)> {
             let fingerprint = found.snippet().fingerprint();
             let matching_snippets = client
                 .lookup_snippets(fingerprint)
-                .wrap_err_with(|| format!("lookup snippet for fingerprint '{fingerprint}'"))?;
+                .map_err(|err| warn!(path = %path.display(), %fingerprint, "lookup snippet: {err:#}"))
+                .ok()?;
             if matching_snippets.is_empty() {
-                continue;
+                trace!(%fingerprint, "no matches in corpus");
+                return None;
+            }
+            for matched in matching_snippets.iter() {
+                trace!(%fingerprint, ?matched, "matched snippet");
             }
 
-            let record = MatchingSnippet::builder()
+            MatchingSnippet::builder()
                 .found_in(found.snippet().file_path())
                 .local_snippet(found.snippet().clone())
                 .local_text(String::from_utf8_lossy(found.content()))
                 .matching_snippets(matching_snippets)
-                .build();
+                .build()
+                .pipe(|record| (path, record))
+                .pipe(Some)
+        })
+        // Snippet lookups were parallelized. Join them back together by path.
+        // Need both fold and reduce; see https://docs.rs/rayon/latest/rayon/iter/trait.ParallelIterator.html#method.fold
+        .fold(HashMap::new, |mut acc, (path, record)| {
+            acc.entry(path).or_insert_with(Vec::new).push(record);
+            acc
+        })
+        .reduce(HashMap::new, |mut acc, partial| {
+            for (k, v) in partial {
+                acc.entry(k).or_insert_with(Vec::new).extend(v);
+            }
+            acc
+        })
+        // Reduce handed back a hashmap. Spread it back out into an iterator,
+        // such that each path corresponds to a single set of records.
+        .into_par_iter()
+        .for_each(|(path, records)| {
+            let record_name = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR_STR, "_");
 
-            records.push(record);
-        }
+            let current_ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
+            let record_path = opts
+                .output()
+                .join(record_name)
+                .with_extension(format!("{current_ext}.json"));
 
-        if records.is_empty() {
-            continue;
-        }
-
-        let record_name = path
-            .strip_prefix(root)
-            .unwrap_or(&path)
-            .to_string_lossy()
-            .replace(std::path::MAIN_SEPARATOR_STR, "_");
-
-        let current_ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
-        let record_path = opts
-            .output()
-            .join(&record_name)
-            .with_extension(format!("{current_ext}.json"));
-
-        let encoded = serde_json::to_string_pretty(&records).context("encode record")?;
-        std::fs::write(&record_path, encoded).context("write records")?;
-
-        info!(
-            "wrote {} match record(s) for '{}' to '{}'",
-            records.len(),
-            record_name,
-            record_path.display()
-        );
-    }
+            let written = serde_json::to_string_pretty(&records)
+                .context("encode records")
+                .and_then(|encoded| std::fs::write(&record_path, encoded).context("write records"));
+            match written {
+                Ok(_) => info!(
+                    "wrote {} matches for '{}' to '{}'",
+                    records.len(),
+                    path.display(),
+                    record_path.display()
+                ),
+                Err(err) => warn!(record_path = %record_path.display(), "failed to write match records: {err:#}"),
+            }
+        });
 
     info!(
-        %total_count_entries,
-        %total_count_snippets,
-        %total_count_files,
-        "Finished extracting snippets",
+        total_count_entries = %total_count_entries.into_inner(),
+        total_count_snippets = %total_count_snippets.into_inner(),
+        total_count_files = %total_count_files.into_inner(),
+        "finished extracting snippets",
     );
 
     Ok(())

--- a/extlib/millhone/src/cmd/commit.rs
+++ b/extlib/millhone/src/cmd/commit.rs
@@ -185,9 +185,9 @@ pub fn main(opts: Subcommand) -> Result<(), Report> {
     let deps_file = FossaDeps { referenced: deps };
     let rendered = match opts.format {
         OutputFormat::Json => {
-            serde_json::to_string_pretty(&deps_file).context("render fossa-deps to json")?
+            serde_json::to_string_pretty(&deps_file).context("render fossa-deps")?
         }
-        OutputFormat::Yml => unimplemented!(),
+        OutputFormat::Yml => serde_yaml::to_string(&deps_file).context("render fossa-deps")?,
     };
     std::fs::write(&output_file, rendered)
         .wrap_err_with(|| format!("write fossa-deps at '{}'", output_file.display()))?;

--- a/extlib/millhone/src/cmd/commit.rs
+++ b/extlib/millhone/src/cmd/commit.rs
@@ -3,31 +3,38 @@ use std::{collections::HashSet, path::PathBuf};
 use clap::{Parser, ValueEnum};
 use getset::Getters;
 use itertools::Itertools;
-use millhone::{
-    api::prelude::*,
-    extract::{Kind, Target, Transform},
+use millhone::extract::{Kind, Method, Target, Transform};
+use serde::{Deserialize, Serialize};
+use srclib::{Fetcher, Locator};
+use stable_eyre::{
+    eyre::{bail, eyre, Context},
+    Report,
 };
-use stable_eyre::{eyre::Context, Report};
 use strum::{Display, IntoEnumIterator};
-use tracing::{info, warn};
+use tap::{Pipe, Tap, TapFallible};
+use tracing::{debug, info, warn};
 
-use crate::cmd::MatchingSnippet;
+use crate::cmd::{latest_temp_dir, MatchingSnippet};
 
 /// Options for snippet ingestion.
 #[derive(Debug, Parser, Getters)]
 #[getset(get = "pub")]
 #[clap(version)]
 pub struct Subcommand {
-    /// The path to the directory in which to write the `fossa-deps` file.
+    /// The path to the directory in which the `analyze` subcommand wrote its output.
     ///
     /// If not specified, attempts to discover the most recent
     /// temporary directory created by the `analyze` subcommand.
     #[clap(long)]
-    analyze_dir: Option<PathBuf>,
+    analyze_output_dir: Option<PathBuf>,
 
     /// The output format for the generated `fossa-deps` file.
     #[clap(long, default_value_t = OutputFormat::Json)]
     format: OutputFormat,
+
+    /// If specified, overwrites the output file if it exists.
+    #[clap(long)]
+    overwrite_fossa_deps: bool,
 
     /// Only commit matches with the specified targets.
     ///
@@ -53,7 +60,7 @@ pub struct Subcommand {
 
     /// The directory being analyzed by FOSSA.
     ///
-    /// The `fossa-deps` file is written into this directory.
+    /// The `fossa-deps` file is written into the root of this directory.
     target: PathBuf,
 }
 
@@ -69,9 +76,9 @@ pub enum OutputFormat {
 }
 
 #[tracing::instrument(skip_all, fields(target = %opts.target().display()))]
-pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
+pub fn main(opts: Subcommand) -> Result<(), Report> {
     info!(
-        analyze_dir = ?opts.analyze_dir,
+        analyze_dir = ?opts.analyze_output_dir,
         format = %opts.format,
         targets = ?opts.targets,
         kinds = ?opts.kinds,
@@ -79,23 +86,176 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
         "Committing local snippet matches",
     );
 
-    let root = opts.target();
-    let targets = default_if_empty(opts.targets(), Target::iter);
-    let kinds = default_if_empty(opts.kinds(), Kind::iter);
-    let transforms = default_if_empty(opts.transforms(), Transform::iter);
+    let output_file = opts
+        .target()
+        .join("fossa-deps")
+        .with_extension(opts.format().to_string());
+    if !opts.overwrite_fossa_deps() && output_file.exists() {
+        bail!(
+            "The output file '{}' already exists. This program does not currently merge `fossa-deps` files.",
+            output_file.display(),
+        );
+    }
 
+    let analyze_output_dir = opts
+        .analyze_output_dir()
+        .as_ref()
+        .cloned()
+        .map(Ok)
+        .or_else(|| latest_temp_dir().transpose())
+        .transpose()
+        .context("discover most recently created temp dir")?
+        .ok_or_else(|| eyre!("Unable to find the output of previous `analyze` subcommand"))?;
+
+    let match_targets = default_if_empty(opts.targets(), Target::iter);
+    let match_kinds = default_if_empty(opts.kinds(), Kind::iter);
+    let match_methods = if opts.transforms().is_empty() {
+        Method::iter()
+            .map(|m| m.to_string())
+            .collect::<HashSet<_>>()
+    } else {
+        opts.transforms()
+            .iter()
+            .copied()
+            .pipe(Method::iter_constrained)
+            .map(|m| m.to_string())
+            .collect::<HashSet<_>>()
+    };
+
+    let deps = std::fs::read_dir(&analyze_output_dir)
+        .wrap_err_with(|| format!("list contents of '{}'", analyze_output_dir.display()))?
+        .inspect(|entry| debug!(analyze_output_dir = %analyze_output_dir.display(), ?entry, "walk contents"))
+        .filter_ok(|entry| {
+            let path = entry.path();
+            path.extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext == "json")
+                .unwrap_or_default()
+                .tap(|valid| debug!(path = %entry.path().display(), %valid, "filter to json"))
+        })
+        .map_ok(|entry| {
+            std::fs::read(entry.path())
+                .wrap_err_with(|| format!("read '{}'", entry.path().display()))
+                .tap_ok(|_| debug!(path = %entry.path().display(), "read entry"))
+        })
+        .flatten()
+        .map_ok(|content| serde_json::from_slice::<Vec<MatchingSnippet>>(&content))
+        .flatten()
+        .flatten_ok()
+        .map_ok(|m| {
+            m.matching_snippets
+                .iter()
+                .filter_map(|m| {
+                    let matches = match_kinds.contains(m.snippet().kind())
+                        || match_targets.contains(m.snippet().target())
+                        || match_methods.contains(m.snippet().method());
+                    debug!(
+                        ?match_kinds,
+                        ?match_targets,
+                        ?match_methods,
+                        "snippet {m:?} matches criteria: {matches}"
+                    );
+
+                    if matches {
+                        Some(m.locator().clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect_vec()
+        })
+        .flatten_ok()
+        .collect::<Result<HashSet<_>, _>>()
+        .context("find matching snippets")?
+        .into_iter()
+        .filter_map(|loc| {
+            ReferencedDependency::try_from(loc)
+                .tap_err(|(loc, err)| {
+                    warn!("unable to translate locator '{loc}' to referenced dependency: {err:#}")
+                })
+                .ok()
+        })
+        .collect_vec();
+
+    if deps.is_empty() {
+        info!("No dependencies committed");
+        return Ok(());
+    }
+
+    let deps_file = FossaDeps { referenced: deps };
+    let rendered = match opts.format {
+        OutputFormat::Json => {
+            serde_json::to_string_pretty(&deps_file).context("render fossa-deps to json")?
+        }
+        OutputFormat::Yml => unimplemented!(),
+    };
+    std::fs::write(&output_file, rendered)
+        .wrap_err_with(|| format!("write fossa-deps at '{}'", output_file.display()))?;
+
+    info!(
+        "Wrote output to '{}' with dependency count: {}",
+        output_file.display(),
+        deps_file.referenced.len(),
+    );
     Ok(())
 }
 
-fn default_if_empty<F, I, T>(items: &[T], or_default: F) -> HashSet<T>
+fn default_if_empty<F, I, T>(items: &[T], or_default: F) -> HashSet<String>
 where
     F: FnOnce() -> I,
     I: IntoIterator<Item = T>,
-    T: Copy + std::hash::Hash + Eq,
+    T: ToString,
 {
     if items.is_empty() {
-        or_default().into_iter().collect()
+        or_default().into_iter().map(|s| s.to_string()).collect()
     } else {
-        items.iter().copied().collect()
+        items.iter().map(|s| s.to_string()).collect()
     }
+}
+
+/// Serialize the entries of the `referenced-dependencies` type in `fossa-deps`:
+/// https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-deps.md#referenced-dependencies
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ReferencedDependency {
+    #[serde(rename = "type")]
+    kind: String,
+    name: String,
+    version: String,
+}
+
+impl ReferencedDependency {
+    fn kind_for_fetcher(fetcher: Fetcher) -> Result<String, Report> {
+        match fetcher {
+            Fetcher::Git => Ok("git".into()),
+            _ => Err(eyre!("unsupported fetcher: {fetcher}")),
+        }
+    }
+}
+
+impl TryFrom<Locator> for ReferencedDependency {
+    type Error = (Locator, Report);
+
+    fn try_from(loc: Locator) -> Result<Self, Self::Error> {
+        let kind = Self::kind_for_fetcher(loc.fetcher())
+            .context("translate fetcher to 'referenced-dependency'.type")
+            .map_err(|err| (loc.clone(), err))?;
+        let version = loc
+            .revision()
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| (loc.clone(), eyre!("version required for locator")))?;
+
+        Ok(Self {
+            kind,
+            version,
+            name: loc.project().to_string(),
+        })
+    }
+}
+
+/// Serialize a `fossa-deps` file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FossaDeps {
+    #[serde(rename = "referenced-dependencies")]
+    referenced: Vec<ReferencedDependency>,
 }

--- a/extlib/millhone/src/cmd/commit.rs
+++ b/extlib/millhone/src/cmd/commit.rs
@@ -1,0 +1,101 @@
+use std::{collections::HashSet, path::PathBuf};
+
+use clap::{Parser, ValueEnum};
+use getset::Getters;
+use itertools::Itertools;
+use millhone::{
+    api::prelude::*,
+    extract::{Kind, Target, Transform},
+};
+use stable_eyre::{eyre::Context, Report};
+use strum::{Display, IntoEnumIterator};
+use tracing::{info, warn};
+
+use crate::cmd::MatchingSnippet;
+
+/// Options for snippet ingestion.
+#[derive(Debug, Parser, Getters)]
+#[getset(get = "pub")]
+#[clap(version)]
+pub struct Subcommand {
+    /// The path to the directory in which to write the `fossa-deps` file.
+    ///
+    /// If not specified, attempts to discover the most recent
+    /// temporary directory created by the `analyze` subcommand.
+    #[clap(long)]
+    analyze_dir: Option<PathBuf>,
+
+    /// The output format for the generated `fossa-deps` file.
+    #[clap(long, default_value_t = OutputFormat::Json)]
+    format: OutputFormat,
+
+    /// Only commit matches with the specified targets.
+    ///
+    /// Defaults to all supported targets.
+    /// Specify the argument multiple times to indicate additional options.
+    #[clap(long = "target")]
+    targets: Vec<Target>,
+
+    /// Only commit matches with the specified kinds.
+    ///
+    /// Defaults to all supported kinds.
+    /// Specify the argument multiple times to indicate additional options.
+    #[clap(long = "kind")]
+    kinds: Vec<Kind>,
+
+    /// Only commit matches with the specified transforms.
+    ///
+    /// Defaults to all supported transforms. Raw matches (i.e. no transforms)
+    /// are always committed and cannot be disabled.
+    /// Specify the argument multiple times to indicate additional options.
+    #[clap(long = "transform")]
+    transforms: Vec<Transform>,
+
+    /// The directory being analyzed by FOSSA.
+    ///
+    /// The `fossa-deps` file is written into this directory.
+    target: PathBuf,
+}
+
+/// The output format for the generated `fossa-deps` file.
+#[derive(Debug, Clone, Copy, ValueEnum, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum OutputFormat {
+    /// Commit as `fossa-deps.json`.
+    Json,
+
+    /// Commit as `fossa-deps.yml`.
+    Yml,
+}
+
+#[tracing::instrument(skip_all, fields(target = %opts.target().display()))]
+pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
+    info!(
+        analyze_dir = ?opts.analyze_dir,
+        format = %opts.format,
+        targets = ?opts.targets,
+        kinds = ?opts.kinds,
+        transforms = ?opts.transforms,
+        "Committing local snippet matches",
+    );
+
+    let root = opts.target();
+    let targets = default_if_empty(opts.targets(), Target::iter);
+    let kinds = default_if_empty(opts.kinds(), Kind::iter);
+    let transforms = default_if_empty(opts.transforms(), Transform::iter);
+
+    Ok(())
+}
+
+fn default_if_empty<F, I, T>(items: &[T], or_default: F) -> HashSet<T>
+where
+    F: FnOnce() -> I,
+    I: IntoIterator<Item = T>,
+    T: Copy + std::hash::Hash + Eq,
+{
+    if items.is_empty() {
+        or_default().into_iter().collect()
+    } else {
+        items.iter().copied().collect()
+    }
+}

--- a/extlib/millhone/src/extract.rs
+++ b/extlib/millhone/src/extract.rs
@@ -16,9 +16,9 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use snippets::{language::c99_tc3, Extractor};
 use strum::{Display, EnumIter, IntoEnumIterator};
-use tap::Pipe;
+use tap::{Pipe, Tap};
 use thiserror::Error;
-use tracing::debug;
+use tracing::{debug, trace};
 use typed_builder::TypedBuilder;
 
 /// Errors encountered in this module.
@@ -278,46 +278,57 @@ impl Snippet {
     }
 
     /// Extract instances from a file on disk.
-    #[tracing::instrument]
+    /// If the file is not supported, the returned results are empty.
+    #[tracing::instrument(skip_all, fields(path = %path.display()))]
     pub fn from_file(
         scan_root: &Path,
         opts: &snippets::Options,
         path: &Path,
     ) -> Result<HashSet<Self>, Error> {
-        Self::from_file_with_content(scan_root, opts, path).map(|(found, _)| found)
+        match Support::by_ext(path) {
+            Support::Unknown => {
+                debug!("file extension support unknown");
+                HashSet::new().pipe(Ok)
+            }
+            Support::Unsupported => {
+                debug!("file extension not supported");
+                HashSet::new().pipe(Ok)
+            }
+            Support::Supported(language) => {
+                let content = std::fs::read(path).map_err(Error::ReadFile)?;
+                Self::from_content(scan_root, opts, path, language, &content)
+            }
+        }
     }
 
-    /// Extract instances from a file on disk,
-    /// returning the content of the file along with the snippet.
+    /// Extract instances from content already read from disk.
     ///
-    /// If the file is not supported, the returned file content is empty.
-    pub fn from_file_with_content(
+    /// It's recommended to use [`Support`] to determine the [`Language`]
+    /// to pass to this function.
+    #[tracing::instrument(skip_all)]
+    pub fn from_content(
         scan_root: &Path,
         opts: &snippets::Options,
         path: &Path,
-    ) -> Result<(HashSet<Self>, Vec<u8>), Error> {
-        match Support::by_ext(path) {
-            Support::Unknown => {
-                debug!("skipping: unknown support status for file");
-                Ok((Default::default(), Default::default()))
-            }
-            Support::Unsupported => {
-                debug!("skipping: file extension not supported");
-                Ok((Default::default(), Default::default()))
-            }
-            Support::Supported(language) => {
-                debug!("extracting snippets of language: {language}");
-                let content = std::fs::read(path).map_err(Error::ReadFile)?;
-                match language {
-                    Language::C => c99_tc3::Extractor::extract(opts, &content)?
-                        .pipe(collapse_raw)
-                        .map(|snippet| Self::from(scan_root, path, &content, snippet))
-                        .collect::<HashSet<_>>()
-                        .pipe(|found| (found, content))
-                        .pipe(Ok),
-                }
-            }
+        language: Language,
+        content: &[u8],
+    ) -> Result<HashSet<Self>, Error> {
+        match language {
+            Language::C => c99_tc3::Extractor::extract(opts, content)?
+                .pipe(collapse_raw)
+                .map(|snippet| Self::from(scan_root, path, content, snippet))
+                .inspect(|snippet| trace!(?snippet, "extracted snippet"))
+                .collect::<HashSet<Self>>(),
         }
+        .tap(|found| {
+            debug!(
+                %language,
+                count = %found.len(),
+                content_len = %content.len(),
+                "extracted snippets",
+            )
+        })
+        .pipe(Ok)
     }
 
     /// Get the [`Location`] referenced by the snippet.
@@ -348,24 +359,37 @@ pub struct ContentSnippet {
 
 impl ContentSnippet {
     /// Extract instances from a file on disk.
-    #[tracing::instrument]
+    /// If the file is not supported, the returned results are empty.
+    #[tracing::instrument(skip_all, fields(path = %path.display()))]
     pub fn from_file(
         scan_root: &Path,
         opts: &snippets::Options,
         path: &Path,
     ) -> Result<HashSet<Self>, Error> {
-        let (found, content) = Snippet::from_file_with_content(scan_root, opts, path)?;
-        found
-            .into_iter()
-            .map(|snippet| {
-                let location = snippet.location();
-                Self {
-                    snippet,
-                    content: location.extract_from(&content).to_owned(),
-                }
-            })
-            .collect::<HashSet<_>>()
-            .pipe(Ok)
+        match Support::by_ext(path) {
+            Support::Unknown => {
+                debug!("file extension support unknown");
+                HashSet::new().pipe(Ok)
+            }
+            Support::Unsupported => {
+                debug!("file extension not supported");
+                HashSet::new().pipe(Ok)
+            }
+            Support::Supported(language) => {
+                let content = std::fs::read(path).map_err(Error::ReadFile)?;
+                Snippet::from_content(scan_root, opts, path, language, &content)?
+                    .into_iter()
+                    .map(|snippet| {
+                        let location = snippet.location();
+                        Self {
+                            snippet,
+                            content: location.extract_from(&content).to_owned(),
+                        }
+                    })
+                    .collect::<HashSet<_>>()
+                    .pipe(Ok)
+            }
+        }
     }
 }
 

--- a/extlib/millhone/src/extract.rs
+++ b/extlib/millhone/src/extract.rs
@@ -76,7 +76,7 @@ impl From<&Options> for snippets::Options {
 }
 
 /// The targets of snippets to extract.
-#[derive(Debug, Clone, Copy, ValueEnum, Display)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, ValueEnum, Display, EnumIter)]
 #[strum(serialize_all = "snake_case")]
 pub enum Target {
     /// Targets function defintions as snippets.
@@ -92,7 +92,7 @@ impl From<Target> for snippets::Target {
 }
 
 /// The kind of item this snippet represents.
-#[derive(Debug, Clone, Copy, ValueEnum, Display)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, ValueEnum, Display, EnumIter)]
 #[strum(serialize_all = "snake_case")]
 pub enum Kind {
     /// The signature of the snippet.
@@ -116,7 +116,7 @@ impl From<Kind> for snippets::Kind {
 }
 
 /// The normalization used to extract this snippet.
-#[derive(Debug, Clone, Copy, ValueEnum, Display)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, ValueEnum, Display, EnumIter)]
 #[strum(serialize_all = "snake_case")]
 pub enum Transform {
     /// Transform the text to have any comments removed and whitespace normalized.

--- a/extlib/millhone/src/extract.rs
+++ b/extlib/millhone/src/extract.rs
@@ -116,6 +116,35 @@ impl From<Kind> for snippets::Kind {
 }
 
 /// The normalization used to extract this snippet.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum Method {
+    /// Generated from the text with the specified normalization applied.
+    Normalized(Transform),
+
+    /// Generated from the text as written.
+    Raw,
+}
+
+impl Method {
+    /// Create an iterator over possible methods used for snippet extraction.
+    pub fn iter() -> impl Iterator<Item = Method> {
+        Self::iter_constrained(Transform::iter())
+    }
+
+    /// Create an iterator over possible methods used for snippet extraction,
+    /// constrained to the provided transforms.
+    pub fn iter_constrained(
+        transforms: impl IntoIterator<Item = Transform>,
+    ) -> impl Iterator<Item = Method> {
+        std::iter::once(Method::Raw)
+            .chain(transforms.into_iter().map(Method::Normalized))
+            .collect_vec()
+            .into_iter()
+    }
+}
+
+/// The normalization used to extract this snippet.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, ValueEnum, Display, EnumIter)]
 #[strum(serialize_all = "snake_case")]
 pub enum Transform {
@@ -364,13 +393,9 @@ impl std::fmt::Display for Fingerprint {
 
 impl std::fmt::Debug for Fingerprint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if f.alternate() {
-            f.debug_tuple("Fingerprint")
-                .field(&self.to_string())
-                .finish()
-        } else {
-            f.debug_tuple("Fingerprint").field(&self.0).finish()
-        }
+        f.debug_tuple("Fingerprint")
+            .field(&self.to_string())
+            .finish()
     }
 }
 

--- a/extlib/millhone/src/main.rs
+++ b/extlib/millhone/src/main.rs
@@ -52,10 +52,13 @@ enum Commands {
 
     /// Ingest snippets to the Millhone backend.
     // Boxed to reduce size difference between variants, a clippy lint.
-    Ingest(Box<cmd::ingest::Subcommand>),
+    Ingest(cmd::ingest::Subcommand),
 
     /// Analyze a local project for matches.
-    Analyze(Box<cmd::analyze::Subcommand>),
+    Analyze(cmd::analyze::Subcommand),
+
+    /// Commit matches discovered during analyze into a fossa-deps file.
+    Commit(cmd::commit::Subcommand),
 }
 
 fn main() -> stable_eyre::Result<()> {
@@ -70,7 +73,8 @@ fn main() -> stable_eyre::Result<()> {
     // And then dispatch to the subcommand.
     match app.commands {
         Commands::Ping => cmd::ping::main(&app.direct_endpoint),
-        Commands::Ingest(opts) => cmd::ingest::main(&app.direct_endpoint, *opts),
-        Commands::Analyze(opts) => cmd::analyze::main(&app.direct_endpoint, *opts),
+        Commands::Ingest(opts) => cmd::ingest::main(&app.direct_endpoint, opts),
+        Commands::Analyze(opts) => cmd::analyze::main(&app.direct_endpoint, opts),
+        Commands::Commit(opts) => cmd::commit::main(opts),
     }
 }


### PR DESCRIPTION
# Overview

Implements the `commit` subcommand, which generates a `fossa-deps` file from the output of `millhone analyze`.

## Acceptance criteria

Users are able to generate a `fossa-deps` file.

## Testing plan

In one terminal, run Millhone. I ran it with the in-memory DB for convenience:

```shell
foundation/millhone on ⑆ millhone/nits [$] is 📦 v0.2.0 via 🦀 v1.72.0
❯ cargo run -- --db-in-memory
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `/Users/jessica/projects/foundation/target/debug/millhone --db-in-memory`
  2023-09-21T23:42:11.659337Z  INFO millhone: creating server, options: Application { port: 3000, tracing: TracingConfig { trace_level: Info, trace_spans: Off, trace_format: Text, trace_colors: Auto }, app_db: AppDbConfig { app_db_host: NonEmptyString("localhost"), app_db_port: 5432, app_db_name: NonEmptyString("millhone"), app_db_user: NonEmptyString("fossa"), app_db_password: Secret([REDACTED alloc::string::String]), app_db_max_pool: 10, app_db_min_pool: 10, app_db_connection_timeout_seconds: 30 }, corpus_db: CorpusDbConfig { corpus_db_nodes: ["localhost:9042"], corpus_db_keyspace: "millhone", corpus_db_username: None, corpus_db_password: None }, db_in_memory: true }
    at millhone/src/main.rs:198

  2023-09-21T23:42:11.669588Z  INFO millhone: booting server, addr: 0.0.0.0:3000
    at millhone/src/main.rs:202
```

I then copied the test files from `foundation-libs/snippets` and ran these steps:
```shell
millhone ingest \
  --direct-endpoint http://localhost:3000 \
  --api-key-id testing \
  --api-secret testing \
  --locator 'git+github.com/fossas/cpp-vsi-demo$76987d9d364bc2c73897549a71d13371a32cd3e7' \
  --kind signature \
  --kind body \
  --kind full \
  --transform space \
  ~/projects/cpp-vsi-demo/example-internal-project

millhone analyze \
  --direct-endpoint http://localhost:3000 \
  --api-key-id testing \
  --api-secret testing \
  --kind signature \
  --kind body \
  --kind full \
  --transform space \
  -o millhone_analyze_output \
  src 

millhone commit \
  --analyze-output-dir millhone_analyze_output \
  --trace-level debug \
  --overwrite-fossa-deps \
  --format yml \
  src

. fossa_prod

fossa analyze -p millhone-demo src
```

And...

<img width="1685" alt="Screenshot 2023-09-21 at 9 49 15 PM" src="https://github.com/fossas/fossa-cli/assets/55713231/f6f90eb0-bd9c-4e86-8731-a45b95793e60">

With a nice little `fossa-deps` file generated:
```yml
referenced-dependencies:
- type: git
  name: github.com/fossas/cpp-vsi-demo
  version: 76987d9d364bc2c73897549a71d13371a32cd3e7
```

## Risks

None

## Metrics

None

## References

Implements https://fossa.atlassian.net/browse/ANE-1115

## Checklist

No real automated tests, because this is nearly 100% in `main()`.

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
