### PR TITLE
[FDN-12] VSI Dep Paths on windows

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -4,6 +4,9 @@
   "ignorePatterns": [
     {
       "pattern": "https://support.fossa.com"
+    },
+    {
+      "pattern": "https://cran.r-project.org"
     }
   ]
 }

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,9 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## v3.8.19
 
 - container scanning: fixes a defect which led to incorrect `NotTarFormat` errors when parsing container layer. ([#1305](https://github.com/fossas/fossa-cli/pull/1305))
+- `--detect-vendored`: fix a defect which caused the `--detect-vendored` flag to fail on Windows ([#1300](https://github.com/fossas/fossa-cli/pull/1300))
 
 ## v3.8.18
 

--- a/docs/contributing/HACKING.md
+++ b/docs/contributing/HACKING.md
@@ -94,7 +94,7 @@ If you installed HLS in the old, complicated way, you can safely remove it.  HLS
 
 You should also set the `FOSSA_SKIP_EMBED_FILE_IN_HLS` environment variable for HLS. This prevents HLS from embedding binaries, which helps to avoid a giant memory footprint for HLS.
 
-You can also tell the Fourmolu plugin to use an external config. This ensures that it picks up our `fourmolu.yaml` file.
+You can also tell the Fourmolu plugin to use an external config. This will tell the language server to use an external executable that you've installed, which ensures that it picks up our `fourmolu.yaml` file.
 
 In VSCode, this is done by adding this to your `settings.json`:
 

--- a/docs/contributing/HACKING.md
+++ b/docs/contributing/HACKING.md
@@ -94,12 +94,15 @@ If you installed HLS in the old, complicated way, you can safely remove it.  HLS
 
 You should also set the `FOSSA_SKIP_EMBED_FILE_IN_HLS` environment variable for HLS. This prevents HLS from embedding binaries, which helps to avoid a giant memory footprint for HLS.
 
+You can also tell the Fourmolu plugin to use an external config. This ensures that it picks up our `fourmolu.yaml` file.
+
 In VSCode, this is done by adding this to your `settings.json`:
 
 ```json
     "haskell.serverEnvironment": {
         "FOSSA_SKIP_EMBED_FILE_IN_HLS": true,
     },
+    "haskell.plugin.fourmolu.config.external": true,
 ```
 
 ## Linting

--- a/integration-test/Analysis/FixtureExpectationUtils.hs
+++ b/integration-test/Analysis/FixtureExpectationUtils.hs
@@ -91,8 +91,9 @@ withProjectOfType result (projType, projPath) =
   find (\(dr, _) -> projectType dr == projType && projectPath dr == projPath) result
 
 testSuiteHasSomeDepResults :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> DiscoveredProjectType -> Spec
-testSuiteHasSomeDepResults fixture projType = aroundAll (withAnalysisOf fixture) $
-  describe (toString $ testName fixture) $ do
+testSuiteHasSomeDepResults fixture projType = aroundAll (withAnalysisOf fixture)
+  $ describe (toString $ testName fixture)
+  $ do
     it "should find targets" $ \(result, extractedDir) ->
       expectProject (projType, extractedDir) result
 
@@ -101,8 +102,9 @@ testSuiteHasSomeDepResults fixture projType = aroundAll (withAnalysisOf fixture)
 
 testSuiteDepResultSummary :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> DiscoveredProjectType -> DependencyResultsSummary -> Spec
 testSuiteDepResultSummary fixture projType depResultSummary =
-  aroundAll (withAnalysisOf fixture) $
-    describe (toString $ testName fixture) $ do
+  aroundAll (withAnalysisOf fixture)
+    $ describe (toString $ testName fixture)
+    $ do
       it "should find targets" $ \(result, extractedDir) ->
         expectProject (projType, extractedDir) result
 

--- a/integration-test/Analysis/FixtureExpectationUtils.hs
+++ b/integration-test/Analysis/FixtureExpectationUtils.hs
@@ -91,22 +91,22 @@ withProjectOfType result (projType, projPath) =
   find (\(dr, _) -> projectType dr == projType && projectPath dr == projPath) result
 
 testSuiteHasSomeDepResults :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> DiscoveredProjectType -> Spec
-testSuiteHasSomeDepResults fixture projType = aroundAll (withAnalysisOf fixture)
-  $ describe (toString $ testName fixture)
-  $ do
-    it "should find targets" $ \(result, extractedDir) ->
-      expectProject (projType, extractedDir) result
-
-    it "should have some dependency results" $ \(result, extractedDir) ->
-      isJust (getDepResultsOf result (projType, extractedDir)) `shouldBe` True
-
-testSuiteDepResultSummary :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> DiscoveredProjectType -> DependencyResultsSummary -> Spec
-testSuiteDepResultSummary fixture projType depResultSummary =
-  aroundAll (withAnalysisOf fixture)
-    $ describe (toString $ testName fixture)
-    $ do
+testSuiteHasSomeDepResults fixture projType = aroundAll (withAnalysisOf fixture) $
+  describe (toString $ testName fixture) $
+    do
       it "should find targets" $ \(result, extractedDir) ->
         expectProject (projType, extractedDir) result
 
-      it "should have expected dependency results" $ \(result, extractedDir) ->
-        depResultSummary `expectDepResultsSummary` getDepResultsOf result (projType, extractedDir)
+      it "should have some dependency results" $ \(result, extractedDir) ->
+        isJust (getDepResultsOf result (projType, extractedDir)) `shouldBe` True
+
+testSuiteDepResultSummary :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> DiscoveredProjectType -> DependencyResultsSummary -> Spec
+testSuiteDepResultSummary fixture projType depResultSummary =
+  aroundAll (withAnalysisOf fixture) $
+    describe (toString $ testName fixture) $
+      do
+        it "should find targets" $ \(result, extractedDir) ->
+          expectProject (projType, extractedDir) result
+
+        it "should have expected dependency results" $ \(result, extractedDir) ->
+          depResultSummary `expectDepResultsSummary` getDepResultsOf result (projType, extractedDir)

--- a/integration-test/Analysis/FixtureExpectationUtils.hs
+++ b/integration-test/Analysis/FixtureExpectationUtils.hs
@@ -92,21 +92,19 @@ withProjectOfType result (projType, projPath) =
 
 testSuiteHasSomeDepResults :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> DiscoveredProjectType -> Spec
 testSuiteHasSomeDepResults fixture projType = aroundAll (withAnalysisOf fixture) $
-  describe (toString $ testName fixture) $
-    do
-      it "should find targets" $ \(result, extractedDir) ->
-        expectProject (projType, extractedDir) result
+  describe (toString $ testName fixture) $ do
+    it "should find targets" $ \(result, extractedDir) ->
+      expectProject (projType, extractedDir) result
 
-      it "should have some dependency results" $ \(result, extractedDir) ->
-        isJust (getDepResultsOf result (projType, extractedDir)) `shouldBe` True
+    it "should have some dependency results" $ \(result, extractedDir) ->
+      isJust (getDepResultsOf result (projType, extractedDir)) `shouldBe` True
 
 testSuiteDepResultSummary :: (AnalyzeProject a, Show a, Eq a) => AnalysisTestFixture a -> DiscoveredProjectType -> DependencyResultsSummary -> Spec
 testSuiteDepResultSummary fixture projType depResultSummary =
   aroundAll (withAnalysisOf fixture) $
-    describe (toString $ testName fixture) $
-      do
-        it "should find targets" $ \(result, extractedDir) ->
-          expectProject (projType, extractedDir) result
+    describe (toString $ testName fixture) $ do
+      it "should find targets" $ \(result, extractedDir) ->
+        expectProject (projType, extractedDir) result
 
-        it "should have expected dependency results" $ \(result, extractedDir) ->
-          depResultSummary `expectDepResultsSummary` getDepResultsOf result (projType, extractedDir)
+      it "should have expected dependency results" $ \(result, extractedDir) ->
+        depResultSummary `expectDepResultsSummary` getDepResultsOf result (projType, extractedDir)

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -523,6 +523,7 @@ test-suite unit-tests
     App.Fossa.ReportSpec
     App.Fossa.RunThemisSpec
     App.Fossa.VendoredDependencySpec
+    App.Fossa.VSIDepsSpec
     App.Fossa.VSI.DynLinked.Internal.BinarySpec
     App.Fossa.VSI.DynLinked.Internal.Lookup.DEBSpec
     App.Fossa.VSI.DynLinked.Internal.Lookup.RPMSpec

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -523,7 +523,6 @@ test-suite unit-tests
     App.Fossa.ReportSpec
     App.Fossa.RunThemisSpec
     App.Fossa.VendoredDependencySpec
-    App.Fossa.VSIDepsSpec
     App.Fossa.VSI.DynLinked.Internal.BinarySpec
     App.Fossa.VSI.DynLinked.Internal.Lookup.DEBSpec
     App.Fossa.VSI.DynLinked.Internal.Lookup.RPMSpec
@@ -532,6 +531,7 @@ test-suite unit-tests
     App.Fossa.VSI.FingerprintSpec
     App.Fossa.VSI.IAT.ResolveSpec
     App.Fossa.VSI.TypesSpec
+    App.Fossa.VSIDepsSpec
     BerkeleyDB.BerkeleyDBSpec
     BundlerSpec
     Cargo.CargoTomlSpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -518,7 +518,7 @@ buildResult includeAll srcUnits projects licenseSourceUnits =
       Just licenseUnits -> do
         NE.toList $ mergeSourceAndLicenseUnits finalSourceUnits licenseUnits
     finalSourceUnits = srcUnits ++ scannedUnits
-    scannedUnits = map (Srclib.toSourceUnit (fromFlag IncludeAll includeAll)) projects
+    scannedUnits = map (Srclib.projectToSourceUnit (fromFlag IncludeAll includeAll)) projects
 
 buildProject :: ProjectResult -> Aeson.Value
 buildProject project =

--- a/src/App/Fossa/Analyze/Filter.hs
+++ b/src/App/Fossa/Analyze/Filter.hs
@@ -54,6 +54,6 @@ checkForEmptyUpload includeAll xs ys additionalUnits firstPartyScanResults = do
 
     -- The smaller list is the post-filter list, since filtering cannot add projects
     filtered = if xlen > ylen then ys else xs
-    discoveredUnits = map (Srclib.toSourceUnit (fromFlag IncludeAll includeAll)) filtered
+    discoveredUnits = map (Srclib.projectToSourceUnit (fromFlag IncludeAll includeAll)) filtered
     isActualLicense :: LicenseUnit -> Bool
     isActualLicense licenseUnit = licenseUnitName licenseUnit /= "No_license_found"

--- a/src/App/Fossa/BinaryDeps.hs
+++ b/src/App/Fossa/BinaryDeps.hs
@@ -80,7 +80,7 @@ toProject dir = ProjectResult BinaryDepsProjectType dir mempty Complete []
 
 toSourceUnit :: ProjectResult -> [SourceUserDefDep] -> SourceUnit
 toSourceUnit project deps = do
-  let unit = Srclib.toSourceUnit False project
+  let unit = Srclib.projectToSourceUnit False project
   unit{additionalData = Just $ AdditionalDepData (Just deps) Nothing}
 
 -- | Just render the first few characters of the fingerprint.

--- a/src/App/Fossa/Container/Sources/DockerArchive.hs
+++ b/src/App/Fossa/Container/Sources/DockerArchive.hs
@@ -181,7 +181,7 @@ analyzeLayer systemDepsOnly filters capabilities osInfo layerFs tarball = do
         GoModulesBasedTactic -- Discovery is the same for both module and package centric analysis.
     toSourceUnit :: [DiscoveredProjectScan] -> [SourceUnit]
     toSourceUnit =
-      map (Srclib.toSourceUnit False)
+      map (Srclib.projectToSourceUnit False)
         . mapMaybe toProjectResult
 
 runAnalyzers ::

--- a/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Resolve.hs
@@ -53,7 +53,7 @@ toSourceUnit root distro dependencies = do
   binaries <- traverse (analyzeSingleBinary root) unresolved
 
   let project = toProject root . Graphing.directs $ map (toDependency distro) resolved
-  let unit = Srclib.toSourceUnit False project
+  let unit = Srclib.projectToSourceUnit False project
   pure $ unit{additionalData = fmap toDepData (Just binaries)}
   where
     toDepData :: [SourceUserDefDep] -> AdditionalDepData

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -32,7 +32,7 @@ import Path (Abs, Dir, Path, SomeBase (..), parseAbsDir)
 import Path.Extra (SomePath (SomeDir))
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
-import System.FilePath (makeValid)
+import System.FilePath (normalise)
 import Types (DiscoveredProjectType (VsiProjectType), GraphBreadth (Complete))
 
 -- | VSI analysis is sufficiently different from other analysis types that it cannot be just another strategy.
@@ -72,9 +72,9 @@ ruleToSourceUnit :: (Has Diagnostics sig m, Has FossaApiClient sig m) => VSI.Ski
 ruleToSourceUnit skipResolving VSI.VsiRule{..} = do
   resolvedGraph <- resolveGraph [vsiRuleLocator] skipResolving
   dependencies <- fromEither $ Graphing.gtraverse VSI.toDependency resolvedGraph
-  case parseAbsDir (makeValid $ toString vsiRulePath) of
+  case parseAbsDir (normalise $ toString vsiRulePath) of
     Just ruleDir -> pure $ toSourceUnit (toProject ruleDir dependencies) Nothing
-    Nothing -> fatal $ "Could not parse rule path: " <> (show vsiRulePath) <> ", valid: " <> makeValid (toString vsiRulePath)
+    Nothing -> fatal $ "Could not parse rule path: " <> (show vsiRulePath) <> ", normalized: " <> normalise (toString vsiRulePath)
 
 toProject :: Path Abs Dir -> Graphing Dependency -> ProjectResult
 toProject dir graph = ProjectResult VsiProjectType dir graph Complete [SomeDir . Abs $ dir]

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -34,7 +34,6 @@ import Path.Extra (SomePath (SomeDir))
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
 import Types (DiscoveredProjectType (VsiProjectType), GraphBreadth (Complete))
-import qualified Control.Carrier.Accum.Strict as it
 
 #ifdef mingw32_HOST_OS
 import Path (fromAbsDir)

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -74,7 +74,7 @@ ruleToSourceUnit skipResolving VSI.VsiRule{..} = do
   dependencies <- fromEither $ Graphing.gtraverse VSI.toDependency resolvedGraph
   case parseAbsDir (makeValid $ toString vsiRulePath) of
     Just ruleDir -> pure $ toSourceUnit (toProject ruleDir dependencies) Nothing
-    Nothing -> fatal $ "Could not parse rule path: " <> show vsiRulePath
+    Nothing -> fatal $ "Could not parse rule path: " <> (show vsiRulePath) <> ", valid: " <> makeValid (toString vsiRulePath)
 
 toProject :: Path Abs Dir -> Graphing Dependency -> ProjectResult
 toProject dir graph = ProjectResult VsiProjectType dir graph Complete [SomeDir . Abs $ dir]

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.VSIDeps (
@@ -33,12 +32,6 @@ import Path (Abs, Dir, Path, toFilePath)
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
 import Types (DiscoveredProjectType (..))
-
-#ifdef mingw32_HOST_OS
-import Path (fromAbsDir)
-import Effect.ReadFS (getCurrentDir)
-import System.FilePath (joinDrive, normalise, takeDrive)
-#endif
 
 -- | VSI analysis is sufficiently different from other analysis types that it cannot be just another strategy.
 -- Instead, VSI analysis is run separately over the entire scan directory, outputting its own source unit.

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -28,8 +28,9 @@ import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
 import Graphing (Graphing)
 import Graphing qualified
-import Path (Abs, Dir, Path, SomeBase (..), parseAbsDir)
+import Path (Abs, Dir, Path, SomeBase (..))
 import Path.Extra (SomePath (SomeDir))
+import Path.Posix (parseAbsDir) -- This needs to be Path.Posix as we are parsing unix-style paths
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
 import Types (DiscoveredProjectType (VsiProjectType), GraphBreadth (Complete))

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -30,8 +30,8 @@ import Graphing (Graphing)
 import Graphing qualified
 import Path (Abs, Dir, Path, toFilePath)
 import Srclib.Converter qualified as Srclib
-import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
-import Types (DiscoveredProjectType (..))
+import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep, textToOriginPath)
+import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 -- | VSI analysis is sufficiently different from other analysis types that it cannot be just another strategy.
 -- Instead, VSI analysis is run separately over the entire scan directory, outputting its own source unit.
@@ -62,9 +62,8 @@ analyzeVSIDeps dir projectRevision filters skipResolving = do
 
   -- These deps have to get up to the backend somehow on a 'SourceUnit's 'additionalData'.
   -- This generates an empty-graph source unit and puts the userdeps on it.
-
   let renderedPath = toText (toFilePath dir)
-  let userDepSrcUnits = toSourceUnit renderedPath mempty resolvedUserDeps
+      userDepSrcUnits = toSourceUnit renderedPath mempty resolvedUserDeps
 
   pure . Just $ userDepSrcUnits : directSrcUnits
 
@@ -76,7 +75,7 @@ ruleToSourceUnit skipResolving VSI.VsiRule{..} = do
 
 toSourceUnit :: Text -> Graphing Dependency -> Maybe [SourceUserDefDep] -> SourceUnit
 toSourceUnit path deps additionalDeps = do
-  let unit = Srclib.toSourceUnit False path deps VsiProjectType
+  let unit = Srclib.toSourceUnit False path deps VsiProjectType Complete [textToOriginPath path]
   unit{additionalData = fmap toDepData additionalDeps}
   where
     toDepData d = AdditionalDepData (Just d) Nothing

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -34,6 +34,7 @@ import Path.Extra (SomePath (SomeDir))
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
 import Types (DiscoveredProjectType (VsiProjectType), GraphBreadth (Complete))
+import qualified Control.Carrier.Accum.Strict as it
 
 #ifdef mingw32_HOST_OS
 import Path (fromAbsDir)
@@ -75,6 +76,9 @@ analyzeVSIDeps dir projectRevision filters skipResolving = do
   pure . Just $ userDepSrcUnits : directSrcUnits
 
 #ifdef mingw32_HOST_OS
+-- The path we get back from Core is a Unix-style path, so we need to turn it into a Windows-style path by
+-- prepending a drive (e.g. "C:\") to it and running `normalise` on it.
+-- For example, if we get a path like "/Framework/Common/fjlic/private/WINx64/", we want to end up with "C:\Framework\Common\fjlic\private\WINx64\"
 ruleToSourceUnit :: (Has Diagnostics sig m, Has FossaApiClient sig m, Has ReadFS sig m) => VSI.SkipResolution -> VSI.VsiRule -> m (SourceUnit)
 ruleToSourceUnit skipResolving VSI.VsiRule{..} = do
   resolvedGraph <- resolveGraph [vsiRuleLocator] skipResolving

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -28,11 +28,11 @@ import Effect.Logger (Logger)
 import Effect.ReadFS (ReadFS)
 import Graphing (Graphing)
 import Graphing qualified
-import Path (Abs, Dir, Path, SomeBase (..))
+import Path (Abs, Dir, Path, SomeBase (..), parseAbsDir)
 import Path.Extra (SomePath (SomeDir))
-import Path.Posix qualified as Posix -- This needs to be Path.Posix as we are parsing unix-style paths
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
+import System.FilePath (makeValid)
 import Types (DiscoveredProjectType (VsiProjectType), GraphBreadth (Complete))
 
 -- | VSI analysis is sufficiently different from other analysis types that it cannot be just another strategy.
@@ -72,7 +72,7 @@ ruleToSourceUnit :: (Has Diagnostics sig m, Has FossaApiClient sig m) => VSI.Ski
 ruleToSourceUnit skipResolving VSI.VsiRule{..} = do
   resolvedGraph <- resolveGraph [vsiRuleLocator] skipResolving
   dependencies <- fromEither $ Graphing.gtraverse VSI.toDependency resolvedGraph
-  case Posix.parseAbsDir (toString vsiRulePath) of
+  case parseAbsDir (makeValid $ toString vsiRulePath) of
     Just ruleDir -> pure $ toSourceUnit (toProject ruleDir dependencies) Nothing
     Nothing -> fatal $ "Could not parse rule path: " <> show vsiRulePath
 

--- a/src/App/Fossa/VSIDeps.hs
+++ b/src/App/Fossa/VSIDeps.hs
@@ -30,7 +30,7 @@ import Graphing (Graphing)
 import Graphing qualified
 import Path (Abs, Dir, Path, SomeBase (..))
 import Path.Extra (SomePath (SomeDir))
-import Path.Posix (parseAbsDir) -- This needs to be Path.Posix as we are parsing unix-style paths
+import Path.Posix qualified as Posix -- This needs to be Path.Posix as we are parsing unix-style paths
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (AdditionalDepData (..), SourceUnit (..), SourceUserDefDep)
 import Types (DiscoveredProjectType (VsiProjectType), GraphBreadth (Complete))
@@ -72,7 +72,7 @@ ruleToSourceUnit :: (Has Diagnostics sig m, Has FossaApiClient sig m) => VSI.Ski
 ruleToSourceUnit skipResolving VSI.VsiRule{..} = do
   resolvedGraph <- resolveGraph [vsiRuleLocator] skipResolving
   dependencies <- fromEither $ Graphing.gtraverse VSI.toDependency resolvedGraph
-  case parseAbsDir (toString vsiRulePath) of
+  case Posix.parseAbsDir (toString vsiRulePath) of
     Just ruleDir -> pure $ toSourceUnit (toProject ruleDir dependencies) Nothing
     Nothing -> fatal $ "Could not parse rule path: " <> show vsiRulePath
 

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -43,6 +43,7 @@ import Srclib.Types (
     buildSucceeded
   ),
   SourceUnitDependency (..),
+  textToOriginPath,
  )
 import Types (DiscoveredProjectType, GraphBreadth (..))
 
@@ -55,9 +56,9 @@ projectToSourceUnit leaveUnfiltered ProjectResult{..} =
 toSourceUnit :: Bool -> Text -> Graphing Dependency -> DiscoveredProjectType -> SourceUnit
 toSourceUnit leaveUnfiltered vsiRulePath dependencies projectType =
   SourceUnit
-    { sourceUnitName = toText vsiRulePath
+    { sourceUnitName = vsiRulePath
     , sourceUnitType = toText projectType
-    , sourceUnitManifest = toText vsiRulePath
+    , sourceUnitManifest = vsiRulePath
     , sourceUnitBuild =
         Just $
           SourceUnitBuild
@@ -67,7 +68,7 @@ toSourceUnit leaveUnfiltered vsiRulePath dependencies projectType =
             , buildDependencies = deps
             }
     , sourceUnitGraphBreadth = Complete
-    , sourceUnitOriginPaths = []
+    , sourceUnitOriginPaths = [textToOriginPath vsiRulePath]
     , additionalData = Nothing
     }
   where

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -54,11 +54,11 @@ projectToSourceUnit leaveUnfiltered ProjectResult{..} =
     renderedPath = toText (toFilePath projectResultPath)
 
 toSourceUnit :: Bool -> Text -> Graphing Dependency -> DiscoveredProjectType -> SourceUnit
-toSourceUnit leaveUnfiltered vsiRulePath dependencies projectType =
+toSourceUnit leaveUnfiltered path dependencies projectType =
   SourceUnit
-    { sourceUnitName = vsiRulePath
+    { sourceUnitName = path
     , sourceUnitType = toText projectType
-    , sourceUnitManifest = vsiRulePath
+    , sourceUnitManifest = path
     , sourceUnitBuild =
         Just $
           SourceUnitBuild
@@ -68,7 +68,7 @@ toSourceUnit leaveUnfiltered vsiRulePath dependencies projectType =
             , buildDependencies = deps
             }
     , sourceUnitGraphBreadth = Complete
-    , sourceUnitOriginPaths = [textToOriginPath vsiRulePath]
+    , sourceUnitOriginPaths = [textToOriginPath path]
     , additionalData = Nothing
     }
   where

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -34,6 +34,7 @@ import Graphing qualified
 import Path (toFilePath)
 import Srclib.Types (
   Locator (..),
+  OriginPath,
   SourceUnit (..),
   SourceUnitBuild (
     SourceUnitBuild,
@@ -43,18 +44,19 @@ import Srclib.Types (
     buildSucceeded
   ),
   SourceUnitDependency (..),
-  textToOriginPath,
+  somePathToOriginPath,
  )
 import Types (DiscoveredProjectType, GraphBreadth (..))
 
 projectToSourceUnit :: Bool -> ProjectResult -> SourceUnit
 projectToSourceUnit leaveUnfiltered ProjectResult{..} =
-  toSourceUnit leaveUnfiltered renderedPath projectResultGraph projectResultType
+  toSourceUnit leaveUnfiltered renderedPath projectResultGraph projectResultType projectResultGraphBreadth originPaths
   where
     renderedPath = toText (toFilePath projectResultPath)
+    originPaths = map somePathToOriginPath projectResultManifestFiles
 
-toSourceUnit :: Bool -> Text -> Graphing Dependency -> DiscoveredProjectType -> SourceUnit
-toSourceUnit leaveUnfiltered path dependencies projectType =
+toSourceUnit :: Bool -> Text -> Graphing Dependency -> DiscoveredProjectType -> GraphBreadth -> [OriginPath] -> SourceUnit
+toSourceUnit leaveUnfiltered path dependencies projectType graphBreadth originPaths =
   SourceUnit
     { sourceUnitName = path
     , sourceUnitType = toText projectType
@@ -67,8 +69,8 @@ toSourceUnit leaveUnfiltered path dependencies projectType =
             , buildImports = imports
             , buildDependencies = deps
             }
-    , sourceUnitGraphBreadth = Complete
-    , sourceUnitOriginPaths = [textToOriginPath path]
+    , sourceUnitGraphBreadth = graphBreadth
+    , sourceUnitOriginPaths = originPaths
     , additionalData = Nothing
     }
   where

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -32,6 +32,7 @@ import Data.Aeson
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe)
+import Data.String (IsString)
 import Data.String.Conversion (ToText, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -56,7 +57,7 @@ instance ToJSON LicenseScanType where
 --  The reason we cannot use `SomePath` for this is that outputting an `OriginPath` to JSON in a form like @/foo/bar/path_end@ doesn't say whether the path is a file or directory which is required for parsing to a `SomePath` in `FromJSON`.
 --  This type and its exported smart constructors describe that OriginPath is a path, but has no information about whether the path is a file or directory.
 newtype OriginPath = OriginPath FilePath
-  deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, ToText)
+  deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, ToText, IsString)
 
 pathToOriginPath :: Path b t -> OriginPath
 pathToOriginPath = OriginPath . toFilePath
@@ -235,13 +236,20 @@ instance ToJSON LicenseUnit where
 instance FromJSON LicenseUnit where
   parseJSON = withObject "LicenseUnit" $ \obj ->
     LicenseUnit
-      <$> obj .: "Name"
-      <*> obj .: "Type"
-      <*> obj .:? "Title"
-      <*> obj .: "Dir"
-      <*> obj .: "Files"
-      <*> obj .: "Data"
-      <*> obj .: "Info"
+      <$> obj
+      .: "Name"
+      <*> obj
+      .: "Type"
+      <*> obj
+      .:? "Title"
+      <*> obj
+      .: "Dir"
+      <*> obj
+      .: "Files"
+      <*> obj
+      .: "Data"
+      <*> obj
+      .: "Info"
 
 newtype LicenseUnitInfo = LicenseUnitInfo
   {licenseUnitInfoDescription :: Maybe Text}
@@ -298,12 +306,18 @@ instance ToJSON LicenseUnitData where
 instance FromJSON LicenseUnitData where
   parseJSON = withObject "LicenseUnitData" $ \obj ->
     LicenseUnitData
-      <$> obj .: "path"
-      <*> obj .:? "Copyright"
-      <*> obj .: "ThemisVersion"
-      <*> obj .:? "match_data"
-      <*> obj .:? "Copyrights"
-      <*> obj .:? "Contents"
+      <$> obj
+      .: "path"
+      <*> obj
+      .:? "Copyright"
+      <*> obj
+      .: "ThemisVersion"
+      <*> obj
+      .:? "match_data"
+      <*> obj
+      .:? "Copyrights"
+      <*> obj
+      .:? "Contents"
 
 data LicenseUnitMatchData = LicenseUnitMatchData
   { licenseUnitMatchDataMatchString :: Maybe Text
@@ -329,12 +343,18 @@ instance ToJSON LicenseUnitMatchData where
 instance FromJSON LicenseUnitMatchData where
   parseJSON = withObject "LicenseUnitMatchData" $ \obj ->
     LicenseUnitMatchData
-      <$> obj .:? "match_string"
-      <*> obj .: "location"
-      <*> obj .: "length"
-      <*> obj .: "index"
-      <*> obj .: "start_line"
-      <*> obj .: "end_line"
+      <$> obj
+      .:? "match_string"
+      <*> obj
+      .: "location"
+      <*> obj
+      .: "length"
+      <*> obj
+      .: "index"
+      <*> obj
+      .: "start_line"
+      <*> obj
+      .: "end_line"
 
 data SourceUnit = SourceUnit
   { sourceUnitName :: Text
@@ -426,13 +446,20 @@ instance ToJSON SourceUnit where
 instance FromJSON SourceUnit where
   parseJSON = withObject "SourceUnit" $ \obj ->
     SourceUnit
-      <$> obj .: "Name"
-      <*> obj .: "Type"
-      <*> obj .: "Manifest"
-      <*> obj .:? "Build"
-      <*> obj .: "GraphBreadth"
-      <*> obj .: "OriginPaths"
-      <*> obj .:? "AdditionalDependencyData"
+      <$> obj
+      .: "Name"
+      <*> obj
+      .: "Type"
+      <*> obj
+      .: "Manifest"
+      <*> obj
+      .:? "Build"
+      <*> obj
+      .: "GraphBreadth"
+      <*> obj
+      .: "OriginPaths"
+      <*> obj
+      .:? "AdditionalDependencyData"
 
 instance ToJSON SourceUnitBuild where
   toJSON SourceUnitBuild{..} =
@@ -446,10 +473,14 @@ instance ToJSON SourceUnitBuild where
 instance FromJSON SourceUnitBuild where
   parseJSON = withObject "SourceUnitBuild" $ \obj ->
     SourceUnitBuild
-      <$> obj .: "Artifact"
-      <*> obj .: "Succeeded"
-      <*> obj .: "Imports"
-      <*> obj .: "Dependencies"
+      <$> obj
+      .: "Artifact"
+      <*> obj
+      .: "Succeeded"
+      <*> obj
+      .: "Imports"
+      <*> obj
+      .: "Dependencies"
 
 instance ToJSON SourceUnitDependency where
   toJSON SourceUnitDependency{..} =
@@ -461,8 +492,10 @@ instance ToJSON SourceUnitDependency where
 instance FromJSON SourceUnitDependency where
   parseJSON = withObject "SourceUnitDependency" $ \obj ->
     SourceUnitDependency
-      <$> obj .: "locator"
-      <*> obj .: "imports"
+      <$> obj
+      .: "locator"
+      <*> obj
+      .: "imports"
 
 instance ToJSON AdditionalDepData where
   toJSON AdditionalDepData{..} =
@@ -474,8 +507,10 @@ instance ToJSON AdditionalDepData where
 instance FromJSON AdditionalDepData where
   parseJSON = withObject "AdditionalDepData" $ \obj ->
     AdditionalDepData
-      <$> obj .:? "UserDefinedDependencies"
-      <*> obj .:? "RemoteDependencies"
+      <$> obj
+      .:? "UserDefinedDependencies"
+      <*> obj
+      .:? "RemoteDependencies"
 
 instance ToJSON SourceUserDefDep where
   toJSON SourceUserDefDep{..} =
@@ -491,12 +526,18 @@ instance ToJSON SourceUserDefDep where
 instance FromJSON SourceUserDefDep where
   parseJSON = withObject "SourceUserDefDep" $ \obj ->
     SourceUserDefDep
-      <$> obj .: "Name"
-      <*> obj .: "Version"
-      <*> obj .: "License"
-      <*> obj .:? "Description"
-      <*> obj .:? "Homepage"
-      <*> obj .:? "Origin"
+      <$> obj
+      .: "Name"
+      <*> obj
+      .: "Version"
+      <*> obj
+      .: "License"
+      <*> obj
+      .:? "Description"
+      <*> obj
+      .:? "Homepage"
+      <*> obj
+      .:? "Origin"
 
 instance ToJSON SourceRemoteDep where
   toJSON SourceRemoteDep{..} =
@@ -511,11 +552,16 @@ instance ToJSON SourceRemoteDep where
 instance FromJSON SourceRemoteDep where
   parseJSON = withObject "SourceRemoteDep" $ \obj ->
     SourceRemoteDep
-      <$> obj .: "Name"
-      <*> obj .: "Version"
-      <*> obj .: "Url"
-      <*> obj .:? "Description"
-      <*> obj .:? "Homepage"
+      <$> obj
+      .: "Name"
+      <*> obj
+      .: "Version"
+      <*> obj
+      .: "Url"
+      <*> obj
+      .:? "Description"
+      <*> obj
+      .:? "Homepage"
 
 instance ToJSON Locator where
   -- render as text

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -236,20 +236,13 @@ instance ToJSON LicenseUnit where
 instance FromJSON LicenseUnit where
   parseJSON = withObject "LicenseUnit" $ \obj ->
     LicenseUnit
-      <$> obj
-        .: "Name"
-      <*> obj
-        .: "Type"
-      <*> obj
-        .:? "Title"
-      <*> obj
-        .: "Dir"
-      <*> obj
-        .: "Files"
-      <*> obj
-        .: "Data"
-      <*> obj
-        .: "Info"
+      <$> obj .: "Name"
+      <*> obj .: "Type"
+      <*> obj .:? "Title"
+      <*> obj .: "Dir"
+      <*> obj .: "Files"
+      <*> obj .: "Data"
+      <*> obj .: "Info"
 
 newtype LicenseUnitInfo = LicenseUnitInfo
   {licenseUnitInfoDescription :: Maybe Text}
@@ -306,18 +299,12 @@ instance ToJSON LicenseUnitData where
 instance FromJSON LicenseUnitData where
   parseJSON = withObject "LicenseUnitData" $ \obj ->
     LicenseUnitData
-      <$> obj
-        .: "path"
-      <*> obj
-        .:? "Copyright"
-      <*> obj
-        .: "ThemisVersion"
-      <*> obj
-        .:? "match_data"
-      <*> obj
-        .:? "Copyrights"
-      <*> obj
-        .:? "Contents"
+      <$> obj .: "path"
+      <*> obj .:? "Copyright"
+      <*> obj .: "ThemisVersion"
+      <*> obj .:? "match_data"
+      <*> obj .:? "Copyrights"
+      <*> obj .:? "Contents"
 
 data LicenseUnitMatchData = LicenseUnitMatchData
   { licenseUnitMatchDataMatchString :: Maybe Text
@@ -343,18 +330,12 @@ instance ToJSON LicenseUnitMatchData where
 instance FromJSON LicenseUnitMatchData where
   parseJSON = withObject "LicenseUnitMatchData" $ \obj ->
     LicenseUnitMatchData
-      <$> obj
-        .:? "match_string"
-      <*> obj
-        .: "location"
-      <*> obj
-        .: "length"
-      <*> obj
-        .: "index"
-      <*> obj
-        .: "start_line"
-      <*> obj
-        .: "end_line"
+      <$> obj .:? "match_string"
+      <*> obj .: "location"
+      <*> obj .: "length"
+      <*> obj .: "index"
+      <*> obj .: "start_line"
+      <*> obj .: "end_line"
 
 data SourceUnit = SourceUnit
   { sourceUnitName :: Text
@@ -446,20 +427,13 @@ instance ToJSON SourceUnit where
 instance FromJSON SourceUnit where
   parseJSON = withObject "SourceUnit" $ \obj ->
     SourceUnit
-      <$> obj
-        .: "Name"
-      <*> obj
-        .: "Type"
-      <*> obj
-        .: "Manifest"
-      <*> obj
-        .:? "Build"
-      <*> obj
-        .: "GraphBreadth"
-      <*> obj
-        .: "OriginPaths"
-      <*> obj
-        .:? "AdditionalDependencyData"
+      <$> obj .: "Name"
+      <*> obj .: "Type"
+      <*> obj .: "Manifest"
+      <*> obj .:? "Build"
+      <*> obj .: "GraphBreadth"
+      <*> obj .: "OriginPaths"
+      <*> obj .:? "AdditionalDependencyData"
 
 instance ToJSON SourceUnitBuild where
   toJSON SourceUnitBuild{..} =
@@ -473,14 +447,10 @@ instance ToJSON SourceUnitBuild where
 instance FromJSON SourceUnitBuild where
   parseJSON = withObject "SourceUnitBuild" $ \obj ->
     SourceUnitBuild
-      <$> obj
-        .: "Artifact"
-      <*> obj
-        .: "Succeeded"
-      <*> obj
-        .: "Imports"
-      <*> obj
-        .: "Dependencies"
+      <$> obj .: "Artifact"
+      <*> obj .: "Succeeded"
+      <*> obj .: "Imports"
+      <*> obj .: "Dependencies"
 
 instance ToJSON SourceUnitDependency where
   toJSON SourceUnitDependency{..} =
@@ -492,10 +462,8 @@ instance ToJSON SourceUnitDependency where
 instance FromJSON SourceUnitDependency where
   parseJSON = withObject "SourceUnitDependency" $ \obj ->
     SourceUnitDependency
-      <$> obj
-        .: "locator"
-      <*> obj
-        .: "imports"
+      <$> obj .: "locator"
+      <*> obj .: "imports"
 
 instance ToJSON AdditionalDepData where
   toJSON AdditionalDepData{..} =
@@ -507,10 +475,8 @@ instance ToJSON AdditionalDepData where
 instance FromJSON AdditionalDepData where
   parseJSON = withObject "AdditionalDepData" $ \obj ->
     AdditionalDepData
-      <$> obj
-        .:? "UserDefinedDependencies"
-      <*> obj
-        .:? "RemoteDependencies"
+      <$> obj .:? "UserDefinedDependencies"
+      <*> obj .:? "RemoteDependencies"
 
 instance ToJSON SourceUserDefDep where
   toJSON SourceUserDefDep{..} =
@@ -526,18 +492,12 @@ instance ToJSON SourceUserDefDep where
 instance FromJSON SourceUserDefDep where
   parseJSON = withObject "SourceUserDefDep" $ \obj ->
     SourceUserDefDep
-      <$> obj
-        .: "Name"
-      <*> obj
-        .: "Version"
-      <*> obj
-        .: "License"
-      <*> obj
-        .:? "Description"
-      <*> obj
-        .:? "Homepage"
-      <*> obj
-        .:? "Origin"
+      <$> obj .: "Name"
+      <*> obj .: "Version"
+      <*> obj .: "License"
+      <*> obj .:? "Description"
+      <*> obj .:? "Homepage"
+      <*> obj .:? "Origin"
 
 instance ToJSON SourceRemoteDep where
   toJSON SourceRemoteDep{..} =
@@ -552,16 +512,11 @@ instance ToJSON SourceRemoteDep where
 instance FromJSON SourceRemoteDep where
   parseJSON = withObject "SourceRemoteDep" $ \obj ->
     SourceRemoteDep
-      <$> obj
-        .: "Name"
-      <*> obj
-        .: "Version"
-      <*> obj
-        .: "Url"
-      <*> obj
-        .:? "Description"
-      <*> obj
-        .:? "Homepage"
+      <$> obj .: "Name"
+      <*> obj .: "Version"
+      <*> obj .: "Url"
+      <*> obj .:? "Description"
+      <*> obj .:? "Homepage"
 
 instance ToJSON Locator where
   -- render as text

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -26,6 +26,7 @@ module Srclib.Types (
   emptyLicenseUnitData,
   sourceUnitToFullSourceUnit,
   licenseUnitToFullSourceUnit,
+  textToOriginPath,
 ) where
 
 import Data.Aeson
@@ -33,7 +34,7 @@ import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe)
 import Data.String (IsString)
-import Data.String.Conversion (ToText, toText)
+import Data.String.Conversion (ToString (toString), ToText, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Path (File, Path, SomeBase (..), toFilePath)
@@ -69,6 +70,9 @@ someBaseToOriginPath (Rel p) = pathToOriginPath p
 somePathToOriginPath :: SomePath -> OriginPath
 somePathToOriginPath (SomeFile f) = someBaseToOriginPath f
 somePathToOriginPath (SomeDir d) = someBaseToOriginPath d
+
+textToOriginPath :: Text -> OriginPath
+textToOriginPath = OriginPath . toString
 
 -- export interface SourceUnit {
 --   Name?: string;

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -237,19 +237,19 @@ instance FromJSON LicenseUnit where
   parseJSON = withObject "LicenseUnit" $ \obj ->
     LicenseUnit
       <$> obj
-      .: "Name"
+        .: "Name"
       <*> obj
-      .: "Type"
+        .: "Type"
       <*> obj
-      .:? "Title"
+        .:? "Title"
       <*> obj
-      .: "Dir"
+        .: "Dir"
       <*> obj
-      .: "Files"
+        .: "Files"
       <*> obj
-      .: "Data"
+        .: "Data"
       <*> obj
-      .: "Info"
+        .: "Info"
 
 newtype LicenseUnitInfo = LicenseUnitInfo
   {licenseUnitInfoDescription :: Maybe Text}
@@ -307,17 +307,17 @@ instance FromJSON LicenseUnitData where
   parseJSON = withObject "LicenseUnitData" $ \obj ->
     LicenseUnitData
       <$> obj
-      .: "path"
+        .: "path"
       <*> obj
-      .:? "Copyright"
+        .:? "Copyright"
       <*> obj
-      .: "ThemisVersion"
+        .: "ThemisVersion"
       <*> obj
-      .:? "match_data"
+        .:? "match_data"
       <*> obj
-      .:? "Copyrights"
+        .:? "Copyrights"
       <*> obj
-      .:? "Contents"
+        .:? "Contents"
 
 data LicenseUnitMatchData = LicenseUnitMatchData
   { licenseUnitMatchDataMatchString :: Maybe Text
@@ -344,17 +344,17 @@ instance FromJSON LicenseUnitMatchData where
   parseJSON = withObject "LicenseUnitMatchData" $ \obj ->
     LicenseUnitMatchData
       <$> obj
-      .:? "match_string"
+        .:? "match_string"
       <*> obj
-      .: "location"
+        .: "location"
       <*> obj
-      .: "length"
+        .: "length"
       <*> obj
-      .: "index"
+        .: "index"
       <*> obj
-      .: "start_line"
+        .: "start_line"
       <*> obj
-      .: "end_line"
+        .: "end_line"
 
 data SourceUnit = SourceUnit
   { sourceUnitName :: Text
@@ -447,19 +447,19 @@ instance FromJSON SourceUnit where
   parseJSON = withObject "SourceUnit" $ \obj ->
     SourceUnit
       <$> obj
-      .: "Name"
+        .: "Name"
       <*> obj
-      .: "Type"
+        .: "Type"
       <*> obj
-      .: "Manifest"
+        .: "Manifest"
       <*> obj
-      .:? "Build"
+        .:? "Build"
       <*> obj
-      .: "GraphBreadth"
+        .: "GraphBreadth"
       <*> obj
-      .: "OriginPaths"
+        .: "OriginPaths"
       <*> obj
-      .:? "AdditionalDependencyData"
+        .:? "AdditionalDependencyData"
 
 instance ToJSON SourceUnitBuild where
   toJSON SourceUnitBuild{..} =
@@ -474,13 +474,13 @@ instance FromJSON SourceUnitBuild where
   parseJSON = withObject "SourceUnitBuild" $ \obj ->
     SourceUnitBuild
       <$> obj
-      .: "Artifact"
+        .: "Artifact"
       <*> obj
-      .: "Succeeded"
+        .: "Succeeded"
       <*> obj
-      .: "Imports"
+        .: "Imports"
       <*> obj
-      .: "Dependencies"
+        .: "Dependencies"
 
 instance ToJSON SourceUnitDependency where
   toJSON SourceUnitDependency{..} =
@@ -493,9 +493,9 @@ instance FromJSON SourceUnitDependency where
   parseJSON = withObject "SourceUnitDependency" $ \obj ->
     SourceUnitDependency
       <$> obj
-      .: "locator"
+        .: "locator"
       <*> obj
-      .: "imports"
+        .: "imports"
 
 instance ToJSON AdditionalDepData where
   toJSON AdditionalDepData{..} =
@@ -508,9 +508,9 @@ instance FromJSON AdditionalDepData where
   parseJSON = withObject "AdditionalDepData" $ \obj ->
     AdditionalDepData
       <$> obj
-      .:? "UserDefinedDependencies"
+        .:? "UserDefinedDependencies"
       <*> obj
-      .:? "RemoteDependencies"
+        .:? "RemoteDependencies"
 
 instance ToJSON SourceUserDefDep where
   toJSON SourceUserDefDep{..} =
@@ -527,17 +527,17 @@ instance FromJSON SourceUserDefDep where
   parseJSON = withObject "SourceUserDefDep" $ \obj ->
     SourceUserDefDep
       <$> obj
-      .: "Name"
+        .: "Name"
       <*> obj
-      .: "Version"
+        .: "Version"
       <*> obj
-      .: "License"
+        .: "License"
       <*> obj
-      .:? "Description"
+        .:? "Description"
       <*> obj
-      .:? "Homepage"
+        .:? "Homepage"
       <*> obj
-      .:? "Origin"
+        .:? "Origin"
 
 instance ToJSON SourceRemoteDep where
   toJSON SourceRemoteDep{..} =
@@ -553,15 +553,15 @@ instance FromJSON SourceRemoteDep where
   parseJSON = withObject "SourceRemoteDep" $ \obj ->
     SourceRemoteDep
       <$> obj
-      .: "Name"
+        .: "Name"
       <*> obj
-      .: "Version"
+        .: "Version"
       <*> obj
-      .: "Url"
+        .: "Url"
       <*> obj
-      .:? "Description"
+        .:? "Description"
       <*> obj
-      .:? "Homepage"
+        .:? "Homepage"
 
 instance ToJSON Locator where
   -- render as text

--- a/test/App/Fossa/VSIDepsSpec.hs
+++ b/test/App/Fossa/VSIDepsSpec.hs
@@ -1,0 +1,27 @@
+module App.Fossa.VSIDepsSpec (
+  spec,
+) where
+
+import App.Fossa.VSI.Types (Locator (..), SkipResolution (..), VsiRule (..), VsiRulePath (..))
+import App.Fossa.VSIDeps (ruleToSourceUnit)
+import Data.Set qualified as Set
+import Test.Effect (it', shouldBe')
+import Test.Fixtures qualified as Fixtures
+import Test.Hspec (Spec, describe)
+
+locator :: Locator
+locator =
+  Locator
+    { locatorFetcher = "mvn"
+    , locatorProject = "something/mavenish"
+    , locatorRevision = "1.2.3"
+    }
+
+spec :: Spec
+spec = do
+  describe "ruleToSourceUnit" $ do
+    it' "should find deps" $ do
+      let path = VsiRulePath "/tmp/one/two"
+      let vsiRule = VsiRule path locator
+      sourceUnit <- ruleToSourceUnit (SkipResolution Set.empty) vsiRule
+      sourceUnit `shouldBe'` Fixtures.vsiSourceUnit

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -36,6 +36,7 @@ module Test.Fixtures (
   diffRevision,
   issuesDiffAvailable,
   standardAnalyzeConfig,
+  vsiSourceUnit,
 ) where
 
 import App.Fossa.Config.Analyze (AnalyzeConfig (AnalyzeConfig), ExperimentalAnalyzeConfig (..), GoDynamicTactic (..), IncludeAll (..), JsonOutput (JsonOutput), NoDiscoveryExclusion (..), ScanDestination (..), UnpackArchives (..), VSIModeOptions (..), VendoredDependencyOptions (..))
@@ -63,13 +64,7 @@ import Effect.Logger (Severity (..))
 import Fossa.API.Types (Archive (..))
 import Fossa.API.Types qualified as API
 import Path (Abs, Dir, Path, mkAbsDir, mkRelDir, parseAbsDir, (</>))
-import Srclib.Types (
-  LicenseScanType (..),
-  LicenseSourceUnit (..),
-  Locator (..),
-  SourceUnit (..),
-  emptyLicenseUnit,
- )
+import Srclib.Types (LicenseScanType (..), LicenseSourceUnit (..), Locator (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (..), emptyLicenseUnit)
 import System.Directory (getTemporaryDirectory)
 import Text.URI.QQ (uri)
 import Types (ArchiveUploadType (..), GraphBreadth (..))
@@ -153,6 +148,41 @@ sourceUnits = NE.fromList [unit]
         , additionalData = Nothing
         }
 
+vsiSourceUnit :: SourceUnit
+vsiSourceUnit =
+  SourceUnit
+    { sourceUnitName = "/tmp/one/two/"
+    , sourceUnitType = "vsi"
+    , sourceUnitManifest = "/tmp/one/two/"
+    , sourceUnitBuild =
+        Just
+          SourceUnitBuild
+            { buildArtifact = "default"
+            , buildSucceeded = True
+            , buildImports =
+                [ Locator
+                    { locatorFetcher = "mvn"
+                    , locatorProject = "something/mavenish"
+                    , locatorRevision = Just "1.2.3"
+                    }
+                ]
+            , buildDependencies =
+                [ SourceUnitDependency
+                    { sourceDepLocator =
+                        Locator
+                          { locatorFetcher = "mvn"
+                          , locatorProject = "something/mavenish"
+                          , locatorRevision = Just "1.2.3"
+                          }
+                    , sourceDepImports = []
+                    }
+                ]
+            }
+    , sourceUnitGraphBreadth = Complete
+    , sourceUnitOriginPaths = ["/tmp/one/two/"]
+    , additionalData = Nothing
+    }
+
 -- | A base dir for testing.  This directory is not guaranteed to exist.  If you
 -- want a real directory you should use `withTempDir`.
 baseDir :: IO App.BaseDir
@@ -162,10 +192,11 @@ baseDir = do
 
 contributors :: API.Contributors
 contributors =
-  API.Contributors . Map.fromList $
-    [ ("testContributor1", "testContributor1")
-    , ("testContributor2", "testContributor2")
-    ]
+  API.Contributors
+    . Map.fromList
+    $ [ ("testContributor1", "testContributor1")
+      , ("testContributor2", "testContributor2")
+      ]
 
 build :: API.Build
 build =

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -200,11 +200,10 @@ baseDir = do
 
 contributors :: API.Contributors
 contributors =
-  API.Contributors
-    . Map.fromList
-    $ [ ("testContributor1", "testContributor1")
-      , ("testContributor2", "testContributor2")
-      ]
+  API.Contributors . Map.fromList $
+    [ ("testContributor1", "testContributor1")
+    , ("testContributor2", "testContributor2")
+    ]
 
 build :: API.Build
 build =

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -55,6 +55,7 @@ import Data.Flag (toFlag)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as Map
+import Data.String.Conversion (ToText (toText))
 import Data.Text (Text)
 import Data.Text.Extra (showT)
 import Discovery.Filters (
@@ -158,9 +159,9 @@ vsiOriginPath = "/tmp/one/two/"
 vsiSourceUnit :: SourceUnit
 vsiSourceUnit =
   SourceUnit
-    { sourceUnitName = "/tmp/one/two/"
+    { sourceUnitName = toText vsiOriginPath
     , sourceUnitType = "vsi"
-    , sourceUnitManifest = "/tmp/one/two/"
+    , sourceUnitManifest = toText vsiOriginPath
     , sourceUnitBuild =
         Just
           SourceUnitBuild

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -55,7 +55,6 @@ import Data.Flag (toFlag)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as Map
-import Data.String.Conversion (ToText (toText))
 import Data.Text (Text)
 import Data.Text.Extra (showT)
 import Discovery.Filters (
@@ -65,7 +64,7 @@ import Effect.Logger (Severity (..))
 import Fossa.API.Types (Archive (..))
 import Fossa.API.Types qualified as API
 import Path (Abs, Dir, Path, mkAbsDir, mkRelDir, parseAbsDir, (</>))
-import Srclib.Types (LicenseScanType (..), LicenseSourceUnit (..), Locator (..), OriginPath, SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (..), emptyLicenseUnit)
+import Srclib.Types (LicenseScanType (..), LicenseSourceUnit (..), Locator (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (..), emptyLicenseUnit)
 import System.Directory (getTemporaryDirectory)
 import Text.URI.QQ (uri)
 import Types (ArchiveUploadType (..), GraphBreadth (..))
@@ -149,19 +148,12 @@ sourceUnits = NE.fromList [unit]
         , additionalData = Nothing
         }
 
-vsiOriginPath :: OriginPath
-#ifdef mingw32_HOST_OS
-vsiOriginPath = "D:\\tmp\\one\\two\\"
-#else
-vsiOriginPath = "/tmp/one/two/"
-#endif
-
 vsiSourceUnit :: SourceUnit
 vsiSourceUnit =
   SourceUnit
-    { sourceUnitName = toText vsiOriginPath
+    { sourceUnitName = "/tmp/one/two"
     , sourceUnitType = "vsi"
-    , sourceUnitManifest = toText vsiOriginPath
+    , sourceUnitManifest = "/tmp/one/two"
     , sourceUnitBuild =
         Just
           SourceUnitBuild
@@ -187,7 +179,7 @@ vsiSourceUnit =
                 ]
             }
     , sourceUnitGraphBreadth = Complete
-    , sourceUnitOriginPaths = [vsiOriginPath]
+    , sourceUnitOriginPaths = ["/tmp/one/two"]
     , additionalData = Nothing
     }
 

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -64,7 +64,7 @@ import Effect.Logger (Severity (..))
 import Fossa.API.Types (Archive (..))
 import Fossa.API.Types qualified as API
 import Path (Abs, Dir, Path, mkAbsDir, mkRelDir, parseAbsDir, (</>))
-import Srclib.Types (LicenseScanType (..), LicenseSourceUnit (..), Locator (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (..), emptyLicenseUnit)
+import Srclib.Types (LicenseScanType (..), LicenseSourceUnit (..), Locator (..), OriginPath, SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (..), emptyLicenseUnit)
 import System.Directory (getTemporaryDirectory)
 import Text.URI.QQ (uri)
 import Types (ArchiveUploadType (..), GraphBreadth (..))
@@ -148,6 +148,13 @@ sourceUnits = NE.fromList [unit]
         , additionalData = Nothing
         }
 
+vsiOriginPath :: OriginPath
+#ifdef mingw32_HOST_OS
+vsiOriginPath = "D:\\tmp\\one\\two"
+#else
+vsiOriginPath = "/tmp/one/two"
+#endif
+
 vsiSourceUnit :: SourceUnit
 vsiSourceUnit =
   SourceUnit
@@ -179,7 +186,7 @@ vsiSourceUnit =
                 ]
             }
     , sourceUnitGraphBreadth = Complete
-    , sourceUnitOriginPaths = ["/tmp/one/two/"]
+    , sourceUnitOriginPaths = [vsiOriginPath]
     , additionalData = Nothing
     }
 

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -150,9 +150,9 @@ sourceUnits = NE.fromList [unit]
 
 vsiOriginPath :: OriginPath
 #ifdef mingw32_HOST_OS
-vsiOriginPath = "D:\\tmp\\one\\two"
+vsiOriginPath = "D:\\tmp\\one\\two\\"
 #else
-vsiOriginPath = "/tmp/one/two"
+vsiOriginPath = "/tmp/one/two/"
 #endif
 
 vsiSourceUnit :: SourceUnit


### PR DESCRIPTION
# Overview

[Delivers FDN-12](https://fossa.atlassian.net/browse/FDN-12) — Investigate "Could not Parse Rule Path" for GlobalDots (Fujitsu)

The bug was that when you ran `fossa analyze --detect-vendored` on a Windows machine and got matches to vendored binaries, the CLI would fail with an error like this:

```
Could not parse rule path: "/Framework/Common/fjlic/private/WINx64/"
```

This was caused by an attempt to call `parseAbsDir` on the rule path on a Windows machine, which failed.

It turned out that there was no real need to parse the path in this case, so I renamed `Srclib.toSourceUnit` to `Srclib.projectToSourceUnit`, and made that call another function that took in the path as Text. Then I called that second function from the VSI code paths.

## Acceptance criteria

- This fixes the problem

## Testing plan

Do the following on a Windows machine:

```
mkdir tester
cd tester
mkdir vendor/make
<download make-4.4 from https://ftp.gnu.org/gnu/make/ and untar it into this directory>
cd ../..
fossa analyze --detect-vendored
```

Previous to this we would get the following error:

```
Could not parse rule path: "/vendor/make/"
```

## Risks

## Metrics

## References

Two Slack threads:

- Me asking for help on reproducing this: https://teamfossa.slack.com/archives/C054BCAU5N1/p1696964780382109 
- Original bug report from Deepak: https://teamfossa.slack.com/archives/C043EM3L96Z/p1696871963231889

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
