### PR TITLE
Millhone: finishing touches

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -150,6 +150,7 @@ jobs:
         find . -type f -path '*/fossa/fossa.exe' -exec cp {} release \;
         find . -type f -path '*/pathfinder/pathfinder.exe' -exec cp {} release \;
         cp target/release/diagnose.exe release
+        cp target/release/millhone.exe release
 
     - name: Find and move binaries (non-Windows)
       if: ${{ !contains(matrix.os, 'windows') }}
@@ -158,6 +159,7 @@ jobs:
         find . -type f -path '*/fossa/fossa' -exec cp {} release \;
         find . -type f -path '*/pathfinder/pathfinder' -exec cp {} release \;
         cp target/release/diagnose release
+        cp target/release/millhone release
 
     - name: Strip binaries
       run: |
@@ -195,6 +197,7 @@ jobs:
         codesign --options runtime -s 'FOSSA, Inc.' release/fossa
         codesign --options runtime -s 'FOSSA, Inc.' release/pathfinder
         codesign --options runtime -s 'FOSSA, Inc.' release/diagnose
+        codesign --options runtime -s 'FOSSA, Inc.' release/millhone
 
         # Perform notarization
         zip -rj notarization-archive.zip release
@@ -261,6 +264,7 @@ jobs:
         cosign sign-blob --yes --bundle "Linux-binaries/fossa.bundle" "Linux-binaries/fossa"
         cosign sign-blob --yes --bundle "Linux-binaries/pathfinder.bundle" "Linux-binaries/pathfinder"
         cosign sign-blob --yes --bundle "Linux-binaries/diagnose.bundle" "Linux-binaries/diagnose"
+        cosign sign-blob --yes --bundle "Linux-binaries/millhone.bundle" "Linux-binaries/millhone"
 
     - name: Verify Signatures
       if: ${{ github.ref_type == 'tag' }}
@@ -268,6 +272,7 @@ jobs:
         cosign verify-blob --bundle "Linux-binaries/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/fossa"
         cosign verify-blob --bundle "Linux-binaries/pathfinder.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/pathfinder"
         cosign verify-blob --bundle "Linux-binaries/diagnose.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/diagnose"
+        cosign verify-blob --bundle "Linux-binaries/millhone.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/millhone"
 
     # This uses names compatible with our install script.
     #
@@ -293,17 +298,21 @@ jobs:
         zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder
         zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa
         zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose
+        zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/millhone
         tar --create --verbose --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa
         tar --create --verbose --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder
         tar --create --verbose --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose
+        tar --create --verbose --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries millhone
 
         if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
           tar --append --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder.bundle
           tar --append --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose.bundle
+          tar --append --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries millhone.bundle
           zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
           zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder.bundle
           zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose.bundle
+          zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/millhone.bundle
         fi
 
         gzip "$LINUX_PATHFINDER_TAR_PATH"
@@ -314,11 +323,13 @@ jobs:
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/fossa
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/pathfinder
         zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/diagnose
+        zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/millhone
 
         chmod +x Windows-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/fossa.exe
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/pathfinder.exe
         zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/diagnose.exe
+        zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/millhone.exe
 
     - name: Create checksums
       # We have to run from within the release dir so that "release" isn't prepended to the relative path of the zip file.

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -289,6 +289,8 @@ jobs:
         LINUX_FOSSA_ZIP_PATH: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
         LINUX_DIAGNOSE_TAR_PATH: "release/diagnose_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
         LINUX_DIAGNOSE_ZIP_PATH: "release/diagnose_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
+        LINUX_MILLHONE_TAR_PATH: "release/millhone_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
+        LINUX_MILLHONE_ZIP_PATH: "release/millhone_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
       run: |
         mkdir release
 
@@ -298,38 +300,39 @@ jobs:
         zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder
         zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa
         zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose
-        zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/millhone
+        zip -j "$LINUX_MILLHONE_ZIP_PATH" Linux-binaries/millhone
         tar --create --verbose --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa
         tar --create --verbose --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder
         tar --create --verbose --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose
-        tar --create --verbose --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries millhone
+        tar --create --verbose --file "$LINUX_MILLHONE_ZIP_PATH" --directory Linux-binaries millhone
 
         if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
           tar --append --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder.bundle
           tar --append --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose.bundle
-          tar --append --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries millhone.bundle
+          tar --append --file "$LINUX_MILLHONE_TAR_PATH" --directory Linux-binaries millhone.bundle
           zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
           zip -j "$LINUX_PATHFINDER_ZIP_PATH" Linux-binaries/pathfinder.bundle
           zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose.bundle
-          zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/millhone.bundle
+          zip -j "$LINUX_MILLHONE_ZIP_PATH" Linux-binaries/millhone.bundle
         fi
 
         gzip "$LINUX_PATHFINDER_TAR_PATH"
         gzip "$LINUX_FOSSA_TAR_PATH"
         gzip "$LINUX_DIAGNOSE_TAR_PATH"
+        gzip "$LINUX_MILLHONE_TAR_PATH"
 
         chmod +x macOS-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/fossa
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/pathfinder
         zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/diagnose
-        zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/millhone
+        zip -j release/millhone_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/millhone
 
         chmod +x Windows-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/fossa.exe
         zip -j release/pathfinder_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/pathfinder.exe
         zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/diagnose.exe
-        zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/millhone.exe
+        zip -j release/millhone_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/millhone.exe
 
     - name: Create checksums
       # We have to run from within the release dir so that "release" isn't prepended to the relative path of the zip file.

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -304,7 +304,7 @@ jobs:
         tar --create --verbose --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa
         tar --create --verbose --file "$LINUX_PATHFINDER_TAR_PATH" --directory Linux-binaries pathfinder
         tar --create --verbose --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose
-        tar --create --verbose --file "$LINUX_MILLHONE_ZIP_PATH" --directory Linux-binaries millhone
+        tar --create --verbose --file "$LINUX_MILLHONE_TAR_PATH" --directory Linux-binaries millhone
 
         if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,8 +1403,8 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "snippets"
-version = "0.1.1"
-source = "git+https://github.com/fossas/foundation-libs#6f910a61bf3dd06655770aea9d65c219815a5fd2"
+version = "0.1.2"
+source = "git+https://github.com/fossas/foundation-libs#0b97d709291c7cad9ec23b24b5ec736c4feb8063"
 dependencies = [
  "base64 0.21.4",
  "derivative",
@@ -1435,7 +1435,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "srclib"
 version = "0.1.0"
-source = "git+https://github.com/fossas/foundation-libs#6f910a61bf3dd06655770aea9d65c219815a5fd2"
+source = "git+https://github.com/fossas/foundation-libs#0b97d709291c7cad9ec23b24b5ec736c4feb8063"
 dependencies = [
  "getset",
  "lazy_static",
@@ -1628,7 +1628,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "traceconf"
 version = "1.1.0"
-source = "git+https://github.com/fossas/foundation-libs#6f910a61bf3dd06655770aea9d65c219815a5fd2"
+source = "git+https://github.com/fossas/foundation-libs#0b97d709291c7cad9ec23b24b5ec736c4feb8063"
 dependencies = [
  "atty",
  "clap 4.4.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "millhone"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64 0.21.4",
  "clap 4.4.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2135563fb5c609d2b2b87c1e8ce7bc41b0b45430fa9661f457981503dd5bf0"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.4"
+version = "4.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
+checksum = "824956d0dca8334758a5b7f7e50518d66ea319330cbceedcf76905c2f6ab30e3"
 dependencies = [
  "clap_builder",
  "clap_derive 4.4.2",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.4"
+version = "4.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
+checksum = "122ec64120a49b4563ccaedcbea7818d069ed8e9aa6d829b82d8a4128936b2ab"
 dependencies = [
  "anstream",
  "anstyle",
@@ -411,7 +411,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.4.4",
+ "clap 4.4.5",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -509,7 +509,7 @@ dependencies = [
 name = "diagnose"
 version = "1.0.0"
 dependencies = [
- "clap 4.4.4",
+ "clap 4.4.5",
  "getset",
  "metrics",
  "regex",
@@ -686,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "idna"
@@ -732,7 +732,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.3",
  "rustix",
  "windows-sys",
 ]
@@ -851,7 +851,7 @@ name = "millhone"
 version = "0.2.1"
 dependencies = [
  "base64 0.21.4",
- "clap 4.4.4",
+ "clap 4.4.5",
  "derive_more",
  "getset",
  "itertools 0.11.0",
@@ -873,7 +873,7 @@ dependencies = [
  "tikv-jemallocator",
  "traceconf",
  "tracing",
- "typed-builder 0.16.1",
+ "typed-builder 0.16.2",
  "ureq",
  "url",
  "uuid",
@@ -1171,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.13"
+version = "0.38.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -1190,7 +1190,7 @@ checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.5",
+ "rustls-webpki 0.101.6",
  "sct",
 ]
 
@@ -1227,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.5"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
  "ring",
  "untrusted",
@@ -1315,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
 
 [[package]]
 name = "serde"
@@ -1365,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1397,14 +1397,14 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "snippets"
 version = "0.1.1"
-source = "git+https://github.com/fossas/foundation-libs#d3f67c0920ff710fbb4daa35afa801557a5ee443"
+source = "git+https://github.com/fossas/foundation-libs#6f910a61bf3dd06655770aea9d65c219815a5fd2"
 dependencies = [
  "base64 0.21.4",
  "derivative",
@@ -1435,7 +1435,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "srclib"
 version = "0.1.0"
-source = "git+https://github.com/fossas/foundation-libs#d3f67c0920ff710fbb4daa35afa801557a5ee443"
+source = "git+https://github.com/fossas/foundation-libs#6f910a61bf3dd06655770aea9d65c219815a5fd2"
 dependencies = [
  "getset",
  "lazy_static",
@@ -1537,9 +1537,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -1628,10 +1628,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "traceconf"
 version = "1.1.0"
-source = "git+https://github.com/fossas/foundation-libs#d3f67c0920ff710fbb4daa35afa801557a5ee443"
+source = "git+https://github.com/fossas/foundation-libs#6f910a61bf3dd06655770aea9d65c219815a5fd2"
 dependencies = [
  "atty",
- "clap 4.4.4",
+ "clap 4.4.5",
  "getset",
  "strum 0.25.0",
  "tracing",
@@ -1760,11 +1760,11 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f727af476880274a8a198e1276d56fe61fbb07832b19884d2ecee72715f593"
+checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
 dependencies = [
- "typed-builder-macro 0.16.1",
+ "typed-builder-macro 0.16.2",
 ]
 
 [[package]]
@@ -1780,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8edc122087639fa8f8dff897ca93c9b8eec999e1c0a94d72c40ed429edac2f2"
+checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1993,9 +1993,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "millhone"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 [features]
@@ -9,7 +9,7 @@ jemalloc = ["dep:tikv-jemallocator"]
 
 [dependencies]
 tikv-jemallocator = { version = "0.5.4", optional = true }
-clap = { version = "4.3.21", features = ["derive"] }
+clap = { version = "4.3.21", features = ["derive", "env", "cargo"] }
 stable-eyre = "0.2.2"
 srclib = { version = "*", git = "https://github.com/fossas/foundation-libs" }
 snippets = { version = "*", git = "https://github.com/fossas/foundation-libs", features = ["lang-all"] }

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -12,7 +12,7 @@ tikv-jemallocator = { version = "0.5.4", optional = true }
 clap = { version = "4.3.21", features = ["derive", "env", "cargo"] }
 stable-eyre = "0.2.2"
 srclib = { version = "*", git = "https://github.com/fossas/foundation-libs" }
-snippets = { version = "*", git = "https://github.com/fossas/foundation-libs", features = ["lang-all"] }
+snippets = { version = "0.1.2", git = "https://github.com/fossas/foundation-libs", features = ["lang-all"] }
 traceconf = { git = "https://github.com/fossas/foundation-libs", version = "1.1.0" }
 serde = { version = "1.0.183", features = ["derive"] }
 thiserror = "1.0.46"

--- a/extlib/millhone/src/cmd.rs
+++ b/extlib/millhone/src/cmd.rs
@@ -29,11 +29,41 @@ pub mod ping;
 #[getset(get = "pub")]
 pub struct ApiAuthentication {
     /// Provide the API Key ID for authentication.
+    ///
+    /// The default value is a generic API token for Millhone which allows
+    /// matching snippets against the API.
+    ///
+    /// When connection is implemented via FOSSA API reverse proxy
+    /// instead of direct connection to the millhone API,
+    /// these keys will be revoked.
     #[clap(long, env = "MILLHONE_API_KEY_ID")]
+    #[cfg_attr(
+        debug_assertions,
+        clap(default_value = "462fce0f-f282-4b2b-85c3-00362d10394a")
+    )]
+    #[cfg_attr(
+        not(debug_assertions),
+        clap(default_value = "3cc46e2f-0a4d-4f9d-967e-66d2aaf4378d")
+    )]
     api_key_id: String,
 
     /// Provide the API Secret for authentication.
+    ///
+    /// The default value is a generic API token for Millhone which allows
+    /// matching snippets against the API.
+    ///
+    /// When connection is implemented via FOSSA API reverse proxy
+    /// instead of direct connection to the millhone API,
+    /// these keys will be revoked.
     #[clap(long, env = "MILLHONE_API_SECRET")]
+    #[cfg_attr(
+        debug_assertions,
+        clap(default_value = "7dfe4c82-b558-4838-aa7c-a68657aff44e")
+    )]
+    #[cfg_attr(
+        not(debug_assertions),
+        clap(default_value = "ef469165-8c4d-4a15-9233-5832ba5f0a6b")
+    )]
     api_secret: Secret<String>,
 }
 

--- a/extlib/millhone/src/cmd.rs
+++ b/extlib/millhone/src/cmd.rs
@@ -29,11 +29,11 @@ pub mod ping;
 #[getset(get = "pub")]
 pub struct ApiAuthentication {
     /// Provide the API Key ID for authentication.
-    #[clap(long)]
+    #[clap(long, env = "MILLHONE_API_KEY_ID")]
     api_key_id: String,
 
     /// Provide the API Secret for authentication.
-    #[clap(long)]
+    #[clap(long, env = "MILLHONE_API_SECRET")]
     api_secret: Secret<String>,
 }
 

--- a/extlib/millhone/src/main.rs
+++ b/extlib/millhone/src/main.rs
@@ -33,10 +33,14 @@ struct Application {
     /// FOSSA's backend, similar to VSI functionality.
     /// At such time this argument will be hidden and only used for debugging,
     /// replaced with `endpoint`.
-    #[clap(
-        long,
-        global = true,
-        default_value = "https://api.millhone-staging.sherlock.fossa.team"
+    #[clap(long, global = true)]
+    #[cfg_attr(
+        debug_assertions,
+        clap(default_value = "https://api.millhone-staging.sherlock.fossa.team")
+    )]
+    #[cfg_attr(
+        not(debug_assertions),
+        clap(default_value = "https://api.millhone-prod.sherlock.fossa.team")
     )]
     direct_endpoint: BaseUrl,
 


### PR DESCRIPTION
# Overview

Adds finishing touches for Millhone to be usable standalone:
- Published as a binary (we need this for ingestion at least, for now).
- Embeds read-only API credentials. This is only until we have reverse proxying set up in Core.
- Defaults the URL to the API. Again, only until we have reverse proxying set up.
- Scans with all snippet kinds/transforms/targets.
- Validated in prod!

## Acceptance criteria

Users outside FOSSA can run read-only requests in `millhone` without needing API keys or server URLs.

## Testing plan

Tested staging values via `cargo run`:
```shell
fossa-cli/extlib/millhone on ⑆ millhone/finishing-touches [$] is 📦 v0.3.0 via 🦀 v1.72.0
❯ rm -rf ~/projects/scratch/millhone_analyze_output

fossa-cli/extlib/millhone on ⑆ millhone/finishing-touches [$] is 📦 v0.3.0 via 🦀 v1.72.0
❯ rm -rf ~/projects/scratch/src/fossa-deps.yml

fossa-cli/extlib/millhone on ⑆ millhone/finishing-touches [$] is 📦 v0.3.0 via 🦀 v1.72.0
❯ cargo run -- analyze \
  --trace-level off \
  --overwrite-output \
  -o ~/projects/scratch/millhone_analyze_output \
  ~/projects/scratch/src
    Finished dev [unoptimized + debuginfo] target(s) in 0.18s
     Running `/Users/jessica/projects/fossa-cli/target/debug/millhone analyze --trace-level off --overwrite-output -o /Users/jessica/projects/scratch/millhone_analyze_output /Users/jessica/projects/scratch/src`

fossa-cli/extlib/millhone on ⑆ millhone/finishing-touches [$] is 📦 v0.3.0 via 🦀 v1.72.0
❯ ll ~/projects/scratch/millhone_analyze_output
.rw-r--r-- 6.5k 27 Sep 00:32 hello_world.c.json
.rw-r--r-- 2.2k 27 Sep 00:32 hello_world_error.c.json

fossa-cli/extlib/millhone on ⑆ millhone/finishing-touches [$] is 📦 v0.3.0 via 🦀 v1.72.0
❯ cargo run -- commit \
  --trace-level off \
  --analyze-output-dir ~/projects/scratch/millhone_analyze_output \
  --overwrite-fossa-deps \
  --format yml \
  ~/projects/scratch/src
    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
     Running `/Users/jessica/projects/fossa-cli/target/debug/millhone commit --trace-level off --analyze-output-dir /Users/jessica/projects/scratch/millhone_analyze_output --overwrite-fossa-deps --format yml /Users/jessica/projects/scratch/src`

fossa-cli/extlib/millhone on ⑆ millhone/finishing-touches [$] is 📦 v0.3.0 via 🦀 v1.72.0
❯ cat ~/projects/scratch/src/fossa-deps.yml
───────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: /Users/jessica/projects/scratch/src/fossa-deps.yml
───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ referenced-dependencies:
   2   │ - type: git
   3   │   name: github.com/fossas/cpp-vsi-demo
   4   │   version: 76987d9d364bc2c73897549a71d13371a32cd3e7
───────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

Validated these API keys don't give access to `ingest`:
```shell
❯ cargo run -- ingest \
  --trace-level off \
  --locator 'git+github.com/fossas/cpp-vsi-demo$76987d9d364bc2c73897549a71d13371a32cd3e7' \
  ~/projects/cpp-vsi-demo/example-internal-project

    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
     Running `/Users/jessica/projects/fossa-cli/target/debug/millhone ingest --trace-level off --locator 'git+github.com/fossas/cpp-vsi-demo$76987d9d364bc2c73897549a71d13371a32cd3e7' /Users/jessica/projects/cpp-vsi-demo/example-internal-project`
Error: upload 15 snippets from '/Users/jessica/projects/cpp-vsi-demo/example-internal-project/vendor/libssh2/example/sftp.c'

Caused by:
    status code '401'

❯ millhone ingest \
  --trace-level off \
  --locator 'git+github.com/fossas/cpp-vsi-demo$76987d9d364bc2c73897549a71d13371a32cd3e7' \
  ~/projects/cpp-vsi-demo/example-internal-project
Error: upload 18 snippets from '/Users/jessica/projects/cpp-vsi-demo/example-internal-project/vendor/libssh2/example/scp_write_nonblock.c'

Caused by:
    status code '401'
```

Validated in prod:
```
~/projects/scratch
❯ rm -rf millhone_analyze_output || true && rm -f src/fossa-deps* || true

~/projects/scratch
❯ millhone analyze \
  --trace-level off \
  --overwrite-output \
  -o millhone_analyze_output \
  src


~/projects/scratch
❯ ll millhone_analyze_output
.rw-r--r-- 6.5k 27 Sep 12:26 hello_world.c.json
.rw-r--r-- 2.2k 27 Sep 12:26 hello_world_error.c.json

~/projects/scratch
❯ millhone commit \
  --trace-level off \
  --analyze-output-dir millhone_analyze_output \
  --overwrite-fossa-deps \
  --format yml \
  src


~/projects/scratch
❯ cat src/fossa-deps.yml
───────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: src/fossa-deps.yml
───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ referenced-dependencies:
   2   │ - type: git
   3   │   name: github.com/fossas/cpp-vsi-demo
   4   │   version: 76987d9d364bc2c73897549a71d13371a32cd3e7
───────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

## Risks

I mean, we're embedding API keys. It's never great. But these keys are read-only, so the risk should be quite minimal.

## Metrics

None

## References

None

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
