### PR TITLE
Support toolchain syntax added in go 1.21

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- golang: Updates go.mod parser to be compatible with golang v1.21. ([#1304](https://github.com/fossas/fossa-cli/pull/1304))
 - `fossa list-targets`: list-target command supports `--format` option with: `ndjson`, `text`, and `legacy`. ([#1296](https://github.com/fossas/fossa-cli/pull/1296))
 
 ## v3.8.17

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -82,10 +82,10 @@ data Statement
     -- of go.mod, refer to: https://go.dev/ref/mod#go-mod-file-retract
     RetractStatement
   | GoVersionStatement Text
-    -- | we do not care about values associated with
+  | -- | we do not care about values associated with
     -- the toolchain block as they are of no use to us today.
     -- Refer to: https://go.dev/doc/modules/gomod-ref#toolchain
-  | ToolchainStatement Text
+    ToolchainStatement Text
   deriving (Eq, Ord, Show)
 
 type PackageName = Text
@@ -222,7 +222,7 @@ gomodParser = do
   where
     statement =
       (singleton <$> goVersionStatement) -- singleton wraps the Parser Statement into a Parser [Statement]
-      <|> (singleton <$> toolChainStatements)
+        <|> (singleton <$> toolChainStatements)
         <|> requireStatements
         <|> replaceStatements
         <|> excludeStatements

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -82,6 +82,10 @@ data Statement
     -- of go.mod, refer to: https://go.dev/ref/mod#go-mod-file-retract
     RetractStatement
   | GoVersionStatement Text
+    -- | we do not care about values associated with
+    -- the toolchain block as they are of no use to us today.
+    -- Refer to: https://go.dev/doc/modules/gomod-ref#toolchain
+  | ToolchainStatement Text
   deriving (Eq, Ord, Show)
 
 type PackageName = Text
@@ -218,6 +222,7 @@ gomodParser = do
   where
     statement =
       (singleton <$> goVersionStatement) -- singleton wraps the Parser Statement into a Parser [Statement]
+      <|> (singleton <$> toolChainStatements)
         <|> requireStatements
         <|> replaceStatements
         <|> excludeStatements
@@ -227,6 +232,11 @@ gomodParser = do
     -- e.g., go 1.12
     goVersionStatement :: Parser Statement
     goVersionStatement = GoVersionStatement <$ lexeme (chunk "go") <*> goVersion
+
+    -- top-level go version statement
+    -- e.g., toolchain go1.21.1
+    toolChainStatements :: Parser Statement
+    toolChainStatements = ToolchainStatement <$ lexeme (chunk "toolchain") <*> anyToken
 
     -- top-level require statements
     -- e.g.:

--- a/test/Go/testdata/go.mod.edgecases
+++ b/test/Go/testdata/go.mod.edgecases
@@ -5,6 +5,8 @@ module test/package
 
 go 1.12
 
+toolchain go1.21.1
+
 require repo/name/A v1.0.0 // indirect
 
 require (


### PR DESCRIPTION
# Overview

https://go.dev/doc/toolchain

Go added a new `toolchain` syntax field that broke our parser for `go.mod` files.

## Acceptance criteria

- Go projects with a `toolchain` field now work.

## Testing plan

I created a test project (available in the ticket) with the `toolchain` field that breaks when doing normal fossa analysis.

## Risks

The only risk I can think of is that the toolchain data that we are otherwise discarding is valuable

## References

- [FDN-25](https://fossa.atlassian.net/browse/FDN-25)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[FDN-25]: https://fossa.atlassian.net/browse/FDN-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ