### PR TITLE
download themis and its index from fossas/themis instead of fossas/basis

### DIFF
--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Requires environment variables:
-#   GITHUB_TOKEN    A token with access to the fossas/basis repository
+#   GITHUB_TOKEN    A token with access to the fossas/themis repository
 #
 # Requires binary dependencies in $PATH:
 #   jq              Parse and manipulate json structures.
@@ -31,13 +31,12 @@ rm -f vendor-bins/*
 mkdir -p vendor-bins
 
 ASSET_POSTFIX=""
-BASIS_ASSET_POSTFIX=""
+THEMIS_ASSET_POSTFIX=""
 LERNIE_ASSET_POSTFIX=""
-OS_WINDOWS=false
 case "$(uname -s)" in
   Darwin)
     ASSET_POSTFIX="darwin"
-    BASIS_ASSET_POSTFIX="darwin-amd64"
+    THEMIS_ASSET_POSTFIX="darwin-amd64"
     case "$(uname -m)" in
       arm64)
         LERNIE_ASSET_POSTFIX="aarch64-macos"
@@ -51,22 +50,20 @@ case "$(uname -s)" in
 
   Linux)
     ASSET_POSTFIX="linux"
-    BASIS_ASSET_POSTFIX="linux-amd64"
+    THEMIS_ASSET_POSTFIX="linux-amd64"
     LERNIE_ASSET_POSTFIX="x86_64-linux"
     ;;
 
   *)
     echo "Warn: Assuming $(uname -s) is Windows"
     ASSET_POSTFIX="windows.exe"
-    BASIS_ASSET_POSTFIX="windows-amd64"
+    THEMIS_ASSET_POSTFIX="windows-amd64"
     LERNIE_ASSET_POSTFIX="x86_64-windows.exe"
-    OS_WINDOWS=true
     ;;
 esac
 
 # Download latest release of Themis and its index
 
-TAG="latest"
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
 echo "Downloading themis binary from latest release"
@@ -74,15 +71,15 @@ THEMIS_RELEASE_JSON=vendor-bins/themis-release.json
 curl -sSL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
-    https://api.github.com/repos/fossas/basis/releases/latest > $THEMIS_RELEASE_JSON
+    https://api.github.com/repos/fossas/themis/releases/latest > $THEMIS_RELEASE_JSON
 
 THEMIS_TAG=$(jq -cr ".name" $THEMIS_RELEASE_JSON)
 echo "Using themis release: $THEMIS_TAG"
-FILTER=".name == \"themis-cli-$BASIS_ASSET_POSTFIX\""
+FILTER=".name == \"themis-cli-$THEMIS_ASSET_POSTFIX\""
 jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $THEMIS_RELEASE_JSON | while read ASSET; do
   URL="$(echo $ASSET | jq -c -r '.url')"
   NAME="$(echo $ASSET | jq -c -r '.name')"
-  OUTPUT="$(echo vendor-bins/$NAME | sed 's/-'$BASIS_ASSET_POSTFIX'$//')"
+  OUTPUT="$(echo vendor-bins/$NAME | sed 's/-'$THEMIS_ASSET_POSTFIX'$//')"
 
   echo "Downloading '$NAME' to '$OUTPUT'"
   curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s $URL > $OUTPUT


### PR DESCRIPTION
# Overview

Make `vendor_download.sh` get Themis from its new home, github.com/fossas/themis.

## Acceptance criteria

`vendor_download.sh` gets themis from the right spot

## Testing plan

Run `vendor_download.sh` and verify that it works

```
export GITHUB_TOKEN=....
./vendor_download.sh
```

It should say that it's downloading themis and index.gob from the latest release. Right now that's https://github.com/fossas/themis/releases/tag/2023-11-01-2322526-1698872554.

Check that the files got downloaded. You should see themis-cli, index.gob.xz and lernie:

```
ls -l vendor-bins
total 95416
-rwxr-xr-x  1 scott  staff  25111036 Nov  1 14:08 index.gob.xz
-rwxr-xr-x  1 scott  staff   3378308 Nov  1 14:08 lernie
-rwxr-xr-x  1 scott  staff  18508320 Nov  1 14:08 themis-cli
```

unzip the index and try running themis. It should succeed:

```
xz -d --keep vendor-bins/index.gob.xz
./vendor-bins/themis-cli --license-data-dir vendor-bins .
```

## Risks

This should be safe

## Metrics


## References

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
