### PR TITLE
Custom license search docs: `(i?)` -> `(?i)`

### DIFF
--- a/docs/features/custom-license-and-keyword-searches.md
+++ b/docs/features/custom-license-and-keyword-searches.md
@@ -133,10 +133,10 @@ This will match "Proprietary License", "proprietary license", "proprietary Licen
 
 ### Ignoring case
 
-You can ignore case by using the case-insensitive [flag](./custom-license-and-keyword-search-regular-expression-syntax.md#character-classes#groupings-and-flags), `i`. This is done by adding `(i?)` to your regular expression. Everything after `(?i)` will be matched case-insenitively.
+You can ignore case by using the case-insensitive [flag](./custom-license-and-keyword-search-regular-expression-syntax.md#character-classes#groupings-and-flags), `i`. This is done by prepending `(?i)` to your regular expression. Everything after `(?i)` will be matched case-insenitively.
 
 ```
-(i?)custom license
+(?i)custom license
 ```
 
 This will match "Custom License", "CUSTOM LICENSE", "custom license" or "CusTOm LiCenSe".
@@ -248,7 +248,3 @@ You can also set the `ignoreOrgWideCustomLicenseScanConfigs` flag to `true` in y
 version: 3
 ignoreOrgWideCustomLicenseScanConfigs: true
 ```
-
-
-
-


### PR DESCRIPTION
# Overview

Fix the docs to reference the correct flag.
They mostly did already, but there were two instances where they didn't.

https://teamfossa.slack.com/archives/C043EM3L96Z/p1705366809320579