### PR TITLE
[ANE-1166] Support lock-file v6 for `pnpm`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist-newstyle/
 vendor/
 vendor-bins/
 .vscode/
+sandbox/
 
 # Executables
 /fossa

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## Unreleased
-- `pnpm`: Supports `6.0` version of `pnpm-lockfile.yaml` ([])()
+- `pnpm`: Supports `6.0` version of `pnpm-lockfile.yaml` ([#1320])(https://github.com/fossas/fossa-cli/pull/1320)
 
 
 ## v3.8.21

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- `pnpm`: Supports `6.0` version of `pnpm-lockfile.yaml` ([])()
+
+
 ## v3.8.21
 - archive: considers 0-byte tar file to be valid tar file. ([#1311](https://github.com/fossas/fossa-cli/pull/1311))
 - Cocoapods: Allow Podfile.lock without EXTERNAL SOURCES field ([#1279](https://github.com/fossas/fossa-cli/pull/1279))

--- a/docs/references/strategies/languages/nodejs/pnpm.md
+++ b/docs/references/strategies/languages/nodejs/pnpm.md
@@ -151,6 +151,8 @@ CLI will infer the package name and version using `/${dependencyName}/${dependen
 * Pnpm workspaces are supported.
 * Development dependencies (`dev: true`) are ignored by default from analysis. To include them in the analysis, execute CLI with `--include-unused` flag e.g. `fossa analyze --include-unused`.
 * Optional dependencies are included in the analysis by default. They can be ignored in FOSSA UI.
+* `fossa-cli` supports lockFileVersion: 4.x, 5.x, and 6.x.
+
 
 # F.A.Q
 

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -162,6 +162,7 @@ instance AnalyzeProject NodeProject where
 getDeps ::
   ( Has ReadFS sig m
   , Has Diagnostics sig m
+  , Has Logger sig m
   ) =>
   NodeProject ->
   m DependencyResults
@@ -170,7 +171,7 @@ getDeps (NPMLock packageLockFile graph) = analyzeNpmLock packageLockFile graph
 getDeps (Pnpm pnpmLockFile _) = analyzePnpmLock pnpmLockFile
 getDeps (NPM graph) = analyzeNpm graph
 
-analyzePnpmLock :: (Has Diagnostics sig m, Has ReadFS sig m) => Manifest -> m DependencyResults
+analyzePnpmLock :: (Has Diagnostics sig m, Has ReadFS sig m, Has Logger sig m) => Manifest -> m DependencyResults
 analyzePnpmLock (Manifest pnpmLockFile) = do
   result <- PnpmLock.analyze pnpmLockFile
   pure $ DependencyResults result Complete [pnpmLockFile]

--- a/src/Strategy/Node/Pnpm/PnpmLock.hs
+++ b/src/Strategy/Node/Pnpm/PnpmLock.hs
@@ -106,6 +106,9 @@ import Path (Abs, File, Path)
 --    * If project has set peerDependencies to be not auto installed, pnpm
 --      by default, does not include them in the lockfile. So, no additional
 --      work is required for newly introduced `settings.autoInstallPeers` field.
+--      This means, that if user has chosen, not to install peerDependencies, they
+--      won't be included in the lock-file, so no additional work is required by fossa-cli.
+--      Note that, fossa-cli by default includes peer dependencies.
 --
 --  References:
 --    - [pnpm](https://pnpm.io/)

--- a/test/Pnpm/testdata/pnpm-lock-v6-workspace.yaml
+++ b/test/Pnpm/testdata/pnpm-lock-v6-workspace.yaml
@@ -1,0 +1,185 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      aws-sdk:
+        specifier: 2.1148.0
+        version: 2.1148.0
+      chalk:
+        specifier: 5.3.0
+        version: 5.3.0
+      colors:
+        specifier: git+https://github.com/Marak/colors.js.git
+        version: github.com/Marak/colors.js/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26
+      lodash:
+        specifier: https://github.com/lodash/lodash/archive/refs/heads/master.tar.gz
+        version: '@github.com/lodash/lodash/archive/refs/heads/master.tar.gz'
+    devDependencies:
+      react:
+        specifier: 18.1.0
+        version: 18.1.0
+
+  packages/a:
+    dependencies:
+      aws-sdk:
+        specifier: 1.0.0
+        version: 1.0.0
+      commander:
+        specifier: 9.2.0
+        version: 9.2.0
+
+packages:
+
+  /aws-sdk@1.0.0:
+    resolution: {integrity: sha512-MhxZ5bSkbnFEp9CnQ1dPeMVbrCVCv+VCx7fttdS0vB8anbFN3yzCxB1q76buci5ugxAKDqrySLssUI/OexoVXg==}
+    engines: {node: '>= 0.6.0'}
+    dependencies:
+      xml2js: 0.2.4
+      xmlbuilder: 15.1.1
+    dev: false
+
+  /aws-sdk@2.1148.0:
+    resolution: {integrity: sha512-FUYAyveKmS5eqIiGQgrGVsLZwwtI+K6S6Gz8oJf56pgypZCo9dV+cXO4aaS+vN0+LSmGh6dSKc6G8h8FYASIJg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      buffer: 4.9.2
+      events: 1.1.1
+      ieee754: 1.1.13
+      jmespath: 0.16.0
+      querystring: 0.2.0
+      sax: 1.2.1
+      url: 0.10.3
+      uuid: 8.0.0
+      xml2js: 0.4.19
+    dev: false
+
+  /base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
+  /buffer@4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.1.13
+      isarray: 1.0.0
+    dev: false
+
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false
+
+  /commander@9.2.0:
+    resolution: {integrity: sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==}
+    engines: {node: ^12.20.0 || >=14}
+    dev: false
+
+  /events@1.1.1:
+    resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
+    engines: {node: '>=0.4.x'}
+    dev: false
+
+  /ieee754@1.1.13:
+    resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
+    dev: false
+
+  /isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    dev: false
+
+  /jmespath@0.16.0:
+    resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
+    engines: {node: '>= 0.6.0'}
+    dev: false
+
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
+  /loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: true
+
+  /punycode@1.3.2:
+    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
+    dev: false
+
+  /querystring@0.2.0:
+    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+    dev: false
+
+  /react@18.1.0:
+    resolution: {integrity: sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: true
+
+  /sax@1.2.1:
+    resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
+    dev: false
+
+  /sax@1.3.0:
+    resolution: {integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==}
+    dev: false
+
+  /url@0.10.3:
+    resolution: {integrity: sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=}
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+    dev: false
+
+  /uuid@8.0.0:
+    resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    hasBin: true
+    dev: false
+
+  /xml2js@0.2.4:
+    resolution: {integrity: sha1-mltXf6HmzfiSPV4TcvejGIQ25E0=}
+    dependencies:
+      sax: 1.3.0
+    dev: false
+
+  /xml2js@0.4.19:
+    resolution: {integrity: sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==}
+    dependencies:
+      sax: 1.3.0
+      xmlbuilder: 9.0.7
+    dev: false
+
+  /xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
+    dev: false
+
+  /xmlbuilder@9.0.7:
+    resolution: {integrity: sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==}
+    engines: {node: '>=4.0'}
+    dev: false
+
+  '@github.com/lodash/lodash/archive/refs/heads/master.tar.gz':
+    resolution: {tarball: https://github.com/lodash/lodash/archive/refs/heads/master.tar.gz}
+    name: lodash
+    version: 5.0.0
+    engines: {node: ^18.17.1, yarn: ^1.22.19}
+    dev: false
+
+  github.com/Marak/colors.js/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26:
+    resolution: {tarball: https://codeload.github.com/Marak/colors.js/tar.gz/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26}
+    name: colors
+    version: 1.4.44-liberty-2
+    engines: {node: '>=0.1.90'}
+    dev: false

--- a/test/Pnpm/testdata/pnpm-lock-v6.yaml
+++ b/test/Pnpm/testdata/pnpm-lock-v6.yaml
@@ -1,0 +1,146 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  aws-sdk:
+    specifier: ^2.0.0
+    version: 2.1148.0
+  chalk:
+    specifier: 5.3.0
+    version: 5.3.0
+  colors:
+    specifier: git+https://github.com/Marak/colors.js.git
+    version: github.com/Marak/colors.js/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26
+  lodash:
+    specifier: https://github.com/lodash/lodash/archive/refs/heads/master.tar.gz
+    version: '@github.com/lodash/lodash/archive/refs/heads/master.tar.gz'
+
+devDependencies:
+  react:
+    specifier: '*'
+    version: 18.1.0
+
+packages:
+
+  /aws-sdk@2.1148.0:
+    resolution: {integrity: sha512-FUYAyveKmS5eqIiGQgrGVsLZwwtI+K6S6Gz8oJf56pgypZCo9dV+cXO4aaS+vN0+LSmGh6dSKc6G8h8FYASIJg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      buffer: 4.9.2
+      events: 1.1.1
+      ieee754: 1.1.13
+      jmespath: 0.16.0
+      querystring: 0.2.0
+      sax: 1.2.1
+      url: 0.10.3
+      uuid: 8.0.0
+      xml2js: 0.4.19
+    dev: false
+
+  /base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
+  /buffer@4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.1.13
+      isarray: 1.0.0
+    dev: false
+
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false
+
+  /events@1.1.1:
+    resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
+    engines: {node: '>=0.4.x'}
+    dev: false
+
+  /ieee754@1.1.13:
+    resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
+    dev: false
+
+  /isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    dev: false
+
+  /jmespath@0.16.0:
+    resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
+    engines: {node: '>= 0.6.0'}
+    dev: false
+
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
+  /loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: true
+
+  /punycode@1.3.2:
+    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
+    dev: false
+
+  /querystring@0.2.0:
+    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+    dev: false
+
+  /react@18.1.0:
+    resolution: {integrity: sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: true
+
+  /sax@1.2.1:
+    resolution: {integrity: sha1-e45lYZCyKOgaZq6nSEgNgozS03o=}
+    dev: false
+
+  /url@0.10.3:
+    resolution: {integrity: sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=}
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+    dev: false
+
+  /uuid@8.0.0:
+    resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    hasBin: true
+    dev: false
+
+  /xml2js@0.4.19:
+    resolution: {integrity: sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==}
+    dependencies:
+      sax: 1.2.1
+      xmlbuilder: 9.0.7
+    dev: false
+
+  /xmlbuilder@9.0.7:
+    resolution: {integrity: sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=}
+    engines: {node: '>=4.0'}
+    dev: false
+
+  '@github.com/lodash/lodash/archive/refs/heads/master.tar.gz':
+    resolution: {tarball: https://github.com/lodash/lodash/archive/refs/heads/master.tar.gz}
+    name: lodash
+    version: 5.0.0
+    engines: {node: ^18.17.1, yarn: ^1.22.19}
+    dev: false
+
+  github.com/Marak/colors.js/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26:
+    resolution: {tarball: https://codeload.github.com/Marak/colors.js/tar.gz/6bc50e79eeaa1d87369bb3e7e608ebed18c5cf26}
+    name: colors
+    version: 1.4.44-liberty-2
+    engines: {node: '>=0.1.90'}
+    dev: false


### PR DESCRIPTION
# Overview

This PR, 

- Adds support for `pnpm` lock-file: `6.0`, which is default format with pnpm `8.x`.

Sibling PR: https://github.com/fossas/example-projects/pull/10

## Acceptance criteria

As a user, 
- [ ] I can analyze `pnpm` project using lock-file, with`6.0` 
- [ ] I can analyze `pnpm` workspace project using lock-file, with`6.0` 

## Testing plan

I added automated tests. 

- You can also test by performing `fossa analyze -o` against any `pnpm` project using `8.x`

For example, 
```bash
# Make fossa-cli
git pull origin && git checkout feat/pnpm-lock-v6 && make install-dev

# Get cases
cd ..
git clone -b feat/adds-pnpm-v6 git clone https://github.com/fossas/example-projects

# Analyze
fossa-dev analyze ./example-projects/javascript/pnpm-v6/ -o | jq
fossa-dev analyze ./example-projects/javascript/pnpm-v6-workspace/ -o | jq
```

Let's take popular project:
```bash
git clone https://github.com/vitejs/vite.git --depth 0
cd viite && fossa-dev analyze -o --only-target pnpm@./
```

There is also example: https://fossa.atlassian.net/browse/ANE-1166

## Risks

N/A

## Metrics

N/A

## References

https://fossa.atlassian.net/browse/ANE-1166

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
