### PR TITLE
[ANE-1092] Path Dependency (2/2)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 - archive: considers 0-byte tar file to be valid tar file. ([#1311](https://github.com/fossas/fossa-cli/pull/1311)) 
-
+- path: adds path dependency scanning functionality. ([#1327](https://github.com/fossas/fossa-cli/pull/1327))
 
 ## v3.8.22
 

--- a/docs/references/experimental/path-dependency.md
+++ b/docs/references/experimental/path-dependency.md
@@ -1,0 +1,54 @@
+# Path Dependency
+
+
+## What is a path dependency?
+
+Path dependencies, are dependencies which were sourced from file-system,
+as opposed to package manager registry, or internet URL. 
+
+For example from following `go.mod` file, `fossa-cli` would consider `` to
+be a path dependency.  
+
+```
+```
+
+In FOSSA UI, path dependencies will be shown with `Local` tag. 
+
+## How path dependencies are scanned
+
+Path dependencies are scanned using "CLI license scan", similar to how vendor dependencies
+are scanned. A "CLI license scan" inspects path for licensing on the local system within the CLI, 
+and only uploads the matched license data to FOSSA's servers.
+
+The FOSSA service caches the results of a path dependency by the combination of its `(project id, path)`.
+Due to this caching setup, it is normal for the first analysis to take some time, especially for larger projects, 
+but future analysis of dependencies with the same information should be fast.
+
+In the event caching is causing problems, FOSSA can be made to rescan this kind of dependency:
+- Run `fossa analyze` with the `--force-vendored-dependency-rescans` flag, or
+- Set `vendoredDependencies.forceRescans` to `true` in `.fossa.yml` at the root of the project.
+
+## Limitations
+
+- Currently, path dependencies do not support vulnerability scanning.
+- Currently, path dependencies are only supported for `golang`.
+
+## F.A.Q
+
+### How do I enable path dependency in analysis?
+
+Run `fossa analyze` with the `--force-vendored-dependency-rescans` flag
+
+### How do I disable path dependency in analysis?
+
+By default, path dependency analysis is disabled.
+
+### Is `fossa-cli` uploading content of my path dependency to server?
+
+`fossa-cli` only upload findings of license scan result. 
+
+## How are path dependencies different from Vendor dependencies?
+
+Path dependencies, unlike vendor dependencies can be either direct
+or transitive dependencies in the analysis graph. Furthermore, path
+dependencies are scoped to Project, as opposed to entire organization.

--- a/docs/references/experimental/path-dependency.md
+++ b/docs/references/experimental/path-dependency.md
@@ -47,7 +47,10 @@ By default, path dependency analysis is disabled. Note that, in the future, `fos
 
 ### Is `fossa-cli` uploading the content of my path dependency to the server?
 
-`fossa-cli` only uploads findings of the license scan result.
+`fossa-cli` only uploads findings of the license scan, not the entire directory. If `cliLicenseScanRequireFullFileUpload` is enabled in FOSSA endpoint
+for your organization, `fossa-cli` will upload content of any file that has licensing data. By default,  `cliLicenseScanRequireFullFileUpload` is
+disabled for all organizations. Please contact [FOSSA support](https://support.fossa.com) to enable, this functionality.
+
 
 ## How are path dependencies different from vendor dependencies?
 

--- a/docs/references/experimental/path-dependency.md
+++ b/docs/references/experimental/path-dependency.md
@@ -1,54 +1,54 @@
 # Path Dependency
 
+## What is path dependency?
 
-## What is a path dependency?
+Path dependency is a reliance on the file system as the source, as opposed to a package manager registry or URL. A path dependency may or may not have transitive dependencies.
 
-Path dependencies, are dependencies which were sourced from file-system,
-as opposed to package manager registry, or internet URL. 
+For example, in the following `go.mod` file, with `gomod` analysis and the `--experimental-analyze-path-dependencies` flag, `fossa-cli` would consider `../vendor/squirrel` a path dependency in the final dependency graph. If path dependency analysis is disabled, `fossa-cli` would ignore this dependency completely and only show transitive dependencies originating from `../vendor/squirrel`. In such a case, license and copyright obligations originating from `../vendor/squirrel` will not be captured in FOSSA's findings, and subsequent software bill of materials generated.
 
-For example from following `go.mod` file, `fossa-cli` would consider `` to
-be a path dependency.  
+```go
+// Example go.mod file
+module tester
 
+go 1.14
+
+replace github.com/Masterminds/squirrel => ../vendor/squirrel
+require github.com/Masterminds/squirrel v1.4.0
 ```
-```
 
-In FOSSA UI, path dependencies will be shown with `Local` tag. 
+In the FOSSA UI, path dependencies are shown with the `Local` tag.
 
-## How path dependencies are scanned
+## How are path dependencies scanned?
 
-Path dependencies are scanned using "CLI license scan", similar to how vendor dependencies
-are scanned. A "CLI license scan" inspects path for licensing on the local system within the CLI, 
-and only uploads the matched license data to FOSSA's servers.
+Path dependencies are scanned using the "CLI license scan," similar to how [vendor dependencies](./../../features/vendored-dependencies.md) are scanned by default. A "CLI license scan" performs a license scan at the path and uploads the results of these scans to the provided FOSSA endpoint.
 
-The FOSSA service caches the results of a path dependency by the combination of its `(project id, path)`.
-Due to this caching setup, it is normal for the first analysis to take some time, especially for larger projects, 
-but future analysis of dependencies with the same information should be fast.
+For performance reasons, the FOSSA service caches the results of a path dependency by the combination of its `(project id, path, hash of path's content)`. Due to this caching setup, it is normal for the first analysis to take some time, especially for larger projects, but future analyses of dependencies with the same information should be fast.
 
-In the event caching is causing problems, FOSSA can be made to rescan this kind of dependency:
-- Run `fossa analyze` with the `--force-vendored-dependency-rescans` flag, or
-- Set `vendoredDependencies.forceRescans` to `true` in `.fossa.yml` at the root of the project.
+In the event that caching is causing problems, FOSSA can be made to rescan this kind of dependency by:
+- Running `fossa analyze` with the `--force-vendored-dependency-rescans` flag, or
+- Setting `vendoredDependencies.forceRescans` to `true` in `.fossa.yml` at the root of the project.
 
 ## Limitations
 
 - Currently, path dependencies do not support vulnerability scanning.
-- Currently, path dependencies are only supported for `golang`.
+- Currently, path dependencies are only supported in:
+  - `golang` using the [gomod strategy](./../strategies/languages/golang/gomodules.md).
+  - PDM (Python) projects via the [pdm strategy](./../strategies/languages/python/pdm.md).
 
 ## F.A.Q
 
-### How do I enable path dependency in analysis?
+### How do I enable path dependency in FOSSA analysis?
 
-Run `fossa analyze` with the `--force-vendored-dependency-rescans` flag
+Run `fossa analyze` with the `--experimental-analyze-path-dependencies` flag.
 
-### How do I disable path dependency in analysis?
+### How do I disable path dependency in FOSSA analysis?
 
-By default, path dependency analysis is disabled.
+By default, path dependency analysis is disabled. Note that, in the future, `fossa-cli` will enable path dependency analysis by default.
 
-### Is `fossa-cli` uploading content of my path dependency to server?
+### Is `fossa-cli` uploading the content of my path dependency to the server?
 
-`fossa-cli` only upload findings of license scan result. 
+`fossa-cli` only uploads findings of the license scan result.
 
-## How are path dependencies different from Vendor dependencies?
+## How are path dependencies different from vendor dependencies?
 
-Path dependencies, unlike vendor dependencies can be either direct
-or transitive dependencies in the analysis graph. Furthermore, path
-dependencies are scoped to Project, as opposed to entire organization.
+Path dependencies, unlike vendor dependencies, can be either direct or transitive dependencies in the dependency graph, unlike [vendored dependencies](./../../features/vendored-dependencies.md). Furthermore, path dependencies are scoped to the project in FOSSA, as opposed to the entire organization.

--- a/docs/references/experimental/path-dependency.md
+++ b/docs/references/experimental/path-dependency.md
@@ -5,7 +5,7 @@
 Path dependency is a dependency, which is sourced from filesystem, as opposed to a package manager registry or URL. A path dependency may or may not have transitive dependencies. 
 Path dependency is also referred to as `local` or `vendor` dependency by some package managers.
 
-For example, in the following `go.mod` file, with `gomod` analysis and the `--experimental-analyze-path-dependencies` flag, `fossa-cli` would consider `../vendor/squirrel` a path dependency in the final dependency graph. If path dependency analysis is disabled, `fossa-cli` would ignore this dependency completely and only show transitive dependencies originating from `../vendor/squirrel`. In such a case, license and copyright obligations originating from `../vendor/squirrel` will not be captured in FOSSA's findings, and subsequent software bill of materials generated.
+For example, in the following `go.mod` file, with `gomod` analysis and the `--experimental-analyze-path-dependencies` flag, `fossa-cli` would consider `../vendor/squirrel`, to be a path dependency. If path dependency analysis is disabled, `fossa-cli` would ignore this dependency completely and only show transitive dependencies originating from `../vendor/squirrel`. In such a case, license and copyright obligations originating from `../vendor/squirrel` will not be captured in FOSSA's findings, and subsequent software bill of materials generated.
 
 ```go
 // Example go.mod file
@@ -55,4 +55,4 @@ disabled for all organizations. Please contact [FOSSA support](https://support.f
 
 ## How are path dependencies different from FOSSA's vendor dependencies?
 
-Path dependencies, unlike [vendored dependencies](./../../features/vendored-dependencies.md), can be either direct or transitive dependencies in the dependency graph. Furthermore, path dependencies are scoped to the project in FOSSA, as opposed to the entire organization.
+Path dependencies, unlike [vendored dependencies](./../../features/vendored-dependencies.md), can be either direct or transitive in the dependency graph. Furthermore, path dependencies are scoped to the project in FOSSA, as opposed to the entire organization.

--- a/docs/references/experimental/path-dependency.md
+++ b/docs/references/experimental/path-dependency.md
@@ -2,7 +2,8 @@
 
 ## What is path dependency?
 
-Path dependency is a reliance on the file system as the source, as opposed to a package manager registry or URL. A path dependency may or may not have transitive dependencies.
+Path dependency is a dependency, which is sourced from filesystem, as opposed to a package manager registry or URL. A path dependency may or may not have transitive dependencies. 
+Path dependency is also referred to as `local` or `vendor` dependency by some package managers.
 
 For example, in the following `go.mod` file, with `gomod` analysis and the `--experimental-analyze-path-dependencies` flag, `fossa-cli` would consider `../vendor/squirrel` a path dependency in the final dependency graph. If path dependency analysis is disabled, `fossa-cli` would ignore this dependency completely and only show transitive dependencies originating from `../vendor/squirrel`. In such a case, license and copyright obligations originating from `../vendor/squirrel` will not be captured in FOSSA's findings, and subsequent software bill of materials generated.
 
@@ -52,6 +53,6 @@ for your organization, `fossa-cli` will upload the full contents of any file tha
 disabled for all organizations. Please contact [FOSSA support](https://support.fossa.com) to enable, this functionality.
 
 
-## How are path dependencies different from vendor dependencies?
+## How are path dependencies different from FOSSA's vendor dependencies?
 
 Path dependencies, unlike [vendored dependencies](./../../features/vendored-dependencies.md), can be either direct or transitive dependencies in the dependency graph. Furthermore, path dependencies are scoped to the project in FOSSA, as opposed to the entire organization.

--- a/docs/references/experimental/path-dependency.md
+++ b/docs/references/experimental/path-dependency.md
@@ -47,8 +47,8 @@ By default, path dependency analysis is disabled. Note that, in the future, `fos
 
 ### Is `fossa-cli` uploading the content of my path dependency to the server?
 
-`fossa-cli` only uploads findings of the license scan, not the entire directory. If `cliLicenseScanRequireFullFileUpload` is enabled in FOSSA endpoint
-for your organization, `fossa-cli` will upload content of any file that has licensing data. By default,  `cliLicenseScanRequireFullFileUpload` is
+`fossa-cli` only uploads the portions of the file that contain matches to licenses, not the entire file. If `cliLicenseScanRequireFullFileUpload` is enabled in FOSSA endpoint
+for your organization, `fossa-cli` will upload the full contents of any file that has licensing data. By default,  `cliLicenseScanRequireFullFileUpload` is
 disabled for all organizations. Please contact [FOSSA support](https://support.fossa.com) to enable, this functionality.
 
 

--- a/docs/references/experimental/path-dependency.md
+++ b/docs/references/experimental/path-dependency.md
@@ -52,7 +52,6 @@ By default, path dependency analysis is disabled. Note that, in the future, `fos
 for your organization, `fossa-cli` will upload the full contents of any file that has licensing data. By default,  `cliLicenseScanRequireFullFileUpload` is
 disabled for all organizations. Please contact [FOSSA support](https://support.fossa.com) to enable, this functionality.
 
-
 ## How are path dependencies different from FOSSA's vendor dependencies?
 
 Path dependencies, unlike [vendored dependencies](./../../features/vendored-dependencies.md), can be either direct or transitive in the dependency graph. Furthermore, path dependencies are scoped to the project in FOSSA, as opposed to the entire organization.

--- a/docs/references/experimental/path-dependency.md
+++ b/docs/references/experimental/path-dependency.md
@@ -51,4 +51,4 @@ By default, path dependency analysis is disabled. Note that, in the future, `fos
 
 ## How are path dependencies different from vendor dependencies?
 
-Path dependencies, unlike vendor dependencies, can be either direct or transitive dependencies in the dependency graph, unlike [vendored dependencies](./../../features/vendored-dependencies.md). Furthermore, path dependencies are scoped to the project in FOSSA, as opposed to the entire organization.
+Path dependencies, unlike [vendored dependencies](./../../features/vendored-dependencies.md), can be either direct or transitive dependencies in the dependency graph. Furthermore, path dependencies are scoped to the project in FOSSA, as opposed to the entire organization.

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -75,14 +75,14 @@ replace github.com/Masterminds/squirrel => ../vendor/squirrel
 
 With this `go.mod` file and with [experimental path dependencies functionality](./../../../experimental/path-dependency.md) enabled, `fossa-cli` will
 correctly, include `../vendor/squirrel` in the dependency findings. It will identify transitive dependencies
-originating from package at `../vendor/squirrel`. Further, it will perform license scan in the directory to identify
+originating from package at `../vendor/squirrel`. It will also perform license scan in the directory to identify
 any license and copyright obligations. 
 
 Without [experimental path dependencies functionality](./../../../experimental/path-dependency.md) enabled, `fossa-cli` will not include `../vendor/squirrel` 
 in the dependency graph. Further, it will not show [path](https://docs.fossa.com/docs/dependencies-browser#transitive-dependencies) in FOSSA UI 
 for any of it's transitive dependencies.
 
-To learn how more, refer to [path dependency documentation](./../../../experimental/path-dependency.md)
+To learn more, refer to [path dependency documentation](./../../../experimental/path-dependency.md)
 
 ## Strategy: gomod
 

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -76,6 +76,11 @@ where:
 - `replace` rewrites `require`s. In this example, our requires resolve to
   `[github.com/example/one v1.2.3, github.com/example/other v2.0.0]`
 
+
+### Experimental: Path dependencies
+
+To learn more about path dependencies, refer to: [overview of path dependency](./../../../experimental/path-dependency.md)
+
 ## FAQ
 
 ### Why do I see a dependency in `go.mod`, but it is not reflected in FOSSA?

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -104,7 +104,6 @@ where:
 - `replace` rewrites `require`s. In this example, our requires resolve to
   `[github.com/example/one v1.2.3, github.com/example/other v2.0.0]`
 
-
 ## FAQ
 
 ### Why do I see a dependency in `go.mod`, but it is not reflected in FOSSA?

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -56,6 +56,34 @@ Currently, this strategy does not yet include path dependencies or their transit
 This strategy was previously available only under the `--experimental-use-v3-go-resolver` flag but is now the default.
 For more information about this transition please see this [document](./v3-go-resolver-transition-qa.md).
 
+### Experimental: Path dependencies
+
+`golist` strategy, supports experimental [path dependencies](./../../../experimental/path-dependency.md). It is not, 
+enabled by default, and has to be explicitly enabled by using `--experimental-analyze-path-dependencies` flag with `fossa analyze` command.
+
+In your project, you may have path dependencies, which are sourced from file system. For example, 
+consider `go.mod` file, which looks something like:
+
+```go
+module tester
+
+go 1.14
+
+require github.com/Masterminds/squirrel v1.4.0
+replace github.com/Masterminds/squirrel => ../vendor/squirrel
+```
+
+With this `go.mod` file and with [experimental path dependencies functionality](./../../../experimental/path-dependency.md) enabled, `fossa-cli` will
+correctly, include `../vendor/squirrel` in the dependency findings. It will identify transitive dependencies
+originating from package at `../vendor/squirrel`. Further, it will perform license scan in the directory to identify
+any license and copyright obligations. 
+
+Without [experimental path dependencies functionality](./../../../experimental/path-dependency.md) enabled, `fossa-cli` will not include `../vendor/squirrel` 
+in the dependency graph. Further, it will not show [path](https://docs.fossa.com/docs/dependencies-browser#transitive-dependencies) in FOSSA UI 
+for any of it's transitive dependencies.
+
+To learn how more, refer to [path dependency documentation](./../../../experimental/path-dependency.md)
+
 ## Strategy: gomod
 
 FOSSA CLI parses the go.mod file, which looks something like:
@@ -76,10 +104,6 @@ where:
 - `replace` rewrites `require`s. In this example, our requires resolve to
   `[github.com/example/one v1.2.3, github.com/example/other v2.0.0]`
 
-
-### Experimental: Path dependencies
-
-To learn more about path dependencies, refer to: [overview of path dependency](./../../../experimental/path-dependency.md)
 
 ## FAQ
 

--- a/docs/references/strategies/languages/python/pdm.md
+++ b/docs/references/strategies/languages/python/pdm.md
@@ -81,9 +81,8 @@ whereas white signifies unknown environment. If a dependency shared parent who h
 
 ### Limitations
 
-- Any [local dependencies](https://pdm.fming.dev/latest/usage/dependency/#local-dependencies) will not be reported.
-- Any dependeny using: `hg` (mercurial), `svn` (subversion), `bzr` (bazaar) source, will not be reported.
-
+- Any [local dependencies](https://pdm.fming.dev/latest/usage/dependency/#local-dependencies) will not be reported, by default. To enable, local dependencies in analysis, enable experimental path dependencies. Learn more about [path dependencies and how to enable them](./../../../experimental/path-dependency.md).
+- Any dependency using: `hg` (mercurial), `svn` (subversion), `bzr` (bazaar) source, will not be reported.
 
 ## Example
 

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -137,6 +137,8 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 | [`--experimental-skip-vsi-graph 'custom+1/some$locator'`](../experimental/msb/README.md) | Skip resolving the dependencies of the given project that was previously linked via `--experimental-link-project-binary`.                                                                      |
 | `--experimental-force-first-party-scans`                                                 | Force [first party scans](../../features/first-party-license-scans.md) to run                                                                                                                  |
 | `--experimental-block-first-party-scans`                                                 | Force [first party scans](../../features/first-party-license-scans.md) to not run. This can be used to forcibly turn off first-party scans if your organization defaults to first-party scans. |
+| `--experimental-analyze-path-dependencies`                                               | License scan path dependencies, and include them in the final analysis. For more information, see the [path dependency overview](../experimental/path-dependency.md).                          |
+
 
 ### F.A.Q.
 

--- a/integration-test/Analysis/FixtureUtils.hs
+++ b/integration-test/Analysis/FixtureUtils.hs
@@ -123,7 +123,7 @@ testRunnerWithLogger f env =
     & withDefaultLogger SevWarn
     & runReader (mempty :: OverrideDynamicAnalysisBinary)
     & runReader (mempty :: AllFilters)
-    & runReader (ExperimentalAnalyzeConfig Nothing GoModulesBasedTactic)
+    & runReader (ExperimentalAnalyzeConfig Nothing GoModulesBasedTactic False)
     & runFinally
     & runStack
     & withoutTelemetry

--- a/src/App/Docs.hs
+++ b/src/App/Docs.hs
@@ -6,6 +6,7 @@ module App.Docs (
   platformDocUrl,
   fossaSslCertDocsUrl,
   fossaContainerScannerUrl,
+  pathDependencyDocsUrl,
 ) where
 
 import App.Version (versionOrBranch)
@@ -37,3 +38,6 @@ fossaSslCertDocsUrl = guidePathOf versionOrBranch "/docs/walkthroughs/ssl-cert.m
 
 fossaContainerScannerUrl :: Text
 fossaContainerScannerUrl = guidePathOf versionOrBranch "/docs/references/subcommands/container/scanner.md"
+
+pathDependencyDocsUrl :: Text
+pathDependencyDocsUrl = guidePathOf versionOrBranch "/docs/references/experimental/path-dependency.md"

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -271,7 +271,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
       vendoredDepsOptions = Config.vendoredDeps cfg
       grepOptions = Config.grepOptions cfg
       customFossaDepsFile = Config.customFossaDepsFile cfg
-      shouldAnalyzePathDependencies = analyzePathDependencies $ Config.experimental cfg
+      shouldAnalyzePathDependencies = resolvePathDependencies $ Config.experimental cfg
 
   -- additional source units are built outside the standard strategy flow, because they either
   -- require additional information (eg API credentials), or they return additional information (eg user deps).

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -51,7 +51,7 @@ import App.Fossa.FirstPartyScan (runFirstPartyScan)
 import App.Fossa.Lernie.Analyze (analyzeWithLernie)
 import App.Fossa.Lernie.Types (LernieResults (..))
 import App.Fossa.ManualDeps (analyzeFossaDepsFile)
-import App.Fossa.PathDependency (enrichPathDependencies, enrichPathDependencies')
+import App.Fossa.PathDependency (enrichPathDependencies, enrichPathDependencies', withPathDependencyNudge)
 import App.Fossa.Subcommand (SubCommand)
 import App.Fossa.VSI.DynLinked (analyzeDynamicLinkedDeps)
 import App.Fossa.VSI.IAT.AssertRevisionBinaries (assertRevisionBinaries)
@@ -374,7 +374,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
         $ runStickyLogger SevInfo
         $ traverse (enrichPathDependencies includeAll vendoredDepsOptions revision) filteredProjects
     (True, _) -> pure $ map enrichPathDependencies' filteredProjects
-    (False, _) -> pure filteredProjects
+    (False, _) -> traverse (withPathDependencyNudge includeAll) filteredProjects
 
   let analysisResult = AnalysisScanResult projectScans vsiResults binarySearchResults manualSrcUnits dynamicLinkedResults maybeLernieResults
   renderScanSummary (severity cfg) maybeEndpointAppVersion analysisResult $ Config.filterSet cfg

--- a/src/App/Fossa/Analyze/Filter.hs
+++ b/src/App/Fossa/Analyze/Filter.hs
@@ -4,6 +4,7 @@ module App.Fossa.Analyze.Filter (
 ) where
 
 import App.Fossa.Analyze.Project (ProjectResult)
+import App.Fossa.Analyze.Types (DiscoveredProjectScan)
 import App.Fossa.Analyze.Upload (ScanUnits (..))
 import App.Fossa.Config.Analyze (IncludeAll (..))
 import Data.Flag (Flag, fromFlag)
@@ -21,18 +22,13 @@ data CountedResult
 -- that the smaller list is the latter, and return that list.  Starting with user-defined deps,
 -- we also include a check for an additional source unit from fossa-deps.yml
 -- and a check for any licenses found during the firstPartyScan
-checkForEmptyUpload :: Flag IncludeAll -> [ProjectResult] -> [ProjectResult] -> [SourceUnit] -> Maybe LicenseSourceUnit -> CountedResult
-checkForEmptyUpload includeAll xs ys additionalUnits firstPartyScanResults = do
+checkForEmptyUpload :: Flag IncludeAll -> [DiscoveredProjectScan] -> [ProjectResult] -> [SourceUnit] -> Maybe LicenseSourceUnit -> CountedResult
+checkForEmptyUpload includeAll discovered filtered additionalUnits firstPartyScanResults = do
   if null additionalUnits
-    then case (xlen, ylen, licensesMaybeFound) of
-      -- We didn't discover, so we also didn't filter
-      (0, 0, Nothing) ->
-        NoneDiscovered
-      (0, 0, Just licenseSourceUnit) ->
-        CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
-      -- If either list is empty, we have nothing to upload
-      (0, _, Nothing) -> FilteredAll
+    then case (discoveredLen, filteredLen, licensesMaybeFound) of
+      (0, _, Nothing) -> NoneDiscovered
       (_, 0, Nothing) -> FilteredAll
+      (0, 0, Just licenseSourceUnit) -> CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
       -- NE.fromList is a partial, but is safe since we confirm the length is > 0.
       (0, _, Just licenseSourceUnit) -> CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
       (_, 0, Just licenseSourceUnit) -> CountedScanUnits $ LicenseSourceUnitOnly licenseSourceUnit
@@ -43,8 +39,8 @@ checkForEmptyUpload includeAll xs ys additionalUnits firstPartyScanResults = do
       Nothing -> CountedScanUnits . SourceUnitOnly $ fromList (additionalUnits ++ discoveredUnits)
       Just licenseSourceUnit -> CountedScanUnits $ SourceAndLicenseUnits (fromList (additionalUnits ++ discoveredUnits)) licenseSourceUnit
   where
-    xlen = length xs
-    ylen = length ys
+    discoveredLen = length discovered
+    filteredLen = length filtered
     licensesMaybeFound = case firstPartyScanResults of
       Nothing -> Nothing
       Just scanResults ->
@@ -53,7 +49,6 @@ checkForEmptyUpload includeAll xs ys additionalUnits firstPartyScanResults = do
           else Nothing
 
     -- The smaller list is the post-filter list, since filtering cannot add projects
-    filtered = if xlen > ylen then ys else xs
     discoveredUnits = map (Srclib.projectToSourceUnit (fromFlag IncludeAll includeAll)) filtered
     isActualLicense :: LicenseUnit -> Bool
     isActualLicense licenseUnit = licenseUnitName licenseUnit /= "No_license_found"

--- a/src/App/Fossa/Config/ListTargets.hs
+++ b/src/App/Fossa/Config/ListTargets.hs
@@ -110,6 +110,7 @@ collectExperimental maybeCfg =
         (maybeCfg >>= configExperimental >>= gradle)
     )
     GoModulesBasedTactic -- This should be ok because its discovery should not work differently than the old Go modules tactic.
+    False -- This should be ok because discovery has no impact on whether, analysis includes path dependency or not!
 
 data ListTargetsCliOpts = ListTargetsCliOpts
   { commons :: CommonOpts

--- a/src/App/Fossa/Container/Sources/DockerArchive.hs
+++ b/src/App/Fossa/Container/Sources/DockerArchive.hs
@@ -179,6 +179,7 @@ analyzeLayer systemDepsOnly filters capabilities osInfo layerFs tarball = do
       ExperimentalAnalyzeConfig
         Nothing
         GoModulesBasedTactic -- Discovery is the same for both module and package centric analysis.
+        False -- Discovery has no consequence from path dependency analysis config
     toSourceUnit :: [DiscoveredProjectScan] -> [SourceUnit]
     toSourceUnit =
       map (Srclib.projectToSourceUnit False)
@@ -321,6 +322,7 @@ listTargetLayer capabilities osInfo layerFs tarball layerType = do
       ( ExperimentalAnalyzeConfig
           Nothing
           GoModulesBasedTactic -- Targets aren't different between package/module centric analysis for Go.
+          False -- Targets are not impacted by path dependencies.
       )
     . runReader (mempty :: AllFilters)
     $ run

--- a/src/App/Fossa/PathDependency.hs
+++ b/src/App/Fossa/PathDependency.hs
@@ -135,7 +135,7 @@ resolvePaths leaveUnfiltered options projectRevision org baseDir graph = do
       let alreadyScannedDeps = map (transformResolved alreadyAnalyzed) alreadyAnalyzedMeta
 
       -- 4. We scan and upload dependencies, and retrieve transformed dependencies!
-      scannedDeps <- traverse (scanUploadOrTransform Nothing fullFile projectRevision) notAnalyzedMeta
+      scannedDeps <- traverse (scanAndUpload Nothing fullFile projectRevision) notAnalyzedMeta
 
       -- 5. Kickoff job to finalize the build process for path dependencies
       let resolvedLoc = resolvedLocators scannedDeps
@@ -168,7 +168,7 @@ transformResolved alreadyAnalyzed (rawDep, _, version) = case maybeAlreadyAnalyz
     maybeAlreadyAnalyzed = find (\aa -> apdPath aa == dependencyName rawDep && adpVersion aa == version) alreadyAnalyzed
 
 -- | Performs license scanning and upload for single path dependency.
-scanUploadOrTransform ::
+scanAndUpload ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
   , Has Exec sig m
@@ -181,7 +181,7 @@ scanUploadOrTransform ::
   ProjectRevision ->
   (Dependency, SomeResolvedPath, Text) ->
   m (Dependency, Maybe Dependency)
-scanUploadOrTransform pathFilters fullFileUpload projectRevision (rawDep, resolvedPath, version) = context "Path Dependency" $ do
+scanAndUpload pathFilters fullFileUpload projectRevision (rawDep, resolvedPath, version) = context "Path Dependency" $ do
   maybeLicenseUnits <- recover scan
   case maybeLicenseUnits of
     Nothing -> pure (rawDep, Nothing)

--- a/src/App/Fossa/PathDependency.hs
+++ b/src/App/Fossa/PathDependency.hs
@@ -109,8 +109,8 @@ withPathDependencyNudge includeAll pr = do
       redText "NOTE: "
         <> "path dependency detected in project: "
         <> pretty projectLabel
-        <> "! To enable path dependency analysis. Use: --experimental-analyze-path-dependencies flag."
-        <> pretty ("See " <> pathDependencyDocsUrl <> " for more information.")
+        <> "! To enable path dependency analysis, use: --experimental-analyze-path-dependencies flag."
+        <> pretty (" See " <> pathDependencyDocsUrl <> " for more information.")
   pure pr
   where
     projectLabel :: Text

--- a/src/App/Fossa/PathDependency.hs
+++ b/src/App/Fossa/PathDependency.hs
@@ -39,7 +39,7 @@ import Control.Effect.Path ()
 import Control.Effect.StickyLogger (StickyLogger)
 import Control.Monad (unless, when)
 import Data.Flag (Flag, fromFlag)
-import Data.List (find)
+import Data.List (find, partition)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes, fromMaybe, isJust, mapMaybe)
 import Data.String.Conversion (toText)
@@ -152,7 +152,7 @@ resolvePaths leaveUnfiltered options projectRevision org baseDir graph = do
         if forceRescans options
           then pure []
           else getAnalyzedPathRevisions projectRevision
-      let (alreadyAnalyzedMeta, notAnalyzedMeta) = filter' (isAnalyzed alreadyAnalyzed) depsWithMetadata
+      let (alreadyAnalyzedMeta, notAnalyzedMeta) = partition (isAnalyzed alreadyAnalyzed) depsWithMetadata
       let alreadyScannedDeps = map (transformResolved alreadyAnalyzed) alreadyAnalyzedMeta
 
       -- 4. We scan and upload dependencies, and retrieve transformed dependencies!
@@ -305,6 +305,3 @@ metadataOf baseDir dep = case dependencyType dep of
     hash <- hashOf depPath'
     pure $ Just (dep, depPath', hash)
   _ -> pure Nothing
-
-filter' :: (a -> Bool) -> [a] -> ([a], [a])
-filter' f l = (filter f l, filter (not . f) l)

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -62,4 +62,5 @@ runFossaApiClient apiOpts =
           UploadContributors locator contributors -> Core.uploadContributors locator contributors
           UploadLicenseScanResult signedUrl licenseSourceUnit -> LicenseScanning.uploadLicenseScanResult signedUrl licenseSourceUnit
           UploadFirstPartyScanResult signedUrl fullSourceUnits -> LicenseScanning.uploadFirstPartyScanResult signedUrl fullSourceUnits
+          GetAnalyzedPathRevisions projectRevision -> LicenseScanning.alreadyAnalyzedPathRevision projectRevision
       )

--- a/src/Control/Carrier/FossaApiClient/Internal/LicenseScanning.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/LicenseScanning.hs
@@ -8,6 +8,7 @@ module Control.Carrier.FossaApiClient.Internal.LicenseScanning (
   uploadFirstPartyScanResult,
   uploadPathDependencyScanResult,
   finalizePathDependencyScan,
+  alreadyAnalyzedPathRevision,
 ) where
 
 import App.Types (FullFileUploads, ProjectRevision)
@@ -20,7 +21,7 @@ import Control.Effect.Lift (Lift)
 import Control.Effect.Reader (Reader, ask)
 import Control.Monad (void)
 import Data.List.NonEmpty qualified as NE
-import Fossa.API.Types (ApiOpts, ArchiveComponents, PathDependencyUpload, SignedURL)
+import Fossa.API.Types (AnalyzedPathDependenciesResp (analyzedPathDeps), AnalyzedPathDependency, ApiOpts, ArchiveComponents, PathDependencyUpload, SignedURL)
 import Srclib.Types (FullSourceUnit, LicenseSourceUnit, Locator)
 
 getSignedFirstPartyScanUrl ::
@@ -105,3 +106,15 @@ finalizePathDependencyScan ::
 finalizePathDependencyScan locators forceRebuild = do
   apiOpts <- ask
   void $ API.finalizePathDependencyScan apiOpts locators forceRebuild
+
+alreadyAnalyzedPathRevision ::
+  ( Has (Lift IO) sig m
+  , Has Diagnostics sig m
+  , Has Debug sig m
+  , Has (Reader ApiOpts) sig m
+  ) =>
+  ProjectRevision ->
+  m [AnalyzedPathDependency]
+alreadyAnalyzedPathRevision projectRevision = do
+  apiOpts <- ask
+  analyzedPathDeps <$> API.alreadyAnalyzedPathRevision apiOpts projectRevision

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -36,6 +36,7 @@ module Control.Effect.FossaApiClient (
   uploadContributors,
   uploadLicenseScanResult,
   uploadFirstPartyScanResult,
+  getAnalyzedPathRevisions,
 ) where
 
 import App.Fossa.Config.Report (ReportOutputFormat)
@@ -56,6 +57,8 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Text (Text)
 import Fossa.API.Types (
+  AnalyzedPathDependenciesResp,
+  AnalyzedPathDependency,
   ApiOpts,
   Archive,
   ArchiveComponents,
@@ -98,6 +101,7 @@ data FossaApiClientF a where
   GetOrganization :: FossaApiClientF Organization
   GetProject :: ProjectRevision -> FossaApiClientF Project
   GetAnalyzedRevisions :: NonEmpty VendoredDependency -> FossaApiClientF [Text]
+  GetAnalyzedPathRevisions :: ProjectRevision -> FossaApiClientF [AnalyzedPathDependency]
   GetSignedFirstPartyScanUrl :: PackageRevision -> FossaApiClientF SignedURL
   GetSignedLicenseScanUrl :: PackageRevision -> FossaApiClientF SignedURL
   GetPathDependencyScanUrl :: PackageRevision -> ProjectRevision -> FullFileUploads -> FossaApiClientF PathDependencyUpload
@@ -194,6 +198,9 @@ assertUserDefinedBinaries meta fprints = sendSimple (AssertUserDefinedBinaries m
 
 getAnalyzedRevisions :: Has FossaApiClient sig m => NonEmpty VendoredDependency -> m ([Text])
 getAnalyzedRevisions = sendSimple . GetAnalyzedRevisions
+
+getAnalyzedPathRevisions :: Has FossaApiClient sig m => ProjectRevision -> m [AnalyzedPathDependency]
+getAnalyzedPathRevisions = sendSimple . GetAnalyzedPathRevisions
 
 getSignedFirstPartyScanUrl :: Has FossaApiClient sig m => PackageRevision -> m SignedURL
 getSignedFirstPartyScanUrl = sendSimple . GetSignedFirstPartyScanUrl

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -57,7 +57,6 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Text (Text)
 import Fossa.API.Types (
-  AnalyzedPathDependenciesResp,
   AnalyzedPathDependency,
   ApiOpts,
   Archive,

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -29,6 +29,8 @@ module Fossa.API.Types (
   UploadResponse (..),
   PathDependencyUploadReq (..),
   PathDependencyFinalizeReq (..),
+  AnalyzedPathDependenciesResp (..),
+  AnalyzedPathDependency (..),
   useApiOpts,
   defaultApiPollDelay,
   blankOrganization,
@@ -823,4 +825,25 @@ instance FromJSON UploadedPathDependencyLocator where
   parseJSON = withObject "UploadedPathDependencyLocator" $ \obj ->
     UploadedPathDependencyLocator
       <$> obj .: "name"
+      <*> obj .: "version"
+
+newtype AnalyzedPathDependenciesResp = AnalyzedPathDependenciesResp {analyzedPathDeps :: [AnalyzedPathDependency]}
+  deriving (Eq, Ord, Show)
+
+instance FromJSON AnalyzedPathDependenciesResp where
+  parseJSON = withObject "AnalyzedPathDependenciesResp" $ \obj ->
+    AnalyzedPathDependenciesResp <$> obj .: "data"
+
+data AnalyzedPathDependency = AnalyzedPathDependency
+  { apdPath :: Text
+  , adpId :: Text
+  , adpVersion :: Text
+  }
+  deriving (Eq, Ord, Show)
+
+instance FromJSON AnalyzedPathDependency where
+  parseJSON = withObject "AnalyzedPathDependency" $ \obj ->
+    AnalyzedPathDependency
+      <$> obj .: "path"
+      <*> obj .: "id"
       <*> obj .: "version"

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -49,15 +49,15 @@ import Srclib.Types (
  )
 import Types (DiscoveredProjectType, GraphBreadth (..))
 
-projectToSourceUnit :: Bool -> ProjectResult -> SourceUnit
-projectToSourceUnit leaveUnfiltered ProjectResult{..} =
-  toSourceUnit leaveUnfiltered renderedPath projectResultGraph projectResultType projectResultGraphBreadth originPaths
+projectToSourceUnit :: Bool -> Bool -> ProjectResult -> SourceUnit
+projectToSourceUnit isOutputOnly leaveUnfiltered ProjectResult{..} =
+  toSourceUnit isOutputOnly leaveUnfiltered renderedPath projectResultGraph projectResultType projectResultGraphBreadth originPaths
   where
     renderedPath = toText (toFilePath projectResultPath)
     originPaths = map somePathToOriginPath projectResultManifestFiles
 
-toSourceUnit :: Bool -> Text -> Graphing Dependency -> DiscoveredProjectType -> GraphBreadth -> [OriginPath] -> SourceUnit
-toSourceUnit leaveUnfiltered path dependencies projectType graphBreadth originPaths =
+toSourceUnit :: Bool -> Bool -> Text -> Graphing Dependency -> DiscoveredProjectType -> GraphBreadth -> [OriginPath] -> SourceUnit
+toSourceUnit isOutputOnly leaveUnfiltered path dependencies projectType graphBreadth originPaths =
   SourceUnit
     { sourceUnitName = path
     , sourceUnitType = toText projectType
@@ -78,10 +78,14 @@ toSourceUnit leaveUnfiltered path dependencies projectType graphBreadth originPa
     filteredGraph :: Graphing Dependency
     filteredGraph = Graphing.shrinkWithoutPromotionToDirect ff dependencies
       where
+        isSupportedType' :: Dependency -> Bool
+        isSupportedType' = if isOutputOnly then isSupportedForOutputDestination else isSupportedType
+
+        ff :: Dependency -> Bool
         ff =
           if leaveUnfiltered
-            then isSupportedType
-            else (\d -> shouldPublishDep d && isSupportedType d)
+            then isSupportedType'
+            else (\d -> shouldPublishDep d && isSupportedType' d)
 
     locatorGraph :: Graphing Locator
     locatorGraph = Graphing.gmap toLocator filteredGraph
@@ -117,6 +121,12 @@ isSupportedType Dependency{dependencyType} =
     && dependencyType /= GooglesourceType
     && dependencyType /= ConanType
     && dependencyType /= UnresolvedPathType
+
+isSupportedForOutputDestination :: Dependency -> Bool
+isSupportedForOutputDestination Dependency{dependencyType} =
+  dependencyType /= SubprojectType
+    && dependencyType /= GooglesourceType
+    && dependencyType /= ConanType
 
 toLocator :: Dependency -> Locator
 toLocator dep =

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -78,7 +78,6 @@ toSourceUnit leaveUnfiltered path dependencies projectType graphBreadth originPa
     filteredGraph :: Graphing Dependency
     filteredGraph = Graphing.shrinkWithoutPromotionToDirect ff dependencies
       where
-        ff :: Dependency -> Bool
         ff =
           if leaveUnfiltered
             then isSupportedType

--- a/src/Strategy/Python/PDM/PdmLock.hs
+++ b/src/Strategy/Python/PDM/PdmLock.hs
@@ -95,9 +95,10 @@ toDependency prodReqs devReqs pkg =
       _ -> mempty
 
     depName :: Text
-    depName = case (gitUrl pkg, url pkg) of
-      (Just url, _) -> url
-      (_, Just u) -> u
+    depName = case (gitUrl pkg, fsPath pkg, url pkg) of
+      (Just url, _, _) -> url
+      (_, _, Just u) -> u
+      (_, Just p, _) -> p
       _ -> name pkg
 
     depVersion :: Maybe VerConstraint

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -2,7 +2,7 @@ module App.DocsSpec (
   spec,
 ) where
 
-import App.Docs (fossaContainerScannerUrl, fossaYmlDocUrl, newIssueUrl, userGuideUrl)
+import App.Docs (fossaContainerScannerUrl, fossaYmlDocUrl, newIssueUrl, pathDependencyDocsUrl, userGuideUrl)
 import Data.Foldable (for_)
 import Data.Maybe (fromJust)
 import Data.String.Conversion (toString)
@@ -67,6 +67,7 @@ urlsToCheck =
   , refGradleDocUrl
   , scalaFossaDocUrl
   , sbtDepsGraphPluginUrl
+  , pathDependencyDocsUrl
   ]
 
 spec :: Spec

--- a/test/App/Fossa/PathDependencySpec.hs
+++ b/test/App/Fossa/PathDependencySpec.hs
@@ -124,7 +124,7 @@ enrichPathDependenciesSpec = describe "enrichPathDependencies" $ do
     result' <- enrichPathDependencies includeAll noRescanOption pr result
     result' `shouldBe'` result
 
-  it' "should perform upload path deps, if path dependency is not already analyzed" $ do
+  it' "should perform path dependency scan and upload, if path dependency is not already analyzed" $ do
     expectOrg orgSupportPathDeps
     expectPathDependencyMatchData
     expectLicenseScanUpload
@@ -137,7 +137,7 @@ enrichPathDependenciesSpec = describe "enrichPathDependencies" $ do
     result' <- enrichPathDependencies includeAll noRescanOption pr result
     result' `shouldBe'` expectedResult
 
-  it' "should perform not upload path deps, if path dependency is already analyzed" $ do
+  it' "should not perform path dependency scan and upload, if path dependency is already analyzed" $ do
     expectOrg orgSupportPathDeps{orgRequiresFullFileUploads = False}
     expectAnalyzedPathRevisions
 

--- a/test/Container/RegistryApiSpec.hs
+++ b/test/Container/RegistryApiSpec.hs
@@ -177,7 +177,7 @@ redisImageDigest :: RepoDigest
 redisImageDigest = RepoDigest "sha256:dd347200af9dbdb9a5f55851d1a0b8b5fb89462b94e84ac0bba89dfec30504fb"
 
 haskellDevImage :: Text
-haskellDevImage = "ghcr.io/fossas/haskell-dev-tools:9.4.7"
+haskellDevImage = "ghcr.io/fossas/haskell-dev-tools:9.0.2"
 
 haskellDevImageDigest :: RepoDigest
-haskellDevImageDigest = RepoDigest "sha256:10ba4a4661507aa7974eae873644b740ea0e168f2fc1e56c10adc845f1cffa25"
+haskellDevImageDigest = RepoDigest "sha256:06541fab718090e2d346e0313d3f1e841d1ea2b157630ad76ca20eb1507a4223"

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -389,6 +389,7 @@ experimentalConfig =
   ExperimentalAnalyzeConfig
     { allowedGradleConfigs = Nothing
     , useV3GoResolver = GoModulesBasedTactic
+    , analyzePathDependencies = False
     }
 
 vendoredDepsOptions :: VendoredDependencyOptions

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -389,7 +389,7 @@ experimentalConfig =
   ExperimentalAnalyzeConfig
     { allowedGradleConfigs = Nothing
     , useV3GoResolver = GoModulesBasedTactic
-    , analyzePathDependencies = False
+    , resolvePathDependencies = False
     }
 
 vendoredDepsOptions :: VendoredDependencyOptions

--- a/test/Test/MockApi.hs
+++ b/test/Test/MockApi.hs
@@ -231,6 +231,7 @@ matchExpectation a@(UploadContributors{}) (ApiExpectation _ requestExpectation b
 matchExpectation a@(UploadLicenseScanResult{}) (ApiExpectation _ requestExpectation b@(UploadLicenseScanResult{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetPathDependencyScanUrl{}) (ApiExpectation _ requestExpectation b@(GetPathDependencyScanUrl{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(FinalizeLicenseScanForPathDependency{}) (ApiExpectation _ requestExpectation b@(FinalizeLicenseScanForPathDependency{}) resp) = checkResult requestExpectation a b resp
+matchExpectation a@(GetAnalyzedPathRevisions{}) (ApiExpectation _ requestExpectation b@(GetAnalyzedPathRevisions{}) resp) = checkResult requestExpectation a b resp
 matchExpectation _ _ = Nothing
 
 -- | Handles a request in the context of the mock API.


### PR DESCRIPTION
# Overview

This PR is part of the chain, and will not be merged until `CORE` pr is merged!

- Adds path dependency documentation
- Adds path dependency optimization (avoid rescanning if already scanned)
- Adds path dependency nudge (warn users that they have path dependency, and should use experimental flag) 
- Address PR feedback from PR chain 

## Acceptance criteria

As a user, 
- [ ] `fossa-cli` can license scan path dependencies, only when `` flag is present
- [ ] `fossa-cli` nudges to enable path dependencies, if I have path dependency in my project
- [ ] `fossa-cli` does not scan dependency again, if they have already been analyzed
- [ ] `fossa-cli` can be forced to scan dependency again

## Testing plan

- I relied on automated testing.

Load the endpoint from: https://github.com/fossas/FOSSA/pull/11392

1. Create example: (refer to repro case here: https://fossa.atlassian.net/browse/ANE-383)
2. Build `make install-dev`
3. Perform `fossa-dev analyze -e http://localhost:9578 --fossa-api-key <KEY> repro -p path-dep-1 -r 1 --experimental-analyze-path-dependencies`
4. Perform `fossa-dev analyze -e http://localhost:9578 --fossa-api-key <KEY> repro -p path-dep-1 -r 2 --experimental-analyze-path-dependencies` (since path dep is already scanned, you should not see upload/scan msg again)
5. Perform `fossa-dev analyze -e http://localhost:9578 --fossa-api-key <KEY> repro -p path-dep-1 -r 3 --experimental-analyze-path-dependencies --force-vendored-dependency-rescans` (performs upload/scan again)

## Risks

N/A

## References

https://fossa.atlassian.net/browse/ANE-1092

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
