### PR TITLE
[No Ticket] `--detect-dynamic` less error prone

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## 3.8.38
+- `dynamic-deps`: Safely ignores scenarios in ldd output parsing where we run into not found error. ([]()) 
+
 ## 3.8.37
 
 - Container Scans: Bugfix for some registry scans that fail with an STM error. ([#1370](https://github.com/fossas/fossa-cli/pull/1370))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## 3.8.38
-- `dynamic-deps`: Safely ignores scenarios in ldd output parsing where we run into not found error. ([]()) 
+- `--detect-dynamic`: Safely ignores scenarios in ldd output parsing where we run into not found error. ([#1376](https://github.com/fossas/fossa-cli/pull/1376)) 
 
 ## 3.8.37
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # FOSSA CLI Changelog
 
-## 3.9.1
+## v3.9.1
 - `--detect-dynamic`: Safely ignores scenarios in ldd output parsing where we run into not found error. ([#1376](https://github.com/fossas/fossa-cli/pull/1376)) 
 
 ## v3.9.0

--- a/src/App/Fossa/VSI/DynLinked/Internal/Binary.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Binary.hs
@@ -130,7 +130,7 @@ lddParseDependency = Just <$> (LocalDependency <$> (linePrefix *> ident) <* symb
 -- | Parses "not found" case for dependency
 --
 -- > libprotobuf.so.22 => not found
--- 
+--
 -- We want to ignore these, so we do not fatally fail in parsing.
 lddParseDependencyNotFound :: Parser (Maybe LocalDependency)
 lddParseDependencyNotFound = do

--- a/src/App/Fossa/VSI/DynLinked/Internal/Binary.hs
+++ b/src/App/Fossa/VSI/DynLinked/Internal/Binary.hs
@@ -120,11 +120,22 @@ lddParseLocalDependencies =
       ( try lddConsumeSyscallLib
           <|> try lddConsumeLinker
           <|> try lddParseDependency
+          <|> try lddParseDependencyNotFound
       )
     <* eof
 
 lddParseDependency :: Parser (Maybe LocalDependency)
 lddParseDependency = Just <$> (LocalDependency <$> (linePrefix *> ident) <* symbol "=>" <*> path <* printedHex)
+
+-- | Parses "not found" case for dependency
+--
+-- > libprotobuf.so.22 => not found
+-- 
+-- We want to ignore these, so we do not fatally fail in parsing.
+lddParseDependencyNotFound :: Parser (Maybe LocalDependency)
+lddParseDependencyNotFound = do
+  void $ linePrefix <* ident <* symbol "=>" <* symbol "not found"
+  pure Nothing
 
 -- | The userspace library for system calls appears as the following in @ldd@ output:
 --

--- a/test/App/Fossa/VSI/DynLinked/Internal/BinarySpec.hs
+++ b/test/App/Fossa/VSI/DynLinked/Internal/BinarySpec.hs
@@ -37,6 +37,7 @@ spec = do
     Hspec.it "should parse output with a single line" $ do
       singleLine `shouldParseOutputInto` catMaybes [singleLineExpected]
       singleLineMoreSpaces `shouldParseOutputInto` catMaybes [singleLineExpected]
+      singleLineNotFound `shouldParseOutputInto` []
 
     Hspec.it "should parse output with multiple lines" $ do
       multipleLine `shouldParseOutputInto` multipleLineExpected
@@ -64,6 +65,9 @@ shouldParseOutputInto = parseMatch Binary.lddParseLocalDependencies
 
 singleLine :: Text
 singleLine = "libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fbea9a88000)"
+
+singleLineNotFound :: Text
+singleLineNotFound = "        libprotobuf.so.22 => not found"
 
 singleLineMoreSpaces :: Text
 singleLineMoreSpaces = "    libc.so.6   =>    /lib/x86_64-linux-gnu/libc.so.6    (0x00007fbea9a88000)    "


### PR DESCRIPTION
# Overview

This PR, makes ldd parsing less error prone, by safely excluding not found cases

## Acceptance criteria

For cases such as following, `--detect-dynamic` analysis should not fatally fail.
```txt
    libprotobuf.so.22 => not found
    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007ffffff4c000)
```

## Testing plan
I relied on automated testings 

## Risks
N/A

## Metrics
N/A

## References
N/A


## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
