### PR TITLE
Fix install-latest.sh when fossa binary already exists

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.8.21
+
+- install-latest.sh: Fixed a bug where install-latest.sh would result in a broken binary when run on some versions of macOS ([#1317](https://github.com/fossas/fossa-cli/pull/1317))
+
 ## v3.8.20
 - container scanning: Fixes registry network calls, to ensure `fossa-cli` uses `Accept` header on `HEAD` network calls. ([#1309](https://github.com/fossas/fossa-cli/pull/1309))
 

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -54,7 +54,8 @@ execute() {
       binexe="${binexe}.exe"
     fi
     log_debug "installing binary: $binexe"
-    cp "${srcdir}/${binexe}" "${BINDIR}/${binexe}" 2> /dev/null || sudo cp "${srcdir}/${binexe}" "${BINDIR}/"
+    # Use mv instead of cp, as copying when a binary already exists in that spot can create an invalid binary on macOS
+    mv "${srcdir}/${binexe}" "${BINDIR}/${binexe}" 2> /dev/null || sudo cp "${srcdir}/${binexe}" "${BINDIR}/"
     log_info "installed ${BINDIR}/${binexe}"
   done
 }
@@ -103,15 +104,15 @@ adjust_format() {
 adjust_os() {
   # adjust archive name based on OS
   case $(uname_os) in
-   linux) 
+   linux)
     # Before 3.4.7 fossa was distributed in .zip archives on linux.
     # 3.4.7 and later distributed fossa in tar.gz because it is more common than zip on linux.
-	if version_less_than "$VERSION" "3.4.7" 
+	if version_less_than "$VERSION" "3.4.7"
 	then
 	  FORMAT=zip
     else
       FORMAT=tar.gz
-	fi ;;	
+	fi ;;
   esac
   true
 }
@@ -399,7 +400,7 @@ get_binary_name() {
 }
 # Check if one version is less than another.
 # Versions are expected to be of the for X.X.X where X is some integer.
-# 
+#
 # Given version strings X1.X2.X3 and Y1.Y2.Y3:
 # A version is less than another if there exists an Xn/Yn pair where Xn < Yn where for every preceding Xn/Yn pair in the sequence Xn == Yn.
 # Example:
@@ -413,7 +414,7 @@ version_less_than() {
     for i in 1 2 3
     do
         VERSION_PIECE1=$(echo "$1" | cut -d '.' -f $i)
-        VERSION_PIECE2=$(echo "$2" | cut -d '.' -f $i)    
+        VERSION_PIECE2=$(echo "$2" | cut -d '.' -f $i)
 
         if [ "$VERSION_PIECE1" -lt "$VERSION_PIECE2" ]
         then
@@ -435,11 +436,11 @@ print_telemetry_disclaimer() {
   log_info "------"
   log_info ""
   log_info "FOSSA collects warnings, errors, and usage data to improve"
-	log_info "the FOSSA CLI and your experience."  
+	log_info "the FOSSA CLI and your experience."
   log_info ""
   log_info "Read more: https://github.com/fossas/fossa-cli/blob/master/docs/telemetry.md"
   log_info ""
-  log_info "If you want to prevent any telemetry data from being sent to" 
+  log_info "If you want to prevent any telemetry data from being sent to"
   log_info "the server, you can opt out of telemetry by setting"
   log_info "FOSSA_TELEMETRY_SCOPE environment variable to 'off' in your shell."
   log_info ""


### PR DESCRIPTION
# Overview

[Delivers ANE-1262](https://fossa.atlassian.net/browse/ANE-1262)

If you run `install-latest.sh` on macOS and the fossa binary already exists on the system, then the `cp` command will create a binary that fails to run.

This PR fixes that by using `mv` instead of `cp`.

## Acceptance criteria

`install-latest.sh` can be safely run even if `fossa` is already installed

## Testing plan

Run this multiple times in a row:

```
./install-latest.sh
fossa -V
```

## Risks

I think that this is low risk. It's a small change. But if it breaks things it will affect a lot of customers

## Metrics


## References

[ANE-1262](https://fossa.atlassian.net/browse/ANE-1262)


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1262]: https://fossa.atlassian.net/browse/ANE-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ