### PR TITLE
Adds basic reachability integration in cli (Part 1/N)

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -387,7 +387,7 @@ jobs:
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/fossa.exe
         zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/diagnose.exe
         zip -j release/millhone_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/millhone.exe
-        zip -j release/reachability_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/reachability.exe
+        zip -j release/reachability_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip Windows-binaries/reachability.exe
 
     - name: Create checksums
       # We have to run from within the release dir so that "release" isn't prepended to the relative path of the zip file.

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -202,6 +202,7 @@ jobs:
         find . -type f -path '*/fossa/fossa.exe' -exec cp {} release \;
         cp target/release/diagnose.exe release
         cp target/release/millhone.exe release
+        cp target/release/reachability.exe release
 
     - name: Find and move binaries (non-Windows)
       if: ${{ !contains(matrix.os, 'windows') }}
@@ -210,6 +211,7 @@ jobs:
         find . -type f -path '*/fossa/fossa' -exec cp {} release \;
         cp target/release/diagnose release
         cp target/release/millhone release
+        cp target/release/reachability release
 
     - name: Strip binaries
       run: |
@@ -247,6 +249,7 @@ jobs:
         codesign --options runtime -s 'FOSSA, Inc.' release/fossa
         codesign --options runtime -s 'FOSSA, Inc.' release/diagnose
         codesign --options runtime -s 'FOSSA, Inc.' release/millhone
+        codesign --options runtime -s 'FOSSA, Inc.' release/reachability
 
         # Perform notarization
         zip -rj notarization-archive.zip release
@@ -316,6 +319,7 @@ jobs:
         cosign sign-blob --yes --bundle "Linux-binaries/fossa.bundle" "Linux-binaries/fossa"
         cosign sign-blob --yes --bundle "Linux-binaries/diagnose.bundle" "Linux-binaries/diagnose"
         cosign sign-blob --yes --bundle "Linux-binaries/millhone.bundle" "Linux-binaries/millhone"
+        cosign sign-blob --yes --bundle "Linux-binaries/reachability.bundle" "Linux-binaries/reachability"
 
     - name: Verify Signatures
       if: ${{ github.ref_type == 'tag' }}
@@ -323,6 +327,7 @@ jobs:
         cosign verify-blob --bundle "Linux-binaries/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/fossa"
         cosign verify-blob --bundle "Linux-binaries/diagnose.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/diagnose"
         cosign verify-blob --bundle "Linux-binaries/millhone.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/millhone"
+        cosign verify-blob --bundle "Linux-binaries/reachability.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "Linux-binaries/reachability"
 
     # This uses names compatible with our install script.
     #
@@ -339,6 +344,8 @@ jobs:
         LINUX_DIAGNOSE_ZIP_PATH: "release/diagnose_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
         LINUX_MILLHONE_TAR_PATH: "release/millhone_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
         LINUX_MILLHONE_ZIP_PATH: "release/millhone_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
+        LINUX_REACHABILITY_TAR_PATH: "release/reachability_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
+        LINUX_REACHABILITY_ZIP_PATH: "release/reachability_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
       run: |
         mkdir release
 
@@ -348,32 +355,39 @@ jobs:
         zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa
         zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose
         zip -j "$LINUX_MILLHONE_ZIP_PATH" Linux-binaries/millhone
+        zip -j "$LINUX_REACHABILITY_ZIP_PATH" Linux-binaries/reachability
         tar --create --verbose --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa
         tar --create --verbose --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose
         tar --create --verbose --file "$LINUX_MILLHONE_TAR_PATH" --directory Linux-binaries millhone
+        tar --create --verbose --file "$LINUX_REACHABILITY_TAR_PATH" --directory Linux-binaries reachability
 
         if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
           tar --append --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose.bundle
           tar --append --file "$LINUX_MILLHONE_TAR_PATH" --directory Linux-binaries millhone.bundle
+          tar --append --file "$LINUX_REACHABILITY_TAR_PATH" --directory Linux-binaries reachability.bundle
           zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
           zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose.bundle
           zip -j "$LINUX_MILLHONE_ZIP_PATH" Linux-binaries/millhone.bundle
+          zip -j "$LINUX_REACHABILITY_ZIP_PATH" Linux-binaries/reachability.bundle
         fi
 
         gzip "$LINUX_FOSSA_TAR_PATH"
         gzip "$LINUX_DIAGNOSE_TAR_PATH"
         gzip "$LINUX_MILLHONE_TAR_PATH"
+        gzip "$LINUX_REACHABILITY_TAR_PATH"
 
         chmod +x macOS-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/fossa
         zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/diagnose
         zip -j release/millhone_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/millhone
+        zip -j release/reachability_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/reachability
 
         chmod +x Windows-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/fossa.exe
         zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/diagnose.exe
         zip -j release/millhone_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/millhone.exe
+        zip -j release/reachability_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/reachability.exe
 
     - name: Create checksums
       # We have to run from within the release dir so that "release" isn't prepended to the relative path of the zip file.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "simple_logger",
+ "simple_logger 2.3.0",
  "stable-eyre",
  "tikv-jemallocator",
  "typed-builder 0.10.0",
@@ -205,6 +205,17 @@ checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -354,11 +365,10 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
- "is-terminal",
  "lazy_static",
  "windows-sys",
 ]
@@ -480,6 +490,17 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "delegate"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee5df75c70b95bd3aacc8e2fd098797692fb1d54121019c4de481e42f04c8a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -824,9 +845,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -879,7 +900,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "snippets",
+ "snippets 0.1.3",
  "srclib",
  "stable-eyre",
  "strum 0.25.0",
@@ -904,6 +925,12 @@ checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995defdca0a589acfdd1bd2e8e3b896b4d4f7675a31fd14c32611440c7f608e6"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1115,6 +1142,20 @@ checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "reachability"
+version = "0.0.1"
+dependencies = [
+ "clap 4.4.7",
+ "log",
+ "serde",
+ "serde_json",
+ "simple_logger 4.3.3",
+ "snippets 0.2.0",
+ "stable-eyre",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1401,6 +1442,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_logger"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
+dependencies = [
+ "colored",
+ "log",
+ "windows-sys",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1480,35 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-cpp",
+ "tree-sitter-traversal",
+ "typed-builder 0.15.2",
+]
+
+[[package]]
+name = "snippets"
+version = "0.2.0"
+source = "git+https://github.com/fossas/lib-snippets#fda3a846c78a1f1a9a4fa6d9e1eefbf2fbf2a229"
+dependencies = [
+ "base64 0.21.5",
+ "bstr",
+ "colored",
+ "delegate",
+ "derivative",
+ "derive_more",
+ "fallible-iterator",
+ "flagset",
+ "getset",
+ "itertools 0.11.0",
+ "lazy-regex",
+ "nonempty",
+ "once_cell",
+ "sha2",
+ "strum 0.25.0",
+ "tap",
+ "thiserror",
+ "tracing",
+ "tree-sitter",
+ "tree-sitter-java",
  "tree-sitter-traversal",
  "typed-builder 0.15.2",
 ]
@@ -1739,6 +1820,16 @@ name = "tree-sitter-cpp"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b4b625f46a7370544b9cf0545532c26712ae49bfc02eb09825db358b9f79e1"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2adc5696bf5abf761081d7457d2bb82d0e3b28964f4214f63fd7e720ef462653"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "extlib/berkeleydb",
   "extlib/millhone",
+  "extlib/reachability",
   "tools/diagnose",
 ]
 

--- a/extlib/reachability/Cargo.toml
+++ b/extlib/reachability/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "reachability"
+version = "0.0.1"
+edition = "2021"
+
+[features]
+default = []
+
+[dependencies]
+tikv-jemallocator = { version = "0.5.4", optional = true }
+clap = { version = "4.0.0", features = ["derive"] }
+simple_logger = { version = "4.3.3", features = ["stderr", "colors"], default-features = false }
+log = "0.4.17"
+snippets = { git = "https://github.com/fossas/lib-snippets", version = "0.2.0", features = ["lang-java-11"] }
+stable-eyre = "0.2.2"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"

--- a/extlib/reachability/README.md
+++ b/extlib/reachability/README.md
@@ -1,0 +1,21 @@
+# reachability
+
+Parses source code, and produces call graphs for
+set of source code files.
+
+## usage
+
+```shell
+; reachability --target {directory}
+; reachability --target {path_to_file}
+
+# with stdin
+; cat {file} | reachability 
+```
+
+## building
+
+In the root directory, run `cargo build --bin reachability`.
+If release mode is desired, append `--release`.
+
+Output symbols are found in `target/debug/reachability` or `target/release/reachability`.

--- a/extlib/reachability/src/lib.rs
+++ b/extlib/reachability/src/lib.rs
@@ -1,0 +1,33 @@
+//! Parses language source code to create call graphs.
+//!
+//! # Supported Parser
+//! - Java
+use log::debug;
+use serde::Serialize;
+use snippets::content::Content;
+use stable_eyre::{eyre::Context, Result};
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize)]
+pub struct Reachability {}
+
+impl Reachability {
+    pub fn from_stdin() -> Result<Self> {
+        let mut stdin = String::new();
+        io::stdin()
+            .read_to_string(&mut stdin)
+            .context("buffer stdin")?;
+        Reachability::from_string(&stdin)
+    }
+
+    pub fn from_string(s: &str) -> Result<Self> {
+        let _content = Content::new(s.into());
+        todo!();
+    }
+
+    pub fn from_fs(path: &PathBuf) -> Result<Self> {
+        debug!("Parsing file system: {path:?}");
+        todo!();
+    }
+}

--- a/extlib/reachability/src/main.rs
+++ b/extlib/reachability/src/main.rs
@@ -1,0 +1,51 @@
+use clap::Parser;
+use log::debug;
+use reachability::Reachability;
+use simple_logger::SimpleLogger;
+use stable_eyre::{eyre::Context, Result};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[clap(version)]
+struct Args {
+    /// Target file or directory from which to perform call paths extraction.
+    /// Run with no target to parse file content from stdin instead.
+    #[clap(long)]
+    target: Option<PathBuf>,
+
+    /// Whether to emit debug logs.
+    #[clap(short = 'd', long)]
+    debug: bool,
+}
+
+impl Args {
+    fn log_level_filter(&self) -> log::LevelFilter {
+        if self.debug {
+            return log::LevelFilter::Debug;
+        }
+
+        log::LevelFilter::Info
+    }
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    SimpleLogger::default()
+        .with_level(args.log_level_filter())
+        .init()?;
+
+    // Perform extraction
+    let call_graph = if let Some(target) = args.target {
+        debug!("Reading from file system: {target:?}");
+        Reachability::from_fs(&target)
+    } else {
+        debug!("Reading from stdin");
+        Reachability::from_stdin()
+    }?;
+
+    let encoded = serde_json::to_string(&call_graph).context("encode values to JSON")?;
+    println!("{encoded}");
+
+    debug!("Values encoded as JSON to stdout; all done!");
+    Ok(())
+}

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -228,6 +228,7 @@ library
     App.Fossa.ManualDeps
     App.Fossa.PathDependency
     App.Fossa.ProjectInference
+    App.Fossa.Reachability
     App.Fossa.Report
     App.Fossa.Report.Attribution
     App.Fossa.RunThemis

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -8,6 +8,7 @@ import App.Fossa.DumpBinaries qualified as Dump
 import App.Fossa.Init (initCommand)
 import App.Fossa.LicenseScan qualified as LicenseScan (licenseScanSubCommand)
 import App.Fossa.ListTargets qualified as ListTargets
+import App.Fossa.Reachability qualified as Reachability
 import App.Fossa.Report qualified as Report
 import App.Fossa.Snippets qualified as Snippets
 import App.Fossa.Subcommand (GetCommonOpts, GetSeverity, SubCommand (..), runSubCommand)
@@ -75,6 +76,7 @@ subcommands = public <|> private
           , experimentalLicenseScanCommand
           , decodeSubCommand Dump.dumpSubCommand
           , decodeSubCommand LicenseScan.licenseScanSubCommand
+          , decodeSubCommand Reachability.reachabilitySubCommand
           ]
     public =
       hsubparser $

--- a/src/App/Fossa/Reachability.hs
+++ b/src/App/Fossa/Reachability.hs
@@ -1,0 +1,77 @@
+module App.Fossa.Reachability (
+  reachabilitySubCommand,
+)
+where
+
+import App.Fossa.Config.Common (validateExists)
+import App.Fossa.EmbeddedBinary (
+  BinaryPaths,
+  toPath,
+  withReachabilityBinary,
+ )
+import App.Fossa.Subcommand (EffStack, GetCommonOpts, GetSeverity, SubCommand (SubCommand))
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Has, Lift)
+import Data.Aeson (ToJSON, defaultOptions, genericToEncoding)
+import Data.Aeson.Types (ToJSON (toEncoding))
+import Data.String.Conversion (ConvertUtf8 (decodeUtf8), toText)
+import Effect.Exec (AllowErr (..), Command (..), Exec, execThrow')
+import Effect.Logger (Logger, logStdout)
+import Effect.ReadFS (ReadFS)
+import GHC.Generics (Generic)
+import Options.Applicative (InfoMod, argument, help, metavar, progDesc, str, value)
+import Path.Extra (SomePath)
+
+newtype ReachabilityBinsOpts = ReachabilityBinsOpts FilePath
+
+newtype ReachabilityBinConfig = ReachabilityBinConfig SomePath deriving (Show, Generic)
+
+instance ToJSON ReachabilityBinConfig where
+  toEncoding = genericToEncoding defaultOptions
+
+instance GetSeverity ReachabilityBinsOpts
+
+instance GetCommonOpts ReachabilityBinsOpts
+
+reachabilityInfo :: InfoMod a
+reachabilityInfo = progDesc "Execute embedded reachability binary against path"
+
+reachabilitySubCommand :: SubCommand ReachabilityBinsOpts ReachabilityBinConfig
+reachabilitySubCommand = mkSubCommand runReachability
+
+mkSubCommand :: (ReachabilityBinConfig -> EffStack ()) -> SubCommand ReachabilityBinsOpts ReachabilityBinConfig
+mkSubCommand = SubCommand "reachability" reachabilityInfo cliParser noLoadConfig mergeOpts
+  where
+    cliParser = ReachabilityBinsOpts <$> basePathArg
+    noLoadConfig = const $ pure Nothing
+    basePathArg = argument str (metavar "PATH" <> help "Set the base directory for scanning (default: current directory)" <> value ".")
+
+mergeOpts ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has ReadFS sig m
+  ) =>
+  a ->
+  b ->
+  ReachabilityBinsOpts ->
+  m ReachabilityBinConfig
+mergeOpts _ _ (ReachabilityBinsOpts path) = ReachabilityBinConfig <$> validateExists path
+
+runReachability ::
+  ( Has (Lift IO) sig m
+  , Has Exec sig m
+  , Has Diagnostics sig m
+  , Has ReadFS sig m
+  , Has Logger sig m
+  ) =>
+  ReachabilityBinConfig ->
+  m ()
+runReachability (ReachabilityBinConfig targetPath) = logStdout . decodeUtf8 =<< withReachabilityBinary (\bin -> execThrow' $ reachabilityCommand bin targetPath)
+
+reachabilityCommand :: BinaryPaths -> SomePath -> Command
+reachabilityCommand bin target =
+  Command
+    { cmdName = toText $ toPath bin
+    , cmdArgs = ["--target", toText target, "-d"]
+    , cmdAllowErr = Never
+    }


### PR DESCRIPTION
# Overview

This is part of stack PR. This PR will not be merged, until all stacked PR's are merged into this branch.

This PR, 
- Adds basic command line tool for reachability (reachability/extlib)
- Adds hidden `fossa reachability <PATH>` command for debugging

## Acceptance criteria

- Automated build works
- `fossa reachability <PATH>` can be executed (It will fail in part 1 PR)

## Testing plan

```bash
git checkout master && git pull origin && git checkout feat/reachability-cli && make install-dev
```

after which,
```bash
fossa-dev reachability

# Note that this command will fail, as this PR does not add implementation
# so error is to be expected! You should see something like following in error message:
#
# Command error log:
#            DEBUG [reachability] Reading from file system: "/Users/megh/code/fossa-cli/"
#            DEBUG [reachability] Parsing file system: "/Users/megh/code/fossa-cli/"
#            thread 'main' panicked at extlib/reachability/src/lib.rs:31:9:
#            not yet implemented
#            note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```

## Risks
N/A

## Metrics
N/A

## References
N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
