### PR TITLE
Update the "Requirements File Format" URL

### DIFF
--- a/docs/references/strategies/languages/python/setuptools.md
+++ b/docs/references/strategies/languages/python/setuptools.md
@@ -38,7 +38,7 @@ scans for its `install_requires=[...]` attributes, similar to `setup.py`. If bot
 from both files.
 
 [setup.cfg docs]: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
-[requirements-file-format]: https://pip.pypa.io/en/stable/cli/pip_install/#requirements-file-format
+[requirements-file-format]: https://pip.pypa.io/en/stable/reference/requirements-file-format/
 [pep-508]: https://www.python.org/dev/peps/pep-0508/
 
 ## Limitations


### PR DESCRIPTION
# Overview

This just updates the pip documentation to point to the appropriate URL. Hopefully, this will save a click and get ahead of any issues with deprecation of the old PIP docs page.

The old URL still works for the time being, but indicates it has been relocated:
- https://pip.pypa.io/en/stable/cli/pip_install/#requirements-file-format

The new URL is a direct link to the "Requirements File Format" page:
- https://pip.pypa.io/en/stable/reference/requirements-file-format/

## Acceptance criteria

Nothing breaks, and you can find the documentation!

## Testing plan

Click tested in the markdown preview.

## Risks

Other sections of the previous URL may have been deemed useful, and are no longer immediately visible.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
