### PR TITLE
Container scanning: `bdb` and `sqlite` strategies handle alternate locations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.8.31
+
+- Container scanning: `BerkeleyDB` and `Sqlite` strategies now support RPM databases in non-standard locations ([#1365](https://github.com/fossas/fossa-cli/pull/1365)).
+
 ## v3.8.30
 
 - Fix an issue with long-option syntax for older versions of `sbt` ([#1356](https://github.com/fossas/fossa-cli/pull/1356))

--- a/src/Strategy/BerkeleyDB.hs
+++ b/src/Strategy/BerkeleyDB.hs
@@ -72,9 +72,21 @@ findProjects osInfo = walkWithFilters' $ \dir _ files -> do
   case findFileNamed "Packages" files of
     Nothing -> pure ([], WalkContinue)
     Just file -> do
-      if (Text.isInfixOf "var/lib/rpm/" $ toText . toFilePath $ file)
+      if isSupportedPath file
         then pure ([BerkeleyDatabase dir file osInfo], WalkContinue)
         else pure ([], WalkContinue)
+  where
+    -- The standard location for this is '/var/lib/rpm/',
+    -- but some distros in some versions symlink this elsewhere.
+    --
+    -- For maximal compatibility while still being reasonably confident that this is the 'Packages.db'
+    -- for the system RPM install, this function just checks whether the file is a child of any directory that
+    -- contains the word 'rpm'.
+    --
+    -- We may want to consider making walk work with symlinks (so that we are confident we're using the right file)
+    -- or unconditionally trying any 'Packages.db' named file.
+    isSupportedPath :: Path Abs File -> Bool
+    isSupportedPath = Text.isInfixOf "rpm" . toText . toFilePath
 
 mkProject :: BerkeleyDatabase -> DiscoveredProject BerkeleyDatabase
 mkProject project =

--- a/src/Strategy/BerkeleyDB.hs
+++ b/src/Strategy/BerkeleyDB.hs
@@ -79,12 +79,12 @@ findProjects osInfo = walkWithFilters' $ \dir _ files -> do
     -- The standard location for this is '/var/lib/rpm/',
     -- but some distros in some versions symlink this elsewhere.
     --
-    -- For maximal compatibility while still being reasonably confident that this is the 'Packages.db'
+    -- For maximal compatibility while still being reasonably confident that this is the package database
     -- for the system RPM install, this function just checks whether the file is a child of any directory that
     -- contains the word 'rpm'.
     --
     -- We may want to consider making walk work with symlinks (so that we are confident we're using the right file)
-    -- or unconditionally trying any 'Packages.db' named file.
+    -- or unconditionally trying any matching named file.
     isSupportedPath :: Path Abs File -> Bool
     isSupportedPath = Text.isInfixOf "rpm" . toText . toFilePath
 

--- a/src/Strategy/NDB.hs
+++ b/src/Strategy/NDB.hs
@@ -73,11 +73,16 @@ findProjects osInfo = walkWithFilters' $ \dir _ files -> do
         then pure ([NdbLocation dir file osInfo], WalkContinue)
         else pure ([], WalkContinue)
   where
-    -- The standard location for this is '/var/lib/rpm/', but some distros in some versions (e.g. openSUSE) symlink this elsewhere
+    -- The standard location for this is '/var/lib/rpm/',
+    -- but some distros in some versions (e.g. openSUSE) symlink this elsewhere
     -- (the example seen for openSUSE is 'usr/lib/sysimage/rpm/').
-    -- For maximal compatibility while still being reasonably confident that this is the 'Packages.db' for the system RPM install,
-    -- this function just checks whether the file is a child of any directory containing the word 'rpm'.
-    -- We may want to consider making walk work with symlinks or unconditionally trying any 'Packages.db' named file.
+    --
+    -- For maximal compatibility while still being reasonably confident that this is the 'Packages.db'
+    -- for the system RPM install, this function just checks whether the file is a child of any directory that
+    -- contains the word 'rpm'.
+    --
+    -- We may want to consider making walk work with symlinks (so that we are confident we're using the right file)
+    -- or unconditionally trying any 'Packages.db' named file.
     isSupportedPath :: Path Abs File -> Bool
     isSupportedPath = Text.isInfixOf "rpm" . toText . toFilePath
 

--- a/src/Strategy/NDB.hs
+++ b/src/Strategy/NDB.hs
@@ -77,12 +77,12 @@ findProjects osInfo = walkWithFilters' $ \dir _ files -> do
     -- but some distros in some versions (e.g. openSUSE) symlink this elsewhere
     -- (the example seen for openSUSE is 'usr/lib/sysimage/rpm/').
     --
-    -- For maximal compatibility while still being reasonably confident that this is the 'Packages.db'
+    -- For maximal compatibility while still being reasonably confident that this is the package database
     -- for the system RPM install, this function just checks whether the file is a child of any directory that
     -- contains the word 'rpm'.
     --
     -- We may want to consider making walk work with symlinks (so that we are confident we're using the right file)
-    -- or unconditionally trying any 'Packages.db' named file.
+    -- or unconditionally trying any matching named file.
     isSupportedPath :: Path Abs File -> Bool
     isSupportedPath = Text.isInfixOf "rpm" . toText . toFilePath
 

--- a/src/Strategy/Sqlite.hs
+++ b/src/Strategy/Sqlite.hs
@@ -67,9 +67,21 @@ findProjects osInfo = walkWithFilters' $ \dir _ files -> do
   case findFirstMatchingFile ["Packages.sqlite", "rpmdb.sqlite"] files of
     Nothing -> pure ([], WalkContinue)
     Just file -> do
-      if (Text.isInfixOf "var/lib/rpm/" $ toText . toFilePath $ file)
+      if isSupportedPath file
         then pure ([SqliteDB{dbDir = dir, dbFile = file, osInfo = osInfo}], WalkContinue)
         else pure ([], WalkContinue)
+  where
+    -- The standard location for this is '/var/lib/rpm/',
+    -- but some distros in some versions symlink this elsewhere.
+    --
+    -- For maximal compatibility while still being reasonably confident that this is the 'Packages.db'
+    -- for the system RPM install, this function just checks whether the file is a child of any directory that
+    -- contains the word 'rpm'.
+    --
+    -- We may want to consider making walk work with symlinks (so that we are confident we're using the right file)
+    -- or unconditionally trying any 'Packages.db' named file.
+    isSupportedPath :: Path Abs File -> Bool
+    isSupportedPath = Text.isInfixOf "rpm" . toText . toFilePath
 
 mkProject :: SqliteDB -> DiscoveredProject SqliteDB
 mkProject db =

--- a/src/Strategy/Sqlite.hs
+++ b/src/Strategy/Sqlite.hs
@@ -74,12 +74,12 @@ findProjects osInfo = walkWithFilters' $ \dir _ files -> do
     -- The standard location for this is '/var/lib/rpm/',
     -- but some distros in some versions symlink this elsewhere.
     --
-    -- For maximal compatibility while still being reasonably confident that this is the 'Packages.db'
+    -- For maximal compatibility while still being reasonably confident that this is the package database
     -- for the system RPM install, this function just checks whether the file is a child of any directory that
     -- contains the word 'rpm'.
     --
     -- We may want to consider making walk work with symlinks (so that we are confident we're using the right file)
-    -- or unconditionally trying any 'Packages.db' named file.
+    -- or unconditionally trying any matching named file.
     isSupportedPath :: Path Abs File -> Bool
     isSupportedPath = Text.isInfixOf "rpm" . toText . toFilePath
 


### PR DESCRIPTION
# Overview

Updates berkeleydb and sqlite strategies in containers to support rpm databases in non-standard locations.

## Acceptance criteria

Users with BerkeleyDB and Sqlite RPM databases in non-standard locations now have reported dependencies.

## Testing plan

I don't have an image to test this with, as the user reporting this issue uses a private image.
I believe this will fix the issue because in the logs for the image, we see the following line:
```
[BuildLayer] InsertUpdate usr/lib/sysimage/rpm/Packages
```

Which indicates that there is a BerkeleyDB database file in this non-standard location, that would have worked had we supported that location.

I believe this change is safe because we already use this exact method for the NDB strategy, this just also utilizes the same method in the other two strategies.

## Risks

The main risk is that this introduces extra noise by parsing files that should not be parsed.

## Metrics

None.

## References

https://fossa.atlassian.net/browse/FDN-87

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
