### PR TITLE
Ane 1024 locators in fossa deps

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -4,9 +4,6 @@
   "ignorePatterns": [
     {
       "pattern": "https://support.fossa.com"
-    },
-    {
-      "pattern": "https://cran.r-project.org"
     }
   ]
 }

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -169,8 +169,8 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendor
         (ManualJSON path) -> tryMakeRelative root path
         (ManualYaml path) -> tryMakeRelative root path
 
-  pure
-    $ SourceUnit
+  pure $
+    SourceUnit
       { sourceUnitName = renderedPath
       , sourceUnitManifest = renderedPath
       , sourceUnitType = "user-specific-yaml"
@@ -203,8 +203,8 @@ scanAndUpload root vdeps vendoredDepsOptions = do
         ArchiveUpload -> archiveUploadSourceUnit
         CLILicenseScan -> licenseScanSourceUnit vendoredDependencyScanMode pathFilters fullFileUploads
 
-  when (archiveOrCLI == ArchiveUpload && isJust pathFilters)
-    $ fatalText "You have provided path filters in the vendoredDependencies.licenseScanPathFilters section of your .fossa.yml file. Path filters are not allowed when doing archive uploads."
+  when (archiveOrCLI == ArchiveUpload && isJust pathFilters) $
+    fatalText "You have provided path filters in the vendoredDependencies.licenseScanPathFilters section of your .fossa.yml file. Path filters are not allowed when doing archive uploads."
 
   scanner root vdeps
 
@@ -440,11 +440,11 @@ instance FromJSON ReferencedDependency where
         os <- requiredFieldMsg "os" $ obj .: "os"
         unless (toLower os `elem` supportedOSs)
           $ fail
-          . toString
+            . toString
           $ "Provided os: "
-          <> (toLower os)
-          <> " is not supported! Please provide oneOf: "
-          <> Text.intercalate ", " supportedOSs
+            <> (toLower os)
+            <> " is not supported! Please provide oneOf: "
+            <> Text.intercalate ", " supportedOSs
         pure os
 
       requiredFieldMsg :: String -> Parser a -> Parser a
@@ -483,7 +483,7 @@ instance FromJSON CustomDependency where
       <*> (unTextLike <$> obj `neText` "version")
       <*> (obj `neText` "license")
       <*> obj
-      .:? "metadata"
+        .:? "metadata"
       <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
 
 instance FromJSON RemoteDependency where
@@ -493,7 +493,7 @@ instance FromJSON RemoteDependency where
       <*> (unTextLike <$> obj `neText` "version")
       <*> (obj `neText` "url")
       <*> obj
-      .:? "metadata"
+        .:? "metadata"
       <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
 
 validateRemoteDep :: (Has Diagnostics sig m) => RemoteDependency -> Organization -> m RemoteDependency
@@ -531,12 +531,12 @@ instance ToDiagnostic RemoteDepLengthIsGtThanAllowed where
       , indent 2 . pretty $ "Url: " <> remoteUrl r
       , indent 2 . pretty $ "Version: " <> remoteVersion r
       , ""
-      , pretty
-          $ "The combined length of url and version is: "
-          <> show urlRevLength
-          <> ". It must be below: "
-          <> show maxLen
-          <> "."
+      , pretty $
+          "The combined length of url and version is: "
+            <> show urlRevLength
+            <> ". It must be below: "
+            <> show maxLen
+            <> "."
       ]
     where
       urlRevLength :: Int
@@ -547,9 +547,9 @@ instance FromJSON DependencyMetadata where
   parseJSON = withObject "metadata" $ \obj ->
     DependencyMetadata
       <$> obj
-      .:? "description"
+        .:? "description"
       <*> obj
-      .:? "homepage"
+        .:? "homepage"
       <* forbidMembers "metadata" ["url"] obj
 
 -- Parse supported dependency types into their respective type or return Nothing.

--- a/test/App/Fossa/ManualDepsSpec.hs
+++ b/test/App/Fossa/ManualDepsSpec.hs
@@ -71,15 +71,15 @@ spec :: Spec
 spec = do
   describe "fossa-deps json parser" $ do
     theWorksBS <- getTestDataFile "the-works.json"
-    it "should parse json correctly"
-      $ case Json.eitherDecodeStrict' theWorksBS of
+    it "should parse json correctly" $
+      case Json.eitherDecodeStrict' theWorksBS of
         Left err -> expectationFailure err
         Right jsonDeps -> jsonDeps `shouldBe` theWorks
 
   describe "fossa-deps yaml parser" $ do
     theWorksBS <- getTestDataFile "the-works.yml"
-    it "should successfully parse all possible inputs"
-      $ case Yaml.decodeEither' theWorksBS of
+    it "should successfully parse all possible inputs" $
+      case Yaml.decodeEither' theWorksBS of
         Left err -> expectationFailure $ displayException err
         Right yamlDeps -> yamlDeps `shouldBe` theWorks
 
@@ -87,8 +87,8 @@ spec = do
     it "should report an unsupported type" $ exceptionContains unsupportedTypeBS "dep type: notafetcher not supported"
 
     licenseInRefDepBS <- getTestDataFile "license-in-ref-dep.yml"
-    it "should report license used on referenced deps"
-      $ exceptionContains licenseInRefDepBS "Invalid field name for referenced dependencies: license"
+    it "should report license used on referenced deps" $
+      exceptionContains licenseInRefDepBS "Invalid field name for referenced dependencies: license"
 
     referenceDepSpec
     remoteDepSpec
@@ -138,79 +138,79 @@ spec = do
 referenceDepSpec :: Spec
 referenceDepSpec = do
   describe "reference dependency" $ do
-    it "should parse linux reference dependency"
-      $ case Yaml.decodeEither' (encodeUtf8 linuxReferenceDep) of
+    it "should parse linux reference dependency" $
+      case Yaml.decodeEither' (encodeUtf8 linuxReferenceDep) of
         Left err -> expectationFailure $ displayException err
         Right yamlDeps -> yamlDeps `shouldBe` linuxRefManualDep "centos" Nothing
 
-    it "should parse rpm reference dependency with epoch"
-      $ case Yaml.decodeEither' (encodeUtf8 linuxReferenceDepWithEpoch) of
+    it "should parse rpm reference dependency with epoch" $
+      case Yaml.decodeEither' (encodeUtf8 linuxReferenceDepWithEpoch) of
         Left err -> expectationFailure $ displayException err
         Right yamlDeps -> yamlDeps `shouldBe` linuxRefManualDep "centos" (Just "1")
 
-    it "should fail when linux reference dependency of deb or apk contains epoch"
-      $ exceptionContains
+    it "should fail when linux reference dependency of deb or apk contains epoch" $
+      exceptionContains
         (encodeUtf8 apkReferenceDepWithEpoch)
         "Invalid field name for referenced dependencies (of dependency type: apk): epoch"
 
-    it "should fail when linux reference dependency does not include arch information"
-      $ exceptionContains
+    it "should fail when linux reference dependency does not include arch information" $
+      exceptionContains
         (encodeUtf8 linuxReferenceDepWithoutArch)
         "arch is required field for reference dependency (of dependency type: apk, deb, rpm-generic)"
 
-    it "should fail when linux reference dependency does not include os information"
-      $ exceptionContains
+    it "should fail when linux reference dependency does not include os information" $
+      exceptionContains
         (encodeUtf8 linuxReferenceDepWithoutOS)
         "os is required field for reference dependency (of dependency type: apk, deb, rpm-generic)"
 
-    it "should fail when linux reference dependency uses not supported os"
-      $ exceptionContains
+    it "should fail when linux reference dependency uses not supported os" $
+      exceptionContains
         (encodeUtf8 linuxReferenceDepWithUnsupportedOS)
         "Provided os: poky is not supported! Please provide oneOf:"
 
-    it "should fail when managed reference dependency provides os information"
-      $ exceptionContains
+    it "should fail when managed reference dependency provides os information" $
+      exceptionContains
         (encodeUtf8 managedReferenceDepWithOS)
         "Invalid field name for referenced dependencies (of dependency type: gem): os"
 
-    it "should fail when linux reference dependency of deb or apk contains epoch"
-      $ exceptionContains
+    it "should fail when linux reference dependency of deb or apk contains epoch" $
+      exceptionContains
         (encodeUtf8 managedReferenceDepWithEmptyName)
         "expected field 'name' to be non-empty"
 
 remoteDepSpec :: Spec
 remoteDepSpec = do
   describe "remote dependency" $ do
-    it "should fail when remote dependency has empty name or only whitespace"
-      $ exceptionContains
+    it "should fail when remote dependency has empty name or only whitespace" $
+      exceptionContains
         (encodeUtf8 remoteDepWithEmptyName)
         "expected field 'name' to be non-empty"
 
-    it "should fail when remote dependency has empty version or only whitespace"
-      $ exceptionContains
+    it "should fail when remote dependency has empty version or only whitespace" $
+      exceptionContains
         (encodeUtf8 remoteDepWithEmptyVersion)
         "expected field 'version' to be non-empty"
 
-    it "should fail when remote dependency has empty url or only whitespace"
-      $ exceptionContains
+    it "should fail when remote dependency has empty url or only whitespace" $
+      exceptionContains
         (encodeUtf8 remoteDepWithEmptyUrl)
         "expected field 'url' to be non-empty"
 
 customDepSpec :: Spec
 customDepSpec = do
   describe "custom dependency" $ do
-    it "should fail when custom dependency has empty name or only whitespace"
-      $ exceptionContains
+    it "should fail when custom dependency has empty name or only whitespace" $
+      exceptionContains
         (encodeUtf8 customDepWithEmptyName)
         "expected field 'name' to be non-empty"
 
-    it "should fail when custom dependency has empty version or only whitespace"
-      $ exceptionContains
+    it "should fail when custom dependency has empty version or only whitespace" $
+      exceptionContains
         (encodeUtf8 customDepWithEmptyVersion)
         "expected field 'version' to be non-empty"
 
-    it "should fail when custom dependency has empty license or only whitespace"
-      $ exceptionContains
+    it "should fail when custom dependency has empty license or only whitespace" $
+      exceptionContains
         (encodeUtf8 customDepWithEmptyLicense)
         "expected field 'license' to be non-empty"
 
@@ -239,8 +239,8 @@ vendorDepSpec = do
 locatorDepSpec :: Spec
 locatorDepSpec = do
   describe "locator dependency" $ do
-    it "should fail when locator dependency is empty"
-      $ exceptionContains
+    it "should fail when locator dependency is empty" $
+      exceptionContains
         (encodeUtf8 locatorDepWithEmptyDep)
         "parsing Locator failed, expected String, but encountered Null"
 

--- a/test/App/Fossa/ManualDepsSpec.hs
+++ b/test/App/Fossa/ManualDepsSpec.hs
@@ -242,7 +242,7 @@ locatorDepSpec = do
     it "should fail when locator dependency is empty"
       $ exceptionContains
         (encodeUtf8 locatorDepWithEmptyDep)
-        "expected locator dependency to be non-empty"
+        "parsing Locator failed, expected String, but encountered Null"
 
 linuxReferenceDep :: Text
 linuxReferenceDep =
@@ -436,5 +436,5 @@ locatorDepWithEmptyDep :: Text
 locatorDepWithEmptyDep =
   [r|
 locator-dependencies:
-- " "
+- 
 |]

--- a/test/App/Fossa/testdata/the-works.json
+++ b/test/App/Fossa/testdata/the-works.json
@@ -52,5 +52,9 @@
          "version": "1.2.4",
          "url": "www.url2.tar.gz"
       }
+   ],
+   "locator-dependencies": [
+      "fetcher-1+one",
+      "fetcher-2+two$1.0.0"
    ]
 }

--- a/test/App/Fossa/testdata/the-works.yml
+++ b/test/App/Fossa/testdata/the-works.yml
@@ -33,3 +33,7 @@ remote-dependencies:
 - name: url-dep-two
   version: 1.2.4
   url: www.url2.tar.gz
+  
+locator-dependencies:
+- "fetcher-1+one"
+- "fetcher-2+two$1.0.0"


### PR DESCRIPTION
# Overview

Currently, there’s a bit of tedium involved in mapping locators to their appropriate values in a fossa-deps file, and if you’re dealing with multiple types of dependencies it can make macros or using find+replace a little more involved.

Adding support for locators to fossa-deps would be a much-appreciated QoL boost, as it would simplify the reproduction process significantly. Getting locators is often the first step when investigating an issue.

## Acceptance criteria

- Someone can paste a series of locators into a fossa-deps file and scan their project with minimal effort.

```
locator-dependencies:
- pip+Django$2.1.7
```

- Unlinked markdown doc in fossa cli

   - Put under an internal subfolder for debug specific functionality

   - Create a notion page for fossa-cli reference and link to that.

## Testing plan

- Added locator dependencies on the success case ( 2 cases of success)
- Added failing case where there is an error on empty locator dependency
- Added notion page for locator dependency


## Risks

## Metrics

## References

- [ANE-1024](https://fossa.atlassian.net/browse/ANE-1024)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1024]: https://fossa.atlassian.net/browse/ANE-1024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ