### PR TITLE
ANE-1380 - Add color and update formatting in cli

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- Add color and update formatting in cli help commands
+
 ## v3.8.30
 
 - Fix an issue with long-option syntax for older versions of `sbt` ([#1356](https://github.com/fossas/fossa-cli/pull/1356))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## Unreleased
-- Add color and update formatting in cli help commands
+- Add color and update formatting in cli help commands ([#1367](https://github.com/fossas/fossa-cli/pull/1367))
 
 ## v3.8.30
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -485,6 +485,7 @@ library
     Strategy.Swift.Xcode.Pbxproj
     Strategy.Swift.Xcode.PbxprojParser
     Strategy.SwiftPM
+    Style 
     System.Args
     Text.URI.Builder
     Type.Operator

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -489,6 +489,7 @@ library
     Text.URI.Builder
     Type.Operator
     Types
+    Style
 
   hs-source-dirs:  src
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -485,11 +485,11 @@ library
     Strategy.Swift.Xcode.Pbxproj
     Strategy.Swift.Xcode.PbxprojParser
     Strategy.SwiftPM
+    Style
     System.Args
     Text.URI.Builder
     Type.Operator
     Types
-    Style
 
   hs-source-dirs:  src
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -485,7 +485,7 @@ library
     Strategy.Swift.Xcode.Pbxproj
     Strategy.Swift.Xcode.PbxprojParser
     Strategy.SwiftPM
-    Style 
+    Style
     System.Args
     Text.URI.Builder
     Type.Operator

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -114,7 +114,7 @@ import Path (Abs, Dir, Path, Rel)
 import Path.Extra (SomePath)
 import Prettyprinter (Doc, annotate, indent)
 import Prettyprinter.Render.Terminal (AnsiStyle, Color (Green, Red), color)
-import Style (applyFossaStyle, boldItalicized, coloredBoldItalicized, formatDoc, formatStringToDoc, stringToHelpDoc)
+import Style (applyFossaStyle, boldItalicized, coloredBoldItalicized, formatDoc, stringToHelpDoc)
 import Types (ArchiveUploadType (..), LicenseScanPathFilters (..), TargetFilter)
 
 -- CLI flags, for use with 'Data.Flag'

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -35,6 +35,10 @@ module App.Fossa.Config.Common (
   defaultTimeoutDuration,
   collectRevisionData',
   fossaApiKeyCmdText,
+
+  -- * Global Parser Help Message
+  endpointHelp,
+  fossaApiKeyHelp,
 ) where
 
 import App.Fossa.Config.ConfigFile (
@@ -101,7 +105,7 @@ import Data.Text (Text, null, strip, toLower)
 import Diag.Result (Result (Failure, Success), renderFailure)
 import Discovery.Filters (AllFilters (AllFilters), MavenScopeFilters (..), comboExclude, comboInclude, setExclude, setInclude, targetFilterParser)
 import Effect.Exec (Exec)
-import Effect.Logger (Logger, logDebug, logInfo)
+import Effect.Logger (Logger, logDebug, logInfo, vsep)
 import Effect.ReadFS (ReadFS, doesDirExist, doesFileExist)
 import Fossa.API.Types (ApiKey (ApiKey), ApiOpts (ApiOpts), defaultApiPollDelay)
 import GHC.Generics (Generic)
@@ -112,7 +116,6 @@ import Options.Applicative (
   argument,
   auto,
   eitherReader,
-  help,
   long,
   metavar,
   option,
@@ -125,9 +128,14 @@ import Options.Applicative (
   value,
   (<|>),
  )
+import Options.Applicative.Builder (helpDoc)
+import Options.Applicative.Help (AnsiStyle)
 import Path (Abs, Dir, File, Path, Rel, SomeBase (..), parseRelDir)
 import Path.Extra (SomePath (..))
 import Path.IO (resolveDir', resolveFile')
+import Prettyprinter (Doc)
+import Prettyprinter.Render.Terminal (Color (Green))
+import Style (applyFossaStyle, boldItalicized, coloredBoldItalicized, formatDoc, formatStringToDoc)
 import Text.Megaparsec (errorBundlePretty, runParser)
 import Text.URI (URI, mkURI)
 import Types (TargetFilter)
@@ -155,34 +163,57 @@ readMWithError errMsg = auto <|> readerError errMsg
 metadataOpts :: Parser ProjectMetadata
 metadataOpts =
   ProjectMetadata
-    <$> optional (strOption (long "title" <> short 't' <> help "the title of the FOSSA project. (default: the project name)"))
-    <*> optional (strOption (long "project-url" <> short 'P' <> help "this repository's home page"))
-    <*> optional (strOption (long "jira-project-key" <> short 'j' <> help "this repository's JIRA project key"))
-    <*> optional (strOption (long "link" <> short 'L' <> help "a link to attach to the current build"))
-    <*> optional (strOption (long "team" <> short 'T' <> help "this repository's team inside your organization"))
+    <$> optional (strOption (applyFossaStyle <> long "title" <> short 't' <> helpDoc titleHelp))
+    <*> optional (strOption (applyFossaStyle <> long "project-url" <> short 'P' <> helpDoc (formatStringToDoc "This repository's home page")))
+    <*> optional (strOption (applyFossaStyle <> long "jira-project-key" <> short 'j' <> helpDoc (formatStringToDoc "This repository's JIRA project key")))
+    <*> optional (strOption (applyFossaStyle <> long "link" <> short 'L' <> helpDoc (formatStringToDoc "A link to attach to the current build")))
+    <*> optional (strOption (applyFossaStyle <> long "team" <> short 'T' <> helpDoc (formatStringToDoc "This repository's team inside your organization")))
     <*> parsePolicyOptions
-    <*> many (strOption (long "project-label" <> help "assign up to 5 labels to the project"))
+    <*> many (strOption (applyFossaStyle <> long "project-label" <> helpDoc (formatStringToDoc "Assign up to 5 labels to the project")))
     <*> optional releaseGroupMetadataOpts
   where
     policy :: Parser Policy
-    policy = PolicyName <$> (strOption (long "policy" <> help "The name of the policy to assign to this project in FOSSA. Mutually excludes --policy-id."))
+    policy = PolicyName <$> (strOption (applyFossaStyle <> long "policy" <> helpDoc policyHelp))
 
     policyId :: Parser Policy
     policyId =
       PolicyId
         <$> ( option
                 (readMWithError "failed to parse --policy-id, expecting int")
-                (long "policy-id" <> help "The id of the policy to assign to this project in FOSSA. Mutually excludes --policy.")
+                (applyFossaStyle <> long "policy-id" <> helpDoc policyIdHelp)
             )
 
     parsePolicyOptions :: Parser (Maybe Policy)
     parsePolicyOptions = optional (policy <|> policyId) -- For Parsers '<|>' tries every alternative and fails if they all succeed.
+    titleHelp :: Maybe (Doc AnsiStyle)
+    titleHelp =
+      Just $
+        formatDoc $
+          vsep
+            [ "The title of the FOSSA project"
+            , boldItalicized "Default: " <> "The project name"
+            ]
+
+    policyHelp :: Maybe (Doc AnsiStyle)
+    policyHelp =
+      Just $
+        formatDoc $
+          vsep
+            [ "The name of the policy to assign to this project in FOSSA. Mutually excludes " <> coloredBoldItalicized Green "--policy-id" <> "."
+            ]
+    policyIdHelp :: Maybe (Doc AnsiStyle)
+    policyIdHelp =
+      Just $
+        formatDoc $
+          vsep
+            [ "The id of the policy to assign to this project in FOSSA. Mutually excludes " <> coloredBoldItalicized Green "--policy" <> "."
+            ]
 
 releaseGroupMetadataOpts :: Parser ReleaseGroupMetadata
 releaseGroupMetadataOpts =
   ReleaseGroupMetadata
-    <$> strOption (long "release-group-name" <> help "the name of the release group to add this project to")
-    <*> strOption (long "release-group-release" <> help "the release of the release group to add this project to")
+    <$> strOption (applyFossaStyle <> long "release-group-name" <> helpDoc (formatStringToDoc "The name of the release group to add this project to"))
+    <*> strOption (applyFossaStyle <> long "release-group-release" <> helpDoc (formatStringToDoc "The release of the release group to add this project to"))
 
 pathOpt :: String -> Either String (Path Rel Dir)
 pathOpt = first show . parseRelDir
@@ -191,7 +222,15 @@ targetOpt :: String -> Either String TargetFilter
 targetOpt = first errorBundlePretty . runParser targetFilterParser "(Command-line arguments)" . toText
 
 baseDirArg :: Parser String
-baseDirArg = argument str (metavar "DIR" <> help "Set the base directory for scanning (default: current directory)" <> value ".")
+baseDirArg = argument str (applyFossaStyle <> metavar "DIR" <> helpDoc baseDirDoc <> value ".")
+  where
+    baseDirDoc =
+      Just $
+        formatDoc $
+          vsep
+            [ "Set the base directory for scanning"
+            , boldItalicized "Default: " <> "Current directory"
+            ]
 
 collectBaseDir ::
   ( Has Diagnostics sig m
@@ -409,13 +448,65 @@ fossaApiKeyCmdText = "fossa-api-key"
 commonOpts :: Parser CommonOpts
 commonOpts =
   CommonOpts
-    <$> switch (long "debug" <> help "Enable debug logging, and write detailed debug information to `fossa.debug.json`")
-    <*> optional (uriOption (long "endpoint" <> short 'e' <> metavar "URL" <> help "The FOSSA API server base URL (default: https://app.fossa.com)"))
-    <*> optional (strOption (long "project" <> short 'p' <> help "this repository's URL or VCS endpoint (default: VCS remote 'origin')"))
-    <*> optional (strOption (long "revision" <> short 'r' <> help "this repository's current revision hash (default: VCS hash HEAD)"))
-    <*> optional (strOption (long fossaApiKeyCmdText <> help "the FOSSA API server authentication key (default: FOSSA_API_KEY from env)"))
-    <*> optional (strOption (long "config" <> short 'c' <> help "Path to configuration file including filename (default: .fossa.yml)"))
-    <*> optional (option parseTelemetryScope (long "with-telemetry-scope" <> help "Scope of telemetry to use, the options are 'full' or 'off'. (default: 'full')"))
+    <$> switch (applyFossaStyle <> long "debug" <> helpDoc (formatStringToDoc "Enable debug logging, and write detailed debug information to `fossa.debug.json`"))
+    <*> optional (uriOption (applyFossaStyle <> long "endpoint" <> short 'e' <> metavar "URL" <> helpDoc endpointHelp))
+    <*> optional (strOption (applyFossaStyle <> long "project" <> short 'p' <> helpDoc projectHelp))
+    <*> optional (strOption (applyFossaStyle <> long "revision" <> short 'r' <> helpDoc revisionHelp))
+    <*> optional (strOption (applyFossaStyle <> long fossaApiKeyCmdText <> helpDoc fossaApiKeyHelp))
+    <*> optional (strOption (applyFossaStyle <> long "config" <> short 'c' <> helpDoc configHelp))
+    <*> optional (option parseTelemetryScope (applyFossaStyle <> long "with-telemetry-scope" <> helpDoc telemtryScopeHelp))
+  where
+    projectHelp :: Maybe (Doc AnsiStyle)
+    projectHelp =
+      Just $
+        formatDoc $
+          vsep
+            [ "This repository's URL or VCS endpoint"
+            , boldItalicized "Default: " <> "VCS remote 'origin'"
+            ]
+    revisionHelp :: Maybe (Doc AnsiStyle)
+    revisionHelp =
+      Just $
+        formatDoc $
+          vsep
+            [ "This repository's current revision hash"
+            , boldItalicized "Default: " <> "VCS hash HEAD"
+            ]
+    configHelp :: Maybe (Doc AnsiStyle)
+    configHelp =
+      Just $
+        formatDoc $
+          vsep
+            [ "Path to configuration file including filename"
+            , boldItalicized "Default: " <> ".fossa.yml"
+            ]
+    telemtryScopeHelp :: Maybe (Doc AnsiStyle)
+    telemtryScopeHelp =
+      Just $
+        formatDoc $
+          vsep
+            [ "Scope of telemetry to use"
+            , boldItalicized "Options: " <> coloredBoldItalicized Green "full" <> boldItalicized "|" <> coloredBoldItalicized Green "off"
+            , boldItalicized "Default: " <> coloredBoldItalicized Green "full"
+            ]
+
+endpointHelp :: Maybe (Doc AnsiStyle)
+endpointHelp =
+  Just $
+    formatDoc $
+      vsep
+        [ "The FOSSA API server base URL"
+        , boldItalicized "Default: " <> "https://app.fossa.com"
+        ]
+
+fossaApiKeyHelp :: Maybe (Doc AnsiStyle)
+fossaApiKeyHelp =
+  Just $
+    formatDoc $
+      vsep
+        [ "The FOSSA API server authentication key"
+        , boldItalicized "Default: " <> "FOSSA_API_KEY from env"
+        ]
 
 collectConfigFileFilters :: ConfigFile -> AllFilters
 collectConfigFileFilters configFile = do

--- a/src/App/Fossa/Config/Container.hs
+++ b/src/App/Fossa/Config/Container.hs
@@ -33,12 +33,13 @@ import GHC.Generics (Generic)
 import Options.Applicative (
   InfoMod,
   Parser,
-  hsubparser,
-  progDesc,
+  progDescDoc,
+  subparser,
  )
+import Style (formatStringToDoc)
 
 containerCmdInfo :: InfoMod a
-containerCmdInfo = progDesc "Run in container-scanning mode"
+containerCmdInfo = progDescDoc $ formatStringToDoc "Run in container-scanning mode"
 
 mkSubCommand :: (ContainerScanConfig -> EffStack ()) -> SubCommand ContainerCommand ContainerScanConfig
 mkSubCommand = SubCommand "container" containerCmdInfo parser loadConfig mergeOpts
@@ -106,4 +107,4 @@ instance GetCommonOpts ContainerCommand where
 parser :: Parser ContainerCommand
 parser = public
   where
-    public = hsubparser $ Analyze.subcommand ContainerAnalyze <> Test.subcommand ContainerTest <> ListTargets.subcommand ContainerListTargets
+    public = subparser $ Analyze.subcommand ContainerAnalyze <> Test.subcommand ContainerTest <> ListTargets.subcommand ContainerListTargets

--- a/src/App/Fossa/Config/Container/Analyze.hs
+++ b/src/App/Fossa/Config/Container/Analyze.hs
@@ -10,6 +10,7 @@ module App.Fossa.Config.Container.Analyze (
   subcommand,
 ) where
 
+import App.Fossa.Config.Analyze (branchHelp)
 import App.Fossa.Config.Common (
   CommonOpts (CommonOpts, optDebug, optProjectName, optProjectRevision),
   ScanDestination (..),
@@ -47,16 +48,16 @@ import Options.Applicative (
   Mod,
   Parser,
   command,
-  help,
   hidden,
   info,
   long,
   optional,
-  progDesc,
   short,
   strOption,
   switch,
  )
+import Options.Applicative.Builder (helpDoc, progDescDoc)
+import Style (applyFossaStyle, formatStringToDoc)
 
 data NoUpload = NoUpload
 data JsonOutput = JsonOutput deriving (Generic)
@@ -98,7 +99,7 @@ subcommand f =
   command
     "analyze"
     ( info (f <$> cliParser) $
-        progDesc "Scan an image for vulnerabilities"
+        progDescDoc (formatStringToDoc "Scan an image for vulnerabilities")
     )
 
 cliParser :: Parser ContainerAnalyzeOptions
@@ -107,22 +108,24 @@ cliParser =
     <$> commonOpts
     <*> flagOpt
       NoUpload
-      ( long "output"
+      ( applyFossaStyle
+          <> long "output"
           <> short 'o'
-          <> help "Output results to stdout instead of uploading to fossa"
+          <> helpDoc (formatStringToDoc "Output results to stdout instead of uploading to FOSSA")
       )
-    <*> flagOpt JsonOutput (long "json" <> help "Output project metadata as json to the console. Useful for communicating with the FOSSA API")
+    <*> flagOpt JsonOutput (applyFossaStyle <> long "json" <> helpDoc (formatStringToDoc "Output project metadata as JSON to the console. This is useful for communicating with the FOSSA API."))
     <*> optional
       ( strOption
-          ( long "branch"
+          ( applyFossaStyle
+              <> long "branch"
               <> short 'b'
-              <> help "this repository's current branch (default: current VCS branch)"
+              <> helpDoc branchHelp
           )
       )
     <*> metadataOpts
     <*> imageTextArg
-    <*> switch (long "experimental-scanner" <> help "Uses experimental fossa native container scanner." <> hidden)
-    <*> switch (long "only-system-deps" <> help "Only analyzes system dependencies (e.g. apk, dep, rpm).")
+    <*> switch (applyFossaStyle <> long "experimental-scanner" <> helpDoc (formatStringToDoc "Uses experimental fossa native container scanner") <> hidden)
+    <*> switch (applyFossaStyle <> long "only-system-deps" <> helpDoc (formatStringToDoc "Only analyzes system dependencies (e.g. apk, dep, rpm)"))
 
 mergeOpts ::
   (Has Diagnostics sig m) =>

--- a/src/App/Fossa/Config/Container/Common.hs
+++ b/src/App/Fossa/Config/Container/Common.hs
@@ -13,9 +13,8 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
 import Options.Applicative (Parser, argument, metavar, str)
-import Options.Applicative.Builder (helpDoc)
 import Prettyprinter (pretty, vsep)
-import Style (applyFossaStyle, formatStringToDoc, stringToHelpDoc)
+import Style (applyFossaStyle, stringToHelpDoc)
 import System.Info (arch)
 
 newtype ImageText = ImageText

--- a/src/App/Fossa/Config/Container/Common.hs
+++ b/src/App/Fossa/Config/Container/Common.hs
@@ -12,8 +12,10 @@ import Data.String.Conversion (toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
-import Options.Applicative (Parser, argument, help, metavar, str)
+import Options.Applicative (Parser, argument, metavar, str)
+import Options.Applicative.Builder (helpDoc)
 import Prettyprinter (pretty, vsep)
+import Style (applyFossaStyle, formatStringToDoc)
 import System.Info (arch)
 
 newtype ImageText = ImageText
@@ -25,7 +27,7 @@ instance ToJSON ImageText where
   toEncoding = genericToEncoding defaultOptions
 
 imageTextArg :: Parser ImageText
-imageTextArg = ImageText <$> argument str (metavar "IMAGE" <> help "The image to scan")
+imageTextArg = ImageText <$> argument str (applyFossaStyle <> metavar "IMAGE" <> helpDoc (formatStringToDoc "The image to scan"))
 
 -- | Get current runtime arch, We use this to find suitable image,
 -- if multi-platform image is discovered. This is similar to

--- a/src/App/Fossa/Config/Container/ListTargets.hs
+++ b/src/App/Fossa/Config/Container/ListTargets.hs
@@ -27,8 +27,9 @@ import Options.Applicative (
   Parser,
   command,
   info,
-  progDesc,
+  progDescDoc,
  )
+import Style (formatStringToDoc)
 
 newtype ContainerListTargetsOptions = ContainerListTargetsOptions
   { imageLocator :: ImageText
@@ -53,7 +54,7 @@ subcommand f =
   command
     "list-targets"
     ( info (f <$> listTargetParser) $
-        progDesc "Lists target with container image"
+        progDescDoc (formatStringToDoc "Lists target with container image")
     )
 
 listTargetParser :: Parser ContainerListTargetsOptions

--- a/src/App/Fossa/Config/Container/Test.hs
+++ b/src/App/Fossa/Config/Container/Test.hs
@@ -24,7 +24,7 @@ import App.Fossa.Config.Container.Common (
   imageTextArg,
  )
 import App.Fossa.Config.EnvironmentVars (EnvVars)
-import App.Fossa.Config.Test (TestOutputFormat (TestOutputJson, TestOutputPretty), defaultOutputFmt, testOutputFormatList, validateOutputFormat)
+import App.Fossa.Config.Test (TestOutputFormat (TestOutputJson, TestOutputPretty), defaultOutputFmt, testFormatHelp, validateOutputFormat)
 import App.Types (OverrideProject (OverrideProject))
 import Control.Effect.Diagnostics (Diagnostics, Has)
 import Control.Monad (when)
@@ -41,22 +41,23 @@ import Options.Applicative (
   auto,
   command,
   flag,
-  help,
   info,
   internal,
   long,
   option,
   optional,
-  progDesc,
+  progDescDoc,
   strOption,
  )
+import Options.Applicative.Builder (helpDoc)
+import Style (applyFossaStyle, formatStringToDoc)
 
 subcommand :: (ContainerTestOptions -> a) -> Mod CommandFields a
 subcommand f =
   command
     "test"
     ( info (f <$> cliParser) $
-        progDesc "Check for issues from FOSSA and exit non-zero when issues are found"
+        progDescDoc (formatStringToDoc "Check for issues from FOSSA and exit non-zero when issues are found")
     )
 
 data ContainerTestConfig = ContainerTestConfig
@@ -85,9 +86,9 @@ cliParser :: Parser ContainerTestOptions
 cliParser =
   ContainerTestOptions
     <$> commonOpts
-    <*> optional (option auto (long "timeout" <> help "Duration to wait for build completion (in seconds)"))
-    <*> flag TestOutputPretty TestOutputJson (long "json" <> help "Output issues as json" <> internal)
-    <*> optional (strOption (long "format" <> help ("Output the report in the specified format. Currently available formats: (" <> testOutputFormatList <> ")")))
+    <*> optional (option auto (applyFossaStyle <> long "timeout" <> helpDoc (formatStringToDoc "Duration to wait for build completion (in seconds)")))
+    <*> flag TestOutputPretty TestOutputJson (applyFossaStyle <> long "json" <> helpDoc (formatStringToDoc "Output issues as JSON") <> internal)
+    <*> optional (strOption (applyFossaStyle <> long "format" <> helpDoc testFormatHelp))
     <*> imageTextArg
 
 mergeOpts ::

--- a/src/App/Fossa/Config/DumpBinaries.hs
+++ b/src/App/Fossa/Config/DumpBinaries.hs
@@ -11,11 +11,12 @@ import Control.Effect.Lift (Has, Lift)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Options.Applicative (InfoMod, progDesc)
+import Options.Applicative (InfoMod, progDescDoc)
 import Path (Abs, Dir, Path)
+import Style (formatStringToDoc)
 
 dumpInfo :: InfoMod a
-dumpInfo = progDesc "Output all embedded binaries to specified path"
+dumpInfo = progDescDoc $ formatStringToDoc "Output all embedded binaries to specified path"
 
 mkSubCommand :: (DumpBinsConfig -> EffStack ()) -> SubCommand DumpBinsOpts DumpBinsConfig
 mkSubCommand = SubCommand "dump-binaries" dumpInfo cliParser noLoadConfig mergeOpts

--- a/src/App/Fossa/Config/LicenseScan.hs
+++ b/src/App/Fossa/Config/LicenseScan.hs
@@ -10,6 +10,7 @@ import App.Types (BaseDir)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Has, Lift)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
+import Effect.Logger (vsep)
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
 import Options.Applicative (
@@ -17,15 +18,17 @@ import Options.Applicative (
   InfoMod,
   Parser,
   command,
-  hsubparser,
   info,
   internal,
-  progDesc,
+  progDescDoc,
   subparser,
  )
+import Prettyprinter (Doc)
+import Prettyprinter.Render.Terminal (AnsiStyle, Color (Green))
+import Style (coloredBoldItalicized, formatDoc, formatStringToDoc)
 
 licenseScanInfo :: InfoMod a
-licenseScanInfo = progDesc "Utilities for native license-scanning"
+licenseScanInfo = progDescDoc $ formatStringToDoc "Utilities for native license-scanning"
 
 mkSubCommand :: (LicenseScanConfig -> EffStack ()) -> SubCommand LicenseScanCommand LicenseScanConfig
 mkSubCommand = SubCommand "license-scan" licenseScanInfo cliParser noLoadConfig mergeOpts
@@ -62,17 +65,25 @@ mergeOpts _ _ (FossaDeps path) = VendoredDepsOutput <$> collectBaseDir path
 cliParser :: Parser LicenseScanCommand
 cliParser = public <|> private
   where
-    public = hsubparser fossaDepsCommand
+    public = subparser fossaDepsCommand
     private = subparser $ internal <> directScanCommand
     fossaDepsCommand =
       command
         "fossa-deps"
         ( info (FossaDeps <$> baseDirArg) $
-            progDesc "Like `fossa analyze --output`, but only for native scanning of vendored-dependencies."
+            progDescDoc fossaDepsDesc
         )
     directScanCommand =
       command
         "direct"
         ( info (DirectScan <$> baseDirArg) $
-            progDesc "Run a license scan directly on the provided path."
+            progDescDoc $
+              formatStringToDoc "Run a license scan directly on the provided path"
         )
+    fossaDepsDesc :: Maybe (Doc AnsiStyle)
+    fossaDepsDesc =
+      Just $
+        formatDoc $
+          vsep
+            [ "Like " <> coloredBoldItalicized Green "fossa analyze --output" <> " but only for native scanning of vendored-dependencies"
+            ]

--- a/src/App/Fossa/Config/LinkUserBinaries.hs
+++ b/src/App/Fossa/Config/LinkUserBinaries.hs
@@ -38,21 +38,24 @@ import Options.Applicative (
   InfoMod,
   Parser,
   argument,
-  help,
+  helpDoc,
   long,
   metavar,
   optional,
-  progDesc,
+  progDescDoc,
   str,
   strOption,
   value,
  )
+import Prettyprinter (Doc, vsep)
+import Prettyprinter.Render.Terminal (AnsiStyle)
+import Style (applyFossaStyle, boldItalicized, formatDoc, formatStringToDoc)
 
 cmdName :: String
 cmdName = "experimental-link-user-defined-dependency-binary"
 
 linkInfo :: InfoMod a
-linkInfo = progDesc "Link one or more binary fingerprints as a user-defined dependency"
+linkInfo = progDescDoc $ formatStringToDoc "Link one or more binary fingerprints as a user-defined dependency"
 
 mkSubCommand :: (LinkUserBinsConfig -> EffStack ()) -> SubCommand LinkUserBinsOpts LinkUserBinsConfig
 mkSubCommand = SubCommand cmdName linkInfo cliParser loadConfig mergeOpts
@@ -118,10 +121,18 @@ cliParser =
     assertUserDefinedBinariesMeta :: Parser UserDefinedAssertionMeta
     assertUserDefinedBinariesMeta =
       UserDefinedAssertionMeta
-        <$> (strOption (long "name" <> help "The name to display for the dependency"))
-        <*> (strOption (long "version" <> help "The version to display for the dependency"))
-        <*> (strOption (long "license" <> help "The license identifier to use for the dependency"))
-        <*> optional (strOption (long "description" <> help "The description to use for the dependency"))
-        <*> optional (strOption (long "homepage" <> help "The URL to the homepage for the dependency"))
+        <$> (strOption (applyFossaStyle <> long "name" <> helpDoc (formatStringToDoc "The name to display for the dependency")))
+        <*> (strOption (applyFossaStyle <> long "version" <> helpDoc (formatStringToDoc "The version to display for the dependency")))
+        <*> (strOption (applyFossaStyle <> long "license" <> helpDoc (formatStringToDoc "The license identifier to use for the dependency")))
+        <*> optional (strOption (applyFossaStyle <> long "description" <> helpDoc (formatStringToDoc "The description to use for the dependency")))
+        <*> optional (strOption (applyFossaStyle <> long "homepage" <> helpDoc (formatStringToDoc "The URL to the homepage for the dependency")))
     assertUserDefinedBinariesDir :: Parser String
-    assertUserDefinedBinariesDir = argument str (metavar "DIR" <> help "The directory containing one or more binaries to assert to the provided values (default: current directory)" <> value ".")
+    assertUserDefinedBinariesDir = argument str (applyFossaStyle <> metavar "DIR" <> helpDoc dirHelp <> value ".")
+    dirHelp :: Maybe (Doc AnsiStyle)
+    dirHelp =
+      Just $
+        formatDoc $
+          vsep
+            [ "The directory containing one or more binaries to assert to the provided values"
+            , boldItalicized "Default: " <> "Current directory"
+            ]

--- a/src/App/Fossa/Config/ListTargets.hs
+++ b/src/App/Fossa/Config/ListTargets.hs
@@ -32,10 +32,13 @@ import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (toText)
 import Data.Text (strip, toLower)
-import Effect.Logger (Has, Logger, Severity (SevDebug, SevInfo))
+import Effect.Logger (Has, Logger, Severity (SevDebug, SevInfo), vsep)
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Options.Applicative (InfoMod, Parser, ReadM, eitherReader, help, long, option, optional, progDesc)
+import Options.Applicative (InfoMod, Parser, ReadM, eitherReader, helpDoc, long, option, optional, progDescDoc)
+import Prettyprinter (Doc)
+import Prettyprinter.Render.Terminal (AnsiStyle, Color (Green))
+import Style (applyFossaStyle, boldItalicized, coloredBoldItalicized, formatDoc, formatStringToDoc)
 
 data ListTargetOutputFormat
   = Legacy
@@ -68,7 +71,7 @@ loadConfig ::
 loadConfig = resolveLocalConfigFile . optConfig . commons
 
 listTargetsInfo :: InfoMod a
-listTargetsInfo = progDesc "List available analysis-targets in a directory (projects and sub-projects)"
+listTargetsInfo = progDescDoc $ formatStringToDoc "List available analysis-targets in a directory (projects and sub-projects)"
 
 parser :: Parser ListTargetsCliOpts
 parser =
@@ -78,10 +81,20 @@ parser =
     <*> optional
       ( option
           parseListTargetOutput
-          ( long "format"
-              <> help "output format to use: legacy, ndjson, text (default: legacy)"
+          ( applyFossaStyle
+              <> long "format"
+              <> helpDoc listTargetsFormatHelp
           )
       )
+  where
+    listTargetsFormatHelp :: Maybe (Doc AnsiStyle)
+    listTargetsFormatHelp =
+      Just $
+        formatDoc $
+          vsep
+            [ boldItalicized "Formats: " <> coloredBoldItalicized Green "legacy" <> boldItalicized "|" <> coloredBoldItalicized Green "ndjson" <> boldItalicized "|" <> coloredBoldItalicized Green "text"
+            , boldItalicized "Default: " <> coloredBoldItalicized Green "legacy"
+            ]
 
 mergeOpts ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Config/Snippets.hs
+++ b/src/App/Fossa/Config/Snippets.hs
@@ -13,7 +13,7 @@ module App.Fossa.Config.Snippets (
   labelForTransform,
 ) where
 
-import App.Fossa.Config.Common (baseDirArg, collectBaseDir, fossaApiKeyCmdText)
+import App.Fossa.Config.Common (baseDirArg, collectBaseDir, endpointHelp, fossaApiKeyCmdText, fossaApiKeyHelp)
 import App.Fossa.Subcommand (EffStack, GetCommonOpts, GetSeverity (..), SubCommand (..))
 import App.OptionExtensions (uriOption)
 import App.Types (BaseDir)
@@ -27,9 +27,10 @@ import Data.Text (Text)
 import Effect.Logger (Severity (..))
 import Effect.ReadFS (ReadFS)
 import GHC.Generics (Generic)
-import Options.Applicative (InfoMod, Parser, command, eitherReader, help, hsubparser, info, long, many, metavar, option, optional, progDesc, short, strOption, switch, (<|>))
+import Options.Applicative (InfoMod, Parser, command, eitherReader, helpDoc, info, long, many, metavar, option, optional, progDescDoc, short, strOption, subparser, switch, (<|>))
 import Path (Abs, Dir, Path)
 import Path.IO qualified as Path
+import Style (applyFossaStyle, formatStringToDoc)
 import Text.URI (URI)
 
 data SnippetsCommand
@@ -56,13 +57,13 @@ data SnippetsCommand
       [SnippetTransform]
 
 snippetsInfo :: InfoMod a
-snippetsInfo = progDesc "FOSSA snippet scanning"
+snippetsInfo = progDescDoc $ formatStringToDoc "FOSSA snippet scanning"
 
 snippetsAnalyzeInfo :: InfoMod a
-snippetsAnalyzeInfo = progDesc "Analyze a local project for snippet matches"
+snippetsAnalyzeInfo = progDescDoc $ formatStringToDoc "Analyze a local project for snippet matches"
 
 snippetsCommitInfo :: InfoMod a
-snippetsCommitInfo = progDesc "Commit matches discovered during analyze into a fossa-deps file"
+snippetsCommitInfo = progDescDoc $ formatStringToDoc "Commit matches discovered during analyze into a fossa-deps file"
 
 instance GetSeverity SnippetsCommand where
   getSeverity :: SnippetsCommand -> Severity
@@ -79,31 +80,31 @@ mkSubCommand = SubCommand "snippets" snippetsInfo cliParser noLoadConfig mergeOp
 cliParser :: Parser SnippetsCommand
 cliParser = analyze <|> commit
   where
-    analyze = hsubparser . command "analyze" $ info analyzeOpts snippetsAnalyzeInfo
+    analyze = subparser . command "analyze" $ info analyzeOpts snippetsAnalyzeInfo
     analyzeOpts =
       CommandAnalyze
         <$> baseDirArg
-        <*> switch (long "debug" <> help "Enable debug logging")
-        <*> optional (uriOption (long "endpoint" <> short 'e' <> metavar "URL" <> help "The FOSSA API server base URL (default: https://app.fossa.com)"))
-        <*> optional (strOption (long fossaApiKeyCmdText <> help "the FOSSA API server authentication key (default: FOSSA_API_KEY from env)"))
-        <*> strOption (long "output" <> short 'o' <> help "The directory to which matches are output")
-        <*> switch (long "overwrite-output" <> help "If specified, overwrites the output directory if it exists")
-        <*> many (option (eitherReader parseTarget) (long "target" <> help ("Analyze this combination of targets") <> metavar "TARGET"))
-        <*> many (option (eitherReader parseKind) (long "kind" <> help ("Analyze this combination of kinds") <> metavar "KIND"))
-        <*> many (option (eitherReader parseTransform) (long "transform" <> help ("Analyze this combination of transforms") <> metavar "TRANSFORM"))
-    commit = hsubparser . command "commit" $ info commitOpts snippetsCommitInfo
+        <*> switch (applyFossaStyle <> long "debug" <> helpDoc (formatStringToDoc "Enable debug logging"))
+        <*> optional (uriOption (applyFossaStyle <> long "endpoint" <> short 'e' <> metavar "URL" <> helpDoc endpointHelp))
+        <*> optional (strOption (applyFossaStyle <> long fossaApiKeyCmdText <> helpDoc fossaApiKeyHelp))
+        <*> strOption (applyFossaStyle <> long "output" <> short 'o' <> helpDoc (formatStringToDoc "The directory to which matches are output"))
+        <*> switch (applyFossaStyle <> long "overwrite-output" <> helpDoc (formatStringToDoc "If specified, overwrites the output directory if it exists"))
+        <*> many (option (eitherReader parseTarget) (applyFossaStyle <> long "target" <> helpDoc (formatStringToDoc ("Analyze this combination of targets")) <> metavar "TARGET"))
+        <*> many (option (eitherReader parseKind) (applyFossaStyle <> long "kind" <> helpDoc (formatStringToDoc "Analyze this combination of kinds") <> metavar "KIND"))
+        <*> many (option (eitherReader parseTransform) (applyFossaStyle <> long "transform" <> helpDoc (formatStringToDoc "Analyze this combination of transforms") <> metavar "TRANSFORM"))
+    commit = subparser . command "commit" $ info commitOpts snippetsCommitInfo
     commitOpts =
       CommandCommit
         <$> baseDirArg
-        <*> switch (long "debug" <> help "Enable debug logging")
-        <*> optional (uriOption (long "endpoint" <> short 'e' <> metavar "URL" <> help "The FOSSA API server base URL (default: https://app.fossa.com)"))
-        <*> optional (strOption (long fossaApiKeyCmdText <> help "the FOSSA API server authentication key (default: FOSSA_API_KEY from env)"))
-        <*> strOption (long "analyze-output" <> help "The directory to which 'analyze' matches were saved")
-        <*> switch (long "overwrite-fossa-deps" <> help "If specified, overwrites the 'fossa-deps' file if it exists")
-        <*> optional (option (eitherReader parseCommitOutputFormat) (long "format" <> help ("The output format for the generated `fossa-deps` file") <> metavar "FORMAT"))
-        <*> many (option (eitherReader parseTarget) (long "target" <> help ("Commit this combination of targets") <> metavar "TARGET"))
-        <*> many (option (eitherReader parseKind) (long "kind" <> help ("Commit this combination of kinds") <> metavar "KIND"))
-        <*> many (option (eitherReader parseTransform) (long "transform" <> help ("Commit this combination of transforms") <> metavar "TRANSFORM"))
+        <*> switch (applyFossaStyle <> long "debug" <> helpDoc (formatStringToDoc "Enable debug logging"))
+        <*> optional (uriOption (applyFossaStyle <> long "endpoint" <> short 'e' <> metavar "URL" <> helpDoc endpointHelp))
+        <*> optional (strOption (applyFossaStyle <> long fossaApiKeyCmdText <> helpDoc fossaApiKeyHelp))
+        <*> strOption (applyFossaStyle <> long "analyze-output" <> helpDoc (formatStringToDoc "The directory to which 'analyze' matches were saved"))
+        <*> switch (applyFossaStyle <> long "overwrite-fossa-deps" <> helpDoc (formatStringToDoc "If specified, overwrites the 'fossa-deps' file if it exists"))
+        <*> optional (option (eitherReader parseCommitOutputFormat) (applyFossaStyle <> long "format" <> helpDoc (formatStringToDoc ("The output format for the generated `fossa-deps` file")) <> metavar "FORMAT"))
+        <*> many (option (eitherReader parseTarget) (applyFossaStyle <> long "target" <> helpDoc (formatStringToDoc "Commit this combination of targets") <> metavar "TARGET"))
+        <*> many (option (eitherReader parseKind) (applyFossaStyle <> long "kind" <> helpDoc (formatStringToDoc "Commit this combination of kinds") <> metavar "KIND"))
+        <*> many (option (eitherReader parseTransform) (applyFossaStyle <> long "transform" <> helpDoc (formatStringToDoc "Commit this combination of transforms") <> metavar "TRANSFORM"))
 
 mergeOpts ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Init.hs
+++ b/src/App/Fossa/Init.hs
@@ -21,7 +21,7 @@ import Data.ByteString qualified as BS
 import Data.FileEmbed.Extra (embedFileIfExists)
 import Effect.Logger (Logger, Severity (SevInfo), logInfo, pretty, withDefaultLogger)
 import Effect.ReadFS (ReadFS, getCurrentDir, runReadFSIO)
-import Options.Applicative (CommandFields, Mod, Parser, info, progDesc)
+import Options.Applicative (CommandFields, Mod, Parser, info, progDescDoc)
 import Options.Applicative.Builder (command)
 import Path (
   Abs,
@@ -33,9 +33,10 @@ import Path (
   toFilePath,
   (</>),
  )
+import Style (formatStringToDoc)
 
 initCommand :: Mod CommandFields (IO ())
-initCommand = command "init" (info run $ progDesc "Creates .fossa.yml.example and fossa-deps.yml.example file")
+initCommand = command "init" (info run $ progDescDoc $ formatStringToDoc "Creates .fossa.yml.example and fossa-deps.yml.example file")
   where
     run :: Parser (IO ())
     run = pure $ withTelemetry . runStack . withDefaultLogger SevInfo . logWithExit_ . runReadFSIO $ runInit

--- a/src/App/Fossa/Main.hs
+++ b/src/App/Fossa/Main.hs
@@ -18,46 +18,32 @@ import Control.Concurrent.CGroup (initRTSThreads)
 import Control.Monad (join)
 import Data.Aeson (ToJSON)
 import Data.String.Conversion (toString)
-import Options.Applicative (
-  CommandFields,
-  InfoMod,
-  Mod,
-  Parser,
-  ParserPrefs,
-  command,
-  customExecParser,
-  footer,
-  fullDesc,
-  header,
-  help,
-  helpShowGlobals,
-  helper,
-  hsubparser,
-  info,
-  infoOption,
-  internal,
-  long,
-  prefs,
-  progDesc,
-  short,
-  showHelpOnEmpty,
-  showHelpOnError,
-  subparser,
-  subparserInline,
-  (<**>),
-  (<|>),
- )
+import Options.Applicative (CommandFields, InfoMod, Mod, Parser, ParserPrefs, columns, command, customExecParser, footer, fullDesc, header, helpIndent, helpShowGlobals, info, infoOption, internal, long, prefs, progDescDoc, short, showHelpOnEmpty, showHelpOnError, subparser, subparserInline, (<**>), (<|>))
+import Options.Applicative.Builder (helpDoc)
+import Options.Applicative.Extra (helperWith)
+import Style (applyFossaStyle, formatStringToDoc)
 
 appMain :: IO ()
 appMain = do
   initRTSThreads
-  join $ customExecParser mainPrefs $ info (subcommands <**> helper <**> versionOpt) progData
+  join $ customExecParser mainPrefs $ info (subcommands <**> helperOpt <**> versionOpt) progData
 
 versionOpt :: Parser (a -> a)
 versionOpt =
   infoOption (toString fullVersionDescription) $
     mconcat
-      [long "version", short 'V', help "show version information and exit"]
+      [applyFossaStyle, long "version", short 'V', helpDoc $ formatStringToDoc "Show version information and exit"]
+
+helperOpt :: Parser (a -> a)
+helperOpt =
+  helperWith
+    ( mconcat
+        [ applyFossaStyle
+        , long "help"
+        , short 'h'
+        , helpDoc $ formatStringToDoc "Show this help text"
+        ]
+    )
 
 progData :: InfoMod (IO ())
 progData =
@@ -77,7 +63,7 @@ subcommands = public <|> private
           , decodeSubCommand LicenseScan.licenseScanSubCommand
           ]
     public =
-      hsubparser $
+      subparser $
         mconcat
           [ decodeSubCommand Analyze.analyzeSubCommand
           , decodeSubCommand Test.testSubCommand
@@ -90,7 +76,7 @@ subcommands = public <|> private
           ]
 
 experimentalLicenseScanCommand :: Mod CommandFields (IO ())
-experimentalLicenseScanCommand = command "experimental-license-scan" (info runInit $ progDesc "The 'experimental-license-scan' command has been deprecated and renamed to 'license-scan'")
+experimentalLicenseScanCommand = command "experimental-license-scan" (info runInit $ progDescDoc $ formatStringToDoc "The 'experimental-license-scan' command has been deprecated and renamed to 'license-scan'")
   where
     runInit :: Parser (IO ())
     runInit = pure $ putStrLn "The 'experimental-license-scan' has been deprecated and renamed to 'license-scan'. Please use the 'license-scan' command instead."
@@ -105,5 +91,7 @@ mainPrefs =
       [ showHelpOnEmpty
       , showHelpOnError
       , subparserInline
+      , columns 150
       , helpShowGlobals
+      , helpIndent 1 -- allows the help message to appear on new line
       ]

--- a/src/App/Fossa/Subcommand.hs
+++ b/src/App/Fossa/Subcommand.hs
@@ -6,6 +6,7 @@ module App.Fossa.Subcommand (
   GetSeverity (..),
   GetCommonOpts (..),
   SubCommand (..),
+  updateCommandName,
 ) where
 
 import App.Fossa.Config.Common (CommonOpts, collectTelemetrySink)
@@ -49,6 +50,9 @@ class GetSeverity a where
 class GetCommonOpts a where
   getCommonOpts :: a -> Maybe CommonOpts
   getCommonOpts = const Nothing
+
+updateCommandName :: SubCommand cli cfg -> String -> SubCommand cli cfg
+updateCommandName subCmd newName = subCmd{commandName = newName}
 
 runSubCommand :: forall cli cfg. (GetCommonOpts cli, GetSeverity cli, Show cfg, ToJSON cfg) => SubCommand cli cfg -> Parser (IO ())
 runSubCommand SubCommand{..} = uncurry (runEffs) . mergeAndRun <$> parser

--- a/src/Style.hs
+++ b/src/Style.hs
@@ -1,0 +1,37 @@
+module Style (
+    coloredText,
+    formatStringToDoc,
+    formatDoc,
+    applyFossaStyle,
+    boldItalicized,
+    coloredBoldItalicized,
+    coloredBoldItalicizedString,
+) where
+
+import Data.String.Conversion (toString)
+import Effect.Logger (newlineTrailing, vsep)
+import Options.Applicative (style)
+import Options.Applicative.Builder (Mod)
+import Prettyprinter (Doc, annotate, defaultLayoutOptions, indent, layoutPretty, pretty)
+import Prettyprinter.Render.Terminal (AnsiStyle, Color (Green), bold, color, italicized, renderStrict)
+
+formatStringToDoc :: String -> Maybe (Doc AnsiStyle)
+formatStringToDoc s = Just $ indent 2 $ vsep [newlineTrailing $ pretty s]
+
+formatDoc :: Doc AnsiStyle -> Doc AnsiStyle
+formatDoc doc = indent 2 $ newlineTrailing doc
+
+coloredText :: Color -> Doc AnsiStyle -> String
+coloredText clr str = toString . renderStrict . layoutPretty defaultLayoutOptions $ annotate (color clr) str
+
+coloredBoldItalicizedString :: Color -> Doc AnsiStyle -> String
+coloredBoldItalicizedString clr str = toString . renderStrict . layoutPretty defaultLayoutOptions $ annotate (color clr <> bold <> italicized) str
+
+applyFossaStyle :: Mod f a
+applyFossaStyle = style $ annotate (color Green <> bold <> italicized)
+
+boldItalicized :: Doc AnsiStyle -> Doc AnsiStyle
+boldItalicized = annotate (bold <> italicized)
+
+coloredBoldItalicized :: Color -> Doc AnsiStyle -> Doc AnsiStyle
+coloredBoldItalicized clr = annotate (color clr <> bold <> italicized)

--- a/src/Style.hs
+++ b/src/Style.hs
@@ -1,12 +1,4 @@
-module Style (
-    coloredText,
-    formatStringToDoc,
-    formatDoc,
-    applyFossaStyle,
-    boldItalicized,
-    coloredBoldItalicized,
-    coloredBoldItalicizedString,
-) where
+module Style (coloredText, formatStringToDoc, formatDoc, applyFossaStyle, boldItalicized, coloredBoldItalicized, coloredBoldItalicizedString) where
 
 import Data.String.Conversion (toString)
 import Effect.Logger (newlineTrailing, vsep)


### PR DESCRIPTION
# Overview

Currently, the cli provides minimal color and the description in our help command is provided in a column format. Improve, the overall formatting by adding color and changing the structure to allow an user friendly experience for users.

## Acceptance criteria

- Add color to our text

- Change the structure so that the description of our commands are oriented in rows as opposed to columns

## Testing plan

To validate `git checkout ANE-1380-Add-Color-Update-Format`

Run: 

Ran -h for all the commands 
cabal run fossa --  report -h  , cabal run fossa --  analyze -h  , ... 


fossa analyze -h 
![Screenshot 2024-01-20 at 4 25 14 PM](https://github.com/fossas/fossa-cli/assets/28590628/ce0073f9-52fb-4d09-aa6d-9e1d13180c66)


fossa report -h
![Screenshot 2024-01-20 at 4 26 07 PM](https://github.com/fossas/fossa-cli/assets/28590628/2385ba28-3e6e-454e-a87f-50db838165d9)


## Risks

## Metrics

## References

- [ANE-1380](https://fossa.atlassian.net/browse/ANE-1380)
- 
## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1380]: https://fossa.atlassian.net/browse/ANE-1380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ