### PR TITLE
Millhone: Parallelization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,16 +439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "millhone"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.21.4",
  "clap 4.4.4",
@@ -868,6 +858,7 @@ dependencies = [
  "maplit",
  "pretty_assertions",
  "rand",
+ "rayon",
  "retry",
  "secrecy",
  "serde",
@@ -915,16 +906,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.2",
- "libc",
 ]
 
 [[package]]
@@ -1102,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -1112,14 +1093,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "millhone"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [features]
@@ -32,6 +32,7 @@ uuid = { version = "1.4.1", features = ["v4"] }
 secrecy = "0.8.0"
 serde_json = "1.0.107"
 serde_yaml = "0.9.25"
+rayon = "1.8.0"
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/extlib/millhone/docs/subcommands/ingest.md
+++ b/extlib/millhone/docs/subcommands/ingest.md
@@ -3,14 +3,14 @@
 This subcommand adds an open-source library to the FOSSA knowledge base.
 For more information on possible options, run `millhone ingest --help`.
 
-# Internal Users
+# FOSSA employees
 
 This subcommand is run by internal FOSSA employees;
 end users are not able to use this command to ingest matches.
 
 This is controlled by the permissions granted to the API keys for the service.
 
-# Ingesting a library
+## Ingesting a library
 
 First, download the library locally, and determine the locator that FOSSA would use
 to refer to this library in the future.
@@ -30,6 +30,6 @@ millhone ingest \
 
 For more information on possible options, run `millhone ingest --help`.
 
-# Next Steps
+## Next Steps
 
 Now that the library is ingested, you can discover matches via `millhone analyze`.

--- a/extlib/millhone/src/api/v1/lookup.rs
+++ b/extlib/millhone/src/api/v1/lookup.rs
@@ -5,7 +5,7 @@ use retry::{
     retry_with_index,
 };
 use tap::{Pipe, TapFallible};
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 use ureq::Agent;
 use url::Url;
 
@@ -27,7 +27,7 @@ pub fn run(agent: &Agent, base: &BaseUrl, fp: &Fingerprint) -> Result<HashSet<Ap
         agent
             .get(target.as_str())
             .call()
-            .tap_ok(|_| info!(%retry, "fetched matching snippets"))
+            .tap_ok(|_| debug!(%retry, "fetched matching snippets"))
     });
 
     match response {

--- a/extlib/millhone/src/cmd/analyze.rs
+++ b/extlib/millhone/src/cmd/analyze.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, collections::{HashMap, HashSet}};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 use clap::Parser;
 use getset::Getters;
@@ -95,7 +98,7 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
             } else {
                 debug!(path = %path.display(), "skipped: not a file");
                 None
-            } 
+            }
         })
         // Extract snippets from each file in parallel.
         .filter_map(|path| -> Option<(PathBuf, HashSet<ContentSnippet>)> {

--- a/extlib/millhone/src/cmd/analyze.rs
+++ b/extlib/millhone/src/cmd/analyze.rs
@@ -1,16 +1,18 @@
-use std::{fs, path::PathBuf};
+use std::{path::PathBuf, collections::{HashMap, HashSet}};
 
 use clap::Parser;
 use getset::Getters;
 use millhone::{api::prelude::*, extract::ContentSnippet};
+use rayon::prelude::*;
 use stable_eyre::{
     eyre::{bail, Context},
     Report,
 };
-use tracing::{debug, info, warn};
+use tap::Pipe;
+use tracing::{debug, info, trace, warn};
 use walkdir::WalkDir;
 
-use crate::cmd::MatchingSnippet;
+use crate::cmd::{AtomicCounter, MatchingSnippet};
 
 /// Options for snippet ingestion.
 #[derive(Debug, Parser, Getters)]
@@ -36,123 +38,160 @@ pub struct Subcommand {
 pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
     info!(
         api_key_id = %opts.auth.api_key_id(),
-        "Analyzing local snippet matches",
+        output = %opts.output.display(),
+        overwrite_output = %opts.overwrite_output,
+        extract_opts = ?opts.extract,
+        "analyzing local snippet matches",
     );
-
-    let creds = opts.auth.as_credentials();
-    let client = ApiClientV1::authenticated(endpoint, creds);
-    let root = opts.extract().target();
-    let walk = WalkDir::new(root)
-        // Follow symlinks; loops are yielded as errors automatically.
-        .follow_links(true)
-        // Not chosen for a specific reason, just seems reasonable.
-        .max_depth(1000)
-        // Just make the walk deterministic (per directory anyway).
-        .sort_by_file_name();
-
-    let mut total_count_entries = 0usize;
-    let mut total_count_snippets = 0usize;
-    let mut total_count_files = 0usize;
 
     if opts.output().exists() {
         if opts.overwrite_output {
             std::fs::remove_dir_all(opts.output()).context("remove existing output directory")?;
+            debug!("removed existing output dir: {}", opts.output().display());
         } else {
             bail!(
-                "The output directory '{}' already exists.",
+                "the output directory '{}' already exists.",
                 opts.output().display(),
             );
         }
     }
     if !opts.output().exists() {
         std::fs::create_dir_all(opts.output()).context("create output directory")?;
+        debug!("created output dir: {}", opts.output().display());
     }
 
-    // Future enhancement: walk and analyze in parallel with rayon.
+    let creds = opts.auth.as_credentials();
+    let client = ApiClientV1::authenticated(endpoint, creds);
+    let root = opts.extract().target();
     let snippet_opts = opts.extract().into();
-    for entry in walk.into_iter() {
-        total_count_entries += 1;
-        let Some(entry) = super::unwrap_dir_entry(entry) else {
-            continue;
-        };
 
-        let path = if entry.path_is_symlink() {
-            let path = entry.path();
-            fs::read_link(path)
-                .wrap_err_with(|| format!("resolve symlink of '{}'", path.display()))?
-        } else {
-            entry.path().to_path_buf()
-        };
+    let total_count_entries = AtomicCounter::default();
+    let total_count_snippets = AtomicCounter::default();
+    let total_count_files = AtomicCounter::default();
 
-        if !path.is_file() {
-            debug!(path = %path.display(), "skipped: not a file");
-            continue;
-        }
+    WalkDir::new(root)
+        // Follow symlinks; loops are yielded as errors automatically.
+        .follow_links(true)
+        // Not chosen for a specific reason, just seems reasonable.
+        .max_depth(1000)
+        // Just make the walk deterministic (per directory anyway).
+        .sort_by_file_name()
+        .into_iter()
+        .inspect(|_| total_count_entries.increment())
+        .filter_map(super::unwrap_dir_entry)
+        // Bridge into rayon for parallelization.
+        .par_bridge()
+        // Resolve symlinks into full paths and filter to only files.
+        .filter_map(|entry| -> Option<PathBuf> {
+            debug!(path = %entry.path().display(), "resolve path");
+            let path = super::resolve_path(&entry)
+                .map_err(|err| warn!(path = %entry.path().display(), "failed to resolve symlink to path: {err:#}"))
+                .ok()?;
 
-        total_count_files += 1;
-        info!(path = %path.display(), "analyze");
+            if path.is_file() {
+                debug!(path = %path.display(), "enqueued for processing");
+                total_count_files.increment();
+                Some(path)
+            } else {
+                debug!(path = %path.display(), "skipped: not a file");
+                None
+            } 
+        })
+        // Extract snippets from each file in parallel.
+        .filter_map(|path| -> Option<(PathBuf, HashSet<ContentSnippet>)> {
+            debug!(path = %path.display(), "extract snippets");
+            let snippets = ContentSnippet::from_file(root, &snippet_opts, &path)
+                .map_err(|err| warn!(path = %path.display(), "extract snippets: {err:#}"))
+                .ok()?;
 
-        let snippets = ContentSnippet::from_file(root, &snippet_opts, &path)
-            .wrap_err_with(|| format!("process '{}'", path.display()))?;
+            if snippets.is_empty() {
+                debug!(path = %path.display(), "no snippets extracted");
+                return None;
+            }
 
-        info!(snippet_count = %snippets.len(), "extracted snippets");
-        total_count_snippets += snippets.len();
-        if snippets.is_empty() {
-            continue;
-        }
+            let snippet_count = snippets.len();
+            debug!(path = %path.display(), %snippet_count, "extracted snippets");
+            total_count_snippets.increment_by(snippet_count);
 
-        let mut records = Vec::new();
-        for found in snippets {
+            (path, snippets).pipe(Some)
+        })
+        // The goal is to then parallelize API calls, so flatten collections of snippets.
+        // Using the serial `flat_map_iter` because this inner iterator has no computation aside from a clone.
+        .flat_map_iter(|(path, snippets)| std::iter::repeat(path).zip(snippets))
+        // Now match snippets up with the API into collections of matches.
+        .filter_map(|(path, found)| -> Option<(PathBuf, MatchingSnippet)> {
             let fingerprint = found.snippet().fingerprint();
             let matching_snippets = client
                 .lookup_snippets(fingerprint)
-                .wrap_err_with(|| format!("lookup snippet for fingerprint '{fingerprint}'"))?;
+                .wrap_err_with(|| format!("lookup snippet for fingerprint '{fingerprint}'"))
+                .map_err(|err| warn!(path = %path.display(), "lookup snippet: {err:#}"))
+                .ok()?;
             if matching_snippets.is_empty() {
-                continue;
+                trace!(%fingerprint, "no matches in corpus");
+                debug!(path = %path.display(), "no snippets matched corpus");
+                return None;
+            }
+            for matched in matching_snippets.iter() {
+                trace!(%fingerprint, ?matched, "matched snippet");
             }
 
-            let record = MatchingSnippet::builder()
+            MatchingSnippet::builder()
                 .found_in(found.snippet().file_path())
                 .local_snippet(found.snippet().clone())
                 .local_text(String::from_utf8_lossy(found.content()))
                 .matching_snippets(matching_snippets)
-                .build();
+                .build()
+                .pipe(|record| (path, record))
+                .pipe(Some)
+        })
+        // Snippet lookups were parallelized. Join them back together by path.
+        // Need both fold and reduce because fold is still parallelized;
+        // see https://docs.rs/rayon/latest/rayon/iter/trait.ParallelIterator.html#method.fold
+        .fold(HashMap::new, |mut acc, (path, record)| {
+            acc.entry(path).or_insert_with(Vec::new).push(record);
+            acc
+        })
+        .reduce(HashMap::new, |mut acc, partial| {
+            for (k, v) in partial {
+                acc.entry(k).or_insert_with(Vec::new).extend(v);
+            }
+            acc
+        })
+        // Reduce handed back a hashmap. Spread it back out into an iterator,
+        // such that each path corresponds to a single set of records.
+        .into_par_iter()
+        .for_each(|(path, records)| {
+            let record_name = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR_STR, "_");
 
-            records.push(record);
-        }
+            let current_ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
+            let record_path = opts
+                .output()
+                .join(record_name)
+                .with_extension(format!("{current_ext}.json"));
 
-        if records.is_empty() {
-            continue;
-        }
-
-        let record_name = path
-            .strip_prefix(root)
-            .unwrap_or(&path)
-            .to_string_lossy()
-            .replace(std::path::MAIN_SEPARATOR_STR, "_");
-
-        let current_ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
-        let record_path = opts
-            .output()
-            .join(&record_name)
-            .with_extension(format!("{current_ext}.json"));
-
-        let encoded = serde_json::to_string_pretty(&records).context("encode record")?;
-        std::fs::write(&record_path, encoded).context("write records")?;
-
-        info!(
-            "wrote {} match record(s) for '{}' to '{}'",
-            records.len(),
-            record_name,
-            record_path.display()
-        );
-    }
+            let written = serde_json::to_string_pretty(&records)
+                .context("encode records")
+                .and_then(|encoded| std::fs::write(&record_path, encoded).context("write records"));
+            match written {
+                Ok(_) => info!(
+                    "wrote {} matches for '{}' to '{}'",
+                    records.len(),
+                    path.display(),
+                    record_path.display()
+                ),
+                Err(err) => warn!(record_path = %record_path.display(), "failed to write match records: {err:#}"),
+            }
+        });
 
     info!(
-        %total_count_entries,
-        %total_count_snippets,
-        %total_count_files,
-        "Finished extracting snippets",
+        total_count_entries = %total_count_entries.into_inner(),
+        total_count_snippets = %total_count_snippets.into_inner(),
+        total_count_files = %total_count_files.into_inner(),
+        "finished extracting snippets",
     );
 
     Ok(())

--- a/extlib/millhone/src/extract.rs
+++ b/extlib/millhone/src/extract.rs
@@ -16,9 +16,9 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use snippets::{language::c99_tc3, Extractor};
 use strum::{Display, EnumIter, IntoEnumIterator};
-use tap::Pipe;
+use tap::{Pipe, Tap};
 use thiserror::Error;
-use tracing::debug;
+use tracing::{debug, trace};
 use typed_builder::TypedBuilder;
 
 /// Errors encountered in this module.
@@ -278,46 +278,57 @@ impl Snippet {
     }
 
     /// Extract instances from a file on disk.
-    #[tracing::instrument]
+    /// If the file is not supported, the returned results are empty.
+    #[tracing::instrument(skip_all, fields(path = %path.display()))]
     pub fn from_file(
         scan_root: &Path,
         opts: &snippets::Options,
         path: &Path,
     ) -> Result<HashSet<Self>, Error> {
-        Self::from_file_with_content(scan_root, opts, path).map(|(found, _)| found)
+        match Support::by_ext(path) {
+            Support::Unknown => {
+                debug!("file extension support unknown");
+                HashSet::new().pipe(Ok)
+            }
+            Support::Unsupported => {
+                debug!("file extension not supported");
+                HashSet::new().pipe(Ok)
+            }
+            Support::Supported(language) => {
+                let content = std::fs::read(path).map_err(Error::ReadFile)?;
+                Self::from_content(scan_root, opts, path, language, &content)
+            }
+        }
     }
 
-    /// Extract instances from a file on disk,
-    /// returning the content of the file along with the snippet.
+    /// Extract instances from content already read from disk.
     ///
-    /// If the file is not supported, the returned file content is empty.
-    pub fn from_file_with_content(
+    /// It's recommended to use [`Support`] to determine the [`Language`]
+    /// to pass to this function.
+    #[tracing::instrument(skip_all)]
+    pub fn from_content(
         scan_root: &Path,
         opts: &snippets::Options,
         path: &Path,
-    ) -> Result<(HashSet<Self>, Vec<u8>), Error> {
-        match Support::by_ext(path) {
-            Support::Unknown => {
-                debug!("skipping: unknown support status for file");
-                Ok((Default::default(), Default::default()))
-            }
-            Support::Unsupported => {
-                debug!("skipping: file extension not supported");
-                Ok((Default::default(), Default::default()))
-            }
-            Support::Supported(language) => {
-                debug!("extracting snippets of language: {language}");
-                let content = std::fs::read(path).map_err(Error::ReadFile)?;
-                match language {
-                    Language::C => c99_tc3::Extractor::extract(opts, &content)?
-                        .pipe(collapse_raw)
-                        .map(|snippet| Self::from(scan_root, path, &content, snippet))
-                        .collect::<HashSet<_>>()
-                        .pipe(|found| (found, content))
-                        .pipe(Ok),
-                }
-            }
+        language: Language,
+        content: &[u8],
+    ) -> Result<HashSet<Self>, Error> {
+        match language {
+            Language::C => c99_tc3::Extractor::extract(opts, content)?
+                .pipe(collapse_raw)
+                .map(|snippet| Self::from(scan_root, path, content, snippet))
+                .inspect(|snippet| trace!(?snippet, "extracted snippet"))
+                .collect::<HashSet<Self>>(),
         }
+        .tap(|found| {
+            debug!(
+                %language,
+                count = %found.len(),
+                content_len = %content.len(),
+                "extracted snippets",
+            )
+        })
+        .pipe(Ok)
     }
 
     /// Get the [`Location`] referenced by the snippet.
@@ -348,24 +359,37 @@ pub struct ContentSnippet {
 
 impl ContentSnippet {
     /// Extract instances from a file on disk.
-    #[tracing::instrument]
+    /// If the file is not supported, the returned results are empty.
+    #[tracing::instrument(skip_all, fields(path = %path.display()))]
     pub fn from_file(
         scan_root: &Path,
         opts: &snippets::Options,
         path: &Path,
     ) -> Result<HashSet<Self>, Error> {
-        let (found, content) = Snippet::from_file_with_content(scan_root, opts, path)?;
-        found
-            .into_iter()
-            .map(|snippet| {
-                let location = snippet.location();
-                Self {
-                    snippet,
-                    content: location.extract_from(&content).to_owned(),
-                }
-            })
-            .collect::<HashSet<_>>()
-            .pipe(Ok)
+        match Support::by_ext(path) {
+            Support::Unknown => {
+                debug!("file extension support unknown");
+                HashSet::new().pipe(Ok)
+            }
+            Support::Unsupported => {
+                debug!("file extension not supported");
+                HashSet::new().pipe(Ok)
+            }
+            Support::Supported(language) => {
+                let content = std::fs::read(path).map_err(Error::ReadFile)?;
+                Snippet::from_content(scan_root, opts, path, language, &content)?
+                    .into_iter()
+                    .map(|snippet| {
+                        let location = snippet.location();
+                        Self {
+                            snippet,
+                            content: location.extract_from(&content).to_owned(),
+                        }
+                    })
+                    .collect::<HashSet<_>>()
+                    .pipe(Ok)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Overview

Updates the `analyze` and `ingest` commands to support parallelization.
I did not parallelize `commit` as I think that is not overall not worth the effort, it's not nearly so performance sensitive.

Additionally:
- Transforms all fatal errors in `analyze` into warnings.
- Makes default tracing less verbose.
- Adds more detail to verbose tracing (`--trace-level trace`).
- Minor reorganization for the code.

## Acceptance criteria

Everything works as before, but now with more parallelization.

My testing project is rather small so I only saw modest gains, but in general my CPU use went from 70%-ish to 200%-ish during these two subcommands.

## Testing plan

I performed the steps in https://github.com/fossas/fossa-cli/pull/1285 and saw no difference in functionality.

No tests were added for this change; in Rust safe parallelization is statically guaranteed by the type system and borrow checker.

## Risks

None

## Metrics

None

## References

https://fossa.atlassian.net/browse/ANE-1186

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
