### PR TITLE
Ane 797 static only flag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.8.31
+
+- Options: Add a `--static-only-analysis` option. ([#1362](https://github.com/fossas/fossa-cli/pull/1362))
+
 ## v3.8.30
 
 - Fix an issue with long-option syntax for older versions of `sbt` ([#1356](https://github.com/fossas/fossa-cli/pull/1356))

--- a/docs/references/strategies/README.md
+++ b/docs/references/strategies/README.md
@@ -123,8 +123,9 @@ See the linked documentation above for details.
 
 Languages supported by FOSSA CLI can have multiple strategies for detecting dependencies, one primary strategy that yields ideal results and zero or more fallback strategies. Within this list of strategies, we have the concept of _static_ and _dynamic_ strategies. Static strategies parse files to find a dependency graph (example: parse a `package-lock.json` file). Dynamic strategies are required when analyzing package managers that do not offer complete lockfiles, such as Gradle or Go. Dynamic strategies require a working build environment to operate in.
 
-While we recommend running the tool with all possible strategies enabled if you need to limit FOSSA CLI's run to only use static strategies we offer the `--static-only-analysis` flag. 
+Running the tool with all possible strategies enabled is recommended, but if you need to limit FOSSA CLI's run to only only use static strategies the CLI offers the `--static-only-analysis` flag. 
 This flag makes the the FOSSA CLI not attempt to use any third party tools, such as `npm`, `pip`, etc.
+FOSSA CLI may still use FOSSA-developed tools that ship with the CLI binary, however.
 
 It is important to note that neither type of strategy has an inherent benefit when detecting dependencies. If a supported language has only a static or only a dynamic strategy, this does not mean it is less supported than a language that has both.
 

--- a/docs/references/strategies/README.md
+++ b/docs/references/strategies/README.md
@@ -123,7 +123,10 @@ See the linked documentation above for details.
 
 Languages supported by FOSSA CLI can have multiple strategies for detecting dependencies, one primary strategy that yields ideal results and zero or more fallback strategies. Within this list of strategies, we have the concept of _static_ and _dynamic_ strategies. Static strategies parse files to find a dependency graph (example: parse a `package-lock.json` file). Dynamic strategies are required when analyzing package managers that do not offer complete lockfiles, such as Gradle or Go. Dynamic strategies require a working build environment to operate in.
 
-It is important to note that neither type of strategy has an inherent benefit when detecting dependencies. If a supported language has only a static or only a dynamic strategy, this does not mean it is less supported than a language that
+While we recommend running the tool with all possible strategies enabled if you need to limit FOSSA CLI's run to only use static strategies we offer the `--static-only-analysis` flag. 
+This flag makes the the FOSSA CLI not attempt to use any third party tools, such as `npm`, `pip`, etc.
+
+It is important to note that neither type of strategy has an inherent benefit when detecting dependencies. If a supported language has only a static or only a dynamic strategy, this does not mean it is less supported than a language that has both.
 
 ### Strategies by type
 

--- a/docs/references/strategies/README.md
+++ b/docs/references/strategies/README.md
@@ -124,7 +124,7 @@ See the linked documentation above for details.
 Languages supported by FOSSA CLI can have multiple strategies for detecting dependencies, one primary strategy that yields ideal results and zero or more fallback strategies. Within this list of strategies, we have the concept of _static_ and _dynamic_ strategies. Static strategies parse files to find a dependency graph (example: parse a `package-lock.json` file). Dynamic strategies are required when analyzing package managers that do not offer complete lockfiles, such as Gradle or Go. Dynamic strategies require a working build environment to operate in.
 
 Running the tool with all possible strategies enabled is recommended, but if you need to limit FOSSA CLI to only use static strategies the CLI offers the `--static-only-analysis` flag.
-This flag prevents the FOSSA CLI from using any third party tools, such as `npm`, `pip`, maven plugins, etc.
+This flag prevents FOSSA CLI from using any third party tools, such as `npm`, `pip`, maven plugins, etc.
 With this option enabled, strategies that don't offer a way to analyze statically will fail with an error.
 
 It is important to note that neither type of strategy has an inherent benefit when detecting dependencies. If a supported language has only a static or only a dynamic strategy, this does not mean it is less supported than a language that has both.

--- a/docs/references/strategies/README.md
+++ b/docs/references/strategies/README.md
@@ -123,8 +123,9 @@ See the linked documentation above for details.
 
 Languages supported by FOSSA CLI can have multiple strategies for detecting dependencies, one primary strategy that yields ideal results and zero or more fallback strategies. Within this list of strategies, we have the concept of _static_ and _dynamic_ strategies. Static strategies parse files to find a dependency graph (example: parse a `package-lock.json` file). Dynamic strategies are required when analyzing package managers that do not offer complete lockfiles, such as Gradle or Go. Dynamic strategies require a working build environment to operate in.
 
-Running the tool with all possible strategies enabled is recommended, but if you need to limit FOSSA CLI's run to only only use static strategies the CLI offers the `--static-only-analysis` flag. 
-This flag makes the the FOSSA CLI not attempt to use any third party tools, such as `npm`, `pip`, etc.
+Running the tool with all possible strategies enabled is recommended, but if you need to limit FOSSA CLI's run to only use static strategies the CLI offers the `--static-only-analysis` flag. 
+This flag prevents the FOSSA CLI from using any third party tools, such as `npm`, `pip`, maven plugins, etc.
+With this option enabled, strategies that don't offer a way to analyze statically will fail with an error.
 FOSSA CLI may still use FOSSA-developed tools that ship with the CLI binary, however.
 
 It is important to note that neither type of strategy has an inherent benefit when detecting dependencies. If a supported language has only a static or only a dynamic strategy, this does not mean it is less supported than a language that has both.

--- a/docs/references/strategies/README.md
+++ b/docs/references/strategies/README.md
@@ -123,7 +123,7 @@ See the linked documentation above for details.
 
 Languages supported by FOSSA CLI can have multiple strategies for detecting dependencies, one primary strategy that yields ideal results and zero or more fallback strategies. Within this list of strategies, we have the concept of _static_ and _dynamic_ strategies. Static strategies parse files to find a dependency graph (example: parse a `package-lock.json` file). Dynamic strategies are required when analyzing package managers that do not offer complete lockfiles, such as Gradle or Go. Dynamic strategies require a working build environment to operate in.
 
-Running the tool with all possible strategies enabled is recommended, but if you need to limit FOSSA CLI's run to only use static strategies the CLI offers the `--static-only-analysis` flag. 
+Running the tool with all possible strategies enabled is recommended, but if you need to limit FOSSA CLI to only use static strategies the CLI offers the `--static-only-analysis` flag.
 This flag prevents the FOSSA CLI from using any third party tools, such as `npm`, `pip`, maven plugins, etc.
 With this option enabled, strategies that don't offer a way to analyze statically will fail with an error.
 

--- a/docs/references/strategies/README.md
+++ b/docs/references/strategies/README.md
@@ -126,7 +126,6 @@ Languages supported by FOSSA CLI can have multiple strategies for detecting depe
 Running the tool with all possible strategies enabled is recommended, but if you need to limit FOSSA CLI's run to only use static strategies the CLI offers the `--static-only-analysis` flag. 
 This flag prevents the FOSSA CLI from using any third party tools, such as `npm`, `pip`, maven plugins, etc.
 With this option enabled, strategies that don't offer a way to analyze statically will fail with an error.
-FOSSA CLI may still use FOSSA-developed tools that ship with the CLI binary, however.
 
 It is important to note that neither type of strategy has an inherent benefit when detecting dependencies. If a supported language has only a static or only a dynamic strategy, this does not mean it is less supported than a language that has both.
 

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -114,14 +114,15 @@ We support the following archive formats:
   - `xz` compression
   - `zstd` compression
 
-### Enabling additional strategies
+### Enabling or disabling additional strategies
 
 In addition to the [standard flags](#specifying-fossa-project-details), the analyze command supports the following additional strategy flags:
 
 | Name                                                             | Description                                                                                                                                                              |
 |------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`--detect-vendored`](./analyze/detect-vendored.md)              | Enable the vendored source identification engine. For more information, see the [C and C++ overview](../strategies/languages/c-cpp/c-cpp.md).                            |
-| [`--detect-dynamic './some-binary`](./analyze/detect-dynamic.md) | Analyze the binary at the provided path for dynamically linked dependencies. For more information, see the [C and C++ overview](../strategies/languages/c-cpp/c-cpp.md). |
+| [`--detect-vendored`](./analyze/detect-vendored.md)                               | Enable the vendored source identification engine. For more information, see the [C and C++ overview](../strategies/languages/c-cpp/c-cpp.md).                            |
+| [`--detect-dynamic './some-binary`](./analyze/detect-dynamic.md)                  | Analyze the binary at the provided path for dynamically linked dependencies. For more information, see the [C and C++ overview](../strategies/languages/c-cpp/c-cpp.md). |
+| [`--static-only-analysis`](../strategies/README.md#static-and-dynamic-strategies) | Do not use third-party tools when analyzing projects.
 
 
 ### Experimental Options

--- a/src/App/Docs.hs
+++ b/src/App/Docs.hs
@@ -8,6 +8,7 @@ module App.Docs (
   fossaSslCertDocsUrl,
   fossaContainerScannerUrl,
   pathDependencyDocsUrl,
+  staticAndDynamicStrategies,
 ) where
 
 import App.Version (versionOrBranch)
@@ -45,3 +46,6 @@ fossaContainerScannerUrl = guidePathOf versionOrBranch "/docs/references/subcomm
 
 pathDependencyDocsUrl :: Text
 pathDependencyDocsUrl = guidePathOf versionOrBranch "/docs/references/experimental/path-dependency.md"
+
+staticAndDynamicStrategies :: Text
+staticAndDynamicStrategies = guidePathOf versionOrBranch "/docs/references/strategies/README.md#static-and-dynamic-strategies"

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -135,14 +135,6 @@ debugBundlePath = "fossa.debug.json.gz"
 analyzeSubCommand :: SubCommand AnalyzeCliOpts AnalyzeConfig
 analyzeSubCommand = Config.mkSubCommand dispatch
 
-staticOnlyAnalysisMessage :: Doc a
-staticOnlyAnalysisMessage =
-  vsep
-    [ "Performing static-only analysis!!!"
-    , "Results may be different in comparison to an analysis using build tools."
-    , "See https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/README.md#static-and-dynamic-strategies for more information."
-    ]
-
 dispatch ::
   ( Has Diag.Diagnostics sig m
   , Has Exec sig m
@@ -374,9 +366,6 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   let filteredProjects = mapMaybe toProjectResult projectScans
   logDebug $ "Filtered project scans: " <> pretty (show filteredProjects)
 
-  when (allowedTactics == StaticOnly) $ do
-    logInfo staticOnlyAnalysisMessage
-
   maybeEndpointAppVersion <- case destination of
     UploadScan apiOpts _ -> runFossaApiClient apiOpts $ do
       -- Using 'recovery' as API corresponding to 'getEndpointVersion',
@@ -401,7 +390,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   logDebug $ "Filtered projects with path dependencies: " <> pretty (show filteredProjects')
 
   let analysisResult = AnalysisScanResult projectScans vsiResults binarySearchResults manualSrcUnits dynamicLinkedResults maybeLernieResults
-  renderScanSummary (severity cfg) maybeEndpointAppVersion analysisResult $ Config.filterSet cfg
+  renderScanSummary (severity cfg) maybeEndpointAppVersion analysisResult cfg
 
   -- Need to check if vendored is empty as well, even if its a boolean that vendoredDeps exist
   let licenseSourceUnits =

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -35,6 +35,7 @@ import App.Fossa.Analyze.Types (
 import App.Fossa.Analyze.Upload (mergeSourceAndLicenseUnits, uploadSuccessfulAnalysis)
 import App.Fossa.BinaryDeps (analyzeBinaryDeps)
 import App.Fossa.Config.Analyze (
+  AnalysisTacticTypes (..),
   AnalyzeCliOpts,
   AnalyzeConfig (..),
   BinaryDiscovery (BinaryDiscovery),
@@ -134,6 +135,14 @@ debugBundlePath = "fossa.debug.json.gz"
 analyzeSubCommand :: SubCommand AnalyzeCliOpts AnalyzeConfig
 analyzeSubCommand = Config.mkSubCommand dispatch
 
+staticOnlyAnalysisMessage :: Doc a
+staticOnlyAnalysisMessage =
+  vsep
+    [ "Performing static-only analysis!!!"
+    , "Results may be different in comparison to an analysis using build tools."
+    , "See https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/README.md#static-and-dynamic-strategies for more information."
+    ]
+
 dispatch ::
   ( Has Diag.Diagnostics sig m
   , Has Exec sig m
@@ -190,10 +199,11 @@ runDependencyAnalysis ::
   AllFilters ->
   -- | An optional path prefix to prepend to paths of discovered manifestFiles
   Maybe FileAncestry ->
+  AnalysisTacticTypes ->
   -- | The project to analyze
   DiscoveredProject proj ->
   m ()
-runDependencyAnalysis basedir filters pathPrefix project@DiscoveredProject{..} = do
+runDependencyAnalysis basedir filters pathPrefix allowedTactics project@DiscoveredProject{..} = do
   let dpi = DiscoveredProjectIdentifier projectPath projectType
   let hasNonProductionPath = isDefaultNonProductionPath basedir projectPath
 
@@ -209,7 +219,10 @@ runDependencyAnalysis basedir filters pathPrefix project@DiscoveredProject{..} =
       let ctxMessage = "Project Analysis: " <> showT projectType
       graphResult <- Diag.runDiagnosticsIO . diagToDebug . stickyLogStack . withEmptyStack . Diag.context ctxMessage $ do
         debugMetadata "DiscoveredProject" project
-        trackTimeSpent (showT projectType) $ analyzeProject targets projectData
+        let analyzeFn = case allowedTactics of
+              StaticOnly -> analyzeProjectStaticOnly
+              Any -> analyzeProject
+        trackTimeSpent (showT projectType) $ analyzeFn targets projectData
       Diag.flushLogs SevError SevDebug graphResult
       trackResult graphResult
       output $ Scanned dpi (mkResult basedir project pathPrefix <$> graphResult)
@@ -230,18 +243,19 @@ runAnalyzers ::
   , Has TaskPool sig m
   , Has AtomicCounter sig m
   ) =>
+  AnalysisTacticTypes ->
   AllFilters ->
   Path Abs Dir ->
   Maybe FileAncestry ->
   m ()
-runAnalyzers filters basedir pathPrefix = do
+runAnalyzers allowedTactics filters basedir pathPrefix = do
   if filterIsVSIOnly filters
     then do
       logInfo "Running in VSI only mode, skipping other analyzers"
       pure ()
     else traverse_ single discoverFuncs
   where
-    single (DiscoverFunc f) = withDiscoveredProjects f basedir (runDependencyAnalysis basedir filters pathPrefix)
+    single (DiscoverFunc f) = withDiscoveredProjects f basedir (runDependencyAnalysis basedir filters pathPrefix allowedTactics)
 
 analyze ::
   ( Has Debug sig m
@@ -274,6 +288,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
       grepOptions = Config.grepOptions cfg
       customFossaDepsFile = Config.customFossaDepsFile cfg
       shouldAnalyzePathDependencies = resolvePathDependencies $ Config.experimental cfg
+      allowedTactics = Config.allowedTacticTypes cfg
 
   -- additional source units are built outside the standard strategy flow, because they either
   -- require additional information (eg API credentials), or they return additional information (eg user deps).
@@ -349,15 +364,18 @@ analyze cfg = Diag.context "fossa-analyze" $ do
       . runReader discoveryFilters
       . runReader (Config.overrideDynamicAnalysis cfg)
       $ do
-        runAnalyzers filters basedir Nothing
+        runAnalyzers allowedTactics filters basedir Nothing
         when (fromFlag UnpackArchives $ Config.unpackArchives cfg) $
           forkTask $ do
-            res <- Diag.runDiagnosticsIO . diagToDebug . stickyLogStack . withEmptyStack $ Archive.discover (runAnalyzers filters) basedir ancestryDirect
+            res <- Diag.runDiagnosticsIO . diagToDebug . stickyLogStack . withEmptyStack $ Archive.discover (runAnalyzers allowedTactics filters) basedir ancestryDirect
             Diag.withResult SevError SevWarn res (const (pure ()))
   logDebug $ "Unfiltered project scans: " <> pretty (show projectScans)
 
   let filteredProjects = mapMaybe toProjectResult projectScans
   logDebug $ "Filtered project scans: " <> pretty (show filteredProjects)
+
+  when (allowedTactics == StaticOnly) $ do
+    logInfo staticOnlyAnalysisMessage
 
   maybeEndpointAppVersion <- case destination of
     UploadScan apiOpts _ -> runFossaApiClient apiOpts $ do

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -122,9 +122,9 @@ instance Pretty ScanCount where
 staticOnlyAnalysisMessage :: Doc a
 staticOnlyAnalysisMessage =
   vcat
-    [ "Performed static-only analysis!!!"
+    [ "FOSSA CLI was constrained to static-only analysis."
     , "Results may be different in comparison to an analysis using build tools."
-    , "See " <> pretty staticAndDynamicStrategies <> " for more information."
+    , "More information: " <> pretty staticAndDynamicStrategies
     ]
 
 -- | Renders Analysis Scan Summary with `ServInfo` severity.

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -83,6 +83,7 @@ import Srclib.Types (
   sourceUnitOriginPaths,
  )
 import Types (DepType (ArchiveType), DiscoveredProjectType, projectTypeToText)
+import App.Docs (staticAndDynamicStrategies)
 
 data ScanCount = ScanCount
   { numProjects :: Int
@@ -123,7 +124,7 @@ staticOnlyAnalysisMessage =
   vcat
     [ "Performed static-only analysis!!!"
     , "Results may be different in comparison to an analysis using build tools."
-    , "See https://github.com/fossas/fossa-cli/blob/master/docs/references/strategies/README.md#static-and-dynamic-strategies for more information."
+    , "See " <> pretty staticAndDynamicStrategies <> " for more information."
     ]
 
 -- | Renders Analysis Scan Summary with `ServInfo` severity.

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -6,6 +6,7 @@ module App.Fossa.Analyze.ScanSummary (
   renderScanSummary,
 ) where
 
+import App.Docs (staticAndDynamicStrategies)
 import App.Fossa.Analyze.Project (
   ProjectResult (projectResultPath),
   projectResultType,
@@ -83,7 +84,6 @@ import Srclib.Types (
   sourceUnitOriginPaths,
  )
 import Types (DepType (ArchiveType), DiscoveredProjectType, projectTypeToText)
-import App.Docs (staticAndDynamicStrategies)
 
 data ScanCount = ScanCount
   { numProjects :: Int

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -113,20 +113,10 @@ data DiscoveredProjectIdentifier = DiscoveredProjectIdentifier
   }
   deriving (Eq, Ord, Show)
 
-{-# WARNING analyzeProject' "analyzeProject' has been renamed to analyzeProjectStaticOnly. Please use that name for all future implementations." #-}
 class AnalyzeProject a where
   -- | Analyze a project with any tactic including dynamic ones.
   analyzeProject :: AnalyzeTaskEffs sig m => FoundTargets -> a -> m DependencyResults
 
   -- | Analyze a project with only static tactics.
-  -- Static here generally means not using any external utilities.
-  -- An exception is berkeleydb which calls a program embedded in the CLI.
+  -- See docs/references/strategies/README.md#static-and-dynamic-strategies for information on the difference.
   analyzeProjectStaticOnly :: AnalyzeStaticTaskEffs sig m => FoundTargets -> a -> m DependencyResults
-  -- This is required to satisfy the MINIMAL pragma below and for compatibility with existing consumers of AnalyzeProject.
-  -- Please don't use this default implementation for any new code.
-  analyzeProjectStaticOnly = analyzeProject'
-
-  analyzeProject' :: (AnalyzeStaticTaskEffs sig m) => FoundTargets -> a -> m DependencyResults
-  analyzeProject' = analyzeProjectStaticOnly
-
-  {-# MINIMAL analyzeProject, analyzeProject' | analyzeProject, analyzeProjectStaticOnly #-}

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -113,9 +113,18 @@ data DiscoveredProjectIdentifier = DiscoveredProjectIdentifier
   }
   deriving (Eq, Ord, Show)
 
+{-# WARNING analyzeProject' "analyzeProject' has been renamed to analyzeProjectStaticOnly. Please use that name for all future implementations." #-}
 class AnalyzeProject a where
   -- | Analyze a project with any tactic.
   analyzeProject :: AnalyzeTaskEffs sig m => FoundTargets -> a -> m DependencyResults
 
   -- | Analyze a project with only static tactics.
-  analyzeProject' :: AnalyzeStaticTaskEffs sig m => FoundTargets -> a -> m DependencyResults
+  analyzeProjectStaticOnly :: AnalyzeStaticTaskEffs sig m => FoundTargets -> a -> m DependencyResults
+  -- This is required to satisfy the MINIMAL pragma below and for compatibility with existing consumers of AnalyzeProject.
+  -- Please don't use this default implementation for any new code.
+  analyzeProjectStaticOnly = analyzeProject'
+
+  analyzeProject' :: (AnalyzeStaticTaskEffs sig m) => FoundTargets -> a -> m DependencyResults
+  analyzeProject' = analyzeProjectStaticOnly
+
+  {-# MINIMAL analyzeProject, analyzeProject' | analyzeProject, analyzeProjectStaticOnly #-}

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -115,10 +115,12 @@ data DiscoveredProjectIdentifier = DiscoveredProjectIdentifier
 
 {-# WARNING analyzeProject' "analyzeProject' has been renamed to analyzeProjectStaticOnly. Please use that name for all future implementations." #-}
 class AnalyzeProject a where
-  -- | Analyze a project with any tactic.
+  -- | Analyze a project with any tactic including dynamic ones.
   analyzeProject :: AnalyzeTaskEffs sig m => FoundTargets -> a -> m DependencyResults
 
   -- | Analyze a project with only static tactics.
+  -- Static here generally means not using any external utilities.
+  -- An exception is berkeleydb which calls a program embedded in the CLI.
   analyzeProjectStaticOnly :: AnalyzeStaticTaskEffs sig m => FoundTargets -> a -> m DependencyResults
   -- This is required to satisfy the MINIMAL pragma below and for compatibility with existing consumers of AnalyzeProject.
   -- Please don't use this default implementation for any new code.

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -301,7 +301,7 @@ cliParser =
     <*> flagOpt ForceNoFirstPartyScans (long "experimental-block-first-party-scans" <> help "Block first party scans. This can be used to forcibly turn off first-party scans if your organization defaults to first-party scans.")
     <*> flagOpt IgnoreOrgWideCustomLicenseScanConfigs (long "ignore-org-wide-custom-license-scan-configs" <> help "Ignore custom-license scan configurations for your organization. These configurations are defined in the \"Integrations\" section of the Admin settings in the FOSSA web app")
     <*> optional (strOption (long "fossa-deps-file" <> help "Path to fossa-deps file including filename (default: fossa-deps.{yaml|yml|json})"))
-    <*> flagOpt StaticOnlyTactics (long "static-only-analysis" <> help "Do not use dynamic tools for discovering dependencies.")
+    <*> flagOpt StaticOnlyTactics (long "static-only-analysis" <> help "Only analyze the project using static strategies.")
 
 data GoDynamicTactic
   = GoModulesBasedTactic

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -14,7 +14,7 @@ module App.Fossa.Config.Analyze (
   JsonOutput (..),
   NoDiscoveryExclusion (..),
   ScanDestination (..),
-  AnalysisTacticTypes(..),
+  AnalysisTacticTypes (..),
   AnalyzeConfig (..),
   UnpackArchives (..),
   VendoredDependencyOptions (..),

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -14,12 +14,14 @@ module App.Fossa.Config.Analyze (
   JsonOutput (..),
   NoDiscoveryExclusion (..),
   ScanDestination (..),
+  AnalysisTacticTypes(..),
   AnalyzeConfig (..),
   UnpackArchives (..),
   VendoredDependencyOptions (..),
   VSIAnalysis (..),
   VSIModeOptions (..),
   GoDynamicTactic (..),
+  StaticOnlyTactics (..),
   mkSubCommand,
   loadConfig,
   cliParser,
@@ -123,6 +125,7 @@ data ForceVendoredDependencyRescans = ForceVendoredDependencyRescans deriving (G
 data ForceFirstPartyScans = ForceFirstPartyScans deriving (Generic)
 data ForceNoFirstPartyScans = ForceNoFirstPartyScans deriving (Generic)
 data IgnoreOrgWideCustomLicenseScanConfigs = IgnoreOrgWideCustomLicenseScanConfigs deriving (Generic)
+data StaticOnlyTactics = StaticOnlyTactics deriving (Generic)
 
 data BinaryDiscovery = BinaryDiscovery deriving (Generic)
 data IncludeAll = IncludeAll deriving (Generic)
@@ -208,6 +211,7 @@ data AnalyzeCliOpts = AnalyzeCliOpts
   , analyzeForceNoFirstPartyScans :: Flag ForceNoFirstPartyScans
   , analyzeIgnoreOrgWideCustomLicenseScanConfigs :: Flag IgnoreOrgWideCustomLicenseScanConfigs
   , analyzeCustomFossaDepsFile :: Maybe FilePath
+  , analyzeStaticOnlyTactics :: Flag StaticOnlyTactics
   }
   deriving (Eq, Ord, Show)
 
@@ -219,6 +223,11 @@ instance GetCommonOpts AnalyzeCliOpts where
 
 instance GetSeverity AnalyzeCliOpts where
   getSeverity AnalyzeCliOpts{commons = CommonOpts{optDebug}} = if optDebug then SevDebug else SevInfo
+
+data AnalysisTacticTypes = StaticOnly | Any deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON AnalysisTacticTypes where
+  toEncoding = genericToEncoding defaultOptions
 
 data AnalyzeConfig = AnalyzeConfig
   { baseDir :: BaseDir
@@ -238,6 +247,7 @@ data AnalyzeConfig = AnalyzeConfig
   , firstPartyScansFlag :: FirstPartyScansFlag
   , grepOptions :: GrepOptions
   , customFossaDepsFile :: Maybe FilePath
+  , allowedTacticTypes :: AnalysisTacticTypes
   }
   deriving (Eq, Ord, Show, Generic)
 
@@ -291,6 +301,7 @@ cliParser =
     <*> flagOpt ForceNoFirstPartyScans (long "experimental-block-first-party-scans" <> help "Block first party scans. This can be used to forcibly turn off first-party scans if your organization defaults to first-party scans.")
     <*> flagOpt IgnoreOrgWideCustomLicenseScanConfigs (long "ignore-org-wide-custom-license-scan-configs" <> help "Ignore custom-license scan configurations for your organization. These configurations are defined in the \"Integrations\" section of the Admin settings in the FOSSA web app")
     <*> optional (strOption (long "fossa-deps-file" <> help "Path to fossa-deps file including filename (default: fossa-deps.{yaml|yml|json})"))
+    <*> flagOpt StaticOnlyTactics (long "static-only-analysis" <> help "Do not use dynamic tools for discovering dependencies.")
 
 data GoDynamicTactic
   = GoModulesBasedTactic
@@ -424,6 +435,10 @@ mergeStandardOpts maybeConfig envvars cliOpts@AnalyzeCliOpts{..} = do
       dynamicAnalysisOverrides = OverrideDynamicAnalysisBinary $ envCmdOverrides envvars
       grepOptions = collectGrepOptions maybeConfig cliOpts
       customFossaDepsFile = analyzeCustomFossaDepsFile
+      allowedTacticType =
+        if fromFlag StaticOnlyTactics analyzeStaticOnlyTactics
+          then StaticOnly
+          else Any
 
   firstPartyScansFlag <-
     case (fromFlag ForceFirstPartyScans analyzeForceFirstPartyScans, fromFlag ForceNoFirstPartyScans analyzeForceNoFirstPartyScans) of
@@ -450,6 +465,7 @@ mergeStandardOpts maybeConfig envvars cliOpts@AnalyzeCliOpts{..} = do
     <*> pure firstPartyScansFlag
     <*> pure grepOptions
     <*> pure customFossaDepsFile
+    <*> pure allowedTacticType
 
 collectMavenScopeFilters ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Container/Sources/DockerArchive.hs
+++ b/src/App/Fossa/Container/Sources/DockerArchive.hs
@@ -11,7 +11,7 @@ import App.Fossa.Analyze.Debug (diagToDebug)
 import App.Fossa.Analyze.Discover (DiscoverFunc (DiscoverFunc))
 import App.Fossa.Analyze.Project (mkResult)
 import App.Fossa.Analyze.Types (
-  AnalyzeProject (analyzeProject'),
+  AnalyzeProject (analyzeProjectStaticOnly),
   AnalyzeStaticTaskEffs,
   DiscoveredProjectIdentifier (..),
   DiscoveredProjectScan (..),
@@ -241,7 +241,7 @@ runDependencyAnalysis basedir filters project@DiscoveredProject{..} = do
       let ctxMessage = "Project Analysis: " <> showT projectType
       graphResult <- Diag.runDiagnosticsIO . diagToDebug . stickyLogStack . withEmptyStack $
         Diag.context ctxMessage $ do
-          analyzeProject' targets projectData
+          analyzeProjectStaticOnly targets projectData
       Diag.flushLogs SevError SevDebug graphResult
       output $ Scanned dpi (mkResult basedir project Nothing <$> graphResult)
 

--- a/src/Strategy/ApkDatabase.hs
+++ b/src/Strategy/ApkDatabase.hs
@@ -4,7 +4,7 @@ module Strategy.ApkDatabase (
   mkProject,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProject'))
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProjectStaticOnly))
 import Container.OsRelease (OsInfo)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Reader (Reader)
@@ -39,7 +39,7 @@ instance ToJSON AlpineDatabase
 
 instance AnalyzeProject AlpineDatabase where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 discover ::
   ( Has ReadFS sig m

--- a/src/Strategy/BerkeleyDB.hs
+++ b/src/Strategy/BerkeleyDB.hs
@@ -4,7 +4,7 @@ module Strategy.BerkeleyDB (
   mkProject,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject), analyzeProject')
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject), analyzeProjectStaticOnly)
 import Container.OsRelease (OsInfo (..))
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Lift (Lift)
@@ -48,7 +48,7 @@ instance ToJSON BerkeleyDatabase
 
 instance AnalyzeProject BerkeleyDatabase where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 discover ::
   ( Has ReadFS sig m

--- a/src/Strategy/Bundler.hs
+++ b/src/Strategy/Bundler.hs
@@ -10,7 +10,7 @@ module Strategy.Bundler (
 import App.Fossa.Analyze.LicenseAnalyze (
   LicenseAnalyzeProject (licenseAnalyzeProject),
  )
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (
   Diagnostics,
   context,
@@ -87,7 +87,7 @@ instance ToJSON BundlerProject
 
 instance AnalyzeProject BundlerProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = analyzeGemfileLock
+  analyzeProjectStaticOnly _ = analyzeGemfileLock
 
 instance LicenseAnalyzeProject BundlerProject where
   licenseAnalyzeProject = fmap mconcat . traverse findLicenses . bundlerGemSpec

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -16,7 +16,7 @@ module Strategy.Cargo (
 import App.Fossa.Analyze.LicenseAnalyze (
   LicenseAnalyzeProject (licenseAnalyzeProject),
  )
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
@@ -216,7 +216,7 @@ instance ToJSON CargoProject
 
 instance AnalyzeProject CargoProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = const $ fatalText "Cannot analyze Cargo project statically."
+  analyzeProjectStaticOnly _ = const $ fatalText "Cannot analyze Cargo project statically."
 
 data CargoPackage = CargoPackage
   { license :: Maybe Text.Text

--- a/src/Strategy/Carthage.hs
+++ b/src/Strategy/Carthage.hs
@@ -11,7 +11,7 @@ module Strategy.Carthage (
   CarthageProject (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject, analyzeProject')
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
@@ -106,7 +106,7 @@ instance ToJSON CarthageProject
 
 instance AnalyzeProject CarthageProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 mkProject :: CarthageProject -> DiscoveredProject CarthageProject
 mkProject project =

--- a/src/Strategy/Cocoapods.hs
+++ b/src/Strategy/Cocoapods.hs
@@ -7,7 +7,7 @@ module Strategy.Cocoapods (
 ) where
 
 import App.Fossa.Analyze.LicenseAnalyze (LicenseAnalyzeProject, licenseAnalyzeProject)
-import App.Fossa.Analyze.Types (AnalyzeProject, analyzeProject, analyzeProject')
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context, errCtx, warnOnErr, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
@@ -78,7 +78,7 @@ instance ToJSON CocoapodsProject
 
 instance AnalyzeProject CocoapodsProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps'
+  analyzeProjectStaticOnly _ = getDeps'
 
 instance LicenseAnalyzeProject CocoapodsProject where
   licenseAnalyzeProject = traverse readLicense . cocoapodsSpecFiles

--- a/src/Strategy/Composer.hs
+++ b/src/Strategy/Composer.hs
@@ -7,7 +7,7 @@ module Strategy.Composer (
 ) where
 
 import App.Fossa.Analyze.LicenseAnalyze (LicenseAnalyzeProject (licenseAnalyzeProject))
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
@@ -114,7 +114,7 @@ instance ToJSON ComposerProject
 
 instance AnalyzeProject ComposerProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 instance LicenseAnalyzeProject ComposerProject where
   licenseAnalyzeProject = analyzeLicenses . composerJson

--- a/src/Strategy/Conda.hs
+++ b/src/Strategy/Conda.hs
@@ -4,7 +4,7 @@ module Strategy.Conda (
   discover,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
@@ -58,7 +58,7 @@ instance ToJSON CondaProject
 
 instance AnalyzeProject CondaProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = const $ fatalText "Cannot analyze Conda project statically."
+  analyzeProjectStaticOnly _ = const $ fatalText "Cannot analyze Conda project statically."
 
 mkProject :: CondaProject -> DiscoveredProject CondaProject
 mkProject project =

--- a/src/Strategy/Dpkg.hs
+++ b/src/Strategy/Dpkg.hs
@@ -4,7 +4,7 @@ module Strategy.Dpkg (
   mkProject,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProject'))
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProjectStaticOnly))
 import Container.OsRelease (OsInfo)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Reader (Reader)
@@ -39,7 +39,7 @@ instance ToJSON DpkgDatabase
 
 instance AnalyzeProject DpkgDatabase where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 discover ::
   ( Has ReadFS sig m

--- a/src/Strategy/Elixir/MixTree.hs
+++ b/src/Strategy/Elixir/MixTree.hs
@@ -17,7 +17,7 @@ module Strategy.Elixir.MixTree (
   analyze,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, Has, context, fatalText, warn)
 import Control.Monad (void, when)
 import Control.Monad.Combinators.Expr (Operator (..), makeExprParser)
@@ -105,7 +105,7 @@ instance ToJSON MixProject
 
 instance AnalyzeProject MixProject where
   analyzeProject _ = analyze
-  analyzeProject' _ = const $ fatalText "Cannot analyze mix project statically"
+  analyzeProjectStaticOnly _ = const $ fatalText "Cannot analyze mix project statically"
 
 -- | Name of the Package.
 newtype PackageName = PackageName {unPackageName :: Text} deriving (Show, Eq, Ord)

--- a/src/Strategy/Fpm.hs
+++ b/src/Strategy/Fpm.hs
@@ -1,7 +1,7 @@
 -- | Fpm, the fortran package manager.
 module Strategy.Fpm (discover) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Reader (Reader)
 import Data.Aeson (ToJSON)
@@ -40,7 +40,7 @@ instance ToJSON FpmProject
 
 instance AnalyzeProject FpmProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 mkProject :: FpmProject -> DiscoveredProject FpmProject
 mkProject project =

--- a/src/Strategy/Glide.hs
+++ b/src/Strategy/Glide.hs
@@ -2,7 +2,7 @@ module Strategy.Glide (
   discover,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Reader (Reader)
 import Data.Aeson (ToJSON)
@@ -42,7 +42,7 @@ instance ToJSON GlideProject
 
 instance AnalyzeProject GlideProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 mkProject :: GlideProject -> DiscoveredProject GlideProject
 mkProject project =

--- a/src/Strategy/Godep.hs
+++ b/src/Strategy/Godep.hs
@@ -2,7 +2,7 @@ module Strategy.Godep (
   discover,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context, fatalText, (<||>))
 import Control.Effect.Diagnostics qualified as Diag
@@ -58,7 +58,7 @@ instance ToJSON GodepProject
 
 instance AnalyzeProject GodepProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = const $ fatalText "Cannot analyze Godep project statically"
+  analyzeProjectStaticOnly _ = const $ fatalText "Cannot analyze Godep project statically"
 
 mkProject :: GodepProject -> DiscoveredProject GodepProject
 mkProject project =

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -6,7 +6,7 @@ module Strategy.Gomodules (
   GomodulesProject (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig (useV3GoResolver), GoDynamicTactic (..))
 import Control.Carrier.Diagnostics (warn)
 import Control.Effect.Diagnostics (Diagnostics, context, fatalText, recover, (<||>))
@@ -59,7 +59,7 @@ instance ToJSON GomodulesProject
 
 instance AnalyzeProject GomodulesProject where
   analyzeProject _ proj = asks useV3GoResolver >>= getDeps proj
-  analyzeProject' _ = const $ fatalText "Cannot analyze GoModule project statically"
+  analyzeProjectStaticOnly _ = const $ fatalText "Cannot analyze GoModule project statically"
 
 mkProject :: GomodulesProject -> DiscoveredProject GomodulesProject
 mkProject project =

--- a/src/Strategy/Googlesource/RepoManifest.hs
+++ b/src/Strategy/Googlesource/RepoManifest.hs
@@ -15,7 +15,7 @@ module Strategy.Googlesource.RepoManifest (
   ValidatedProject (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Applicative (optional, (<|>))
 import Control.Effect.Diagnostics (
   Diagnostics,
@@ -110,7 +110,7 @@ mkProject project =
 
 instance AnalyzeProject RepoManifestProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => RepoManifestProject -> m DependencyResults
 getDeps = analyze' . repoManifestXml

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -18,7 +18,7 @@ module Strategy.Gradle (
   GradleProject,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig (allowedGradleConfigs))
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (
@@ -169,7 +169,7 @@ instance ToJSON GradleProject
 
 instance AnalyzeProject GradleProject where
   analyzeProject = getDeps
-  analyzeProject' _ = const $ fatalText "Cannot analyze Gradle target statically"
+  analyzeProjectStaticOnly _ = const $ fatalText "Cannot analyze Gradle target statically"
 
 gradleProjectsCmd :: Text -> Command
 gradleProjectsCmd baseCmd =

--- a/src/Strategy/Haskell/Cabal.hs
+++ b/src/Strategy/Haskell/Cabal.hs
@@ -14,7 +14,7 @@ module Strategy.Haskell.Cabal (
   buildGraph,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
@@ -199,7 +199,7 @@ instance ToJSON CabalProject
 
 instance AnalyzeProject CabalProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = const $ fatalText "Cannot analyze cabal project statically"
+  analyzeProjectStaticOnly _ = const $ fatalText "Cannot analyze cabal project statically"
 
 doGraph :: Has (MappedGrapher PlanId InstallPlan) sig m => InstallPlan -> m ()
 doGraph plan = do

--- a/src/Strategy/Haskell/Stack.hs
+++ b/src/Strategy/Haskell/Stack.hs
@@ -12,7 +12,7 @@ module Strategy.Haskell.Stack (
   StackLocation (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
@@ -146,7 +146,7 @@ instance ToJSON StackProject
 
 instance AnalyzeProject StackProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = const $ fatalText "Cannot analyze stack project statically"
+  analyzeProjectStaticOnly _ = const $ fatalText "Cannot analyze stack project statically"
 
 stackJSONDepsCmd :: Command
 stackJSONDepsCmd =

--- a/src/Strategy/Leiningen.hs
+++ b/src/Strategy/Leiningen.hs
@@ -20,7 +20,7 @@ module Strategy.Leiningen (
   LeiningenProject (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Applicative (optional)
 import Control.Effect.Diagnostics (
   Diagnostics,
@@ -138,7 +138,7 @@ instance ToJSON LeiningenProject
 
 instance AnalyzeProject LeiningenProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = const $ fatalText "Cannot analyze Leiningen project statically"
+  analyzeProjectStaticOnly _ = const $ fatalText "Cannot analyze Leiningen project statically"
 
 analyze :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs File -> m DependencyResults
 analyze file = do

--- a/src/Strategy/Maven.hs
+++ b/src/Strategy/Maven.hs
@@ -6,7 +6,7 @@ module Strategy.Maven (
 ) where
 
 import App.Fossa.Analyze.LicenseAnalyze (LicenseAnalyzeProject, licenseAnalyzeProject)
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, context, warnOnErr, (<||>))
 import Control.Effect.Lift (Lift)
@@ -65,7 +65,7 @@ instance ToJSON MavenProject
 
 instance AnalyzeProject MavenProject where
   analyzeProject = getDeps
-  analyzeProject' = getDeps'
+  analyzeProjectStaticOnly = getDeps'
 
 instance LicenseAnalyzeProject MavenProject where
   licenseAnalyzeProject = pure . Pom.getLicenses . unMavenProject

--- a/src/Strategy/NDB.hs
+++ b/src/Strategy/NDB.hs
@@ -4,7 +4,7 @@ module Strategy.NDB (
   mkProject,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (..), analyzeProject')
+import App.Fossa.Analyze.Types (AnalyzeProject (..))
 import Container.OsRelease (OsInfo (..))
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Reader (Reader)
@@ -45,7 +45,7 @@ instance ToJSON NdbLocation
 
 instance AnalyzeProject NdbLocation where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 discover ::
   ( Has ReadFS sig m

--- a/src/Strategy/Nim.hs
+++ b/src/Strategy/Nim.hs
@@ -4,7 +4,7 @@ module Strategy.Nim (
   mkProject,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProject'))
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProjectStaticOnly))
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Reader (Reader)
 import Data.Aeson (ToJSON)
@@ -32,7 +32,7 @@ instance ToJSON NimbleProject
 
 instance AnalyzeProject NimbleProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps'
+  analyzeProjectStaticOnly _ = getDeps'
 
 discover :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters) sig m) => Path Abs Dir -> m [DiscoveredProject NimbleProject]
 discover = simpleDiscover findProjects mkProject NimbleProjectType

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -12,7 +12,7 @@ module Strategy.Node (
 import Algebra.Graph.AdjacencyMap qualified as AM
 import Algebra.Graph.AdjacencyMap.Extra qualified as AME
 import App.Fossa.Analyze.LicenseAnalyze (LicenseAnalyzeProject, licenseAnalyzeProject)
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProject'))
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProjectStaticOnly))
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
@@ -155,7 +155,7 @@ mkProject project = do
 
 instance AnalyzeProject NodeProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 -- Since we don't natively support workspaces, we don't attempt to preserve them from this point on.
 -- In the future, if you're adding generalized workspace support, start here.

--- a/src/Strategy/NuGet/Nuspec.hs
+++ b/src/Strategy/NuGet/Nuspec.hs
@@ -13,7 +13,7 @@ module Strategy.NuGet.Nuspec (
 ) where
 
 import App.Fossa.Analyze.LicenseAnalyze (LicenseAnalyzeProject, licenseAnalyzeProject)
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Applicative (optional)
 import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Control.Effect.Reader (Reader)
@@ -85,7 +85,7 @@ mkProject project =
 
 instance AnalyzeProject NuspecProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 instance LicenseAnalyzeProject NuspecProject where
   licenseAnalyzeProject = analyzeLicenses . nuspecFile

--- a/src/Strategy/NuGet/PackageReference.hs
+++ b/src/Strategy/NuGet/PackageReference.hs
@@ -12,7 +12,7 @@ module Strategy.NuGet.PackageReference (
   Package (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Applicative (optional, (<|>))
 import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Control.Effect.Reader (Reader)
@@ -67,7 +67,7 @@ instance ToJSON PackageReferenceProject
 
 instance AnalyzeProject PackageReferenceProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 mkProject :: PackageReferenceProject -> DiscoveredProject PackageReferenceProject
 mkProject project =

--- a/src/Strategy/NuGet/PackagesConfig.hs
+++ b/src/Strategy/NuGet/PackagesConfig.hs
@@ -10,7 +10,7 @@ module Strategy.NuGet.PackagesConfig (
   NuGetDependency (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Control.Effect.Reader (Reader)
 import Data.Aeson (ToJSON)
@@ -60,7 +60,7 @@ instance ToJSON PackagesConfigProject
 
 instance AnalyzeProject PackagesConfigProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 mkProject :: PackagesConfigProject -> DiscoveredProject PackagesConfigProject
 mkProject project =

--- a/src/Strategy/NuGet/Paket.hs
+++ b/src/Strategy/NuGet/Paket.hs
@@ -10,7 +10,7 @@ module Strategy.NuGet.Paket (
   Remote (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
@@ -90,7 +90,7 @@ instance ToJSON PaketProject
 
 instance AnalyzeProject PaketProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 mkProject :: PaketProject -> DiscoveredProject PaketProject
 mkProject project =

--- a/src/Strategy/NuGet/ProjectAssetsJson.hs
+++ b/src/Strategy/NuGet/ProjectAssetsJson.hs
@@ -13,7 +13,7 @@ module Strategy.NuGet.ProjectAssetsJson (
   FrameworkName (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
@@ -91,7 +91,7 @@ instance ToJSON ProjectAssetsJsonProject
 
 instance AnalyzeProject ProjectAssetsJsonProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 mkProject :: ProjectAssetsJsonProject -> DiscoveredProject ProjectAssetsJsonProject
 mkProject project =

--- a/src/Strategy/NuGet/ProjectJson.hs
+++ b/src/Strategy/NuGet/ProjectJson.hs
@@ -9,7 +9,7 @@ module Strategy.NuGet.ProjectJson (
   ProjectJson (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, Has)
 import Control.Effect.Reader (Reader)
@@ -69,7 +69,7 @@ instance ToJSON ProjectJsonProject
 
 instance AnalyzeProject ProjectJsonProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 mkProject :: ProjectJsonProject -> DiscoveredProject ProjectJsonProject
 mkProject project =

--- a/src/Strategy/Perl.hs
+++ b/src/Strategy/Perl.hs
@@ -7,7 +7,7 @@ module Strategy.Perl (
   buildGraph,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Reader (Reader)
@@ -68,7 +68,7 @@ data PerlProject = PerlProject
 instance ToJSON PerlProject
 instance AnalyzeProject PerlProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 mkProject :: PerlProject -> DiscoveredProject PerlProject
 mkProject project =

--- a/src/Strategy/Pub.hs
+++ b/src/Strategy/Pub.hs
@@ -1,7 +1,7 @@
 -- | Pub, the Dart dependency manager.
 module Strategy.Pub (discover) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, errCtx, fatalText, recover, warnOnErr, (<||>))
 import Control.Effect.Reader (Reader)
 import Control.Monad (void)
@@ -52,7 +52,7 @@ instance ToJSON PubProject
 
 instance AnalyzeProject PubProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps'
+  analyzeProjectStaticOnly _ = getDeps'
 
 mkProject :: PubProject -> DiscoveredProject PubProject
 mkProject project =

--- a/src/Strategy/Python/PDM/Pdm.hs
+++ b/src/Strategy/Python/PDM/Pdm.hs
@@ -21,7 +21,7 @@ import Strategy.Python.Poetry.PyProject (PyProject (..), PyProjectMetadata (..),
 import Strategy.Python.Util (Req (..), toConstraint)
 import Text.URI qualified as URI
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Reader (Reader)
 import Data.Aeson (ToJSON)
 import Data.Maybe (isNothing)
@@ -64,7 +64,7 @@ instance ToJSON PdmProject
 
 instance AnalyzeProject PdmProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 mkProject :: PdmProject -> DiscoveredProject PdmProject
 mkProject project =

--- a/src/Strategy/Python/Pipenv.hs
+++ b/src/Strategy/Python/Pipenv.hs
@@ -14,7 +14,7 @@ module Strategy.Python.Pipenv (
   buildGraph,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
@@ -146,7 +146,7 @@ instance ToJSON PipenvProject
 
 instance AnalyzeProject PipenvProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps'
+  analyzeProjectStaticOnly _ = getDeps'
 
 pipenvGraphCmd :: Command
 pipenvGraphCmd =

--- a/src/Strategy/Python/Poetry.hs
+++ b/src/Strategy/Python/Poetry.hs
@@ -7,7 +7,7 @@ module Strategy.Python.Poetry (
   PoetryProject (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Algebra (Has)
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, context, errCtx, fatalText, recover, warnOnErr)
@@ -63,7 +63,7 @@ instance ToJSON PoetryProject
 
 instance AnalyzeProject PoetryProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 discover ::
   ( Has ReadFS sig m

--- a/src/Strategy/Python/Setuptools.hs
+++ b/src/Strategy/Python/Setuptools.hs
@@ -6,7 +6,7 @@ module Strategy.Python.Setuptools (
   SetuptoolsProject (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Diagnostics qualified as Diag
 import Control.Effect.Reader (Reader)
@@ -115,7 +115,7 @@ instance ToJSON SetuptoolsProject
 
 instance AnalyzeProject SetuptoolsProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps'
+  analyzeProjectStaticOnly _ = getDeps'
 
 mkProject :: SetuptoolsProject -> DiscoveredProject SetuptoolsProject
 mkProject project =

--- a/src/Strategy/R.hs
+++ b/src/Strategy/R.hs
@@ -4,7 +4,7 @@ module Strategy.R (
   mkProject,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProject'))
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProjectStaticOnly))
 import Control.Effect.Diagnostics (Diagnostics, errCtx, fatalText, recover, warnOnErr)
 import Control.Effect.Reader (Reader)
 import Control.Monad (void)
@@ -53,7 +53,7 @@ instance ToJSON RProject
 
 instance AnalyzeProject RProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 discover ::
   ( Has ReadFS sig m

--- a/src/Strategy/RPM.hs
+++ b/src/Strategy/RPM.hs
@@ -11,7 +11,7 @@ module Strategy.RPM (
   Dependencies (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Control.Effect.Reader (Reader)
 import Data.Aeson (ToJSON)
@@ -88,7 +88,7 @@ instance ToJSON RpmProject
 
 instance AnalyzeProject RpmProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 mkProject :: RpmProject -> DiscoveredProject RpmProject
 mkProject project =

--- a/src/Strategy/Rebar3.hs
+++ b/src/Strategy/Rebar3.hs
@@ -7,7 +7,7 @@ module Strategy.Rebar3 (
   mkProject,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (Diagnostics, fatalText)
 import Control.Effect.Reader (Reader)
 import Data.Aeson (ToJSON)
@@ -48,7 +48,7 @@ instance ToJSON RebarProject
 
 instance AnalyzeProject RebarProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = const $ fatalText "Cannot analyze Rebar3 project statically"
+  analyzeProjectStaticOnly _ = const $ fatalText "Cannot analyze Rebar3 project statically"
 
 mkProject :: RebarProject -> DiscoveredProject RebarProject
 mkProject project =

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -12,7 +12,7 @@ module Strategy.Scala (
   ScalaProject (..),
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject'), analyzeProject)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)
 import Control.Effect.Diagnostics (
   Diagnostics,
   errCtx,
@@ -123,7 +123,7 @@ instance ToJSON ScalaProject where
 
 instance AnalyzeProject ScalaProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = const $ fatalText "Cannot analyze scala project statically"
+  analyzeProjectStaticOnly _ = const $ fatalText "Cannot analyze scala project statically"
 
 mkProject :: ScalaProject -> DiscoveredProject ScalaProject
 mkProject (ScalaProject sbtBuildDir sbtTreeJson closure) =

--- a/src/Strategy/Sqlite.hs
+++ b/src/Strategy/Sqlite.hs
@@ -7,7 +7,7 @@ module Strategy.Sqlite (
   discover,
 ) where
 
-import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProject'))
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject, analyzeProjectStaticOnly))
 import Container.OsRelease (OsInfo (..))
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, context, warn)
@@ -82,7 +82,7 @@ mkProject db =
 
 instance AnalyzeProject SqliteDB where
   analyzeProject _ = analyze
-  analyzeProject' _ = analyze
+  analyzeProjectStaticOnly _ = analyze
 
 data SqliteDBEntry = SqliteDBEntry
   { pkgName :: Text

--- a/src/Strategy/SwiftPM.hs
+++ b/src/Strategy/SwiftPM.hs
@@ -125,7 +125,7 @@ mkProject project =
 
 instance AnalyzeProject SwiftProject where
   analyzeProject _ = getDeps
-  analyzeProject' _ = getDeps
+  analyzeProjectStaticOnly _ = getDeps
 
 getDeps :: (Has ReadFS sig m, Has Diagnostics sig m) => SwiftProject -> m DependencyResults
 getDeps project = do

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -39,7 +39,7 @@ module Test.Fixtures (
   vsiSourceUnit,
 ) where
 
-import App.Fossa.Config.Analyze (AnalyzeConfig (AnalyzeConfig), ExperimentalAnalyzeConfig (..), GoDynamicTactic (..), IncludeAll (..), JsonOutput (JsonOutput), NoDiscoveryExclusion (..), ScanDestination (..), UnpackArchives (..), VSIModeOptions (..), VendoredDependencyOptions (..))
+import App.Fossa.Config.Analyze (AnalysisTacticTypes (Any), AnalyzeConfig (AnalyzeConfig), ExperimentalAnalyzeConfig (..), GoDynamicTactic (..), IncludeAll (..), JsonOutput (JsonOutput), NoDiscoveryExclusion (..), ScanDestination (..), UnpackArchives (..), VSIModeOptions (..), VendoredDependencyOptions (..))
 import App.Fossa.Config.Analyze qualified as ANZ
 import App.Fossa.Config.Analyze qualified as VSI
 import App.Fossa.Config.Test (DiffRevision (DiffRevision))
@@ -441,4 +441,5 @@ standardAnalyzeConfig =
     , ANZ.firstPartyScansFlag = App.FirstPartyScansUseDefault
     , ANZ.grepOptions = grepOptions
     , ANZ.customFossaDepsFile = customFossaDepsFile
+    , ANZ.allowedTacticTypes = Any
     }


### PR DESCRIPTION
# Overview

This PR adds a way to enable static-only analysis as a CLI option. Formerly this was available only to library consumers. Additionally, it provides a way to control which kind of analysis is run as a parameter to the functions in `src/App/Fossa/Analyze.hs`. 

I changed the CLI to output a message in the scan summary stating that only static tactics were used so that this will be more obvious to support staff:

![Screenshot 2024-01-16 at 4 26 26 PM](https://github.com/fossas/fossa-cli/assets/190980/65eddc9a-f2f1-4ff7-b43a-a2335d5997af)

It also adds a new name for `analyseProject'`, `analyseProjectStaticOnly` which better describes the purpose and intent of that function. A compiler warning encourages consumers of `spectrometer` to use the new name. 

I didn't audit each of our `AnalyzeProject` instances to make sure that their implementations of `analyzeProject'` are actually static only. I don't think this is really needed, but if a reviewer disagrees I can do that.

## Acceptance criteria

* Customers and consumers of `spectrometer` have a way to run the CLI but only use static strategies.

## Testing plan

A simple way to see this in action is with a `Go` project:
```
fossa analyze --static-only-analysis example-projects/
```
Go doesn't have any static tactics so it fails with an error whereas running without the flag operates successfully. 

Maven on the other hand has both a static and a dynamic strategy. Using our example-projects repository we can scan with dynamic enabled:
```
fossa analyze example-projects/maven/example-maven-project/  -o
```
You'll notice in the output that the maven plugin was installed and run. Also, the message about static only analysis is not present.

Running against the same project with the static only flag:
```
fossa analyze --static-only-analysis example-projects/maven/example-maven-project/ -o
```
Does not show the plugin running and also outputs the message about doing a static only analysis. 

## Risks

The main risk is that CI customers may try to use static analysis and get poor results that they then ask us about. I've tried to point users of this feature in the right direction to understand why this is the case. 

## Metrics

## References

[ANE-797](https://fossa.atlassian.net/browse/ANE-797)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-797]: https://fossa.atlassian.net/browse/ANE-797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ