### PR TITLE
[FDN-82] Maven dependencies that override the build directory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 # FOSSA CLI Changelog
-## Unreleased
+## v3.8.27
 - Maven: Fix a bug that broke maven analysis if the build directory was in a non-standard location ([#1343](https://github.com/fossas/fossa-cli/pull/1343))
 
 ## v3.8.26

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 # FOSSA CLI Changelog
+## Unreleased
+- Maven: Fix a bug that broke maven analysis if the build directory was in a non-standard location ([#1343](https://github.com/fossas/fossa-cli/pull/1343))
 
 ## v3.8.26
 - Maven: add support for maven submodule filtering [#1339](https://github.com/fossas/fossa-cli/pull/1339)

--- a/integration-test/Analysis/MavenSpec.hs
+++ b/integration-test/Analysis/MavenSpec.hs
@@ -102,17 +102,29 @@ testGuava =
 
 testSimplePomFile :: Spec
 testSimplePomFile = do
-  aroundAll (withAnalysisOf simplePomFile) $ do
-    describe "simple POM file" $ do
-      it "should find targets" $ \(result, extractedDir) ->
-        expectProject (MavenProjectType, extractedDir) result
+  testSuiteDepResultSummary
+    simplePomFile
+    Types.MavenProjectType
+    DependencyResultsSummary
+      { numDeps = 3
+      , numDirectDeps = 1
+      , numEdges = 2
+      , numManifestFiles = 1
+      , graphType = Complete
+      }
 
 testBuildDirOverride :: Spec
 testBuildDirOverride = do
-  aroundAll (withAnalysisOf pomFileWithBuildDirOverride) $ do
-    describe "POM file with build-directory override" $ do
-      it "should find targets" $ \(result, extractedDir) ->
-        expectProject (MavenProjectType, extractedDir) result
+  testSuiteDepResultSummary
+    pomFileWithBuildDirOverride
+    Types.MavenProjectType
+    DependencyResultsSummary
+      { numDeps = 3
+      , numDirectDeps = 1
+      , numEdges = 2
+      , numManifestFiles = 1
+      , graphType = Complete
+      }
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/MavenSpec.hs
+++ b/integration-test/Analysis/MavenSpec.hs
@@ -66,7 +66,7 @@ simplePomFile =
     $ FixtureArtifact
       "https://github.com/fossas/example-pom-file/archive/refs/heads/main.tar.gz"
       [reldir|maven/simple_pom_file/|]
-      [reldir|simple_pom_file|]
+      [reldir|example-pom-file-main|]
 
 pomFileWithBuildDirOverride :: AnalysisTestFixture Maven.MavenProject
 pomFileWithBuildDirOverride =
@@ -78,7 +78,7 @@ pomFileWithBuildDirOverride =
     $ FixtureArtifact
       "https://github.com/fossas/example-pom-file/archive/refs/heads/override-build-directory.tar.gz"
       [reldir|maven/build_dir_override/|]
-      [reldir|build_dir_override|]
+      [reldir|example-pom-file-override-build-directory|]
 
 testKeycloak :: Spec
 testKeycloak = do
@@ -101,30 +101,18 @@ testGuava =
       }
 
 testSimplePomFile :: Spec
-testSimplePomFile =
-  testSuiteDepResultSummary
-    simplePomFile
-    Types.MavenProjectType
-    DependencyResultsSummary
-      { numDeps = 85
-      , numDirectDeps = 17
-      , numEdges = 75
-      , numManifestFiles = 1
-      , graphType = Complete
-      }
+testSimplePomFile = do
+  aroundAll (withAnalysisOf simplePomFile) $ do
+    describe "simple POM file" $ do
+      it "should find targets" $ \(result, extractedDir) ->
+        expectProject (MavenProjectType, extractedDir) result
 
 testBuildDirOverride :: Spec
-testBuildDirOverride =
-  testSuiteDepResultSummary
-    pomFileWithBuildDirOverride
-    Types.MavenProjectType
-    DependencyResultsSummary
-      { numDeps = 85
-      , numDirectDeps = 17
-      , numEdges = 75
-      , numManifestFiles = 1
-      , graphType = Complete
-      }
+testBuildDirOverride = do
+  aroundAll (withAnalysisOf pomFileWithBuildDirOverride) $ do
+    describe "POM file with build-directory override" $ do
+      it "should find targets" $ \(result, extractedDir) ->
+        expectProject (MavenProjectType, extractedDir) result
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/MavenSpec.hs
+++ b/integration-test/Analysis/MavenSpec.hs
@@ -56,6 +56,30 @@ guava =
       [reldir|maven/guava/|]
       [reldir|guava-31.1|]
 
+simplePomFile :: AnalysisTestFixture Maven.MavenProject
+simplePomFile =
+  AnalysisTestFixture
+    "simple-pom-file"
+    Maven.discover
+    mavenEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/fossas/example-pom-file/archive/refs/heads/main.tar.gz"
+      [reldir|maven/simple_pom_file/|]
+      [reldir|simple_pom_file|]
+
+pomFileWithBuildDirOverride :: AnalysisTestFixture Maven.MavenProject
+pomFileWithBuildDirOverride =
+  AnalysisTestFixture
+    "build-dir-override"
+    Maven.discover
+    mavenEnv
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/fossas/example-pom-file/archive/refs/heads/override-build-directory.tar.gz"
+      [reldir|maven/build_dir_override/|]
+      [reldir|build_dir_override|]
+
 testKeycloak :: Spec
 testKeycloak = do
   aroundAll (withAnalysisOf keycloak) $ do
@@ -76,7 +100,35 @@ testGuava =
       , graphType = Complete
       }
 
+testSimplePomFile :: Spec
+testSimplePomFile =
+  testSuiteDepResultSummary
+    simplePomFile
+    Types.MavenProjectType
+    DependencyResultsSummary
+      { numDeps = 85
+      , numDirectDeps = 17
+      , numEdges = 75
+      , numManifestFiles = 1
+      , graphType = Complete
+      }
+
+testBuildDirOverride :: Spec
+testBuildDirOverride =
+  testSuiteDepResultSummary
+    pomFileWithBuildDirOverride
+    Types.MavenProjectType
+    DependencyResultsSummary
+      { numDeps = 85
+      , numDirectDeps = 17
+      , numEdges = 75
+      , numManifestFiles = 1
+      , graphType = Complete
+      }
+
 spec :: Spec
 spec = do
   testKeycloak
   testGuava
+  testBuildDirOverride
+  testSimplePomFile

--- a/integration-test/Analysis/MavenSpec.hs
+++ b/integration-test/Analysis/MavenSpec.hs
@@ -106,9 +106,9 @@ testSimplePomFile = do
     simplePomFile
     Types.MavenProjectType
     DependencyResultsSummary
-      { numDeps = 3
-      , numDirectDeps = 1
-      , numEdges = 2
+      { numDeps = 25
+      , numDirectDeps = 2
+      , numEdges = 23
       , numManifestFiles = 1
       , graphType = Complete
       }
@@ -119,9 +119,9 @@ testBuildDirOverride = do
     pomFileWithBuildDirOverride
     Types.MavenProjectType
     DependencyResultsSummary
-      { numDeps = 3
-      , numDirectDeps = 1
-      , numEdges = 2
+      { numDeps = 25
+      , numDirectDeps = 2
+      , numEdges = 23
       , numManifestFiles = 1
       , graphType = Complete
       }

--- a/src/Strategy/Maven/Plugin.hs
+++ b/src/Strategy/Maven/Plugin.hs
@@ -265,6 +265,8 @@ mavenPluginDependenciesCmd workdir plugin = do
 
 -- | The reactor command is documented
 --  [here.](https://ferstl.github.io/depgraph-maven-plugin/reactor-mojo.html)
+--  We set outputDirectory explicitly so that the file is written to a known spot even if the pom file
+--  overrides the build directory (See FDN-82 for more details)
 mavenPluginReactorCmd :: (CandidateCommandEffs sig m, Has ReadFS sig m) => Path Abs Dir -> Path Abs Dir -> DepGraphPlugin -> m Command
 mavenPluginReactorCmd workdir outputdir plugin = do
   candidates <- mavenCmdCandidates workdir


### PR DESCRIPTION
# Overview

in [FDN-82](https://fossa.atlassian.net/browse/FDN-82), the customer has overridden the build directory for a maven project, by adding this to the pom.xml:

```xml
   <properties>
    <buildDirectory>${project.basedir}/.build</buildDirectory>
  </properties>
  <build>
      <directory>${buildDirectory}</directory>
  </build>
```

This is breaking the Maven PluginStrategy, as `parseReactorOutput` is expecting the output from `execPluginReactor` to be in `<project base>/target` (the default build directory), but it is going in `<project base>/.build` instead.

I fixed this by putting the output from `execPluginReactor` into a temp directory and telling `parseReactorOutput` that it's in that temp directory.

## Acceptance criteria

- You can analyze a maven project if the build directory has been overridden
- You can analyze a maven project if the build directory has not been overridden

## Testing plan

Put this in a `pom.xml` file in an otherwise empty directory:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project
	xmlns="http://maven.apache.org/POM/4.0.0"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
	<modelVersion>4.0.0</modelVersion>
	<groupId>com.example</groupId>
	<artifactId>example</artifactId>
	<version>0.0.1-SNAPSHOT</version>
  <properties>
    <buildDirectory>${project.basedir}/.build</buildDirectory>
  </properties>
	<dependencies>
		<dependency>
			<groupId>com.amazonaws</groupId>
			<artifactId>aws-java-sdk-kms</artifactId>
			<version>1.11.415</version>
		</dependency>
		<dependency>
			<groupId>com.jayway.restassured</groupId>
			<artifactId>rest-assured</artifactId>
			<version>2.9.0</version>
			<scope>test</scope>
		</dependency>
	</dependencies>
  <build>
      <directory>${buildDirectory}</directory>
  </build>
</project>
```

Test with the build directory overridden:

```
make install-dev
```

In the directory with the pom file:

```
install-dev analyze --debug --output > output-with-directory-overridden.json
```

Now edit the pom.xml file to remove the `<build>` section. Analyze again:

```
install-dev analyze --debug --output > output-with-no-override.json
```

Verify that there is no difference between the two outputs:

```
diff output-with-directory-overridden.json output-with-no-override.json
```

## Risks
This seems safe to me

## Metrics

## References

- [FDN-82](https://fossa.atlassian.net/browse/FDN-82)
- [ZD-7359](https://fossa.zendesk.com/agent/tickets/7359)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[FDN-82]: https://fossa.atlassian.net/browse/FDN-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FDN-82]: https://fossa.atlassian.net/browse/FDN-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ