### PR TITLE
Integrate snippet scanning into FOSSA CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "millhone"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "atty",
  "base64 0.21.4",

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # FOSSA CLI Changelog
 
+## v3.8.17
+
+Integrates FOSSA snippet scanning into the main application.
+For more details and a quick start guide, see [the subcommand reference](./docs/references/subcommands/snippets.md).
+
 ## v3.8.16
 
 Delivers another update to the `millhone` early preview of FOSSA snippet scanning:

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,7 @@ Reference guides provide an exhaustive listing of all CLI functionality. If you 
   - [`fossa test`](./references/subcommands/test.md)
   - [`fossa report`](./references/subcommands/report.md)
   - [`fossa list-targets`](./references/subcommands/list-targets.md)
+  - [`fossa snippets`](./references/subcommands/snippets.md)
   <!-- TODO Write this README file
   - [Common flags and options] -->
 - CLI configuration files

--- a/docs/references/subcommands/snippets.md
+++ b/docs/references/subcommands/snippets.md
@@ -1,0 +1,106 @@
+## `fossa snippets`
+
+This subcommand is the home for FOSSA's snippet scanning feature.
+
+It is made up of two subcommands:
+
+- [`fossa snippets analyze`](./snippets/analyze.md)
+- [`fossa snippets commit`](./snippets/commit.md)
+
+See the pages linked above for more details.
+
+## Quickstart
+
+```shell
+# Set your API key. Get this from the FOSSA web application.
+# On Windows, use this instead: $env:FOSSA_API_KEY=XXXX
+export FOSSA_API_KEY=XXXX
+
+# Navigate to your project directory.
+cd $MY_PROJECT_DIR
+
+# Analyze the project for local snippet matches.
+# Match data is output to the directory specified to the `-o` or `--output` argument.
+# If desired, you can manually review the matches output to the directory.
+fossa snippets analyze -o snippets
+
+# Commit matched snippets to a `fossa-deps` file.
+# Provide it the same directory provided to `fossa snippets analyze`.
+# This creates a `fossa-deps` file in your project.
+#
+# Note that you can control what kinds of snippets are committed;
+# see subcommand documentation for more details.
+fossa snippets commit --analyze-output snippets
+
+# Run a standard FOSSA analysis, which will also upload snippet scanned dependencies,
+# since they were stored in your `fossa-deps` file.
+fossa analyze
+```
+
+## FAQ
+
+### Is my source code sent to FOSSA's servers?
+
+**Short version: No.** More detail explaining this is below.
+
+FOSSA CLI fingerprints your first party source code but does not send it to the server.
+The fingerprint is a SHA-256 hashed representation of the content that made up the snippet.
+
+FOSSA CLI does send the fingerprint to the server, but since SHA-256 hashes are
+[cryptographically secure](https://en.wikipedia.org/wiki/SHA-2), it is effectively not possible
+for FOSSA to reproduce the original code that went into the snippet.
+
+Of course, if the fingerprint matches FOSSA could then infer that the project contains that snippet of code,
+but since FOSSA CLI does not send any additional context in the file there's no way for FOSSA or anyone else
+to make use of this information.
+
+The code to perform this is open source in this CLI;
+users can also utilize tooling such as [echotraffic](https://github.com/fossas/echotraffic)
+to report the information being uploaded.
+
+### How does FOSSA snippet scanning work?
+
+FOSSA snippet scanning operates over a matrix of options:
+
+```
+Targets × Kinds × Methods
+```
+
+Valid options for `Targets` are:
+
+Target     | Description
+-----------|-----------------------------------------------------------------------
+`Function` | Considers function declarations in the source code as snippet targets.
+
+Valid options for `Kinds` are:
+
+Kind        | Description
+------------|----------------------------------------------
+`Full`      | The full expression that makes up the target.
+`Signature` | The function signature of `Function` targets.
+`Body`      | The function body of `Function` targets.
+
+Valid options for `Methods` are:
+
+Method              | Description
+--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------
+`Raw`               | The expression that makes up the target as written in the source code file.
+`NormalizedSpace`   | The expression with any character in the Unicode [whitespace character class][] replaced with a space, and any contiguous spaces collapsed to a single space.
+`NormalizedComment` | The expression with comments removed, as defined by the source code language.
+`NormalizedCode`    | Equivalent to `NormalizedComment` followed by `NormalizedSpace`.
+
+Given these options, the fully defined matrix of options is as follows:
+
+```
+{Function} × {Full, Signature, Body} × {Raw, NormalizedSpace, NormalizedComment, NormalizedCode}
+```
+
+FOSSA then scans open source projects for these snippets and records them along with their metadata,
+such as where in the file the snippet originated and from what project.
+
+Finally, when users scan their first-party projects, FOSSA extracts snippets in the same manner
+and compares the fingerprints of the content of those snippets against the database.
+If a match is found, FOSSA reports all open source projects in which the snippet was found,
+along with recorded metadata about that snippet.
+
+[whitespace character class]: https://en.wikipedia.org/wiki/Unicode_character_property#Whitespace

--- a/docs/references/subcommands/snippets/analyze.md
+++ b/docs/references/subcommands/snippets/analyze.md
@@ -1,7 +1,22 @@
-# `analyze`
+## `fossa snippets analyze`
 
-This subcommand analyzes a local project for snippets that match snippets in the FOSSA knowledgebase.
-For more information on possible options, run `millhone analyze --help`.
+This subcommand extracts snippets from a user project and compares them to the FOSSA database of snippets.
+Any matches are then written to the directory provided.
+
+## Options
+
+Argument             | Required | Default                | Description
+---------------------|----------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------
+`-o` / `--output`    | Yes      | None                   | The directory to which matches are output.
+`--debug`            | No       | No                     | Enables debug mode. Note that debug bundles are not currently exported with `fossa snippets`, but this output is similarly useful.
+`--overwrite-output` | No       | No                     | If specified, overwrites the directory indicated by `--output`.
+`--target`           | No       | `function`             | If specified, extracts and matches only the specified targets. Specify multiple options by providing this argument multiple times.
+`--kind`             | No       | `full, snippet, body`  | If specified, extracts and matches only the specified kinds. Specify multiple options by providing this argument multiple times.
+`--transform`        | No       | `space, comment, code` | If specified, extracts and matches only the specified transforms. Specify multiple options by providing this argument multiple times.
+
+> [!NOTE]
+> `--transform` corresponds to the `Normalized` methods [listed here](../snippets.md#how-does-fossa-snippet-scanning-work).
+> The `Raw` method is always enabled and cannot be disabled.
 
 ## Output
 

--- a/docs/references/subcommands/snippets/commit.md
+++ b/docs/references/subcommands/snippets/commit.md
@@ -1,0 +1,43 @@
+## `fossa snippets commit`
+
+This subcommand commits the analysis performed in the `analyze` subcommand into a `fossa-deps` file.
+For more information on possible options, run `millhone commit --help`.
+
+## Options
+
+Argument                 | Required | Default                | Description
+-------------------------|----------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------
+`--analyze-output`       | Yes      | None                   | The directory to which `fossa snippets analyze` output its matches.
+`--debug`                | No       | No                     | Enables debug mode. Note that debug bundles are not currently exported with `fossa snippets`, but this output is similarly useful.
+`--overwrite-fossa-deps` | No       | No                     | If specified, overwrites the `fossa-deps` file if present.
+`--target`               | No       | `function`             | If specified, commits matches consisting of only the specified targets. Specify multiple options by providing this argument multiple times.
+`--kind`                 | No       | `full, snippet, body`  | If specified, commits matches consisting of only the specified kinds. Specify multiple options by providing this argument multiple times.
+`--transform`            | No       | `space, comment, code` | If specified, commits matches consisting of only the specified transforms. Specify multiple options by providing this argument multiple times.
+
+> [!NOTE]
+> `--transform` corresponds to the `Normalized` methods [listed here](../snippets.md#how-does-fossa-snippet-scanning-work).
+> The `Raw` method is always enabled and cannot be disabled.
+
+## Input
+
+The primary thing this subcommand requires is the path to the directory in which the output of `analyze`
+was written. Users can also alter which kinds of matches to commit, and customize the output format
+of the created `fossa-deps` file.
+
+## Output
+
+The result of this subcommand is a `fossa-deps` file written to the root of the project directory.
+
+> [!NOTE]
+> This subcommand will not overwrite an existing `fossa-deps` file by default,
+> and currently does not merge its output into an existing `fossa-deps` file.
+>
+> However, users can customize the output format (via `--format`) and then
+> perform scripted merges themselves.
+
+## Next Steps
+
+After running `fossa snippets commit`, the next step is to run `fossa analyze` on the project.
+
+FOSSA CLI will then pick up the dependencies reported in that `fossa-deps` file and report them
+as dependencies of the project.

--- a/docs/references/subcommands/snippets/commit.md
+++ b/docs/references/subcommands/snippets/commit.md
@@ -1,7 +1,7 @@
 ## `fossa snippets commit`
 
-This subcommand commits the analysis performed in the `analyze` subcommand into a `fossa-deps` file.
-For more information on possible options, run `millhone commit --help`.
+This subcommand commits the analysis performed in the `analyze` subcommand into a `fossa-deps` file ([reference](../../files/fossa-deps.md)).
+For more information on possible options, run `fossa snippets commit --help`.
 
 ## Options
 
@@ -13,6 +13,7 @@ Argument                 | Required | Default                | Description
 `--target`               | No       | `function`             | If specified, commits matches consisting of only the specified targets. Specify multiple options by providing this argument multiple times.
 `--kind`                 | No       | `full, snippet, body`  | If specified, commits matches consisting of only the specified kinds. Specify multiple options by providing this argument multiple times.
 `--transform`            | No       | `space, comment, code` | If specified, commits matches consisting of only the specified transforms. Specify multiple options by providing this argument multiple times.
+`--format`               | No       | `yml`                  | Allows configuring the format of the generated `fossa-deps` file.
 
 > [!NOTE]
 > `--transform` corresponds to the `Normalized` methods [listed here](../snippets.md#how-does-fossa-snippet-scanning-work).

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "millhone"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [features]

--- a/extlib/millhone/src/main.rs
+++ b/extlib/millhone/src/main.rs
@@ -115,6 +115,8 @@ fn main() -> stable_eyre::Result<()> {
                     .with_writer(std::io::stdout)
                     .with_file(false)
                     .with_line_number(false)
+                    .without_time()
+                    .with_target(false)
                     .with_span_events(tracing_subscriber::fmt::format::FmtSpan::NONE)
                     .with_filter(app.level_filter())
                     .with_filter(self_sourced_events(app.log_level)),

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -185,6 +185,7 @@ library
     App.Fossa.Config.LinkUserBinaries
     App.Fossa.Config.ListTargets
     App.Fossa.Config.Report
+    App.Fossa.Config.Snippets
     App.Fossa.Config.Test
     App.Fossa.Container
     App.Fossa.Container.AnalyzeNative
@@ -210,6 +211,9 @@ library
     App.Fossa.Report
     App.Fossa.Report.Attribution
     App.Fossa.RunThemis
+    App.Fossa.Snippets
+    App.Fossa.Snippets.Analyze
+    App.Fossa.Snippets.Commit
     App.Fossa.Subcommand
     App.Fossa.Test
     App.Fossa.VendoredDependency

--- a/src/App/Fossa/Config/Snippets.hs
+++ b/src/App/Fossa/Config/Snippets.hs
@@ -183,7 +183,7 @@ instance ToText SnippetTarget where
 
 instance ToString SnippetTarget where
   toString :: SnippetTarget -> String
-  toString = toString
+  toString = toString . toText
 
 labelForTarget :: Text
 labelForTarget = "--target"
@@ -207,7 +207,7 @@ instance ToText SnippetKind where
 
 instance ToString SnippetKind where
   toString :: SnippetKind -> String
-  toString = toString
+  toString = toString . toText
 
 parseKind :: String -> Either String SnippetKind
 parseKind input = case List.find (\t -> toString t == input) optionsKind of
@@ -239,7 +239,7 @@ instance ToText SnippetTransform where
 
 instance ToString SnippetTransform where
   toString :: SnippetTransform -> String
-  toString = toString
+  toString = toString . toText
 
 parseTransform :: String -> Either String SnippetTransform
 parseTransform input = case List.find (\t -> toString t == input) optionsTransform of
@@ -267,7 +267,7 @@ instance ToText CommitOutputFormat where
 
 instance ToString CommitOutputFormat where
   toString :: CommitOutputFormat -> String
-  toString = toString
+  toString = toString . toText
 
 parseCommitOutputFormat :: String -> Either String CommitOutputFormat
 parseCommitOutputFormat input = case List.find (\t -> toString t == input) optionsCommitOutputFormat of

--- a/src/App/Fossa/Config/Snippets.hs
+++ b/src/App/Fossa/Config/Snippets.hs
@@ -1,0 +1,271 @@
+module App.Fossa.Config.Snippets (
+  mkSubCommand,
+  SnippetsConfig (..),
+  SnippetsCommand,
+  CommitOutputFormat (..),
+  SnippetKind (..),
+  SnippetTarget (..),
+  SnippetTransform (..),
+  AnalyzeConfig (..),
+  CommitConfig (..),
+  labelForKind,
+  labelForTarget,
+  labelForTransform,
+) where
+
+import App.Fossa.Config.Common (baseDirArg, collectBaseDir)
+import App.Fossa.Subcommand (EffStack, GetCommonOpts, GetSeverity (..), SubCommand (..))
+import App.Types (BaseDir)
+import Control.Carrier.Lift (sendIO)
+import Control.Effect.Diagnostics (Diagnostics, Has)
+import Control.Effect.Lift (Lift)
+import Data.Aeson (ToJSON, defaultOptions, genericToEncoding, toEncoding)
+import Data.List qualified as List
+import Data.String.Conversion (ToString, ToText, toString, toText)
+import Data.Text (Text)
+import Effect.Logger (Severity (..))
+import Effect.ReadFS (ReadFS)
+import GHC.Generics (Generic)
+import Options.Applicative (InfoMod, Parser, command, eitherReader, help, hsubparser, info, long, many, metavar, option, optional, progDesc, short, strOption, switch, (<|>))
+import Path (Abs, Dir, Path)
+import Path.IO qualified as Path
+
+data SnippetsCommand
+  = CommandAnalyze
+      FilePath -- Scan root
+      Bool -- Debug
+      FilePath -- Output directory
+      Bool -- Whether to overwrite output directory
+      [SnippetTarget]
+      [SnippetKind]
+      [SnippetTransform]
+  | CommandCommit
+      FilePath -- Scan root
+      Bool -- Debug
+      FilePath -- Output directory
+      Bool -- Whether to overwrite output directory
+      (Maybe CommitOutputFormat)
+      [SnippetTarget]
+      [SnippetKind]
+      [SnippetTransform]
+
+snippetsInfo :: InfoMod a
+snippetsInfo = progDesc "FOSSA snippet scanning"
+
+snippetsAnalyzeInfo :: InfoMod a
+snippetsAnalyzeInfo = progDesc "Analyze a local project for snippet matches"
+
+snippetsCommitInfo :: InfoMod a
+snippetsCommitInfo = progDesc "Commit matches discovered during analyze into a fossa-deps file"
+
+instance GetSeverity SnippetsCommand where
+  getSeverity :: SnippetsCommand -> Severity
+  getSeverity (CommandAnalyze _ analyzeDebug _ _ _ _ _) = if analyzeDebug then SevDebug else SevInfo
+  getSeverity (CommandCommit _ commitDebug _ _ _ _ _ _) = if commitDebug then SevDebug else SevInfo
+
+instance GetCommonOpts SnippetsCommand
+
+mkSubCommand :: (SnippetsConfig -> EffStack ()) -> SubCommand SnippetsCommand SnippetsConfig
+mkSubCommand = SubCommand "snippets" snippetsInfo cliParser noLoadConfig mergeOpts
+  where
+    noLoadConfig = const $ pure Nothing
+
+cliParser :: Parser SnippetsCommand
+cliParser = analyze <|> commit
+  where
+    analyze = hsubparser . command "analyze" $ info analyzeOpts snippetsAnalyzeInfo
+    analyzeOpts =
+      CommandAnalyze
+        <$> baseDirArg
+        <*> switch (long "debug" <> help "Enable debug logging")
+        <*> strOption (long "output" <> short 'o' <> help "The directory to which matches are output")
+        <*> switch (long "overwrite-output" <> help "If specified, overwrites the output directory if it exists")
+        <*> many (option (eitherReader parseTarget) (long "target" <> help ("Analyze this combination of targets") <> metavar "TARGET"))
+        <*> many (option (eitherReader parseKind) (long "kind" <> help ("Analyze this combination of kinds") <> metavar "KIND"))
+        <*> many (option (eitherReader parseTransform) (long "transform" <> help ("Analyze this combination of transforms") <> metavar "TRANSFORM"))
+    commit = hsubparser . command "commit" $ info commitOpts snippetsCommitInfo
+    commitOpts =
+      CommandCommit
+        <$> baseDirArg
+        <*> switch (long "debug" <> help "Enable debug logging")
+        <*> strOption (long "analyze-output" <> help "The directory to which 'analyze' matches were saved")
+        <*> switch (long "overwrite-fossa-deps" <> help "If specified, overwrites the 'fossa-deps' file if it exists")
+        <*> optional (option (eitherReader parseCommitOutputFormat) (long "format" <> help ("The output format for the generated `fossa-deps` file") <> metavar "FORMAT"))
+        <*> many (option (eitherReader parseTarget) (long "target" <> help ("Commit this combination of targets") <> metavar "TARGET"))
+        <*> many (option (eitherReader parseKind) (long "kind" <> help ("Commit this combination of kinds") <> metavar "KIND"))
+        <*> many (option (eitherReader parseTransform) (long "transform" <> help ("Commit this combination of transforms") <> metavar "TRANSFORM"))
+
+mergeOpts ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has ReadFS sig m
+  ) =>
+  a ->
+  b ->
+  SnippetsCommand ->
+  m SnippetsConfig
+mergeOpts _ _ (CommandAnalyze path debug output overwrite targets kinds transforms) = do
+  root <- collectBaseDir path
+  output' <- sendIO $ Path.resolveDir' output
+  pure . Analyze $ AnalyzeConfig root debug output' overwrite targets kinds transforms
+mergeOpts _ _ (CommandCommit path debug analyzeOutput overwrite format targets kinds transforms) = do
+  root <- collectBaseDir path
+  analyzeOutput' <- sendIO $ Path.resolveDir' analyzeOutput
+  pure . Commit $ CommitConfig root debug analyzeOutput' overwrite format targets kinds transforms
+
+data SnippetsConfig
+  = Analyze AnalyzeConfig
+  | Commit CommitConfig
+  deriving (Show, Generic)
+
+instance ToJSON SnippetsConfig where
+  toEncoding = genericToEncoding defaultOptions
+
+data AnalyzeConfig = AnalyzeConfig
+  { analyzeScanDir :: BaseDir
+  , analyzeDebug :: Bool
+  , analyzeOutput :: Path Abs Dir
+  , analyzeOverwriteOutput :: Bool
+  , analyzeTargets :: [SnippetTarget]
+  , analyzeKinds :: [SnippetKind]
+  , analyzeTransforms :: [SnippetTransform]
+  }
+  deriving (Show, Generic)
+
+instance ToJSON AnalyzeConfig where
+  toEncoding = genericToEncoding defaultOptions
+
+data CommitConfig = CommitConfig
+  { commitScanDir :: BaseDir
+  , commitDebug :: Bool
+  , commitAnalyzeOutput :: Path Abs Dir
+  , commitOverwriteFossaDeps :: Bool
+  , commitOutputFormat :: Maybe CommitOutputFormat
+  , commitTargets :: [SnippetTarget]
+  , commitKinds :: [SnippetKind]
+  , commitTransforms :: [SnippetTransform]
+  }
+  deriving (Show, Generic)
+
+instance ToJSON CommitConfig where
+  toEncoding = genericToEncoding defaultOptions
+
+-- | The targets of snippets to extract.
+-- Reference: @millhone::extract::Target@.
+data SnippetTarget
+  = SnippetTargetFunction
+  deriving (Eq, Enum, Bounded, Show, Generic)
+
+instance ToJSON SnippetTarget where
+  toEncoding = genericToEncoding defaultOptions
+
+parseTarget :: String -> Either String SnippetTarget
+parseTarget input = case List.find (\t -> toString t == input) optionsTarget of
+  Just found -> Right found
+  Nothing -> Left $ generateParseError input (toString <$> optionsTarget)
+
+optionsTarget :: [SnippetTarget]
+optionsTarget = enumFromTo minBound maxBound
+
+instance ToText SnippetTarget where
+  toText :: SnippetTarget -> Text
+  toText SnippetTargetFunction = "function"
+
+instance ToString SnippetTarget where
+  toString :: SnippetTarget -> String
+  toString = toString
+
+labelForTarget :: Text
+labelForTarget = "--target"
+
+-- | The kind of item this snippet represents.
+-- Reference: @millhone::extract::Kind@.
+data SnippetKind
+  = SnippetKindSignature
+  | SnippetKindBody
+  | SnippetKindFull
+  deriving (Eq, Enum, Bounded, Show, Generic)
+
+instance ToJSON SnippetKind where
+  toEncoding = genericToEncoding defaultOptions
+
+instance ToText SnippetKind where
+  toText :: SnippetKind -> Text
+  toText SnippetKindSignature = "signature"
+  toText SnippetKindBody = "body"
+  toText SnippetKindFull = "full"
+
+instance ToString SnippetKind where
+  toString :: SnippetKind -> String
+  toString = toString
+
+parseKind :: String -> Either String SnippetKind
+parseKind input = case List.find (\t -> toString t == input) optionsKind of
+  Just found -> Right found
+  Nothing -> Left $ generateParseError input (toString <$> optionsKind)
+
+optionsKind :: [SnippetKind]
+optionsKind = enumFromTo minBound maxBound
+
+labelForKind :: Text
+labelForKind = "--kind"
+
+-- | The normalization used to extract this snippet.
+-- Reference: @millhone::extract::Transform@.
+data SnippetTransform
+  = SnippetTransformCode
+  | SnippetTransformComment
+  | SnippetTransformSpace
+  deriving (Eq, Enum, Bounded, Show, Generic)
+
+instance ToJSON SnippetTransform where
+  toEncoding = genericToEncoding defaultOptions
+
+instance ToText SnippetTransform where
+  toText :: SnippetTransform -> Text
+  toText SnippetTransformCode = "code"
+  toText SnippetTransformComment = "comment"
+  toText SnippetTransformSpace = "space"
+
+instance ToString SnippetTransform where
+  toString :: SnippetTransform -> String
+  toString = toString
+
+parseTransform :: String -> Either String SnippetTransform
+parseTransform input = case List.find (\t -> toString t == input) optionsTransform of
+  Just found -> Right found
+  Nothing -> Left $ generateParseError input (toString <$> optionsTransform)
+
+optionsTransform :: [SnippetTransform]
+optionsTransform = enumFromTo minBound maxBound
+
+labelForTransform :: Text
+labelForTransform = "--transform"
+
+data CommitOutputFormat
+  = Yml
+  | Json
+  deriving (Eq, Enum, Bounded, Show, Generic)
+
+instance ToJSON CommitOutputFormat where
+  toEncoding = genericToEncoding defaultOptions
+
+instance ToText CommitOutputFormat where
+  toText :: CommitOutputFormat -> Text
+  toText Yml = "yml"
+  toText Json = "json"
+
+instance ToString CommitOutputFormat where
+  toString :: CommitOutputFormat -> String
+  toString = toString
+
+parseCommitOutputFormat :: String -> Either String CommitOutputFormat
+parseCommitOutputFormat input = case List.find (\t -> toString t == input) optionsCommitOutputFormat of
+  Just found -> Right found
+  Nothing -> Left $ generateParseError input (toString <$> optionsCommitOutputFormat)
+
+optionsCommitOutputFormat :: [CommitOutputFormat]
+optionsCommitOutputFormat = enumFromTo minBound maxBound
+
+generateParseError :: String -> [String] -> String
+generateParseError input options = "'" <> input <> "' is not a valid option; expected one of: " <> List.intercalate ", " options

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -11,6 +11,7 @@ module App.Fossa.EmbeddedBinary (
   withThemisAndIndex,
   withBerkeleyBinary,
   withLernieBinary,
+  withMillhoneBinary,
   allBins,
   dumpEmbeddedBinary,
   themisVersion,
@@ -56,6 +57,7 @@ data PackagedBinary
   | ThemisIndex
   | BerkeleyDB
   | Lernie
+  | Millhone
   deriving (Show, Eq, Enum, Bounded)
 
 allBins :: [PackagedBinary]
@@ -118,6 +120,13 @@ withLernieBinary ::
   m c
 withLernieBinary = withEmbeddedBinary Lernie
 
+withMillhoneBinary ::
+  ( Has (Lift IO) sig m
+  ) =>
+  (BinaryPaths -> m c) ->
+  m c
+withMillhoneBinary = withEmbeddedBinary Millhone
+
 withEmbeddedBinary ::
   ( Has (Lift IO) sig m
   ) =>
@@ -150,6 +159,7 @@ writeBinary dest bin = sendIO . writeExecutable dest $ case bin of
   ThemisIndex -> embeddedBinaryThemisIndex
   BerkeleyDB -> embeddedBinaryBerkeleyDB
   Lernie -> embeddedBinaryLernie
+  Millhone -> embeddedBinaryMillhone
 
 writeExecutable :: Path Abs File -> ByteString -> IO ()
 writeExecutable path content = do
@@ -163,6 +173,7 @@ extractedPath bin = case bin of
   ThemisIndex -> $(mkRelFile "index.gob.xz")
   BerkeleyDB -> $(mkRelFile "berkeleydb-plugin")
   Lernie -> $(mkRelFile "lernie")
+  Millhone -> $(mkRelFile "millhone")
 
 -- | Extract to @$TMP/fossa-vendor/<timestamp>
 -- We used to extract everything to @$TMP/fossa-vendor@, but there's a subtle issue with that.
@@ -202,6 +213,15 @@ themisVersion = $$(themisVersionQ)
 
 embeddedBinaryLernie :: ByteString
 embeddedBinaryLernie = $(embedFileIfExists "vendor-bins/lernie")
+
+-- To build this, run `make build` or `cargo build --release`.
+#ifdef mingw32_HOST_OS
+embeddedBinaryMillhone :: ByteString
+embeddedBinaryMillhone = $(embedFileIfExists "target/release/millhone.exe")
+#else
+embeddedBinaryMillhone :: ByteString
+embeddedBinaryMillhone = $(embedFileIfExists "target/release/millhone")
+#endif
 
 -- To build this, run `make build` or `cargo build --release`.
 #ifdef mingw32_HOST_OS

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -55,8 +55,8 @@ appMain = do
 
 versionOpt :: Parser (a -> a)
 versionOpt =
-  infoOption (toString fullVersionDescription)
-    $ mconcat
+  infoOption (toString fullVersionDescription) $
+    mconcat
       [long "version", short 'V', help "show version information and exit"]
 
 progData :: InfoMod (IO ())
@@ -69,8 +69,8 @@ subcommands :: Parser (IO ())
 subcommands = public <|> private
   where
     private =
-      subparser
-        $ mconcat
+      subparser $
+        mconcat
           [ internal
           , initCommand
           , experimentalLicenseScanCommand
@@ -79,8 +79,8 @@ subcommands = public <|> private
           , decodeSubCommand LicenseScan.licenseScanSubCommand
           ]
     public =
-      hsubparser
-        $ mconcat
+      hsubparser $
+        mconcat
           [ decodeSubCommand Analyze.analyzeSubCommand
           , decodeSubCommand Test.testSubCommand
           , decodeSubCommand Report.reportSubCommand
@@ -107,8 +107,8 @@ decodeSubCommand cmd@SubCommand{..} = command commandName $ info (runSubCommand 
 
 mainPrefs :: ParserPrefs
 mainPrefs =
-  prefs
-    $ mconcat
+  prefs $
+    mconcat
       [ showHelpOnEmpty
       , showHelpOnError
       , subparserInline

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -9,6 +9,7 @@ import App.Fossa.DumpBinaries qualified as Dump
 import App.Fossa.LicenseScan qualified as LicenseScan (licenseScanSubCommand)
 import App.Fossa.ListTargets qualified as ListTargets
 import App.Fossa.Report qualified as Report
+import App.Fossa.Snippets qualified as Snippets
 import App.Fossa.Subcommand (GetCommonOpts, GetSeverity, SubCommand (..), runSubCommand)
 import App.Fossa.Test qualified as Test
 import App.Fossa.VSI.IAT.AssertUserDefinedBinaries qualified as LinkBins
@@ -54,8 +55,8 @@ appMain = do
 
 versionOpt :: Parser (a -> a)
 versionOpt =
-  infoOption (toString fullVersionDescription) $
-    mconcat
+  infoOption (toString fullVersionDescription)
+    $ mconcat
       [long "version", short 'V', help "show version information and exit"]
 
 progData :: InfoMod (IO ())
@@ -68,8 +69,8 @@ subcommands :: Parser (IO ())
 subcommands = public <|> private
   where
     private =
-      subparser $
-        mconcat
+      subparser
+        $ mconcat
           [ internal
           , initCommand
           , experimentalLicenseScanCommand
@@ -78,14 +79,15 @@ subcommands = public <|> private
           , decodeSubCommand LicenseScan.licenseScanSubCommand
           ]
     public =
-      hsubparser $
-        mconcat
+      hsubparser
+        $ mconcat
           [ decodeSubCommand Analyze.analyzeSubCommand
           , decodeSubCommand Test.testSubCommand
           , decodeSubCommand Report.reportSubCommand
           , decodeSubCommand Container.containerSubCommand
           , decodeSubCommand ListTargets.listSubCommand
           , decodeSubCommand LinkBins.linkBinsSubCommand
+          , decodeSubCommand Snippets.snippetsSubCommand
           ]
 
 initCommand :: Mod CommandFields (IO ())
@@ -105,8 +107,8 @@ decodeSubCommand cmd@SubCommand{..} = command commandName $ info (runSubCommand 
 
 mainPrefs :: ParserPrefs
 mainPrefs =
-  prefs $
-    mconcat
+  prefs
+    $ mconcat
       [ showHelpOnEmpty
       , showHelpOnError
       , subparserInline

--- a/src/App/Fossa/Snippets.hs
+++ b/src/App/Fossa/Snippets.hs
@@ -1,0 +1,44 @@
+-- Types in this module are tightly based on the types in the Millhone CLI.
+--
+-- In the documentation for this module, Millhone symbols are written
+-- using Rust-style paths (e.g. @millhone::extract::Target@).
+--
+-- The Millhone CLI is at @extlib/millhone@.
+--
+-- Notable exceptions:
+-- - Auth config is not included here.
+--   The plan is to use FOSSA reverse proxying eventually,
+--   and until that's done Millhone CLI hard codes authentication information.
+-- - Logging config is not included here.
+--   Instead FOSSA CLI automatically configures it based on
+--   its configured log severity.
+
+module App.Fossa.Snippets (
+  snippetsMain,
+  snippetsSubCommand,
+) where
+
+import App.Fossa.Config.Snippets (SnippetsCommand, SnippetsConfig (..), mkSubCommand)
+import App.Fossa.Snippets.Analyze (analyzeWithMillhone)
+import App.Fossa.Snippets.Commit (commitWithMillhone)
+import App.Fossa.Subcommand (SubCommand)
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Lift)
+import Effect.Exec (Exec)
+import Effect.Logger (Logger)
+
+snippetsSubCommand :: SubCommand SnippetsCommand SnippetsConfig
+snippetsSubCommand = mkSubCommand snippetsMain
+
+snippetsMain ::
+  ( Has (Lift IO) sig m
+  , Has Exec sig m
+  , Has Diagnostics sig m
+  , Has Logger sig m
+  ) =>
+  SnippetsConfig ->
+  m ()
+snippetsMain = \case
+  Analyze cfg -> analyzeWithMillhone cfg
+  Commit cfg -> commitWithMillhone cfg

--- a/src/App/Fossa/Snippets.hs
+++ b/src/App/Fossa/Snippets.hs
@@ -26,7 +26,7 @@ import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Lift)
 import Effect.Exec (Exec)
-import Effect.Logger (Logger)
+import Effect.Logger (Logger, logInfo)
 
 snippetsSubCommand :: SubCommand SnippetsCommand SnippetsConfig
 snippetsSubCommand = mkSubCommand snippetsMain
@@ -39,6 +39,8 @@ snippetsMain ::
   ) =>
   SnippetsConfig ->
   m ()
-snippetsMain = \case
-  Analyze cfg -> analyzeWithMillhone cfg
-  Commit cfg -> commitWithMillhone cfg
+snippetsMain subcommand = do
+  logInfo "Running FOSSA snippets"
+  case subcommand of
+    Analyze cfg -> analyzeWithMillhone cfg
+    Commit cfg -> commitWithMillhone cfg

--- a/src/App/Fossa/Snippets/Analyze.hs
+++ b/src/App/Fossa/Snippets/Analyze.hs
@@ -31,10 +31,13 @@ mkCmd :: BinaryPaths -> Path Abs Dir -> AnalyzeConfig -> Command
 mkCmd bin root AnalyzeConfig{..} =
   Command
     { cmdName = toText $ toPath bin
-    , cmdArgs = "analyze" : argFromPath root : concat [output, overwriteOutput, targets, kinds, transforms]
+    , cmdArgs = concat [debug, cmd, output, overwriteOutput, targets, kinds, transforms, dir]
     , cmdAllowErr = Never
     }
   where
+    cmd = ["analyze"]
+    dir = [argFromPath root]
+    debug = if analyzeDebug then ["--log-level", "debug", "--log-format", "json"] else []
     targets = if null analyzeTargets then [] else argsLabeled labelForTarget analyzeTargets
     kinds = if null analyzeKinds then [] else argsLabeled labelForKind analyzeKinds
     transforms = if null analyzeTransforms then [] else argsLabeled labelForTransform analyzeTransforms

--- a/src/App/Fossa/Snippets/Analyze.hs
+++ b/src/App/Fossa/Snippets/Analyze.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.Snippets.Analyze (
+  analyzeWithMillhone,
+) where
+
+import App.Fossa.Config.Snippets (AnalyzeConfig (..), labelForKind, labelForTarget, labelForTransform)
+import App.Fossa.EmbeddedBinary (BinaryPaths, toPath, withMillhoneBinary)
+import App.Types (BaseDir (unBaseDir))
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Lift)
+import Data.String.Conversion (toText)
+import Effect.Exec (AllowErr (Never), Command (..), Exec, argFromPath, argsLabeled, execEffectful)
+import Effect.Logger (Logger)
+import Path (Abs, Dir, Path)
+
+analyzeWithMillhone ::
+  ( Has (Lift IO) sig m
+  , Has Exec sig m
+  , Has Diagnostics sig m
+  , Has Logger sig m
+  ) =>
+  AnalyzeConfig ->
+  m ()
+analyzeWithMillhone conf = withMillhoneBinary $ \bin -> execEffectful root $ mkCmd bin root conf
+  where
+    root = unBaseDir $ analyzeScanDir conf
+
+mkCmd :: BinaryPaths -> Path Abs Dir -> AnalyzeConfig -> Command
+mkCmd bin root AnalyzeConfig{..} =
+  Command
+    { cmdName = toText $ toPath bin
+    , cmdArgs = "analyze" : argFromPath root : concat [output, overwriteOutput, targets, kinds, transforms]
+    , cmdAllowErr = Never
+    }
+  where
+    targets = if null analyzeTargets then [] else argsLabeled labelForTarget analyzeTargets
+    kinds = if null analyzeKinds then [] else argsLabeled labelForKind analyzeKinds
+    transforms = if null analyzeTransforms then [] else argsLabeled labelForTransform analyzeTransforms
+    output = ["--output", argFromPath analyzeOutput]
+    overwriteOutput = if analyzeOverwriteOutput then ["--overwrite-output"] else []

--- a/src/App/Fossa/Snippets/Commit.hs
+++ b/src/App/Fossa/Snippets/Commit.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.Snippets.Commit (
+  commitWithMillhone,
+) where
+
+import App.Fossa.Config.Snippets (CommitConfig (..), labelForKind, labelForTarget, labelForTransform)
+import App.Fossa.EmbeddedBinary (BinaryPaths, toPath, withMillhoneBinary)
+import App.Types (unBaseDir)
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Lift)
+import Data.String.Conversion (toText)
+import Effect.Exec (AllowErr (Never), Command (..), Exec, argFromPath, argsLabeled, execEffectful)
+import Effect.Logger (Logger)
+import Path (Abs, Dir, Path)
+
+commitWithMillhone ::
+  ( Has (Lift IO) sig m
+  , Has Exec sig m
+  , Has Diagnostics sig m
+  , Has Logger sig m
+  ) =>
+  CommitConfig ->
+  m ()
+commitWithMillhone conf = withMillhoneBinary $ \bin -> execEffectful root $ mkCmd bin root conf
+  where
+    root = unBaseDir $ commitScanDir conf
+
+mkCmd :: BinaryPaths -> Path Abs Dir -> CommitConfig -> Command
+mkCmd bin root CommitConfig{..} =
+  Command
+    { cmdName = toText $ toPath bin
+    , cmdArgs = "commit" : argFromPath root : concat [output, format, overwriteOutput, targets, kinds, transforms]
+    , cmdAllowErr = Never
+    }
+  where
+    targets = if null commitTargets then [] else argsLabeled labelForTarget commitTargets
+    kinds = if null commitKinds then [] else argsLabeled labelForKind commitKinds
+    transforms = if null commitTransforms then [] else argsLabeled labelForTransform commitTransforms
+    output = ["--analyze-output-dir", argFromPath commitAnalyzeOutput]
+    format = case commitOutputFormat of
+      Just format' -> ["--format", toText format']
+      Nothing -> []
+    overwriteOutput = if commitOverwriteFossaDeps then ["--overwrite-fossa-deps"] else []

--- a/src/App/Fossa/Snippets/Commit.hs
+++ b/src/App/Fossa/Snippets/Commit.hs
@@ -31,10 +31,13 @@ mkCmd :: BinaryPaths -> Path Abs Dir -> CommitConfig -> Command
 mkCmd bin root CommitConfig{..} =
   Command
     { cmdName = toText $ toPath bin
-    , cmdArgs = "commit" : argFromPath root : concat [output, format, overwriteOutput, targets, kinds, transforms]
+    , cmdArgs = concat [debug, cmd, output, format, overwriteOutput, targets, kinds, transforms, dir]
     , cmdAllowErr = Never
     }
   where
+    cmd = ["commit"]
+    dir = [argFromPath root]
+    debug = if commitDebug then ["--log-level", "debug", "--log-format", "json"] else []
     targets = if null commitTargets then [] else argsLabeled labelForTarget commitTargets
     kinds = if null commitKinds then [] else argsLabeled labelForKind commitKinds
     transforms = if null commitTransforms then [] else argsLabeled labelForTransform commitTransforms

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -137,9 +137,9 @@ instance FromJSON CmdFailure where
   parseJSON = withObject "CmdFailure" $ \obj ->
     CmdFailure
       <$> obj
-      .: "cmdFailureCmd"
+        .: "cmdFailureCmd"
       <*> obj
-      .: "cmdFailureDir"
+        .: "cmdFailureDir"
       <*> (obj .: "cmdFailureExit" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStdout" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStderr" >>= fromRecordedValue)
@@ -441,12 +441,12 @@ selectBestCmd workdir CandidateAnalysisCommands{..} = selectBestCmd' (NE.toList 
 data CandidateCommandFailed = CandidateCommandFailed {failedCommand :: Text, failedArgs :: [Text]}
 instance ToDiagnostic CandidateCommandFailed where
   renderDiagnostic CandidateCommandFailed{..} =
-    pretty
-      $ "Command "
-      <> show failedCommand
-      <> " not suitable: running with args "
-      <> show failedArgs
-      <> " resulted in a non-zero exit code"
+    pretty $
+      "Command "
+        <> show failedCommand
+        <> " not suitable: running with args "
+        <> show failedArgs
+        <> " resulted in a non-zero exit code"
 
 argFromPath :: Path a b -> Text
 argFromPath = toText . toFilePath

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -4,10 +4,14 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Effect.Exec (
+  argFromPath,
+  argsLabeled,
+  argsLabeledWith,
   Exec,
   ExecF (..),
   ExecErr (..),
   exec,
+  execEffectful,
   execThrow,
   Command (..),
   CmdFailure (..),
@@ -64,18 +68,20 @@ import Data.Aeson (
  )
 import Data.Bifunctor (first)
 import Data.ByteString.Lazy qualified as BL
+import Data.Foldable (traverse_)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
 import Data.String (fromString)
-import Data.String.Conversion (decodeUtf8, toString, toText)
+import Data.String.Conversion (ToText, decodeUtf8, toStrict, toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Void (Void)
 import DepTypes (DepType (..))
+import Effect.Logger (Logger, logInfo)
 import Effect.ReadFS (ReadFS, getCurrentDir)
 import GHC.Generics (Generic)
-import Path (Abs, Dir, Path, SomeBase (..), fromAbsDir)
+import Path (Abs, Dir, Path, SomeBase (..), fromAbsDir, toFilePath)
 import Path.IO (AnyPath (makeAbsolute))
 import Prettyprinter (Doc, indent, pretty, viaShow, vsep)
 import Prettyprinter.Render.Terminal (AnsiStyle)
@@ -131,9 +137,9 @@ instance FromJSON CmdFailure where
   parseJSON = withObject "CmdFailure" $ \obj ->
     CmdFailure
       <$> obj
-        .: "cmdFailureCmd"
+      .: "cmdFailureCmd"
       <*> obj
-        .: "cmdFailureDir"
+      .: "cmdFailureDir"
       <*> (obj .: "cmdFailureExit" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStdout" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStderr" >>= fromRecordedValue)
@@ -333,6 +339,27 @@ execThrow dir cmd = context ("Running command '" <> cmdName cmd <> "'") $ do
     Left failure -> fatal (CommandFailed failure)
     Right stdout -> pure stdout
 
+-- | A variant of 'exec' that is run for its side effects:
+-- * Throws an 'ExecErr' when the command returns a non-zero exit code, like @execThrow@.
+-- * Logs each line of the subcommand's stdout via @logInfo@.
+--
+-- Note: currently this buffers subcommand output; a future version may stream instead.
+execEffectful ::
+  ( Has Exec sig m
+  , Has Diagnostics sig m
+  , Has Logger sig m
+  ) =>
+  Path Abs Dir ->
+  Command ->
+  m ()
+execEffectful dir cmd = context ("Running command '" <> cmdName cmd <> "'") $ do
+  result <- exec dir cmd
+  case result of
+    Left failure -> fatal (CommandFailed failure)
+    Right stdout -> do
+      let outputLines :: [Text] = decodeUtf8 . toStrict <$> BL.splitWith (== 10) stdout
+      traverse_ (logInfo . pretty) outputLines
+
 -- | A variant of 'execThrow' that runs the command in the current directory
 execThrow' :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => Command -> m BL.ByteString
 execThrow' cmd = context ("Running command '" <> cmdName cmd <> "'") $ do
@@ -414,12 +441,22 @@ selectBestCmd workdir CandidateAnalysisCommands{..} = selectBestCmd' (NE.toList 
 data CandidateCommandFailed = CandidateCommandFailed {failedCommand :: Text, failedArgs :: [Text]}
 instance ToDiagnostic CandidateCommandFailed where
   renderDiagnostic CandidateCommandFailed{..} =
-    pretty $
-      "Command "
-        <> show failedCommand
-        <> " not suitable: running with args "
-        <> show failedArgs
-        <> " resulted in a non-zero exit code"
+    pretty
+      $ "Command "
+      <> show failedCommand
+      <> " not suitable: running with args "
+      <> show failedArgs
+      <> " resulted in a non-zero exit code"
+
+argFromPath :: Path a b -> Text
+argFromPath = toText . toFilePath
+
+argsLabeled :: ToText a => Text -> [a] -> [Text]
+argsLabeled = argsLabeledWith toText
+
+argsLabeledWith :: (a -> Text) -> Text -> [a] -> [Text]
+argsLabeledWith render label (arg : args) = [label, render arg] ++ argsLabeledWith render label args
+argsLabeledWith _ _ [] = []
 
 type ExecIOC = SimpleC ExecF
 

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -405,9 +405,9 @@ buildGraph = traverse_ go . resolve
       --    https://golang.org/ref/mod#incompatible-versions for details.
       -- 3. The raw version text for non-canonical versions. Nothing else we can
       --    do here.
-      label pkg
-        $ GolangLabelVersion
-        $ case reqVersion of
-          NonCanonical n -> n
-          Pseudo commitHash -> commitHash
-          Semantic semver -> "v" <> SemVer.toText semver{_versionMeta = []}
+      label pkg $
+        GolangLabelVersion $
+          case reqVersion of
+            NonCanonical n -> n
+            Pseudo commitHash -> commitHash
+            Semantic semver -> "v" <> SemVer.toText semver{_versionMeta = []}

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -405,8 +405,9 @@ buildGraph = traverse_ go . resolve
       --    https://golang.org/ref/mod#incompatible-versions for details.
       -- 3. The raw version text for non-canonical versions. Nothing else we can
       --    do here.
-      label pkg $
-        GolangLabelVersion $ case reqVersion of
+      label pkg
+        $ GolangLabelVersion
+        $ case reqVersion of
           NonCanonical n -> n
           Pseudo commitHash -> commitHash
           Semantic semver -> "v" <> SemVer.toText semver{_versionMeta = []}


### PR DESCRIPTION
# Overview

Integrates snippet scanning into FOSSA CLI as `fossa snippets`.

## Acceptance criteria

Users no longer need to run this as a separate subcommand.

## Testing plan

I tested manually:
```

fossa-cli on ⑆ millhone/integrate [$!] via λ 9.4.7 via 🦀 v1.72.0 took 8s
❯ cabal run fossa snippets analyze -- ~/projects/scratch/src -o ~/projects/scratch/snippets --overwrite-output
 INFO main{target=/Users/jessica/projects/scratch/src/}: Analyzing local snippet matches
 INFO main{target=/Users/jessica/projects/scratch/src/}: Finished matching 20 snippets out of 3 files to 68 matches


fossa-cli on ⑆ millhone/integrate [$!] via λ 9.4.7 via 🦀 v1.72.0
❯ cabal run fossa snippets commit -- ~/projects/scratch/src --analyze-output ~/projects/scratch/snippets --overwrite-fossa-deps
 INFO main{target=/Users/jessica/projects/scratch/src/}: Committing local snippet matches
 INFO main{target=/Users/jessica/projects/scratch/src/}: Wrote output to '/Users/jessica/projects/scratch/src/fossa-deps.yml' with dependency count: 9


fossa-cli on ⑆ millhone/integrate [$!] via λ 9.4.7 via 🦀 v1.72.0
❯ cat /Users/jessica/projects/scratch/src/fossa-deps.yml
───────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: /Users/jessica/projects/scratch/src/fossa-deps.yml
───────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ referenced-dependencies:
   2   │ - type: git
   3   │   name: github.com/fs-c/maniac
   4   │   version: v0.7.0-beta
   5   │ - type: git
   6   │   name: github.com/shiquan/PISA
   7   │   version: v0.10a
   8   │ - type: git
   9   │   name: github.com/shiquan/PISA
  10   │   version: v0.10b
  11   │ - type: git
  12   │   name: github.com/shiquan/PISA
  13   │   version: v0.11a
  14   │ - type: git
  15   │   name: github.com/shiquan/PISA
  16   │   version: v0.12
  17   │ - type: git
  18   │   name: github.com/shiquan/PISA
  19   │   version: v0.12a
  20   │ - type: git
  21   │   name: github.com/shiquan/PISA
  22   │   version: v0.4-alpha
  23   │ - type: git
  24   │   name: github.com/shiquan/PISA
  25   │   version: v0.6
  26   │ - type: git
  27   │   name: github.com/wooorm/levenshtein.c
  28   │   version: 2.0.2
───────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

## Risks

No major risk, although we're taking on some backwards compatibility commitments here.

## Metrics

None

## References

https://fossa.atlassian.net/browse/ANE-1136

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
