### PR TITLE
[ANE-1233] Export lernie and modify serialization to match deserialization

### DIFF
--- a/src/App/Fossa/Lernie/Analyze.hs
+++ b/src/App/Fossa/Lernie/Analyze.hs
@@ -2,6 +2,8 @@
 
 module App.Fossa.Lernie.Analyze (
   analyzeWithLernie,
+  -- Exported for use in hubble
+  analyzeWithLernieMain,
   -- Exported for testing
   analyzeWithLernieWithOrgInfo,
   singletonLernieMessage,

--- a/src/App/Fossa/Lernie/Types.hs
+++ b/src/App/Fossa/Lernie/Types.hs
@@ -57,7 +57,11 @@ data GrepEntry = GrepEntry
   deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON GrepEntry where
-  toEncoding = genericToEncoding defaultOptions
+  toJSON (GrepEntry matchCriteria name) =
+    object
+      [ "matchCriteria" .= matchCriteria
+      , "name" .= name
+      ]
 
 instance FromJSON GrepEntry where
   parseJSON = withObject "GrepEntry" $ \obj ->


### PR DESCRIPTION
# Overview

- As part of adding custom license scans to hubble, this PR exports `analyzeWithLernieMain` so we can include full file licenses (which we default to in hubble). It also modifies the serialization of `GrepEntry` to match what we require to de-serialize. 

## Acceptance criteria

- you can serialize and deserialize GrepEntry values
- `analyzeWithLernieMain` is exported

## Testing plan

- not much to test, you could try serializing a grep entry cabal repl:
```
import Data.Aeson
import Data.Maybe
import App.Fossa.Lernie.Types

encode $ fromJust $ decode @GrepEntry "{\"matchCriteria\": \"license\", \"name\": \"test\"}" 
```

## Risks

- I didnt see any where in the code we expect GrepEntry to deserialize as "grepEntryMatchCriteria" nor "grepEntryName", so should be minimal.

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

_Example:_

part of [ANE-1233](https://fossa.atlassian.net/browse/ANE-1233)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1233]: https://fossa.atlassian.net/browse/ANE-1233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ