### PR TITLE
Strip `!_fossa.virtual_!` from VSI paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,9 @@
 # FOSSA CLI Changelog
-## v3.8.27
-- Maven: Fix a bug that broke maven analysis if the build directory was in a non-standard location ([#1343](https://github.com/fossas/fossa-cli/pull/1343))
+## v3.8.28
+- VSI: no longer reports paths inside of extracted archives with the `!_fossa.virtual_!` literal [#1345](https://github.com/fossas/fossa-cli/pull/1345)
 
 ## v3.8.27
-- VSI: no longer reports paths inside of extracted archives with the `!_fossa.virtual_!` literal [#1345](https://github.com/fossas/fossa-cli/pull/1345)
+- Maven: Fix a bug that broke maven analysis if the build directory was in a non-standard location ([#1343](https://github.com/fossas/fossa-cli/pull/1343))
 
 ## v3.8.26
 - Maven: add support for maven submodule filtering [#1339](https://github.com/fossas/fossa-cli/pull/1339)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.8.27
+- VSI: no longer reports paths inside of extracted archives with the `!_fossa.virtual_!` literal [#1345](https://github.com/fossas/fossa-cli/pull/1345)
+
 ## v3.8.26
 - Maven: add support for maven submodule filtering [#1339](https://github.com/fossas/fossa-cli/pull/1339)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # FOSSA CLI Changelog
+
 ## v3.8.28
 - VSI: no longer reports paths inside of extracted archives with the `!_fossa.virtual_!` literal [#1345](https://github.com/fossas/fossa-cli/pull/1345)
 

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -25,6 +25,8 @@ let-style: inline
 # Docs: https://github.com/fourmolu/fourmolu#language-extensions-dependencies-and-fixities
 # If you have issues with operator formatting, usually you can find the right fixity in the haddocks.
 fixities:
-    - infixl 3 <|>
-    - infix 4 ==
-    - infixr 3 &&
+- infixr 0 $
+- infixl 3 <|>
+- infixr 3 &&
+- infix 4 ==
+- infixl 4 <$>, <*>

--- a/src/App/Fossa/VSI/Types.hs
+++ b/src/App/Fossa/VSI/Types.hs
@@ -78,11 +78,11 @@ instance FromJSON Locator where
   parseJSON = withObject "Locator" $ \obj -> do
     Locator
       <$> obj
-      .: "fetcher"
+        .: "fetcher"
       <*> obj
-      .: "package"
+        .: "package"
       <*> obj
-      .: "revision"
+        .: "revision"
 
 parseLocator :: (ToText a) => a -> Either LocatorParseError Locator
 parseLocator = validateLocator . Srclib.parseLocator . toText

--- a/src/App/Fossa/VSI/Types.hs
+++ b/src/App/Fossa/VSI/Types.hs
@@ -77,9 +77,12 @@ instance ToJSON Locator where
 instance FromJSON Locator where
   parseJSON = withObject "Locator" $ \obj -> do
     Locator
-      <$> obj .: "fetcher"
-      <*> obj .: "package"
-      <*> obj .: "revision"
+      <$> obj
+      .: "fetcher"
+      <*> obj
+      .: "package"
+      <*> obj
+      .: "revision"
 
 parseLocator :: (ToText a) => a -> Either LocatorParseError Locator
 parseLocator = validateLocator . Srclib.parseLocator . toText
@@ -187,7 +190,10 @@ instance FromJSON VsiExportedInferencesBody where
   parseJSON = withObject "VsiExportedInferencesBody" $ \obj -> do
     inferences <- (obj .:? "InferencesByFilePath") .!= KeyMap.empty
     parsedVals <- traverse parseJSON inferences
-    pure . VsiExportedInferencesBody . Map.mapKeys VsiFilePath . KeyMap.toMapText $ parsedVals
+    pure . VsiExportedInferencesBody . Map.mapKeys (VsiFilePath . stripFossaVirtual) . KeyMap.toMapText $ parsedVals
+
+stripFossaVirtual :: Text -> Text
+stripFossaVirtual = Text.replace "!_fossa.virtual_!" ""
 
 data VsiRule = VsiRule
   { vsiRulePath :: VsiRulePath

--- a/src/App/Fossa/VSI/Types.hs
+++ b/src/App/Fossa/VSI/Types.hs
@@ -77,12 +77,9 @@ instance ToJSON Locator where
 instance FromJSON Locator where
   parseJSON = withObject "Locator" $ \obj -> do
     Locator
-      <$> obj
-        .: "fetcher"
-      <*> obj
-        .: "package"
-      <*> obj
-        .: "revision"
+      <$> obj .: "fetcher"
+      <*> obj .: "package"
+      <*> obj .: "revision"
 
 parseLocator :: (ToText a) => a -> Either LocatorParseError Locator
 parseLocator = validateLocator . Srclib.parseLocator . toText

--- a/test/App/Fossa/VSI/TypesSpec.hs
+++ b/test/App/Fossa/VSI/TypesSpec.hs
@@ -164,20 +164,15 @@ vsiTypesSpec = describe "VSI Types" $ do
 generateRulesSpec :: Spec
 generateRulesSpec = describe "generateRules" $ do
   it "Generates a rule correctly" $
-    generateRules expectedSingleInference
-      `shouldBe` singleRuleExpected
+    generateRules expectedSingleInference `shouldBe` singleRuleExpected
   it "Reduces rules to common prefixes" $
-    generateRules' commonPrefixInferences
-      `shouldBe` singleRuleExpected
+    generateRules' commonPrefixInferences `shouldBe` singleRuleExpected
   it "Reports multiple rules for a project" $
-    generateRules' multipleInferences
-      `shouldMatchList` multipleRulesExpected
+    generateRules' multipleInferences `shouldMatchList` multipleRulesExpected
   it "Reports distinct locators for nested projects" $
-    generateRules' nestedProjectInferences
-      `shouldMatchList` nestedProjectRulesExpected
+    generateRules' nestedProjectInferences `shouldMatchList` nestedProjectRulesExpected
   it "Reports root rules correctly" $
-    generateRules' rootRuleInferences
-      `shouldMatchList` rootRuleExpected
+    generateRules' rootRuleInferences `shouldMatchList` rootRuleExpected
   where
     generateRules' :: [(VsiFilePath, VsiInference)] -> [VsiRule]
     generateRules' = generateRules . VsiExportedInferencesBody . Map.fromList

--- a/test/App/Fossa/VSI/TypesSpec.hs
+++ b/test/App/Fossa/VSI/TypesSpec.hs
@@ -72,8 +72,8 @@ invalidLocatorInference =
 
 expectedEmptyLocatorInference :: VsiExportedInferencesBody
 expectedEmptyLocatorInference =
-  VsiExportedInferencesBody
-    $ Map.fromList
+  VsiExportedInferencesBody $
+    Map.fromList
       [
         ( VsiFilePath "/foo/bar.h"
         , VsiInference Nothing
@@ -163,21 +163,21 @@ vsiTypesSpec = describe "VSI Types" $ do
 
 generateRulesSpec :: Spec
 generateRulesSpec = describe "generateRules" $ do
-  it "Generates a rule correctly"
-    $ generateRules expectedSingleInference
-    `shouldBe` singleRuleExpected
-  it "Reduces rules to common prefixes"
-    $ generateRules' commonPrefixInferences
-    `shouldBe` singleRuleExpected
-  it "Reports multiple rules for a project"
-    $ generateRules' multipleInferences
-    `shouldMatchList` multipleRulesExpected
-  it "Reports distinct locators for nested projects"
-    $ generateRules' nestedProjectInferences
-    `shouldMatchList` nestedProjectRulesExpected
-  it "Reports root rules correctly"
-    $ generateRules' rootRuleInferences
-    `shouldMatchList` rootRuleExpected
+  it "Generates a rule correctly" $
+    generateRules expectedSingleInference
+      `shouldBe` singleRuleExpected
+  it "Reduces rules to common prefixes" $
+    generateRules' commonPrefixInferences
+      `shouldBe` singleRuleExpected
+  it "Reports multiple rules for a project" $
+    generateRules' multipleInferences
+      `shouldMatchList` multipleRulesExpected
+  it "Reports distinct locators for nested projects" $
+    generateRules' nestedProjectInferences
+      `shouldMatchList` nestedProjectRulesExpected
+  it "Reports root rules correctly" $
+    generateRules' rootRuleInferences
+      `shouldMatchList` rootRuleExpected
   where
     generateRules' :: [(VsiFilePath, VsiInference)] -> [VsiRule]
     generateRules' = generateRules . VsiExportedInferencesBody . Map.fromList


### PR DESCRIPTION
# Overview

When users view VSI origin paths, the `!_fossa.virtual_!` literal appended to the end of archives is confusing. These are required for the VSI backend, but not for FOSSA CLI nor for the reported results to the FOSSA web app. As such, this PR removes them when decoding the data from the VSI backend.

## Acceptance criteria

VSI results from within archives are not reported with the literal.

## Testing plan

I created an example project:
```shell
❯ zip -r cpp-vsi-demo.zip cpp-vsi-demo
❯ mv cpp-vsi-demo.zip ~/projects/scratch
❯ cabal run fossa -- analyze ~/projects/scratch -p vsi-archive-test --detect-vendored
```

This analyzed successfully and reflects the change in this PR (note that the `cpp-vsi-demo.zip` does not have the trailing literal):
```shell
* vsi analysis: succeeded
  ** /Users/jessica/projects/scratch/
  ** /cpp-vsi-demo.zip/cpp-vsi-demo/node_modules/lodash/ (locator: git+github.com/PandeoF1/px_botnet$66e6e31b39d0c770a9196c7a5443710e32367070)
  ** /cpp-vsi-demo.zip/cpp-vsi-demo/example-internal-project/vendor/facebook-folly-6695020/folly/ (locator: git+github.com/facebook/folly$2016.07.26)
  ** /cpp-vsi-demo.zip/cpp-vsi-demo/example-internal-project/vendor/libssh2/ (locator: git+github.com/libssh2/libssh2$libssh2-1.10.0)
  ** /cpp-vsi-demo.zip/cpp-vsi-demo/example-internal-project/vendor/tesseract-ocr-tesseract-cd65104/trunk/ (locator: git+github.com/tesseract-ocr/tesseract$1.03)
```

The results in FOSSA also show the origin path without the literal:
<img width="1552" alt="Screenshot 2023-12-13 at 1 30 12 PM" src="https://github.com/fossas/fossa-cli/assets/55713231/07e5e61e-9964-4551-a1a3-ffc6eced9a3c">

## Risks

None

## Metrics

No

## References

https://teamfossa.slack.com/archives/C0155DTGWB1/p1702410993592229
https://fossa.atlassian.net/browse/ANE-1353

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
