### PR TITLE
[ANE-458] machine-readable fossa list-target command

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # FOSSA CLI Changelog
 
-## v3.8.18
+## Unreleased
 
 - `fossa list-targets`: list-target command supports `--format` option with: `ndjson`, `text`, and `legacy`. ([#1296](https://github.com/fossas/fossa-cli/pull/1296))
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.8.18
+
+- `fossa list-targets`: list-target command supports `--format` option with: `ndjson`, `text`, and `legacy`. ([#1296](https://github.com/fossas/fossa-cli/pull/1296))
+
 ## v3.8.17
 
 Integrates FOSSA snippet scanning into the main application.

--- a/docs/references/subcommands/list-targets.md
+++ b/docs/references/subcommands/list-targets.md
@@ -16,6 +16,14 @@ $ fossa list-targets
 
 This output tells us that when `fossa analyze` is run, we will be analyzing `cabal`, `cocoapods`, `pipenv`, and `yarn` projects. This can be useful to determine if there are targets you expect or don't expect to see.
 
+#### Command output formats
+
+The list-targets command supports the following formats (via `fossa list-targets --format=<OPTION>`):
+
+- `legacy` (this is the default format, as shown above in the command output section)
+- `text` (renders valid analysis targets per line, in the format of [`fossa analyze --only-target`](./analyze.md#filtering-paths-and-targets) and [`fossa analyze --exclude-target`](./analyze.md#filtering-paths-and-targets))
+- `ndjson` (renders valid analysis targets in JSON format separated by line breaks)
+
 ### Utilizing [analysis target configuration](../files/fossa-yml.md#analysis-target-configuration)
 
 Analysis target configuration through the fossa configuration file allows users to manually determine what they would like to analyze. Looking at the example above, if we know that the dependencies for the `setuptools@scripts/python/` target are not part of the production release, we can exclude it from the analysis. Example exclusion format:
@@ -27,3 +35,30 @@ exclude:
 ```
 
 Adding this section to your configuration file at the root of your project will ensure that when `fossa analyze` is run, the `setuptools` target is skipped.
+
+### F.A.Q.
+
+#### How can I ensure that my project is discoverable before running `fossa analyze` or `fossa test`?
+
+In some scenarios, you may want to set up automation for projects that have been discovered. For example, you might want the process to fail if the project of interest isn't discovered by `fossa` before running `fossa analyze`.
+
+First, execute `fossa list-targets --format=text` to see what `fossa` currently discovers:
+
+```text
+yarn@javascript/with-v2-yarn-workspaces/
+yarn@javascript/with-v1-yarn/
+npm@javascript/with-package-json/
+npm@javascript/with-npm-package-lock/
+npm@javascript/with-npm-lockfile-v3/
+pnpm@javascript/pnpm/
+```
+
+From here, we assert that `fossa` finds the npm project at the directory `javascript/with-npm-package-lock/` before running `fossa analyze` using the following in CI:
+
+```bash
+if fossa list-targets --format=text | grep -q 'npm@javascript/with-npm-package-lock/' ; then
+  fossa analyze && fossa test
+else
+  exit 1
+fi
+```

--- a/src/App/Fossa/ListTargets.hs
+++ b/src/App/Fossa/ListTargets.hs
@@ -8,6 +8,7 @@ module App.Fossa.ListTargets (
 import App.Fossa.Analyze.Discover (DiscoverFunc (DiscoverFunc), discoverFuncs)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig)
 import App.Fossa.Config.ListTargets (
+  ListTargetOutputFormat (..),
   ListTargetsCliOpts,
   ListTargetsConfig (..),
   mkSubCommand,
@@ -33,11 +34,11 @@ import Control.Effect.Debug (Debug)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Stack (Stack)
 import Control.Effect.Telemetry (Telemetry)
-import Data.Aeson (ToJSON)
+import Data.Aeson (ToJSON, encode, object, (.=))
 import Data.Aeson.Extra (encodeJSONToText)
 import Data.Foldable (for_, traverse_)
-import Data.Set qualified as Set
 import Data.Set.NonEmpty (toSet)
+import Data.String.Conversion (decodeUtf8, toText)
 import Discovery.Filters (AllFilters)
 import Discovery.Projects (withDiscoveredProjects)
 import Effect.Exec (Exec)
@@ -50,6 +51,7 @@ import Effect.Logger (
   color,
   logDebug,
   logInfo,
+  logStdout,
   logWarn,
  )
 import Effect.ReadFS (ReadFS)
@@ -82,7 +84,7 @@ listTargetsMain ListTargetsConfig{..} = do
     -- The current version of `fossa list-targets` does not support filters.
     -- TODO: support both discovery and post-discovery filtering.
     . runReader (mempty :: AllFilters)
-    $ runAll (unBaseDir baseDir)
+    $ runAll listTargetOutputFormat (unBaseDir baseDir)
 
 runAll ::
   ( Has ReadFS sig m
@@ -97,14 +99,50 @@ runAll ::
   , Has (Reader AllFilters) sig m
   , Has Telemetry sig m
   ) =>
+  ListTargetOutputFormat ->
   Path Abs Dir ->
   m ()
-runAll basedir = traverse_ single discoverFuncs
+runAll outputFmt basedir = traverse_ single discoverFuncs
   where
-    single (DiscoverFunc f) = withDiscoveredProjects f basedir (printSingle basedir)
+    single (DiscoverFunc f) = withDiscoveredProjects f basedir formatter
+    formatter proj = case outputFmt of
+      Legacy -> renderLegacyFmt basedir proj
+      Text -> renderTextFmt basedir proj
+      NdJSON -> renderNdJson basedir proj
 
-printSingle :: (ToJSON a, Has Logger sig m) => Path Abs Dir -> DiscoveredProject a -> m ()
-printSingle basedir project = do
+-- | Render targets in ndjson format
+-- Reference: https://github.com/ndjson/ndjson-spec
+renderNdJson :: (Has Logger sig m, Has (Lift IO) sig m) => Path Abs Dir -> DiscoveredProject a -> m ()
+renderNdJson basedir project = do
+  let maybeRel = makeRelative basedir (projectPath project)
+  let render txt = logStdout . decodeUtf8 $ (encode txt) <> "\n"
+  case maybeRel of
+    Nothing -> pure ()
+    Just rel ->
+      case projectBuildTargets project of
+        ProjectWithoutTargets ->
+          render $ object ["type" .= projectType project, "path" .= toFilePath rel]
+        FoundTargets targets -> for_ (toSet targets) $ \target -> do
+          render $ object ["type" .= projectType project, "path" .= toFilePath rel, "target" .= unBuildTarget target]
+
+-- | Render targets in textual format.
+-- Textual format is compatible with --only-target and --exclude-target argument
+renderTextFmt :: (Has Logger sig m, Has (Lift IO) sig m) => Path Abs Dir -> DiscoveredProject a -> m ()
+renderTextFmt basedir project = do
+  let maybeRel = makeRelative basedir $ projectPath project
+  let render txt = logStdout $ txt <> "\n"
+
+  case maybeRel of
+    Nothing -> pure ()
+    Just rel ->
+      case projectBuildTargets project of
+        ProjectWithoutTargets -> do
+          render $ toText (projectType project) <> "@" <> toText (toFilePath rel)
+        FoundTargets targets -> for_ (toSet targets) $ \target -> do
+          render $ toText (projectType project) <> "@" <> toText (toFilePath rel) <> ":" <> toText (unBuildTarget target)
+
+renderLegacyFmt :: (ToJSON a, Has Logger sig m) => Path Abs Dir -> DiscoveredProject a -> m ()
+renderLegacyFmt basedir project = do
   let maybeRel = makeRelative basedir (projectPath project)
 
   case maybeRel of
@@ -125,7 +163,7 @@ printSingle basedir project = do
               <> pretty (projectType project)
               <> "@"
               <> pretty (toFilePath rel)
-        FoundTargets targets -> for_ (Set.toList $ toSet targets) $ \target -> do
+        FoundTargets targets -> for_ (toSet targets) $ \target -> do
           logInfo $
             "Found target: "
               <> pretty (projectType project)


### PR DESCRIPTION
# Overview

This PR adds `--format` options to `fossa list-targets` command:
- `legacy` (current format)
- `ndjson` 
- `text` (same format as `--only-target` and `--exclude-target`)


```bash
user@user-MacBook-Pro code % fossa-dev list-targets example-projects --format=ndjson 
{"path":"php/","type":"composer"}
{"path":"cabal/multi-home-cabal-example/","type":"cabal"}
{"path":"fossa-deps/remote-dependencies/","type":"cabal"}
{"path":"fossa-deps/vendored-dependencies/","type":"cabal"}
{"path":"fossa-deps/unarchived-vendored-dependencies/","type":"cabal"}
{"path":"cocoapods/simple-cocoapods-example/","type":"cocoapods"}
{"path":"swift-ios-xcode-proj/using-swift-pm-example.xcodeproj/","type":"swift"}

...
```

```bash
user@user-MacBook-Pro code % fossa-dev list-targets example-projects --format=text
composer@php/
cabal@fossa-deps/vendored-dependencies/
cabal@fossa-deps/remote-dependencies/
cabal@fossa-deps/unarchived-vendored-dependencies/
cabal@cabal/multi-home-cabal-example/
cocoapods@cocoapods/simple-cocoapods-example/
...
```

## Acceptance criteria

On Windows, macOs, and Linux, as a user,

- [x]  I can use `fossa list-targets --format=ndjson` to retrieve line separated valid analysis target in json,
- [x] I can use `fossa list-targets --format=text` to retrieve valid analysis target in text format
    - It renders in same format as one accepted by `fossa analyze --only-target`, and `fossa analyze --exclude-target`
    - I can copy paste single line of output from `fossa list-targets` to `fossa analyze --only-target=<LINE>` and it correctly applies filter 
- [x] I can use `fossa list-targets --format=legacy`
- [x] When no format option is provided for `fossa list-targets`, it uses `legacy` format by default

## Testing plan

1. `git pull origin && git checkout feat/machine-readable-list-targets && make install-dev`
2. `fossa-dev list-targets`
- Check default case, it should produce same output as current release fossa-cli
4. `fossa-dev list-targets --format=ndjson`
- It should print json target per line, if target is not present, it shall not include it in json object
5. `fossa-dev list-targets --format=text`
- It should print target per line

I used, 
1. Multi-module gradle project (to check project with `target` case): https://docs.gradle.org/current/samples/zips/sample_building_java_applications_multi_project-groovy-dsl.zip
2. Example-project repository (to check project without targets): https://github.com/fossas/example-projects

## Risks

N/A

## Metrics

None

## References

- [ANE-458](https://fossa.atlassian.net/browse/ANE-458): Implement machine-readable fossa list-targets command

## Checklist

- [x] ~I added tests for this PR's change (or explained in the PR description why tests don't make sense).~
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-458]: https://fossa.atlassian.net/browse/ANE-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ