### PR TITLE
Switch to supported haskell-actions/setup

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -50,7 +50,7 @@ jobs:
         brew install jq
 
     # Set up Haskell.
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell
       name: Setup ghc/cabal (non-alpine)
       if: ${{ !contains(matrix.os, 'ubuntu') }}


### PR DESCRIPTION
# Overview

The original action we were using to set up Haskell on non-linux builds has been deprecated. This switches to the maintained drop-in replacement. 

## Acceptance criteria

* Nothing should change.

## Testing plan

I changed our GH actions workflow and then observed the build work.

## Risks

None.

## References

A sample [deprecation message](https://github.com/fossas/fossa-cli/actions/runs/7252664722/job/19757612966) under the "Setup GHC/Cabal" section..

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
