### PR TITLE
[FDN-70] Custom licenses should upload file contents if the org requires full-file uploads

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.8.23
+- Custom License Scans: Support full-file uploads for custom license scans ([#1333](https://github.com/fossas/fossa-cli/pull/1333))
+
 ## v3.8.22
 - path: adds path dependency scanning functionality. ([#1327](https://github.com/fossas/fossa-cli/pull/1327))
 - `pnpm`: Supports `6.0` version of `pnpm-lockfile.yaml` ([#1320])(https://github.com/fossas/fossa-cli/pull/1320)

--- a/src/App/Fossa/Lernie/Types.hs
+++ b/src/App/Fossa/Lernie/Types.hs
@@ -16,7 +16,7 @@ module App.Fossa.Lernie.Types (
   LernieScanType (..),
 ) where
 
-import Data.Aeson (FromJSON, KeyValue ((.=)), ToJSON (toJSON), Value (Object), defaultOptions, genericToEncoding, object, withObject, withText)
+import Data.Aeson (FromJSON, KeyValue ((.=)), ToJSON (toJSON), Value (Object), defaultOptions, genericToEncoding, object, withObject, withText, (.:?))
 import Data.Aeson qualified as A
 import Data.Aeson.Types ((.:))
 import Data.String.Conversion (ToText (toText))
@@ -131,6 +131,7 @@ instance FromJSON LernieMessageType where
 data LernieMatch = LernieMatch
   { lernieMatchPath :: Text
   , lernieMatchMatches :: [LernieMatchData]
+  , lernieMatchContents :: Maybe Text
   }
   deriving (Eq, Ord, Show, Generic)
 
@@ -139,6 +140,7 @@ instance FromJSON LernieMatch where
     LernieMatch
       <$> (obj .: "path")
       <*> (obj .: "matches")
+      <*> (obj .:? "contents")
 
 data LernieWarning = LernieWarning
   { lernieWarningMessage :: Text
@@ -233,6 +235,7 @@ instance FromJSON LernieMessage where
         Object d <- o .: "data"
         let path = d .: "path"
         let matches = d .: "matches"
-        match <- LernieMatch <$> path <*> matches
+        let contents = d .:? "contents"
+        match <- LernieMatch <$> path <*> matches <*> contents
         pure $ LernieMessageLernieMatch match
   parseJSON _ = fail "Invalid schema for LernieMessage. It must be an object"

--- a/src/App/Fossa/Lernie/Types.hs
+++ b/src/App/Fossa/Lernie/Types.hs
@@ -70,6 +70,7 @@ instance FromJSON GrepEntry where
 data LernieConfig = LernieConfig
   { rootDir :: Path Abs Dir
   , regexes :: [LernieRegex]
+  , fullFiles :: Bool
   }
   deriving (Eq, Ord, Show, Generic)
 
@@ -78,6 +79,7 @@ instance ToJSON LernieConfig where
     object
       [ "root_dir" .= toText rootDir
       , "regexes" .= toJSON regexes
+      , "full_files" .= fullFiles
       ]
 
 data LernieRegex = LernieRegex

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -45,6 +45,7 @@ customLicenseLernieMatchData =
 -- `extraLineBytes * (lineNumber - 1)` to the bytes.
 -- (line-numbers are 1-indexed, and you have only encountered lineNumber - 1 newLines when you are on line n,
 -- so you have to subtract 1 from them).
+
 extraLineBytes :: Integer
 #ifdef mingw32_HOST_OS
 extraLineBytes = 1
@@ -362,8 +363,10 @@ spec = do
             Just licenseUnits -> do
               let licenseUnitDatas = concatMap (NE.toList . licenseUnitData) licenseUnits
               let contents = map licenseUnitDataContents licenseUnitDatas
+              -- fix newlines on windows so that we get the same contents on both Windows and other OSes
+              let fixedContents = map (fmap $ Text.replace "\r\n" "\n") contents
               -- The result from the .fossa.yml file will be filtered out in actual usage
-              contents
+              fixedContents
                 `shouldBe'` [ Just "# I should not find a Proprietary License in this file, because it is the .fossa.yml file\nversion: 3\n"
                             , Just "This is a Proprietary License.\n\nIs this a Proprietary License too?\n\nThrow in a third Proprietary License just for fun\n"
                             , Just "Keyword Searches are great!\n\nThis file is very confidential\n"

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -364,12 +364,12 @@ spec = do
               let licenseUnitDatas = concatMap (NE.toList . licenseUnitData) licenseUnits
               let contents = map licenseUnitDataContents licenseUnitDatas
               -- fix newlines on windows so that we get the same contents on both Windows and other OSes
-              let fixedContents = map (Text.replace "\r\n" "\n" <$>) contents
+              let fixedContents = sort $ map (Text.replace "\r\n" "\n" <$>) contents
               -- The result from the .fossa.yml file will be filtered out in actual usage
               fixedContents
                 `shouldBe'` [ Just "# I should not find a Proprietary License in this file, because it is the .fossa.yml file\nversion: 3\n"
-                            , Just "This is a Proprietary License.\n\nIs this a Proprietary License too?\n\nThrow in a third Proprietary License just for fun\n"
                             , Just "Keyword Searches are great!\n\nThis file is very confidential\n"
+                            , Just "This is a Proprietary License.\n\nIs this a Proprietary License too?\n\nThrow in a third Proprietary License just for fun\n"
                             ]
 
     it' "should not include the file contents if the org has the full-files flag off" $ do

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -359,6 +359,7 @@ spec = do
           let licenseUnits = licenseSourceUnitLicenseUnits (fromJust sourceUnit)
           let licenseUnitDatas = concatMap (NE.toList . licenseUnitData) licenseUnits
           let contents = map licenseUnitDataContents licenseUnitDatas
+          -- The result from the .fossa.yml file will be filtered out in actual usage
           contents
             `shouldBe'` [ Just "# I should not find a Proprietary License in this file, because it is the .fossa.yml file\nversion: 3\n"
                         , Just "This is a Proprietary License.\n\nIs this a Proprietary License too?\n\nThrow in a third Proprietary License just for fun\n"

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -46,7 +46,11 @@ customLicenseLernieMatchData =
 -- (line-numbers are 1-indexed, and you have only encountered lineNumber - 1 newLines when you are on line n,
 -- so you have to subtract 1 from them).
 extraLineBytes :: Integer
+#ifdef mingw32_HOST_OS
+extraLineBytes = 1
+#else
 extraLineBytes = 0
+#endif
 
 secondCustomLicenseLernieMatchData :: LernieMatchData
 secondCustomLicenseLernieMatchData =

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -364,7 +364,7 @@ spec = do
               let licenseUnitDatas = concatMap (NE.toList . licenseUnitData) licenseUnits
               let contents = map licenseUnitDataContents licenseUnitDatas
               -- fix newlines on windows so that we get the same contents on both Windows and other OSes
-              let fixedContents = map (fmap $ Text.replace "\r\n" "\n") contents
+              let fixedContents = map (Text.replace "\r\n" "\n" <$>) contents
               -- The result from the .fossa.yml file will be filtered out in actual usage
               fixedContents
                 `shouldBe'` [ Just "# I should not find a Proprietary License in this file, because it is the .fossa.yml file\nversion: 3\n"

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -8,6 +8,7 @@ module App.Fossa.LernieSpec (
 
 import App.Fossa.Lernie.Analyze (analyzeWithLernie, analyzeWithLernieWithOrgInfo, grepOptionsToLernieConfig, lernieMessagesToLernieResults, singletonLernieMessage)
 import App.Fossa.Lernie.Types (GrepEntry (..), GrepOptions (..), LernieConfig (..), LernieError (..), LernieMatch (..), LernieMatchData (..), LernieMessage (..), LernieMessages (..), LernieRegex (..), LernieResults (..), LernieScanType (..), LernieWarning (..), OrgWideCustomLicenseConfigPolicy (..))
+import App.Types (FullFileUploads (..))
 import Control.Carrier.Debug (ignoreDebug)
 import Control.Carrier.Telemetry (withoutTelemetry)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
@@ -45,11 +46,7 @@ customLicenseLernieMatchData =
 -- (line-numbers are 1-indexed, and you have only encountered lineNumber - 1 newLines when you are on line n,
 -- so you have to subtract 1 from them).
 extraLineBytes :: Integer
-#ifdef mingw32_HOST_OS
-extraLineBytes = 1
-#else
 extraLineBytes = 0
-#endif
 
 secondCustomLicenseLernieMatchData :: LernieMatchData
 secondCustomLicenseLernieMatchData =
@@ -143,11 +140,7 @@ expectedDoubleLernieResults =
     }
 
 absDir :: Path Abs Dir
-#ifdef mingw32_HOST_OS
-absDir = $(mkAbsDir "C:/")
-#else
 absDir = $(mkAbsDir "/tmp/one")
-#endif
 
 expectedSourceUnit :: LicenseSourceUnit
 expectedSourceUnit =
@@ -258,6 +251,7 @@ expectedLernieConfig =
   LernieConfig
     { rootDir = absDir
     , regexes = [customLicenseLernieRegex, keywordSearchLernieRegex]
+    , fullFiles = False
     }
 
 keywordSearchLernieRegex :: LernieRegex
@@ -300,7 +294,7 @@ spec = do
 
   describe "grepOptionsToLernieConfig" $ do
     it "should create a lernie config" $ do
-      (grepOptionsToLernieConfig absDir grepOptions) `shouldBe` Just expectedLernieConfig
+      grepOptionsToLernieConfig absDir grepOptions (FullFileUploads False) `shouldBe` Just expectedLernieConfig
 
   describe "analyzeWithLernie" $ do
     currDir <- runIO getCurrentDir

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -46,7 +46,11 @@ customLicenseLernieMatchData =
 -- (line-numbers are 1-indexed, and you have only encountered lineNumber - 1 newLines when you are on line n,
 -- so you have to subtract 1 from them).
 extraLineBytes :: Integer
+#ifdef mingw32_HOST_OS
+extraLineBytes = 1
+#else
 extraLineBytes = 0
+#endif
 
 secondCustomLicenseLernieMatchData :: LernieMatchData
 secondCustomLicenseLernieMatchData =
@@ -143,7 +147,11 @@ expectedDoubleLernieResults =
     }
 
 absDir :: Path Abs Dir
+#ifdef mingw32_HOST_OS
+absDir = $(mkAbsDir "C:/")
+#else
 absDir = $(mkAbsDir "/tmp/one")
+#endif
 
 expectedSourceUnit :: LicenseSourceUnit
 expectedSourceUnit =

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -147,7 +147,11 @@ expectedDoubleLernieResults =
     }
 
 absDir :: Path Abs Dir
+#ifdef mingw32_HOST_OS
+absDir = $(mkAbsDir "C:/")
+#else
 absDir = $(mkAbsDir "/tmp/one")
+#endif
 
 expectedSourceUnit :: LicenseSourceUnit
 expectedSourceUnit =

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -372,7 +372,7 @@ spec = do
       case result of
         Nothing -> expectationFailure' "analyzeWithLernie should not return Nothing"
         Just res -> do
-          -- Just assert that we find the contents of the files
+          -- Just assert that the contents are all `Nothing`
           let sourceUnit = lernieResultsSourceUnit res
           let licenseUnits = licenseSourceUnitLicenseUnits (fromJust sourceUnit)
           let licenseUnitDatas = concatMap (NE.toList . licenseUnitData) licenseUnits

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -71,6 +71,7 @@ customLicenseMatchMessage =
   LernieMatch
     { lernieMatchPath = toText . toFilePath $ absDir </> $(mkRelDir "two.txt")
     , lernieMatchMatches = [customLicenseLernieMatchData]
+    , lernieMatchContents = Nothing
     }
 
 secondCustomLicenseMatchMessage :: LernieMatch
@@ -78,6 +79,7 @@ secondCustomLicenseMatchMessage =
   LernieMatch
     { lernieMatchPath = toText . toFilePath $ absDir </> $(mkRelDir "two.txt")
     , lernieMatchMatches = [secondCustomLicenseLernieMatchData]
+    , lernieMatchContents = Nothing
     }
 
 keywordSearchLernieMatchData :: LernieMatchData
@@ -98,6 +100,7 @@ keywordSearchMatchMessage =
   LernieMatch
     { lernieMatchPath = toText . toFilePath $ absDir </> $(mkRelDir "two.txt")
     , lernieMatchMatches = [keywordSearchLernieMatchData]
+    , lernieMatchContents = Nothing
     }
 
 warningMessage :: LernieWarning


### PR DESCRIPTION
# Overview

Pass the `full_files` config option into Lernie, getting its value from the org's full-file-uploads feature flag.

The `full_files` config option was added to Lernie in https://github.com/fossas/lernie/pull/32

## Acceptance criteria

- We should include the contents of the files in the upload to S3 if the org has the full-file-uploads feature flag turned on

## Testing plan

Download the lernie binary from this release: https://github.com/fossas/lernie/releases/tag/v0.1.1-beta

Put it in vendor-bins and make it executable.

```
cargo clean
make install-dev
```

Download this zip file and unzip it:

[grepper.zip](https://github.com/fossas/fossa-cli/files/13453156/grepper.zip)

Add some org-wide custom license scans to your config. Mine looks like this:

<img width="1600" alt="CleanShot 2023-11-23 at 11 59 06@2x" src="https://github.com/fossas/fossa-cli/assets/13045/8787be66-cffc-48a0-b754-55c1127d6f67">

Run `fossa-dev analyze` with and without the "Full-file uploads for CLI License Scans" on for your org.

With it on, you should see the full contents of the file in the match output

<img width="1055" alt="CleanShot 2023-11-23 at 12 00 56@2x" src="https://github.com/fossas/fossa-cli/assets/13045/8c0861ae-4ca1-498e-9898-762d234c2ebb">

With it off, you should see just the parts of the file that matched:

<img width="973" alt="CleanShot 2023-11-23 at 12 02 12@2x" src="https://github.com/fossas/fossa-cli/assets/13045/884c2e1f-e0c8-4848-a585-88c0eeeae186">


## Risks


## Metrics


## References

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
