### PR TITLE
Fix the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Dependency scan](https://img.shields.io/github/actions/workflow/status/fossas/fossa-cli/dependency-scan.yml?label=dependency%20scan)](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml)
 [![FOSSA Security Status](https://app.fossa.com/api/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli.svg?type=shield&issueType=security)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield)
 
-[![FOSSA License Status](https://app.fossa.com/api/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli.svg?type=large)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_large)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli.svg?type=large&issueType=license)](https://app.fossa.com/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli?ref=badge_large&issueType=license)
 <!-- markdown-link-check-enable-->
 
 `fossa-cli` is a zero-configuration polyglot dependency analysis tool. You can point fossa CLI at any codebase or build, and it will automatically detect dependencies being used by your project.


### PR DESCRIPTION
# Overview

We used to have several internal listings for the "FOSSA CLI" project in the FOSSA org, which were there because people were using them to test analysis internally.

However, we recently cleaned these up and chose a canonical one. Unfortunately, we didn't update the license badge at the time, so when clicked the license badge linked to a project that was not found! Also, the badge displayed out of date information. 

This PR fixes the badge.

Rendered view: https://github.com/fossas/fossa-cli/tree/update-badge#fossa-cli

## Acceptance criteria

- The badge displays the correct information.
- The badge, when clicked, opens the correct project.
- The link can be clicked when not logged in to FOSSA and the results are still viewable.

## Testing plan

I manually tested.

## Risks

None

## Metrics

None

## References

https://teamfossa.slack.com/archives/C0394ULAUG7/p1701458922508419

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
