### PR TITLE
[ANE-658] Fixes maven dependency graph defect for plugin tactic

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## Unreleased
-- Maven: Fixes defect, where `fossa-cli` was sometimes ignoring dependency, if the dependency with scopes was part of the project. 
+- Maven: Fixes defect, where `fossa-cli` was sometimes ignoring dependency, if the dependency with scopes was part of the project. ([#1322](https://github.com/fossas/fossa-cli/pull/1322))
 
 ## v3.8.21
 - archive: considers 0-byte tar file to be valid tar file. ([#1311](https://github.com/fossas/fossa-cli/pull/1311))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- Maven: Fixes defect, where `fossa-cli` was sometimes ignoring dependency, if the dependency with scopes was part of the project. 
+
 ## v3.8.21
 - archive: considers 0-byte tar file to be valid tar file. ([#1311](https://github.com/fossas/fossa-cli/pull/1311))
 - Cocoapods: Allow Podfile.lock without EXTERNAL SOURCES field ([#1279](https://github.com/fossas/fossa-cli/pull/1279))


### PR DESCRIPTION
# Overview

This PR, 

- Fixes a defect, where `fossa-cli` was silently ignoring dependency, when dependency with same name existed with multiple scopes.

## Acceptance criteria

- `fossa-cli` can correctly include, dependency with multiple scopes in the analysis.

## Testing plan

I added automated tests.

```bash
git checkout master && git pull origin && git checkout feat/maven-analysis-multiple-scope-w-classifiers
sudo make install-dev

# create example maven project
mkdir sandbox && cd sandbox
mvn archetype:generate -DgroupId=com.mycompany.app -DartifactId=my-app -DarchetypeArtifactId=maven-archetype-quickstart -DarchetypeVersion=1.4 -DinteractiveMode=false
cd my-app

# Add following in <dependencies> block, for my-app/pom.xml
# <dependency>
#   <groupId>org.apache.kafka</groupId>
#   <artifactId>kafka-clients</artifactId>
#   <version>3.0.2</version>
#   <scope>compile</scope>
# </dependency>
# <dependency>
#   <groupId>org.apache.kafka</groupId>
#   <artifactId>kafka-clients</artifactId>
#   <version>3.0.2</version>
#   <classifier>sources</classifier> <!-- 👈 --> 
#   <scope>test</scope>
# </dependency>    

# run it with current cli
fossa analyze sandbox -o | jq # you should see that `mvn+org.apache.kafka:kafka-clients$3.0.2` is missing

# run it with this patch cli
fossa-dev analyze sandbox -o | jq # you should see that `mvn+org.apache.kafka:kafka-clients$3.0.2` is not missing
```

## Risks

This touches, somewhat critical codepath for maven analysis- blast zone is relatively high. 

## Metrics

N/A

## References

https://fossa.atlassian.net/browse/ANE-658

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
