### PR TITLE
Use `-batch` and `-no-colors` for sbt for compatibility with older SBT.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.8.30
+
+- Fix an issue with long-option syntax for older versions of `sbt` ([#1356](https://github.com/fossas/fossa-cli/pull/1356))
+
 ## v3.8.29
 - Prevents showing SCM warnings in fossa analyze, test, and report [#1354](https://github.com/fossas/fossa-cli/pull/1354)
 - Pathfinder: Pathfinder has been deprecated and removed. ([#1350](https://github.com/fossas/fossa-cli/pull/1350))

--- a/integration-test/Analysis/ScalaSpec.hs
+++ b/integration-test/Analysis/ScalaSpec.hs
@@ -14,7 +14,7 @@ import Analysis.FixtureUtils (
  )
 import Path (reldir)
 import Strategy.Scala qualified as Scala
-import Test.Hspec (Spec, focus)
+import Test.Hspec (Spec)
 import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 scalaEnv :: FixtureEnvironment

--- a/integration-test/Analysis/ScalaSpec.hs
+++ b/integration-test/Analysis/ScalaSpec.hs
@@ -20,17 +20,6 @@ import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 scalaEnv :: FixtureEnvironment
 scalaEnv = NixEnv ["scala", "sbt"]
 
-oldScalaEnv :: FixtureEnvironment
-oldScalaEnv =
-  NixEnv
-    [ "scala_2_12"
-    , "sbt"
-    , "jdk"
-    , -- Need jdk 8, it is in this archive.
-      "-I"
-    , "nixpkgs=https://github.com/NixOS/nixpkgs/archive/824421b1796332ad1bcb35bc7855da832c43305f.tar.gz"
-    ]
-
 scalaExampleProject :: AnalysisTestFixture (Scala.ScalaProject)
 scalaExampleProject =
   AnalysisTestFixture
@@ -43,35 +32,6 @@ scalaExampleProject =
       [reldir|scala/scala-3-ex-project/|]
       [reldir|scala3-example-project-main/target/scala-3.1.2/|]
 
--- | Example project which uses a pre 1.4 version of SBT.
---  These versions required manually setting up the dependency graph plugin.
-scalaOldSbt :: AnalysisTestFixture (Scala.ScalaProject)
-scalaOldSbt =
-  AnalysisTestFixture
-    { testName = "scalaExampleOldSbt"
-    , discover = Scala.discover
-    , -- SBT version can be configured in the project definition.
-      environment = oldScalaEnv
-    , buildCmd = Nothing
-    , artifact =
-        FixtureArtifact
-          { tarGzFileUrl = "https://github.com/fossas/example-projects/archive/refs/heads/main.tar.gz"
-          , extractAt = [reldir|example-projects/|]
-          , scopedDir = [reldir|example-projects-main/scala/single_explicit_plugin/target/scala-3.1|]
-          }
-    }
-
-scalaOldSbtExpected :: DependencyResultsSummary
-scalaOldSbtExpected =
-  DependencyResultsSummary
-    { numDeps = 2
-    , numDirectDeps = 1
-    , numEdges = 1
-    , numManifestFiles = 1
-    , graphType = Complete
-    }
-
 spec :: Spec
 spec = do
   testSuiteDepResultSummary scalaExampleProject ScalaProjectType (DependencyResultsSummary 3 2 1 1 Complete)
-  testSuiteDepResultSummary scalaOldSbt ScalaProjectType scalaOldSbtExpected

--- a/integration-test/Analysis/ScalaSpec.hs
+++ b/integration-test/Analysis/ScalaSpec.hs
@@ -4,21 +4,31 @@
 module Analysis.ScalaSpec (spec) where
 
 import Analysis.FixtureExpectationUtils (
-  DependencyResultsSummary (DependencyResultsSummary),
+  DependencyResultsSummary (..),
   testSuiteDepResultSummary,
  )
 import Analysis.FixtureUtils (
-  AnalysisTestFixture (AnalysisTestFixture),
-  FixtureArtifact (FixtureArtifact),
+  AnalysisTestFixture (..),
+  FixtureArtifact (..),
   FixtureEnvironment (NixEnv),
  )
 import Path (reldir)
 import Strategy.Scala qualified as Scala
-import Test.Hspec (Spec)
+import Test.Hspec (Spec, focus)
 import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 scalaEnv :: FixtureEnvironment
 scalaEnv = NixEnv ["scala", "sbt"]
+
+oldScalaEnv :: FixtureEnvironment
+oldScalaEnv =
+  NixEnv
+    [ "scala_2_12"
+    , "jdk"
+    , -- Need jdk 8, it is in this archive.
+      "-I"
+    , "nixpkgs=https://github.com/NixOS/nixpkgs/archive/e296e89d75ab8aa1d0eed1c3688883a4f7937515.tar.gz"
+    ]
 
 scalaExampleProject :: AnalysisTestFixture (Scala.ScalaProject)
 scalaExampleProject =
@@ -32,6 +42,35 @@ scalaExampleProject =
       [reldir|scala/scala-3-ex-project/|]
       [reldir|scala3-example-project-main/target/scala-3.1.2/|]
 
+-- | Example project which uses a pre 1.4 version of SBT.
+--  These versions required manually setting up the dependency graph plugin.
+scalaOldSbt :: AnalysisTestFixture (Scala.ScalaProject)
+scalaOldSbt =
+  AnalysisTestFixture
+    { testName = "scalaExampleOldSbt"
+    , discover = Scala.discover
+    , -- SBT version can be configured in the project definition.
+      environment = oldScalaEnv
+    , buildCmd = Nothing
+    , artifact =
+        FixtureArtifact
+          { tarGzFileUrl = "https://github.com/fossas/example-projects/archive/refs/heads/main.tar.gz"
+          , extractAt = [reldir|example-projects/|]
+          , scopedDir = [reldir|example-projects-main/scala/single_explicit_plugin/target/scala-3.1|]
+          }
+    }
+
+scalaOldSbtExpected :: DependencyResultsSummary
+scalaOldSbtExpected =
+  DependencyResultsSummary
+    { numDeps = 2
+    , numDirectDeps = 1
+    , numEdges = 1
+    , numManifestFiles = 1
+    , graphType = Complete
+    }
+
 spec :: Spec
 spec = do
   testSuiteDepResultSummary scalaExampleProject ScalaProjectType (DependencyResultsSummary 3 2 1 1 Complete)
+  testSuiteDepResultSummary scalaOldSbt ScalaProjectType scalaOldSbtExpected

--- a/integration-test/Analysis/ScalaSpec.hs
+++ b/integration-test/Analysis/ScalaSpec.hs
@@ -24,6 +24,7 @@ oldScalaEnv :: FixtureEnvironment
 oldScalaEnv =
   NixEnv
     [ "scala_2_12"
+    , "sbt"
     , "jdk"
     , -- Need jdk 8, it is in this archive.
       "-I"

--- a/integration-test/Analysis/ScalaSpec.hs
+++ b/integration-test/Analysis/ScalaSpec.hs
@@ -28,7 +28,7 @@ oldScalaEnv =
     , "jdk"
     , -- Need jdk 8, it is in this archive.
       "-I"
-    , "nixpkgs=https://github.com/NixOS/nixpkgs/archive/e296e89d75ab8aa1d0eed1c3688883a4f7937515.tar.gz"
+    , "nixpkgs=https://github.com/NixOS/nixpkgs/archive/824421b1796332ad1bcb35bc7855da832c43305f.tar.gz"
     ]
 
 scalaExampleProject :: AnalysisTestFixture (Scala.ScalaProject)

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -40,7 +40,6 @@ import Discovery.Walk (
   walkWithFilters',
  )
 import Effect.Exec (
-  AllowErr (Never),
   Command (..),
   Exec,
   Has,
@@ -64,6 +63,7 @@ import Strategy.Maven.Pom qualified as Pom
 import Strategy.Maven.Pom.Closure (MavenProjectClosure, buildProjectClosures, closurePath)
 import Strategy.Maven.Pom.PomFile (RawPom (rawPomArtifact, rawPomGroup, rawPomVersion))
 import Strategy.Maven.Pom.Resolver (buildGlobalClosure)
+import Strategy.Scala.Common (mkSbtCommand)
 import Strategy.Scala.Errors (FailedToListProjects (FailedToListProjects), MaybeWithoutDependencyTreeTask (MaybeWithoutDependencyTreeTask), MissingFullDependencyPlugin (MissingFullDependencyPlugin))
 import Strategy.Scala.Plugin (genTreeJson, hasDependencyPlugins)
 import Strategy.Scala.SbtDependencyTree (SbtArtifact (SbtArtifact), analyze, sbtDepTreeCmd)
@@ -230,14 +230,7 @@ analyzeWithSbtDepTree (ScalaProject maybeDepTree _ closure) = context "Analyzing
       pure $ SbtArtifact groupId artifactId version
 
 makePomCmd :: Command
-makePomCmd =
-  Command
-    { cmdName = "sbt"
-    , -- --no-colors to disable ANSI escape codes
-      -- --batch to disable interactivity. normally, if an `sbt` command fails, it'll drop into repl mode: --batch will disable the repl.
-      cmdArgs = ["--no-colors", "--batch", "makePom"]
-    , cmdAllowErr = Never
-    }
+makePomCmd = mkSbtCommand "makePom"
 
 genPoms :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> m [MavenProjectClosure]
 genPoms projectDir = do

--- a/src/Strategy/Scala/Common.hs
+++ b/src/Strategy/Scala/Common.hs
@@ -1,11 +1,31 @@
 module Strategy.Scala.Common (
   removeLogPrefixes,
   SbtArtifact (..),
+  mkSbtCommand,
 ) where
 
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Effect.Exec (AllowErr (Never), Command (..))
+
+-- | Generate an sbt sub-command using which turns off colored output and ensures it does not enter repl mode.
+--
+--  example:
+--  mkSbtCommand "dependencyTree"  results in "sbt -batch -no-colors dependencyTree" as a CLI command.
+mkSbtCommand :: Text -> Command
+mkSbtCommand cmdName =
+  Command
+    { cmdName = "sbt"
+    , -- Use single hyphens rather than double-hyphens for old sbt compatibility.
+      -- Ex: -batch instead of --batch
+      cmdArgs =
+        [ "-batch"
+        , "-no-colors"
+        , cmdName
+        ]
+    , cmdAllowErr = Never
+    }
 
 data SbtArtifact = SbtArtifact
   { groupId :: Text

--- a/src/Strategy/Scala/SbtDependencyTree.hs
+++ b/src/Strategy/Scala/SbtDependencyTree.hs
@@ -61,8 +61,8 @@ sbtDepTreeCmd =
   Command
     { cmdName = "sbt"
     , cmdArgs =
-        [ "--batch" -- ensure sbt does not enter repl mode!
-        , "--no-colors"
+        [ "-batch" -- ensure sbt does not enter repl mode!
+        , "-no-colors"
         , "dependencyTree"
         ]
     , cmdAllowErr = Never

--- a/src/Strategy/Scala/SbtDependencyTree.hs
+++ b/src/Strategy/Scala/SbtDependencyTree.hs
@@ -30,13 +30,12 @@ import DepTypes (
   VerConstraint (CEq),
  )
 import Effect.Exec (
-  AllowErr (Never),
   Command (..),
   Exec,
   ExecErr (CommandParseError),
  )
 import Graphing (Graphing, shrinkRoots, subGraphOf, unfold)
-import Strategy.Scala.Common (SbtArtifact (SbtArtifact, artifactId, groupId, version), removeLogPrefixes)
+import Strategy.Scala.Common (SbtArtifact (SbtArtifact, artifactId, groupId, version), mkSbtCommand, removeLogPrefixes)
 import Text.Megaparsec (
   MonadParsec (eof, takeWhileP, try),
   Parsec,
@@ -57,16 +56,7 @@ import Text.Megaparsec.Char.Lexer qualified as Lexer
 -- This only works with sbt v1.4.0 greater, or with sbt which has DependencyTreePlugin.
 -- Ref: https://www.scala-sbt.org/1.x/docs/sbt-1.4-Release-Notes.html#sbt-dependency-graph+is+in-sourced
 sbtDepTreeCmd :: Command
-sbtDepTreeCmd =
-  Command
-    { cmdName = "sbt"
-    , cmdArgs =
-        [ "-batch" -- ensure sbt does not enter repl mode!
-        , "-no-colors"
-        , "dependencyTree"
-        ]
-    , cmdAllowErr = Never
-    }
+sbtDepTreeCmd = mkSbtCommand "dependencyTree"
 
 data SbtDep = SbtDep
   { artifact :: SbtArtifact


### PR DESCRIPTION
# Overview

An older version of `sbt`, version `1.2.8`, and the sbt dependency-graph-plugin don't understand the double-hyphen long-option option syntax. For example, they require `-batch` rather than `--batch`. 

## Acceptance criteria

* We can scan the new project from this [PR](https://github.com/fossas/example-projects/pull/13).

## Testing plan

I manually tested using current `fossa` and the version from this branch. Analysis succeeds using the plugin on this branch, but not the version from master.

## Risks

There is the risk that some newer version of `sbt` doesn't respect both syntaxes. I think that's unlikely. 

## Metrics


## References


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
