### PR TITLE
Bump index-state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -70,7 +70,7 @@ source-repository-package
   location: https://github.com/fossas/codec-rpm
   tag: 0f7431423d47fdf36945e4ff31fbee76005b7e68
 
-index-state: hackage.haskell.org 2023-08-28T22:23:10Z
+index-state: hackage.haskell.org 2024-01-02T10:02:41Z
 
 package *
   extra-include-dirs: /opt/homebrew/include

--- a/cabal.project.ci.linux
+++ b/cabal.project.ci.linux
@@ -68,5 +68,5 @@ source-repository-package
   location: https://github.com/fossas/codec-rpm
   tag: 0f7431423d47fdf36945e4ff31fbee76005b7e68
 
-index-state: hackage.haskell.org 2023-08-28T22:23:10Z
+index-state: hackage.haskell.org 2024-01-02T10:02:41Z
 

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -66,4 +66,4 @@ source-repository-package
   location: https://github.com/fossas/codec-rpm
   tag: 0f7431423d47fdf36945e4ff31fbee76005b7e68
 
-index-state: hackage.haskell.org 2023-08-28T22:23:10Z
+index-state: hackage.haskell.org 2024-01-02T10:02:41Z

--- a/cabal.project.ci.windows
+++ b/cabal.project.ci.windows
@@ -74,4 +74,4 @@ source-repository-package
   location: https://github.com/fossas/codec-rpm.git
   tag: 0f7431423d47fdf36945e4ff31fbee76005b7e68
 
-index-state: hackage.haskell.org 2023-08-28T22:23:10Z
+index-state: hackage.haskell.org 2024-01-02T10:02:41Z


### PR DESCRIPTION
# Overview

Bumps the index state for cabal so we can get some newer packages. I haven't manually updated any version bounds. I plan to do some work to support keeping up with that in the future.

## Acceptance criteria

## Testing plan

All tests should pass.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
