### PR TITLE
Fix version check

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -249,7 +249,7 @@ jobs:
         echo $GITHUB_SHA
         echo ${GITHUB_SHA:0:12}
         echo $(Linux-binaries/fossa --version)
-        echo "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)"
+        echo "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.4)"
 
         [ "$GITHUB_REF_TYPE" = "tag" ] && echo "Ref type OK"
         [ "$(Linux-binaries/fossa --version)" = "fossa-cli version ${{ steps.get-version.outputs.VERSION }} (revision ${GITHUB_SHA:0:12} compiled with ghc-9.0)" ] && echo "CLI version OK"


### PR DESCRIPTION
# Overview

My release of v3.8.17 is failing [here](https://github.com/fossas/fossa-cli/actions/runs/6501683828/job/17663025793), because it expects the string:
```
fossa-cli version 3.8.17 (revision e3c554482ee1 compiled with ghc-9.0)
```

But is getting the string:
```
fossa-cli version 3.8.17 (revision e3c554482ee1 compiled with ghc-9.4)
```

Note the `9.4` on the end of the new version.