### PR TITLE
turn markdown link checks for https://cran.r-project.org/ back on

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -4,9 +4,6 @@
   "ignorePatterns": [
     {
       "pattern": "https://support.fossa.com"
-    },
-    {
-      "pattern": "https://cran.r-project.org"
     }
   ]
 }


### PR DESCRIPTION
# Overview

https://cran.r-project.org/ was down last week so I turned off the markdown link checks for it.

The site is back up, so this PR reverts the change. 

## Acceptance criteria

The markdown link checks pass

## Testing plan



## Risks



## Metrics


## References

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
