### PR TITLE
Warn when no analysis targets are found

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # FOSSA CLI Changelog
 
-## v3.8.37
+## v3.9.0
 - Emits a warning instead of an error when no analysis targets are found ([#1375](https://github.com/fossas/fossa-cli/pull/1375))
 
 ## v3.8.36

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.8.37
+- Emits a warning instead of error when no analysis targets are found ([#1375](https://github.com/fossas/fossa-cli/pull/1375))
+
 ## v3.8.36
 - `fossa feedback`: Allow users to provide feedback on their cli experience ([#1368](https://github.com/fossas/fossa-cli/pull/1368))
 - Add preflight checks to validate API key, connection to FOSSA app, and ability to write to temp directory in relevant commands

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## v3.8.37
-- Emits a warning instead of error when no analysis targets are found ([#1375](https://github.com/fossas/fossa-cli/pull/1375))
+- Emits a warning instead of an error when no analysis targets are found ([#1375](https://github.com/fossas/fossa-cli/pull/1375))
 
 ## v3.8.36
 - `fossa feedback`: Allow users to provide feedback on their cli experience ([#1368](https://github.com/fossas/fossa-cli/pull/1368))

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -408,7 +408,6 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   let keywordSearchResultsFound = (maybe False (not . null . lernieResultsKeywordSearches) lernieResults)
   let outputResult = buildResult includeAll additionalSourceUnits filteredProjects' licenseSourceUnits
 
-  -- In the case that we don't find any analysis targets, emit a warning
   scanUnits <-
     case (keywordSearchResultsFound, checkForEmptyUpload includeAll projectScans filteredProjects' additionalSourceUnits licenseSourceUnits) of
       (False, NoneDiscovered) -> do

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -96,6 +96,7 @@ import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BL
 import Data.Flag (Flag, fromFlag)
 import Data.Foldable (traverse_)
+import Data.Functor (($>))
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.String.Conversion (decodeUtf8, toText)
@@ -410,18 +411,10 @@ analyze cfg = Diag.context "fossa-analyze" $ do
 
   scanUnits <-
     case (keywordSearchResultsFound, checkForEmptyUpload includeAll projectScans filteredProjects' additionalSourceUnits licenseSourceUnits) of
-      (False, NoneDiscovered) -> do
-        Diag.warn ErrNoProjectsDiscovered
-        pure emptyScanUnits
-      (True, NoneDiscovered) -> do
-        Diag.warn ErrOnlyKeywordSearchResultsFound
-        pure emptyScanUnits
-      (False, FilteredAll) -> do
-        Diag.warn ErrFilteredAllProjects
-        pure emptyScanUnits
-      (True, FilteredAll) -> do
-        Diag.warn ErrOnlyKeywordSearchResultsFound
-        pure emptyScanUnits
+      (False, NoneDiscovered) -> Diag.warn ErrNoProjectsDiscovered $> emptyScanUnits
+      (True, NoneDiscovered) -> Diag.warn ErrOnlyKeywordSearchResultsFound $> emptyScanUnits
+      (False, FilteredAll) -> Diag.warn ErrFilteredAllProjects $> emptyScanUnits
+      (True, FilteredAll) -> Diag.warn ErrOnlyKeywordSearchResultsFound $> emptyScanUnits
       (_, CountedScanUnits scanUnits) -> pure scanUnits
   doUpload outputResult iatAssertion destination basedir jsonOutput revision scanUnits
   pure outputResult

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -32,7 +32,7 @@ import App.Fossa.Analyze.Types (
   DiscoveredProjectIdentifier (..),
   DiscoveredProjectScan (..),
  )
-import App.Fossa.Analyze.Upload (mergeSourceAndLicenseUnits, uploadSuccessfulAnalysis)
+import App.Fossa.Analyze.Upload (ScanUnits (SourceUnitOnly), mergeSourceAndLicenseUnits, uploadSuccessfulAnalysis)
 import App.Fossa.BinaryDeps (analyzeBinaryDeps)
 import App.Fossa.Config.Analyze (
   AnalysisTacticTypes (..),
@@ -411,15 +411,15 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   -- If we find nothing but keyword search, we exit with an error, but explain that the error may be ignorable.
   -- We do not want to succeed, because nothing gets uploaded to the API for keyword searches, so `fossa test` will fail.
   -- So the solution is to still fail, but give a hopefully useful explanation that the error can be ignored if all you were expecting is keyword search results.
-
-  -- In the case that we don't find any analysis targets, we only want to emit a warning.
-  void . recover . Diag.warnOnErr ErrNoProjectsDiscovered $
-    case (keywordSearchResultsFound, checkForEmptyUpload includeAll projectScans filteredProjects' additionalSourceUnits licenseSourceUnits) of
-      (False, NoneDiscovered) -> Diag.fatal ErrNoProjectsDiscovered
-      (True, NoneDiscovered) -> Diag.fatal ErrOnlyKeywordSearchResultsFound
-      (False, FilteredAll) -> Diag.fatal ErrFilteredAllProjects
-      (True, FilteredAll) -> Diag.fatal ErrOnlyKeywordSearchResultsFound
-      (_, CountedScanUnits scanUnits) -> doUpload outputResult iatAssertion destination basedir jsonOutput revision scanUnits
+  -- In the case that we don't find any analysis targets, we want to emit a warning and upload empty source units.
+  case (keywordSearchResultsFound, checkForEmptyUpload includeAll projectScans filteredProjects' additionalSourceUnits licenseSourceUnits) of
+    (False, NoneDiscovered) -> do
+      Diag.warn ErrNoProjectsDiscovered
+      doUpload outputResult iatAssertion destination basedir jsonOutput revision $ SourceUnitOnly []
+    (True, NoneDiscovered) -> Diag.fatal ErrOnlyKeywordSearchResultsFound
+    (False, FilteredAll) -> Diag.fatal ErrFilteredAllProjects
+    (True, FilteredAll) -> Diag.fatal ErrOnlyKeywordSearchResultsFound
+    (_, CountedScanUnits scanUnits) -> doUpload outputResult iatAssertion destination basedir jsonOutput revision scanUnits
   pure outputResult
   where
     doUpload result iatAssertion destination basedir jsonOutput revision scanUnits =

--- a/src/App/Fossa/Analyze/Filter.hs
+++ b/src/App/Fossa/Analyze/Filter.hs
@@ -33,7 +33,7 @@ checkForEmptyUpload includeAll discovered filtered additionalUnits firstPartySca
       (_, _, Nothing) -> CountedScanUnits . SourceUnitOnly $ discoveredUnits
     else -- If we have a additional source units, then there's always something to upload.
     case licensesMaybeFound of
-      Nothing -> CountedScanUnits . SourceUnitOnly $ (additionalUnits ++ discoveredUnits)
+      Nothing -> CountedScanUnits . SourceUnitOnly $ additionalUnits ++ discoveredUnits
       Just licenseSourceUnit -> CountedScanUnits $ SourceAndLicenseUnits (additionalUnits ++ discoveredUnits) licenseSourceUnit
   where
     discoveredLen = length discovered

--- a/src/App/Fossa/Analyze/Upload.hs
+++ b/src/App/Fossa/Analyze/Upload.hs
@@ -68,9 +68,9 @@ import Srclib.Types (
  )
 
 data ScanUnits
-  = SourceUnitOnly (NE.NonEmpty SourceUnit)
+  = SourceUnitOnly [SourceUnit]
   | LicenseSourceUnitOnly LicenseSourceUnit
-  | SourceAndLicenseUnits (NE.NonEmpty SourceUnit) LicenseSourceUnit
+  | SourceAndLicenseUnits [SourceUnit] LicenseSourceUnit
   deriving (Show)
 
 -- units come from standard `fossa analyze`.
@@ -118,7 +118,7 @@ uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnit
       SourceAndLicenseUnits sourceUnits licenseSourceUnit -> do
         org <- getOrganization
         let fullFileUploads = FullFileUploads $ orgRequiresFullFileUploads org
-        let mergedUnits = mergeSourceAndLicenseUnits (NE.toList sourceUnits) licenseSourceUnit
+        let mergedUnits = mergeSourceAndLicenseUnits sourceUnits licenseSourceUnit
         runStickyLogger SevInfo $ uploadAnalysisWithFirstPartyLicensesToS3AndCore revision metadata mergedUnits fullFileUploads
     let locator = uploadLocator uploadResult
     buildUrl <- getFossaBuildUrl revision locator

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -94,7 +94,7 @@ uploadAnalysis ::
   ) =>
   ProjectRevision ->
   ProjectMetadata ->
-  NE.NonEmpty SourceUnit ->
+  [SourceUnit] ->
   m UploadResponse
 uploadAnalysis revision metadata units = do
   apiOpts <- ask

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -638,7 +638,7 @@ uploadAnalysis ::
   ApiOpts ->
   ProjectRevision ->
   ProjectMetadata ->
-  NE.NonEmpty SourceUnit ->
+  [SourceUnit] ->
   m UploadResponse
 uploadAnalysis apiOpts ProjectRevision{..} metadata sourceUnits = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
@@ -653,7 +653,7 @@ uploadAnalysis apiOpts ProjectRevision{..} metadata sourceUnits = fossaReq $ do
           <> mkMetadataOpts metadata projectName
           -- Don't include branch if it doesn't exist, core may not handle empty string properly.
           <> maybe mempty ("branch" =:) projectBranch
-  resp <- req POST (uploadUrl baseUrl) (ReqBodyJson $ NE.toList sourceUnits) jsonResponse (baseOpts <> opts)
+  resp <- req POST (uploadUrl baseUrl) (ReqBodyJson sourceUnits) jsonResponse (baseOpts <> opts)
   pure (responseBody resp)
 
 uploadAnalysisWithFirstPartyLicenses ::

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -113,7 +113,7 @@ data FossaApiClientF a where
   UploadAnalysis ::
     ProjectRevision ->
     ProjectMetadata ->
-    NonEmpty SourceUnit ->
+    [SourceUnit] ->
     FossaApiClientF UploadResponse
   UploadAnalysisWithFirstPartyLicenses ::
     ProjectRevision ->
@@ -153,7 +153,7 @@ getApiOpts :: (Has FossaApiClient sig m) => m ApiOpts
 getApiOpts = sendSimple GetApiOpts
 
 -- | Uploads the results of an analysis and associates it to a project
-uploadAnalysis :: (Has FossaApiClient sig m) => ProjectRevision -> ProjectMetadata -> NonEmpty SourceUnit -> m UploadResponse
+uploadAnalysis :: (Has FossaApiClient sig m) => ProjectRevision -> ProjectMetadata -> [SourceUnit] -> m UploadResponse
 uploadAnalysis revision metadata units = sendSimple (UploadAnalysis revision metadata units)
 
 -- | Uploads the results of a first-party analysis and associates it to a project

--- a/test/App/Fossa/Analyze/UploadSpec.hs
+++ b/test/App/Fossa/Analyze/UploadSpec.hs
@@ -69,7 +69,7 @@ expectGetFirstPartySignedUrl packageRevision = GetSignedFirstPartyScanUrl packag
 
 expectUploadFirstPartyDataToS3 :: Has MockApi sig m => m ()
 expectUploadFirstPartyDataToS3 = do
-  let mergedUnits = mergeSourceAndLicenseUnits (NE.toList Fixtures.sourceUnits) Fixtures.firstLicenseSourceUnit
+  let mergedUnits = mergeSourceAndLicenseUnits Fixtures.sourceUnits Fixtures.firstLicenseSourceUnit
   UploadFirstPartyScanResult Fixtures.signedUrl mergedUnits `returnsOnceForAnyRequest` ()
 
 expectedMergedFullSourceUnits :: NE.NonEmpty FullSourceUnit
@@ -255,7 +255,7 @@ mergeSourceAndLicenseUnitsSpec =
     "mergeSourceAndLicenseUnits"
     $ do
       it' "merges source and license units" $ do
-        let mergedUnits = mergeSourceAndLicenseUnits (NE.toList Fixtures.sourceUnits) Fixtures.firstLicenseSourceUnit
+        let mergedUnits = mergeSourceAndLicenseUnits Fixtures.sourceUnits Fixtures.firstLicenseSourceUnit
         mergedUnits `shouldBe'` expectedMergedFullSourceUnits
 
 spec :: Spec

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -132,8 +132,8 @@ packageRevision =
     , App.packageVersion = "1.0"
     }
 
-sourceUnits :: NE.NonEmpty SourceUnit
-sourceUnits = NE.fromList [unit]
+sourceUnits :: [SourceUnit]
+sourceUnits = [unit]
   where
     unit =
       SourceUnit


### PR DESCRIPTION
# Overview

Current the CLI returns an error when we scan a project without any analysis targets. Change it so that we return a warning instead of an error.

## Acceptance criteria

Emit a warning when there are no analysis targets

## Testing plan

run fossa analyze && fossa test on an empty folder

Before:
![Screenshot 2024-02-07 at 12 21 45 PM](https://github.com/fossas/fossa-cli/assets/28590628/8d143034-973a-4c6a-bf6c-3f6b7dabfe8e)

After:

`fossa analyze`  results

![Screenshot 2024-02-07 at 1 58 07 PM](https://github.com/fossas/fossa-cli/assets/28590628/44354fae-e844-4ec3-94fb-351b30667354)

`fossa test` results

![Screenshot 2024-02-07 at 1 53 13 PM](https://github.com/fossas/fossa-cli/assets/28590628/d924993f-2506-465d-9edc-f1f10bbfff91)



## Risks


## Metrics


## References

[Slack thread](https://teamfossa.slack.com/archives/C039KE5ERNE/p1707240999977229)

_Example:_

- [ANE-1434](https://fossa.atlassian.net/browse/ANE-1434)
## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1434]: https://fossa.atlassian.net/browse/ANE-1434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ