### PR TITLE
Millhone client tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e723bd417b2df60a0f6a2b6825f297ea04b245d4ba52b5a22cb679bdf58b05fa"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a1d9139f0ee2e862e08a9c5d0ba0470f2aa21cd1e1aa1b1562f83116c725f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +879,7 @@ dependencies = [
  "derive_more",
  "getset",
  "itertools 0.11.0",
+ "lazy-regex",
  "maplit",
  "pretty_assertions",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,7 @@ dependencies = [
 name = "millhone"
 version = "0.3.1"
 dependencies = [
+ "atty",
  "base64 0.21.4",
  "clap 4.4.5",
  "derive_more",
@@ -873,6 +874,7 @@ dependencies = [
  "tikv-jemallocator",
  "traceconf",
  "tracing",
+ "tracing-subscriber",
  "typed-builder 0.16.2",
  "ureq",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,8 +1403,8 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "snippets"
-version = "0.1.2"
-source = "git+https://github.com/fossas/foundation-libs#0b97d709291c7cad9ec23b24b5ec736c4feb8063"
+version = "0.1.3"
+source = "git+https://github.com/fossas/foundation-libs#062318675ed143c53bee0af1a028624377a85e21"
 dependencies = [
  "base64 0.21.4",
  "derivative",
@@ -1422,6 +1422,7 @@ dependencies = [
  "tracing",
  "tree-sitter",
  "tree-sitter-c",
+ "tree-sitter-cpp",
  "tree-sitter-traversal",
  "typed-builder 0.15.2",
 ]
@@ -1435,7 +1436,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "srclib"
 version = "0.1.0"
-source = "git+https://github.com/fossas/foundation-libs#0b97d709291c7cad9ec23b24b5ec736c4feb8063"
+source = "git+https://github.com/fossas/foundation-libs#062318675ed143c53bee0af1a028624377a85e21"
 dependencies = [
  "getset",
  "lazy_static",
@@ -1628,7 +1629,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "traceconf"
 version = "1.1.0"
-source = "git+https://github.com/fossas/foundation-libs#0b97d709291c7cad9ec23b24b5ec736c4feb8063"
+source = "git+https://github.com/fossas/foundation-libs#062318675ed143c53bee0af1a028624377a85e21"
 dependencies = [
  "atty",
  "clap 4.4.5",
@@ -1724,6 +1725,16 @@ name = "tree-sitter-c"
 version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b03bdf218020057abee831581a74bff8c298323d6c6cd1a70556430ded9f4b"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b4b625f46a7370544b9cf0545532c26712ae49bfc02eb09825db358b9f79e1"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "millhone"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.21.4",
  "clap 4.4.5",

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,29 @@
 # FOSSA CLI Changelog
 
+## v3.8.16
+
+Delivers another update to the `millhone` early preview of FOSSA snippet scanning:
+
+- Fixes surprising semantics in some subcommands, especially `commit`.
+- Sorts and makes unique dependencies written to `fossa-deps` files.
+- Overly noisy snippets are filtered entirely.
+- Adds C++ snippet parsing.
+- Reduces config and logging verbosity.
+
+## v3.8.15
+
+This version is a special release: it does not alter anything in FOSSA CLI, but instead adds `millhone`,
+the new snippet scanning functionality for FOSSA, as a release asset.
+
+Future releases will bundle this functionality into FOSSA CLI instead,
+but we're making this CLI available standalone for now to enable immediate use!
+
+Initial documentation for this functionality is here.
+When we integrate this functionality into FOSSA CLI itself we'll have improved documentation as well.
+
+Note: FOSSA is still ingesting sources into the snippet scanning database;
+while this CLI is available earlier results will steadily improve as we crawl more sources.
+
 ## v3.8.14
 
 - Custom License Searches and Keyword Searches allow you to search through your codebase, find matches to regular expressions and then either log the results to the scan summary (keyword search) or create a custom license match (custom license searches) ([#1274](https://github.com/fossas/fossa-cli/pull/1274))

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -12,7 +12,7 @@ tikv-jemallocator = { version = "0.5.4", optional = true }
 clap = { version = "4.3.21", features = ["derive", "env", "cargo"] }
 stable-eyre = "0.2.2"
 srclib = { version = "*", git = "https://github.com/fossas/foundation-libs" }
-snippets = { version = "0.1.2", git = "https://github.com/fossas/foundation-libs", features = ["lang-all"] }
+snippets = { version = "0.1.3", git = "https://github.com/fossas/foundation-libs", features = ["lang-all"] }
 traceconf = { git = "https://github.com/fossas/foundation-libs", version = "1.1.0" }
 serde = { version = "1.0.183", features = ["derive"] }
 thiserror = "1.0.46"

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -33,6 +33,8 @@ secrecy = "0.8.0"
 serde_json = "1.0.107"
 serde_yaml = "0.9.25"
 rayon = "1.8.0"
+atty = "0.2.14"
+tracing-subscriber = { version = "0.3.17", features = ["json"] }
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -35,6 +35,7 @@ serde_yaml = "0.9.25"
 rayon = "1.8.0"
 atty = "0.2.14"
 tracing-subscriber = { version = "0.3.17", features = ["json"] }
+lazy-regex = { version = "3.0.2", features = ["std", "regex"] }
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "millhone"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [features]

--- a/extlib/millhone/src/api.rs
+++ b/extlib/millhone/src/api.rs
@@ -62,7 +62,7 @@ fn build_default_agent(creds: Option<Credentials>) -> Agent {
         // so that we can track deployed app versions over time.
         .user_agent(&format!("{app_name}/{app_version}"))
         // Not based on anything specific but seems reasonable.
-        .timeout(Duration::from_secs(30));
+        .timeout(Duration::from_secs(300));
 
     // Inject authorization into every request here so that each method doesn't have to remember to.
     if let Some(creds) = creds {

--- a/extlib/millhone/src/api.rs
+++ b/extlib/millhone/src/api.rs
@@ -62,7 +62,7 @@ fn build_default_agent(creds: Option<Credentials>) -> Agent {
         // so that we can track deployed app versions over time.
         .user_agent(&format!("{app_name}/{app_version}"))
         // Not based on anything specific but seems reasonable.
-        .timeout(Duration::from_secs(300));
+        .timeout(Duration::from_secs(30));
 
     // Inject authorization into every request here so that each method doesn't have to remember to.
     if let Some(creds) = creds {

--- a/extlib/millhone/src/api/v1/ingest.rs
+++ b/extlib/millhone/src/api/v1/ingest.rs
@@ -7,7 +7,7 @@ use retry::{
 };
 use serde::Serialize;
 use tap::{Conv, Pipe, TapFallible};
-use tracing::{debug, info};
+use tracing::debug;
 use ureq::Agent;
 use url::Url;
 
@@ -51,7 +51,7 @@ pub fn run(agent: &Agent, base: &BaseUrl, snippets: HashSet<ApiSnippet>) -> Resu
             agent
                 .post(target.as_str())
                 .send_json(&batch)
-                .tap_ok(|_| info!(%retry, %batch_num, %batch_count, "uploaded batch"))
+                .tap_ok(|_| debug!(%retry, %batch_num, %batch_count, "uploaded batch"))
         });
         if let Err(retry::Error { error, .. }) = upload {
             return error.conv::<Error>().pipe(Err);

--- a/extlib/millhone/src/api/v1/ping.rs
+++ b/extlib/millhone/src/api/v1/ping.rs
@@ -14,5 +14,7 @@ pub fn run(agent: &Agent, base: &BaseUrl) -> Result<Health, Error> {
     let response = agent.get(target.as_str()).call().or_any_status()?;
     tracing::Span::current().record("status", response.status());
 
-    response.into_json().map_err(Error::ReadResponseBody)
+    response
+        .into_json()
+        .map_err(|err| Error::ReadResponseBody(target.to_string(), err))
 }

--- a/extlib/millhone/src/cmd/analyze.rs
+++ b/extlib/millhone/src/cmd/analyze.rs
@@ -218,6 +218,10 @@ fn snippet_is_noise(m: &ContentSnippet) -> bool {
             m.snippet().kind() == &Kind::Signature.to_string()
                 && contains_bytes(m.content(), b"int main")
         }
+        Language::CPP => {
+            m.snippet().kind() == &Kind::Signature.to_string()
+                && contains_bytes(m.content(), b"int main")
+        }
     }
 }
 

--- a/extlib/millhone/src/cmd/analyze.rs
+++ b/extlib/millhone/src/cmd/analyze.rs
@@ -43,13 +43,8 @@ pub struct Subcommand {
 
 #[tracing::instrument(skip_all, fields(target = %opts.extract.target().display()))]
 pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
-    info!(
-        api_key_id = %opts.auth.api_key_id(),
-        output = %opts.output.display(),
-        overwrite_output = %opts.overwrite_output,
-        extract_opts = ?opts.extract,
-        "analyzing local snippet matches",
-    );
+    debug!(?endpoint, ?opts, "analyzing local snippet matches");
+    info!("Analyzing local snippet matches");
 
     if opts.output().exists() {
         if opts.overwrite_output {
@@ -185,21 +180,21 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
                 .context("encode records")
                 .and_then(|encoded| std::fs::write(&record_path, encoded).context("write records"));
             match written {
-                Ok(_) => info!(
-                    "wrote {} matches for '{}' to '{}'",
-                    records.len(),
-                    path.display(),
-                    record_path.display()
+                Ok(_) => debug!(
+                    match_count = %records.len(),
+                    file = %path.display(),
+                    record = %record_path.display(),
+                    "wrote matches",
                 ),
                 Err(err) => warn!(record_path = %record_path.display(), "failed to write match records: {err:#}"),
             }
         });
 
     info!(
-        total_count_entries = %total_count_entries.into_inner(),
-        total_count_snippets = %total_count_snippets.into_inner(),
-        total_count_files = %total_count_files.into_inner(),
-        "finished extracting snippets",
+        "Finished extracting {} snippets out of {} entries, of which {} were files",
+        total_count_snippets.into_inner(),
+        total_count_entries.into_inner(),
+        total_count_files.into_inner(),
     );
 
     Ok(())

--- a/extlib/millhone/src/cmd/commit.rs
+++ b/extlib/millhone/src/cmd/commit.rs
@@ -141,8 +141,8 @@ pub fn main(opts: Subcommand) -> Result<(), Report> {
                 .iter()
                 .filter_map(|m| {
                     let matches = match_kinds.contains(m.snippet().kind())
-                        || match_targets.contains(m.snippet().target())
-                        || match_methods.contains(m.snippet().method());
+                        && match_targets.contains(m.snippet().target())
+                        && match_methods.contains(m.snippet().method());
                     debug!(
                         ?match_kinds,
                         ?match_targets,

--- a/extlib/millhone/src/cmd/commit.rs
+++ b/extlib/millhone/src/cmd/commit.rs
@@ -160,6 +160,7 @@ pub fn main(opts: Subcommand) -> Result<(), Report> {
                 None
             }
         })
+        .unique()
         .sorted_by_key(|loc| loc.to_string())
         .filter_map(|loc| {
             ReferencedDependency::try_from(loc)

--- a/extlib/millhone/src/cmd/commit.rs
+++ b/extlib/millhone/src/cmd/commit.rs
@@ -26,7 +26,7 @@ pub struct Subcommand {
     analyze_output_dir: PathBuf,
 
     /// The output format for the generated `fossa-deps` file.
-    #[clap(long, default_value_t = OutputFormat::Json)]
+    #[clap(long, default_value_t = OutputFormat::default())]
     format: OutputFormat,
 
     /// If specified, overwrites the output file if it exists.
@@ -62,14 +62,15 @@ pub struct Subcommand {
 }
 
 /// The output format for the generated `fossa-deps` file.
-#[derive(Debug, Clone, Copy, ValueEnum, Display)]
+#[derive(Debug, Clone, Copy, Default, ValueEnum, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum OutputFormat {
+    /// Commit as `fossa-deps.yml`.
+    #[default]
+    Yml,
+
     /// Commit as `fossa-deps.json`.
     Json,
-
-    /// Commit as `fossa-deps.yml`.
-    Yml,
 }
 
 #[tracing::instrument(skip_all, fields(target = %opts.target().display()))]

--- a/extlib/millhone/src/cmd/commit.rs
+++ b/extlib/millhone/src/cmd/commit.rs
@@ -75,14 +75,8 @@ pub enum OutputFormat {
 
 #[tracing::instrument(skip_all, fields(target = %opts.target().display()))]
 pub fn main(opts: Subcommand) -> Result<(), Report> {
-    info!(
-        analyze_output_dir = ?opts.analyze_output_dir,
-        format = %opts.format,
-        targets = ?opts.targets,
-        kinds = ?opts.kinds,
-        transforms = ?opts.transforms,
-        "Committing local snippet matches",
-    );
+    debug!(?opts, "committing local snippet matches");
+    info!("Committing local snippet matches");
 
     let output_file = opts
         .target()

--- a/extlib/millhone/src/cmd/commit.rs
+++ b/extlib/millhone/src/cmd/commit.rs
@@ -160,6 +160,7 @@ pub fn main(opts: Subcommand) -> Result<(), Report> {
                 None
             }
         })
+        .sorted_by_key(|loc| loc.to_string())
         .filter_map(|loc| {
             ReferencedDependency::try_from(loc)
                 .tap_err(|(loc, err)| {

--- a/extlib/millhone/src/cmd/ingest.rs
+++ b/extlib/millhone/src/cmd/ingest.rs
@@ -39,13 +39,8 @@ pub struct Subcommand {
 
 #[tracing::instrument(skip_all, fields(target = %opts.extract().target().display()))]
 pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
-    info!(
-        ingest_id = %opts.ingest_id(),
-        api_key_id = %opts.auth.api_key_id(),
-        locator = %opts.locator(),
-        extract_opts = ?opts.extract,
-        "Ingesting snippets",
-    );
+    debug!(?opts, "ingesting snippets");
+    info!("Ingesting snippets");
 
     let creds = opts.auth.as_credentials();
     let client = ApiClientV1::authenticated(endpoint, creds);
@@ -85,7 +80,7 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
                 .collect::<HashSet<_>>();
 
             if snippets.is_empty() {
-                info!(path = %path.display(), "no snippets extracted");
+                debug!(path = %path.display(), "no snippets extracted");
                 return Ok(());
             }
 
@@ -95,15 +90,15 @@ pub fn main(endpoint: &BaseUrl, opts: Subcommand) -> Result<(), Report> {
             })?;
 
             total_count_snippets.increment_by(snippet_count);
-            info!(path = %path.display(), %snippet_count, "extracted snippets");
+            debug!(path = %path.display(), %snippet_count, "extracted snippets");
             Ok(())
         })?;
 
     info!(
-        total_count_entries = %total_count_entries.into_inner(),
-        total_count_snippets = %total_count_snippets.into_inner(),
-        total_count_files = %total_count_files.into_inner(),
-        "Finished extracting snippets",
+        "Finished extracting {} snippets out of {} entries, of which {} were files",
+        total_count_snippets.into_inner(),
+        total_count_entries.into_inner(),
+        total_count_files.into_inner(),
     );
     Ok(())
 }

--- a/extlib/millhone/src/extract.rs
+++ b/extlib/millhone/src/extract.rs
@@ -751,7 +751,7 @@ impl SnippetNoiseFilter for snippets::Snippet<c99_tc3::Language> {
     fn is_noise(&self, content: &[u8]) -> bool {
         match self.metadata().kind() {
             snippets::Kind::Signature => contains_bytes(b"int main", content),
-            snippets::Kind::Body => regex_is_match!(r"\s*\{\s*\}\s*"B, content),
+            snippets::Kind::Body => regex_is_match!(r"^\s*\{\s*\}\s*$"B, content),
             _ => false,
         }
     }
@@ -761,7 +761,7 @@ impl SnippetNoiseFilter for snippets::Snippet<cpp_98::Language> {
     fn is_noise(&self, content: &[u8]) -> bool {
         match self.metadata().kind() {
             snippets::Kind::Signature => contains_bytes(b"int main", content),
-            snippets::Kind::Body => regex_is_match!(r"\s*\{\s*\}\s*"B, content),
+            snippets::Kind::Body => regex_is_match!(r"^\s*\{\s*\}\s*$"B, content),
             _ => false,
         }
     }

--- a/extlib/millhone/src/extract.rs
+++ b/extlib/millhone/src/extract.rs
@@ -6,6 +6,7 @@ use std::{
     collections::HashSet,
     hash::Hash,
     path::{Path, PathBuf},
+    str::FromStr,
 };
 
 use base64::prelude::*;
@@ -618,6 +619,23 @@ impl Language {
     /// Report whether the language declares it supports files with the given file extension.
     pub fn supports_file_extension(self, ext: &str) -> bool {
         self.supported_file_extensions().contains(&ext)
+    }
+
+    /// Report the language identifier, rendered by mapping to a [`snippets::Language`].
+    pub fn identifier(self) -> String {
+        match self {
+            Language::C => snippets::language::c99_tc3::Language.to_string(),
+        }
+    }
+}
+
+impl FromStr for Language {
+    type Err = stable_eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::iter()
+            .find(|l| l.identifier() == s)
+            .ok_or_else(|| stable_eyre::eyre::eyre!("language identifier unknown: '{s}'"))
     }
 }
 

--- a/extlib/millhone/src/main.rs
+++ b/extlib/millhone/src/main.rs
@@ -132,13 +132,13 @@ fn main() -> stable_eyre::Result<()> {
     }
 }
 
-/// Filters traces from other crates if debug log level isn't set.
+/// Filters traces from other crates if trace log level isn't set.
 fn self_sourced_events<S>(log_level: Level) -> impl tracing_subscriber::layer::Filter<S> {
     const CURRENT_CRATE: &str = env!("CARGO_PKG_NAME");
     fn is_current_crate(meta: &tracing::Metadata<'_>) -> bool {
         meta.target().starts_with(CURRENT_CRATE)
     }
 
-    let enable_debug_logging = log_level >= Level::Debug;
+    let enable_debug_logging = log_level >= Level::Trace;
     filter_fn(move |meta| is_current_crate(meta) || enable_debug_logging)
 }


### PR DESCRIPTION
# Overview

Includes a slew of fixes for user-facing functionality in Millhone:

- Fixes filters for `commit`, which previously had surprising semantics.
- Dependencies written to `fossa-deps` are unique.
- Dependencies written to `fossa-deps` are sorted.
- Filters overly noisy snippets during `analyze`. Currently this filters:
  - `signature` snippets for C and C++ containing `int main`.
  - `body` snippets where the body is empty (matching `\s*\{\s*\}\s*`).
- Fixes error reporting during `commit`.
  - Errors are now written as `error` messages instead of dropped.
- Adds C++ snippet parsing (#1293).
- Reduces the verbosity of logging config.
- Reduces verbosity of logs in general (except when logging at debug or trace level).

## Acceptance criteria

Users now:
- Have smaller, but still equivalent, `fossa-deps` files.
- Can more easily review `fossa-deps` files at a glance due to sorting.
- No longer have overly noisy matches due to nearly universal signature matches.
- Can scan C++ code for snippets.

## Testing plan

I tested this locally using the `cpp-vsi-demo` and the results look reasonable.

## Risks

None.

## Metrics

None.

## References

https://fossa.atlassian.net/browse/ANE-1211

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
