### PR TITLE
Don't die on no VSI dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.8.35
+- Running `fossa analyze --detect-vendored` no longer fails if there are no detected vendored dependencies ([#1373](https://github.com/fossas/fossa-cli/pull/1373)).
+
 ## v3.8.34
 - Add color and update formatting in cli help commands ([#1367](https://github.com/fossas/fossa-cli/pull/1367))
 

--- a/src/App/Fossa/VSI/Analyze.hs
+++ b/src/App/Fossa/VSI/Analyze.hs
@@ -25,7 +25,6 @@ import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Stack (Stack)
 import Control.Effect.StickyLogger (StickyLogger, logSticky, logSticky')
 import Control.Effect.TaskPool (TaskPool, forkTask)
-import Control.Monad (when)
 import Data.Aeson (encode)
 import Data.Foldable (traverse_)
 import Data.Map qualified as Map
@@ -78,15 +77,11 @@ runVsiAnalysis dir projectRevision filters = context "VSI" $ do
   logInfo "Waiting for cloud analysis"
   context "Wait for cloud analysis" $ waitForAnalysis scanID
 
-  rules <- context "Download analysis results" $ do
+  context "Download analysis results" $ do
     inferences <- getVsiInferences scanID
     let rules = generateRules inferences
     logDebug . pretty $ "Generated Rules: " <> (decodeUtf8 @Text . encode $ rules)
     pure rules
-
-  when (null rules) $ fatalText "No dependencies discovered with VSI"
-
-  pure rules
 
 uploadBufferSize :: Int
 uploadBufferSize = 1000


### PR DESCRIPTION
# Overview

No longer error when VSI finds no dependencies.

## Acceptance criteria

- Users are able to upload the results of VSI scans that simply have no dependencies found.
- This does not alter functionality when no strategies succeed, only VSI.
  - IMO, at least for VSI this makes sense: by running `--detect-vendored` the user implicitly is enabling a strategy that _always_ finds a target to analyze at the root of their project; this change just removes a special case error.
  - For cases when all strategies fail, we have [this ticket](https://fossa.atlassian.net/browse/ANE-1155) but that is out of scope for this PR.

## Testing plan

I created a project that would find no dependencies:
```
mkdir -p ~/projects/scratch/empty
touch ~/projects/scratch/empty/nothing.c
```

I then ran a VSI scan against that project with these changes:
```
cabal run fossa -- analyze ~/projects/scratch/empty -p vsi-empty --detect-vendored
Unable to infer project revision from VCS, using current timestamp as the revision.
Running VSI analysis
Created Scan ID: a1b96f6e-93f3-4acc-8a65-416abf1bd8da
Finalizing scan
Waiting for cloud analysis

Scan Summary
------------
fossa-cli version 3.8.34 (revision b78c3ba13e53 compiled with ghc-9.4)
fossa endpoint server version: 4.16.43

1 projects scanned;  0 skipped,  1 succeeded,  0 failed,  0 analysis warnings

-
* vsi analysis: succeeded
  ** /Users/jessica/projects/scratch/empty/

  Some projects may not appear in the summary if they were filtered during discovery.
  You can run `fossa list-targets` to see all discoverable projects.

You can pass `--debug` option to eagerly show all warning and failure messages.
You can also view analysis summary with warning and error messages at: "/private/var/folders/q7/3nvvpy0d6js28m8lypw3tcx80000gn/T/fossa-analyze-scan-summary.txt"
------------

Using project name: `vsi-empty`
Using revision: `2024-02-02T23:43:56Z`
Using branch: `No branch (detached HEAD)`
============================================================

    View FOSSA Report:
    https://app.fossa.com/projects/custom%2b24357%2fvsi-empty/refs/branch/master/2024-02-02T23:43:56Z

============================================================
```

I also ran one before making the changes and it errored as expected.

## Risks

Theoretically someone might be depending on this old workflow but I seriously doubt it.

## Metrics

None

## References

https://teamfossa.slack.com/archives/C039KE5ERNE/p1706913911829629

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
