### PR TITLE
1/2 Removing SCM warnings

### DIFF
--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -302,10 +302,16 @@ collectRevisionData (BaseDir basedir) maybeConfig cacheStrategy cliOverride = do
   let override = collectRevisionOverride maybeConfig cliOverride
   case cacheStrategy of
     ReadOnly -> do
-      inferred <- inferProjectFromVCS basedir <||> inferProjectCached basedir <||> inferProjectDefault basedir
+      maybeInferred <- inferProjectFromVCS basedir
+      inferred <- case maybeInferred of
+        Nothing -> inferProjectCached basedir <||> inferProjectDefault basedir
+        Just inferredFromVCS -> pure inferredFromVCS
       pure $ mergeOverride override inferred
     WriteOnly -> do
-      inferred <- inferProjectFromVCS basedir <||> inferProjectDefault basedir
+      maybeInferred <- inferProjectFromVCS basedir
+      inferred <- case maybeInferred of
+        Nothing -> inferProjectDefault basedir
+        Just inferredFromVCS -> pure inferredFromVCS
       let revision = mergeOverride override inferred
       saveRevision revision
       pure revision

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -31,7 +31,6 @@ import Data.Text.IO qualified as TIO
 import Data.Time.Clock.POSIX (getCurrentTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Effect.Exec
-import Effect.Logger
 import Effect.ReadFS
 import Path
 import Path.IO (getTempDir)


### PR DESCRIPTION
# Overview

We are currently showing SCM warnings, but we want to avoid this in certain situations.

TO DO:
- unit tests
- info level logging 

## Acceptance criteria

SCM warnings never result in an error/warning because the CLI works fine without them, it just uses a date for a revision.

If the SCM warning would normally occur and the user has not provided a version with --revision, output an info message noting that we didn’t get a revision with --revision and couldn’t automatically discover one from SCM and will use a date instead.

The above should apply to both fossa analyze, fossa test, and fossa report .

## Testing plan


## Risks


## Metrics


## References

- [ANE-1255](https://fossa.atlassian.net/browse/ANE-1255)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1255]: https://fossa.atlassian.net/browse/ANE-1255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ