### PR TITLE
Implementation to add custom fossa-deps file on analyze run

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## v3.8.22
 
-- Introduce `fossa-deps-file` to specify custom fossa-deps file ([#1303](https://github.com/fossas/fossa-cli/pull/1303))
+- `fossa-deps`: `--fossa-deps-file` to specify custom fossa-deps file ([#1303](https://github.com/fossas/fossa-cli/pull/1303))
 
 ## v3.8.21
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.8.22
+
+- Introduce `fossa-deps-file` to specify custom fossa-deps file ([#1303](https://github.com/fossas/fossa-cli/pull/1303))
+
 ## v3.8.21
 
 - install-latest.sh: Fixed a bug where install-latest.sh would result in a broken binary when run on some versions of macOS ([#1317](https://github.com/fossas/fossa-cli/pull/1317))

--- a/docs/references/files/fossa-deps.md
+++ b/docs/references/files/fossa-deps.md
@@ -2,7 +2,7 @@
 
 `fossa-deps` file is a file named `fossa-deps.{yaml, yml, json}` at the root of the project. It can be used to provide manual and vendor dependencies. 
 
-By default, the `fossa-deps.{yaml, yml, json}` file at the root of the project is used. However, if the `--fossa-deps-config` flag is present, then the provided `<name-of-file>.{yaml, yaml, json}` file will be used instead.
+By default, the `fossa-deps.{yaml, yml, json}` file at the root of the project is used. However, if the `--fossa-deps-file` flag is present, then the provided `<name-of-file>.{yaml, yaml, json}` file will be used instead.
 
 For more details on specifying a fossa-deps file, please refer to the [subcommand](../subcommands/analyze.md) documentation.
 

--- a/docs/references/files/fossa-deps.md
+++ b/docs/references/files/fossa-deps.md
@@ -2,6 +2,10 @@
 
 `fossa-deps` file is a file named `fossa-deps.{yaml, yml, json}` at the root of the project. It can be used to provide manual and vendor dependencies. 
 
+By default, the `fossa-deps.{yaml, yml, json}` file at the root of the project is used. However, if the `--fossa-deps-config` flag is present, then the provided `<name-of-file>.{yaml, yaml, json}` file will be used instead.
+
+For more details on specifying a fossa-deps file, please refer to the [subcommand](../subcommands/analyze.md) documentation.
+
 ## Fields
 
 ### `referenced-dependencies:`

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -58,6 +58,16 @@ fossa analyze --json
 {"project":{"name":"custom@new-project","branch":"master","revision":"123","url":"https://app.fossa.com/projects/custom+<org-id>/new-project/refs/branch/master/123","id":"custom+<org-id>/new-project$123"}}
 ```
 
+### Running a specific fossa-deps file
+
+The `--fossa-deps-config` flag can be used to specify the `fossa-deps` configuration that you want to use. The name of the file is arbitrary.
+
+See the [fossa-deps documentation](../files/fossa-deps.md) for configuration.
+
+```sh
+fossa analyze --fossa-deps-config /path/to/file
+```
+
 ### Vendored Dependencies
 
 The Vendored Dependencies feature allows you to scan for licenses directly in your code. For more information, please see the [Vendored Dependencies documentation](../../features/vendored-dependencies.md).

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -60,7 +60,7 @@ fossa analyze --json
 
 ### Running a specific fossa-deps file
 
-The `--fossa-deps-config` flag can be used to specify the `fossa-deps` file that you want to use. The name of the file is arbitrary.
+The `--fossa-deps-file` flag can be used to specify the `fossa-deps` file that you want to use. The name of the file is arbitrary.
 
 See the [fossa-deps documentation](../files/fossa-deps.md) for configuration.
 

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -60,12 +60,12 @@ fossa analyze --json
 
 ### Running a specific fossa-deps file
 
-The `--fossa-deps-config` flag can be used to specify the `fossa-deps` configuration that you want to use. The name of the file is arbitrary.
+The `--fossa-deps-config` flag can be used to specify the `fossa-deps` file that you want to use. The name of the file is arbitrary.
 
 See the [fossa-deps documentation](../files/fossa-deps.md) for configuration.
 
 ```sh
-fossa analyze --fossa-deps-config /path/to/file
+fossa analyze --fossa-deps-file /path/to/file
 ```
 
 ### Vendored Dependencies

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -118,6 +118,7 @@ common deps
     , retry                        ^>=0.9.0.0
     , safe-exceptions              ^>=0.1.7
     , semver                       ^>=0.4.0.1
+    , split                        ^>=0.2.3.5
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
     , tar                          ^>=0.6.0.0

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -118,7 +118,6 @@ common deps
     , retry                        ^>=0.9.0.0
     , safe-exceptions              ^>=0.1.7
     , semver                       ^>=0.4.0.1
-    , split                        ^>=0.2.3.5
     , stm                          ^>=2.5.0
     , stm-chans                    ^>=3.0.0
     , tar                          ^>=0.6.0.0

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -299,7 +299,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
         then do
           logInfo "Running in VSI only mode, skipping manual source units"
           pure Nothing
-        else do Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir customFossaDepsPath maybeApiOpts vendoredDepsOptions
+        else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir customFossaDepsPath maybeApiOpts vendoredDepsOptions
   maybeLernieResults <-
     Diag.errorBoundaryIO . diagToDebug $
       if filterIsVSIOnly filters

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -269,7 +269,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
       skipResolutionSet = Config.vsiSkipSet $ Config.vsiOptions cfg
       vendoredDepsOptions = Config.vendoredDeps cfg
       grepOptions = Config.grepOptions cfg
-      customFossaDepsPath = Config.customFossaDepsPath cfg
+      customFossaDepsFile = Config.customFossaDepsFile cfg
 
   -- additional source units are built outside the standard strategy flow, because they either
   -- require additional information (eg API credentials), or they return additional information (eg user deps).
@@ -299,7 +299,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
         then do
           logInfo "Running in VSI only mode, skipping manual source units"
           pure Nothing
-        else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir customFossaDepsPath maybeApiOpts vendoredDepsOptions
+        else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir customFossaDepsFile maybeApiOpts vendoredDepsOptions
   maybeLernieResults <-
     Diag.errorBoundaryIO . diagToDebug $
       if filterIsVSIOnly filters

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -268,7 +268,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
       skipResolutionSet = Config.vsiSkipSet $ Config.vsiOptions cfg
       vendoredDepsOptions = Config.vendoredDeps cfg
       grepOptions = Config.grepOptions cfg
-      BaseDir fossaDepsDir = Config.fossaDepsDir cfg
+      customFossaDepsPath = Config.customFossaDepsPath cfg
 
   -- additional source units are built outside the standard strategy flow, because they either
   -- require additional information (eg API credentials), or they return additional information (eg user deps).
@@ -306,7 +306,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
         then do
           logInfo "Running in VSI only mode, skipping manual source units"
           pure Nothing
-        else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile fossaDepsDir maybeApiOpts vendoredDepsOptions
+        else do Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir customFossaDepsPath maybeApiOpts vendoredDepsOptions
   maybeLernieResults <-
     Diag.errorBoundaryIO
       . diagToDebug

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -254,7 +254,6 @@ analyze ::
   m Aeson.Value
 analyze cfg = Diag.context "fossa-analyze" $ do
   capabilities <- sendIO getNumCapabilities
-
   let maybeApiOpts = case destination of
         OutputStdout -> Nothing
         UploadScan opts _ -> Just opts
@@ -269,11 +268,16 @@ analyze cfg = Diag.context "fossa-analyze" $ do
       skipResolutionSet = Config.vsiSkipSet $ Config.vsiOptions cfg
       vendoredDepsOptions = Config.vendoredDeps cfg
       grepOptions = Config.grepOptions cfg
+      BaseDir fossaDepsDir = Config.fossaDepsDir cfg
 
   -- additional source units are built outside the standard strategy flow, because they either
   -- require additional information (eg API credentials), or they return additional information (eg user deps).
-  vsiResults <- Diag.errorBoundaryIO . diagToDebug $
-    Diag.context "analyze-vsi" . runStickyLogger SevInfo . runFinally $ do
+  vsiResults <- Diag.errorBoundaryIO
+    . diagToDebug
+    $ Diag.context "analyze-vsi"
+      . runStickyLogger SevInfo
+      . runFinally
+    $ do
       let shouldRunVSI = fromFlag Config.VSIAnalysis $ Config.vsiAnalysisEnabled $ Config.vsiOptions cfg
       case (shouldRunVSI, maybeApiOpts) of
         (True, Just apiOpts') ->
@@ -284,24 +288,29 @@ analyze cfg = Diag.context "fossa-analyze" $ do
     Diag.errorBoundaryIO
       . diagToDebug
       . runReader filters
-      $ Diag.context "discover-dynamic-linking" . doAnalyzeDynamicLinkedBinary basedir . Config.dynamicLinkingTarget
+      $ Diag.context "discover-dynamic-linking"
+        . doAnalyzeDynamicLinkedBinary basedir
+        . Config.dynamicLinkingTarget
       $ Config.vsiOptions cfg
   binarySearchResults <-
-    Diag.errorBoundaryIO . diagToDebug $
-      Diag.context "discover-binaries" $
-        if (fromFlag BinaryDiscovery $ Config.binaryDiscoveryEnabled $ Config.vsiOptions cfg)
-          then analyzeDiscoverBinaries basedir filters
-          else pure Nothing
+    Diag.errorBoundaryIO
+      . diagToDebug
+      $ Diag.context "discover-binaries"
+      $ if (fromFlag BinaryDiscovery $ Config.binaryDiscoveryEnabled $ Config.vsiOptions cfg)
+        then analyzeDiscoverBinaries basedir filters
+        else pure Nothing
   manualSrcUnits <-
-    Diag.errorBoundaryIO . diagToDebug $
-      if filterIsVSIOnly filters
+    Diag.errorBoundaryIO
+      . diagToDebug
+      $ if filterIsVSIOnly filters
         then do
           logInfo "Running in VSI only mode, skipping manual source units"
           pure Nothing
-        else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir maybeApiOpts vendoredDepsOptions
+        else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile fossaDepsDir maybeApiOpts vendoredDepsOptions
   maybeLernieResults <-
-    Diag.errorBoundaryIO . diagToDebug $
-      if filterIsVSIOnly filters
+    Diag.errorBoundaryIO
+      . diagToDebug
+      $ if filterIsVSIOnly filters
         then do
           logInfo "Running in VSI only mode, skipping keyword search and custom-license search"
           pure Nothing
@@ -323,8 +332,9 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   traverse_ (Diag.flushLogs SevError SevDebug) [maybeLernieResults]
 
   maybeFirstPartyScanResults <-
-    Diag.errorBoundaryIO . diagToDebug $
-      if firstPartyScansFlag cfg == FirstPartyScansOffFromFlag
+    Diag.errorBoundaryIO
+      . diagToDebug
+      $ if firstPartyScansFlag cfg == FirstPartyScansOffFromFlag
         then do
           logInfo "first party scans forced off by the --experimental-block-first-party-scans flag. Skipping first party scans"
           pure Nothing
@@ -345,9 +355,10 @@ analyze cfg = Diag.context "fossa-analyze" $ do
       $ do
         runAnalyzers filters basedir Nothing
         when (fromFlag UnpackArchives $ Config.unpackArchives cfg) $
-          forkTask $ do
-            res <- Diag.runDiagnosticsIO . diagToDebug . stickyLogStack . withEmptyStack $ Archive.discover (runAnalyzers filters) basedir ancestryDirect
-            Diag.withResult SevError SevWarn res (const (pure ()))
+          forkTask $
+            do
+              res <- Diag.runDiagnosticsIO . diagToDebug . stickyLogStack . withEmptyStack $ Archive.discover (runAnalyzers filters) basedir ancestryDirect
+              Diag.withResult SevError SevWarn res (const (pure ()))
 
   let projectResults = mapMaybe toProjectResult projectScans
   let filteredProjects = mapMaybe toProjectResult projectScans

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -324,9 +324,8 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   traverse_ (Diag.flushLogs SevError SevDebug) [maybeLernieResults]
 
   maybeFirstPartyScanResults <-
-    Diag.errorBoundaryIO
-      . diagToDebug
-      $ if firstPartyScansFlag cfg == FirstPartyScansOffFromFlag
+    Diag.errorBoundaryIO . diagToDebug $
+      if firstPartyScansFlag cfg == FirstPartyScansOffFromFlag
         then do
           logInfo "first party scans forced off by the --experimental-block-first-party-scans flag. Skipping first party scans"
           pure Nothing

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -74,6 +74,8 @@ import Control.Effect.Lift (Lift)
 import Control.Monad (when)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.Flag (Flag, flagOpt, fromFlag)
+import Data.List.Extra
+import Data.List.Split
 import Data.Monoid.Extra (isMempty)
 import Data.Set (Set)
 import Data.Set qualified as Set
@@ -205,6 +207,7 @@ data AnalyzeCliOpts = AnalyzeCliOpts
   , analyzeForceFirstPartyScans :: Flag ForceFirstPartyScans
   , analyzeForceNoFirstPartyScans :: Flag ForceNoFirstPartyScans
   , analyzeIgnoreOrgWideCustomLicenseScanConfigs :: Flag IgnoreOrgWideCustomLicenseScanConfigs
+  , fossaDepsConfig :: Maybe FilePath
   }
   deriving (Eq, Ord, Show)
 
@@ -233,6 +236,7 @@ data AnalyzeConfig = AnalyzeConfig
   , overrideDynamicAnalysis :: OverrideDynamicAnalysisBinary
   , firstPartyScansFlag :: FirstPartyScansFlag
   , grepOptions :: GrepOptions
+  , fossaDepsDir :: BaseDir
   }
   deriving (Eq, Ord, Show, Generic)
 
@@ -283,6 +287,7 @@ cliParser =
     <*> flagOpt ForceFirstPartyScans (long "experimental-force-first-party-scans" <> help "Force first party scans")
     <*> flagOpt ForceNoFirstPartyScans (long "experimental-block-first-party-scans" <> help "Block first party scans. This can be used to forcibly turn off first-party scans if your organization defaults to first-party scans.")
     <*> flagOpt IgnoreOrgWideCustomLicenseScanConfigs (long "ignore-org-wide-custom-license-scan-configs" <> help "Ignore custom-license scan configurations for your organization. These configurations are defined in the \"Integrations\" section of the Admin settings in the FOSSA web app")
+    <*> optional (strOption (long "fossa-deps-config" <> help "Path to fossa-deps configuration file including filename (default: .fossa.yml)"))
 
 data GoDynamicTactic
   = GoModulesBasedTactic
@@ -406,6 +411,9 @@ mergeStandardOpts maybeConfig envvars cliOpts@AnalyzeCliOpts{..} = do
       vendoredDepsOptions = collectVendoredDeps maybeConfig cliOpts
       dynamicAnalysisOverrides = OverrideDynamicAnalysisBinary $ envCmdOverrides envvars
       grepOptions = collectGrepOptions maybeConfig cliOpts
+      fossaDepsDir = case fossaDepsConfig of
+        Just filePath -> collectBaseDir (head (splitOn "fossa-deps" filePath))
+        _ -> collectBaseDir analyzeBaseDir
   firstPartyScansFlag <-
     case (fromFlag ForceFirstPartyScans analyzeForceFirstPartyScans, fromFlag ForceNoFirstPartyScans analyzeForceNoFirstPartyScans) of
       (True, True) -> fatalText "You provided both the --experimental-force-first-party-scans and --experimental-block-first-party-scans flags. Only one of these flags may be used"
@@ -429,6 +437,7 @@ mergeStandardOpts maybeConfig envvars cliOpts@AnalyzeCliOpts{..} = do
     <*> pure dynamicAnalysisOverrides
     <*> pure firstPartyScansFlag
     <*> pure grepOptions
+    <*> fossaDepsDir
 
 collectFilters ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -205,7 +205,7 @@ data AnalyzeCliOpts = AnalyzeCliOpts
   , analyzeForceFirstPartyScans :: Flag ForceFirstPartyScans
   , analyzeForceNoFirstPartyScans :: Flag ForceNoFirstPartyScans
   , analyzeIgnoreOrgWideCustomLicenseScanConfigs :: Flag IgnoreOrgWideCustomLicenseScanConfigs
-  , analyzeCustomFossaDepsPath :: Maybe FilePath
+  , analyzeCustomFossaDepsFile :: Maybe FilePath
   }
   deriving (Eq, Ord, Show)
 
@@ -234,7 +234,7 @@ data AnalyzeConfig = AnalyzeConfig
   , overrideDynamicAnalysis :: OverrideDynamicAnalysisBinary
   , firstPartyScansFlag :: FirstPartyScansFlag
   , grepOptions :: GrepOptions
-  , customFossaDepsPath :: Maybe FilePath
+  , customFossaDepsFile :: Maybe FilePath
   }
   deriving (Eq, Ord, Show, Generic)
 
@@ -285,7 +285,7 @@ cliParser =
     <*> flagOpt ForceFirstPartyScans (long "experimental-force-first-party-scans" <> help "Force first party scans")
     <*> flagOpt ForceNoFirstPartyScans (long "experimental-block-first-party-scans" <> help "Block first party scans. This can be used to forcibly turn off first-party scans if your organization defaults to first-party scans.")
     <*> flagOpt IgnoreOrgWideCustomLicenseScanConfigs (long "ignore-org-wide-custom-license-scan-configs" <> help "Ignore custom-license scan configurations for your organization. These configurations are defined in the \"Integrations\" section of the Admin settings in the FOSSA web app")
-    <*> optional (strOption (long "fossa-deps-config" <> help "Path to fossa-deps configuration file"))
+    <*> optional (strOption (long "fossa-deps-file" <> help "Path to fossa-deps file including filename (default: fossa-deps.{yaml|yml|json})"))
 
 data GoDynamicTactic
   = GoModulesBasedTactic
@@ -409,7 +409,7 @@ mergeStandardOpts maybeConfig envvars cliOpts@AnalyzeCliOpts{..} = do
       vendoredDepsOptions = collectVendoredDeps maybeConfig cliOpts
       dynamicAnalysisOverrides = OverrideDynamicAnalysisBinary $ envCmdOverrides envvars
       grepOptions = collectGrepOptions maybeConfig cliOpts
-      customFossaDepsPath = analyzeCustomFossaDepsPath
+      customFossaDepsFile = analyzeCustomFossaDepsFile
 
   firstPartyScansFlag <-
     case (fromFlag ForceFirstPartyScans analyzeForceFirstPartyScans, fromFlag ForceNoFirstPartyScans analyzeForceNoFirstPartyScans) of
@@ -434,7 +434,7 @@ mergeStandardOpts maybeConfig envvars cliOpts@AnalyzeCliOpts{..} = do
     <*> pure dynamicAnalysisOverrides
     <*> pure firstPartyScansFlag
     <*> pure grepOptions
-    <*> pure customFossaDepsPath
+    <*> pure customFossaDepsFile
 
 collectFilters ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -103,7 +103,6 @@ findAndReadFossaDepsFile root = do
     Just depsFile -> do
       manualDeps <- readFoundDeps depsFile
       pure $ Just manualDeps
-
 readFoundDeps :: (Has Diagnostics sig m, Has ReadFS sig m) => FoundDepsFile -> m ManualDependencies
 readFoundDeps (ManualJSON path) = readContentsJson path
 readFoundDeps (ManualYaml path) = readContentsYaml path
@@ -145,7 +144,6 @@ toSourceUnit ::
 toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendoredDepsOptions = do
   -- If the file exists and we have no dependencies to report, that's a failure.
   when (hasNoDeps manualDeps) $ fatalText "No dependencies found in fossa-deps file"
-
   archiveLocators <- case (maybeApiOpts, NE.nonEmpty vendoredDependencies) of
     (Just apiOpts, Just vdeps) -> NE.toList <$> runFossaApiClient apiOpts (scanAndUpload root vdeps vendoredDepsOptions)
     (Nothing, Just vdeps) -> pure $ noSourceUnits $ NE.toList vdeps
@@ -433,12 +431,13 @@ instance FromJSON ReferencedDependency where
       parseOS :: Object -> Parser Text
       parseOS obj = do
         os <- requiredFieldMsg "os" $ obj .: "os"
-        unless (toLower os `elem` supportedOSs) $
-          fail . toString $
-            "Provided os: "
-              <> (toLower os)
-              <> " is not supported! Please provide oneOf: "
-              <> Text.intercalate ", " supportedOSs
+        unless (toLower os `elem` supportedOSs)
+          $ fail
+            . toString
+          $ "Provided os: "
+            <> (toLower os)
+            <> " is not supported! Please provide oneOf: "
+            <> Text.intercalate ", " supportedOSs
         pure os
 
       requiredFieldMsg :: String -> Parser a -> Parser a
@@ -476,7 +475,8 @@ instance FromJSON CustomDependency where
       <$> (obj `neText` "name")
       <*> (unTextLike <$> obj `neText` "version")
       <*> (obj `neText` "license")
-      <*> obj .:? "metadata"
+      <*> obj
+        .:? "metadata"
       <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
 
 instance FromJSON RemoteDependency where
@@ -485,7 +485,8 @@ instance FromJSON RemoteDependency where
       <$> (obj `neText` "name")
       <*> (unTextLike <$> obj `neText` "version")
       <*> (obj `neText` "url")
-      <*> obj .:? "metadata"
+      <*> obj
+        .:? "metadata"
       <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
 
 validateRemoteDep :: (Has Diagnostics sig m) => RemoteDependency -> Organization -> m RemoteDependency
@@ -537,8 +538,10 @@ instance ToDiagnostic RemoteDepLengthIsGtThanAllowed where
 instance FromJSON DependencyMetadata where
   parseJSON = withObject "metadata" $ \obj ->
     DependencyMetadata
-      <$> obj .:? "description"
-      <*> obj .:? "homepage"
+      <$> obj
+        .:? "description"
+      <*> obj
+        .:? "homepage"
       <* forbidMembers "metadata" ["url"] obj
 
 -- Parse supported dependency types into their respective type or return Nothing.

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -106,14 +106,13 @@ retrieveCustomFossaDepsFile ::
   m (Maybe FoundDepsFile)
 retrieveCustomFossaDepsFile fossaDepsPath = do
   let extension = takeExtension fossaDepsPath
-  file <- (validateFile fossaDepsPath)
+  file <- validateFile fossaDepsPath
 
-  if extension == ".yml" || extension == ".yaml"
-    then pure $ Just $ ManualYaml file
-    else
-      if extension == ".json"
-        then pure $ Just $ ManualJSON file
-        else pure Nothing
+  case extension of
+    ".yml" -> pure $ Just $ ManualYaml file
+    ".yaml" -> pure $ Just $ ManualYaml file
+    ".json" -> pure $ Just $ ManualJSON file
+    _ -> fatalText $ "Expected <name-of-file>.{yml|yaml|json} but received: " <> toText fossaDepsPath
 
 findAndReadFossaDepsFile ::
   ( Has Diagnostics sig m

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -408,8 +408,8 @@ grepOptions =
     , configFilePath = Nothing
     }
 
-customFossaDepsPath :: Maybe FilePath
-customFossaDepsPath = Nothing
+customFossaDepsFile :: Maybe FilePath
+customFossaDepsFile = Nothing
 
 #ifdef mingw32_HOST_OS
 absDir :: Path Abs Dir
@@ -437,5 +437,5 @@ standardAnalyzeConfig =
     , ANZ.overrideDynamicAnalysis = App.OverrideDynamicAnalysisBinary{unOverrideDynamicAnalysisBinary = mempty}
     , ANZ.firstPartyScansFlag = App.FirstPartyScansUseDefault
     , ANZ.grepOptions = grepOptions
-    , ANZ.customFossaDepsPath = customFossaDepsPath
+    , ANZ.customFossaDepsFile = customFossaDepsFile
     }

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -379,6 +379,9 @@ grepOptions =
     , configFilePath = Nothing
     }
 
+customFossaDepsPath :: Maybe FilePath
+customFossaDepsPath = Nothing
+
 #ifdef mingw32_HOST_OS
 absDir :: Path Abs Dir
 absDir = $(mkAbsDir "C:/")
@@ -405,5 +408,5 @@ standardAnalyzeConfig =
     , ANZ.overrideDynamicAnalysis = App.OverrideDynamicAnalysisBinary{unOverrideDynamicAnalysisBinary = mempty}
     , ANZ.firstPartyScansFlag = App.FirstPartyScansUseDefault
     , ANZ.grepOptions = grepOptions
-    , ANZ.fossaDepsDir = App.BaseDir absDir
+    , ANZ.customFossaDepsPath = customFossaDepsPath
     }

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -162,11 +162,10 @@ baseDir = do
 
 contributors :: API.Contributors
 contributors =
-  API.Contributors
-    . Map.fromList
-    $ [ ("testContributor1", "testContributor1")
-      , ("testContributor2", "testContributor2")
-      ]
+  API.Contributors . Map.fromList $
+    [ ("testContributor1", "testContributor1")
+    , ("testContributor2", "testContributor2")
+    ]
 
 build :: API.Build
 build =

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -162,10 +162,11 @@ baseDir = do
 
 contributors :: API.Contributors
 contributors =
-  API.Contributors . Map.fromList $
-    [ ("testContributor1", "testContributor1")
-    , ("testContributor2", "testContributor2")
-    ]
+  API.Contributors
+    . Map.fromList
+    $ [ ("testContributor1", "testContributor1")
+      , ("testContributor2", "testContributor2")
+      ]
 
 build :: API.Build
 build =
@@ -404,4 +405,5 @@ standardAnalyzeConfig =
     , ANZ.overrideDynamicAnalysis = App.OverrideDynamicAnalysisBinary{unOverrideDynamicAnalysisBinary = mempty}
     , ANZ.firstPartyScansFlag = App.FirstPartyScansUseDefault
     , ANZ.grepOptions = grepOptions
+    , ANZ.fossaDepsDir = App.BaseDir absDir
     }


### PR DESCRIPTION
# Overview

As a user, I want to provide path to fossa-deps file during analysis, similar to how I can use -c | --config to provide custom config file. This is so I can run analysis across multiple fossa-deps file.  

## Acceptance criteria

As a user, I can provide different path to fossa-deps file during analysis.

For example, I should be able to use custom/configs/zlib.fossa-deps.yml as fossa-deps file during analysis

```
/custom
 - /libs
 - /zlib
 - /configs
    - zlib.fossa-deps.yml
    - libs.fossa-deps.yml
```

## Testing plan

- Tested and confirmed we are pulling the targeted fossa-deps config file with flag `--fossa-deps-config 
Paths and file formats tested:
  - a.yml (relative path and absolute path)
  - ../fossa-deps.yaml
  - ../z.json
  
 - When ran with no flag, it just goes through the normal experience and searches for the fossa-deps-config in the analyze directory

## Risks

- Flag name
- Implementation 

## Metrics

## References

- [ANE-979](https://fossa.atlassian.net/browse/ANE-979)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-979]: https://fossa.atlassian.net/browse/ANE-979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ