### PR TITLE
Gradle reachability

### DIFF
--- a/docs/contributing/reachability.md
+++ b/docs/contributing/reachability.md
@@ -4,11 +4,22 @@
 Reachability Analysis is a security offering designed to enhance FOSSA's security analysis by providing context on vulnerable packages. It alleviates the constraints of traditional CVE assessments through the static analysis of application and dependency code, confirming the presence of vulnerable call paths. 
 
 ### Limitations
-Reachability currently supports all Maven projects dynamically analyzed by fossa-cli. The target jar of the project must exist, prior to the analysis.
+- Reachability currently supports all Maven and Gradle projects dynamically analyzed by fossa-cli. 
+- The target jar of the project must exist, prior to the analysis. If the jar artifact is not present, or FOSSA CLI fails to
+associate this jar with project, FOSSA CLI will not perform reachability analysis.
+- Reachability requires that `java` is present in PATH, and `java` version must be greater than `1.8` (jdk8+).
+
+For example, 
+- if you are using maven, you should run `mvn package` to ensure jar artifact exists, prior to running `fossa analyze`
+- if you are using gradle, you should run `gradlew build` to ensure jar artifact exists, prior to running `fossa analyze`
 
 ### Maven Analysis
 
 For Maven projects, FOSSA CLI performs an analysis to infer dependencies. If FOSSA CLI identifies a complete dependency graph, which may include both direct and transitive dependencies, it attempts to infer the built JAR file for reachability analysis. It looks for `./target/{artifact}-{version}.jar` from the POM directory. If the POM file provides `build.directory` or `build.finalName` attributes, they are used instead of the default target jar path. For this reason, perform `fossa analyze` after the project of interest is built (g.g. `mvn package`), and target artifact exists in the directory.
+
+### Gradle Analysis
+
+For Gradle projects, FOSSA CLI invokes `./gradlew -I jsonpaths.gradle jsonPaths`. Where [jsonpaths.gradle](./../../scripts/jarpaths.gradle) is gradle script, which uses `java` plugin, and `jar` task associated with gradle to infer path of the built jar file. If neither of those are present, FOSSA CLI won't be able to identify jar artifacts for analysis.
 
 ### How do I debug reachability from `fossa-cli`?
 

--- a/scripts/jarpaths.gradle
+++ b/scripts/jarpaths.gradle
@@ -1,0 +1,29 @@
+// Simple Jar filepath retriever script
+// ---
+// - ./gradlew -I jarpaths.gradle jarPaths
+// - ./gradlew -I jarpaths.gradle :jarPaths
+allprojects {
+    tasks.register("jarPaths") {
+        // specifies actions to be performed when the task is executed.
+        // Ref: https://docs.gradle.org/current/dsl/org.gradle.api.Task.html#org.gradle.api.Task:doLast(groovy.lang.Closure)
+        doLast {            
+            // Ref: https://docs.gradle.org/current/dsl/org.gradle.api.Project.html
+            println "debug: project is ${project}"
+
+            // Ref: https://docs.gradle.org/current/dsl/org.gradle.api.plugins.PluginManager.html#org.gradle.api.plugins.PluginManager:hasPlugin(java.lang.String)
+            def hasJavaPlugin = project.plugins.hasPlugin('java')            
+            println "debug: hasJavaPlugin is ${hasJavaPlugin}"
+
+            if (hasJavaPlugin) {
+                // Ref: https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/TaskContainer.html
+                def runTask = tasks.findByName('jar')
+                println "debug: runTask is ${runTask}"
+
+                if (runTask) {
+                    // Ref: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html
+                    println "JARFILE::${runTask.archiveFile.get().asFile}"
+                }
+            }
+        }
+    }
+}

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -229,6 +229,7 @@ library
     App.Fossa.PathDependency
     App.Fossa.PreflightChecks
     App.Fossa.ProjectInference
+    App.Fossa.Reachability.Gradle
     App.Fossa.Reachability.Jar
     App.Fossa.Reachability.Maven
     App.Fossa.Reachability.Types
@@ -647,6 +648,7 @@ test-suite unit-tests
     Python.SetupPySpec
     R.DescriptionSpec
     R.RenvSpec
+    Reachability.GradleSpec
     Reachability.JarSpec
     Reachability.MavenSpec
     Reachability.UploadSpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -101,7 +101,7 @@ import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text.Extra (showT)
-import Diag.Result (resultToMaybe, Result (..))
+import Diag.Result (Result (..), resultToMaybe)
 import Discovery.Archive qualified as Archive
 import Discovery.Filters (AllFilters, MavenScopeFilters, applyFilters, filterIsVSIOnly, ignoredPaths, isDefaultNonProductionPath)
 import Discovery.Projects (withDiscoveredProjects)

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -101,7 +101,7 @@ import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text.Extra (showT)
-import Diag.Result (resultToMaybe)
+import Diag.Result (resultToMaybe, Result (..))
 import Discovery.Archive qualified as Archive
 import Discovery.Filters (AllFilters, MavenScopeFilters, applyFilters, filterIsVSIOnly, ignoredPaths, isDefaultNonProductionPath)
 import Discovery.Projects (withDiscoveredProjects)
@@ -397,7 +397,11 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   logDebug $ "Filtered projects with path dependencies: " <> pretty (show filteredProjects')
 
   let analysisResult = AnalysisScanResult projectScans vsiResults binarySearchResults manualSrcUnits dynamicLinkedResults maybeLernieResults
-  reachabilityUnits <- analyzeForReachability analysisResult
+  reachabilityUnitsResult <- Diag.errorBoundaryIO . diagToDebug $ analyzeForReachability analysisResult
+  reachabilityUnits <- case reachabilityUnitsResult of
+    Diag.Result.Failure _ _ -> pure []
+    Diag.Result.Success _ units -> pure units
+
   renderScanSummary (severity cfg) maybeEndpointAppVersion analysisResult cfg
 
   -- Need to check if vendored is empty as well, even if its a boolean that vendoredDeps exist

--- a/src/App/Fossa/Reachability/Gradle.hs
+++ b/src/App/Fossa/Reachability/Gradle.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.Fossa.Reachability.Gradle (gradleJarCallGraph, jarFileSignifier, jarPathsFromScriptOutput) where
+
+import App.Fossa.Reachability.Jar (callGraphFromJar, isValidJar)
+import App.Fossa.Reachability.Types (CallGraphAnalysis (..))
+import App.Support (reportDefectWithDebugBundle)
+import Control.Carrier.Lift (Lift)
+import Control.Carrier.Reader (Reader, runReader)
+import Control.Effect.Diagnostics (Diagnostics, ToDiagnostic, context, errCtx, renderDiagnostic)
+import Control.Effect.Lift (sendIO)
+import Control.Effect.Path (withSystemTempDir)
+import Control.Monad.List (filterM)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
+import Data.FileEmbed.Extra (embedFile')
+import Data.Maybe (catMaybes, fromMaybe)
+import Data.Set (Set, toList)
+import Data.Set.NonEmpty (toSet)
+import Data.String.Conversion (ToString (..), ToText (toText), decodeUtf8)
+import Data.Text qualified as Text
+import Discovery.Filters (AllFilters)
+import Effect.Exec (AllowErr (..), Command (..), Exec)
+import Effect.Logger (Logger, logDebug, pretty)
+import Effect.ReadFS (Has, ReadFS)
+import Path (Abs, Dir, File, Path, fromAbsDir, parseAbsFile)
+import Prettyprinter (indent, vsep)
+import Strategy.Gradle (GradleProject, discover, runGradle)
+import System.FilePath qualified as FilePath
+import Text.Pretty.Simple (pShow)
+import Types (BuildTarget (..), DiscoveredProject (DiscoveredProject), FoundTargets (..))
+
+gradleJarCallGraph ::
+  ( Has Logger sig m
+  , Has ReadFS sig m
+  , Has Diagnostics sig m
+  , Has Exec sig m
+  , Has (Lift IO) sig m
+  ) =>
+  Path Abs Dir ->
+  m CallGraphAnalysis
+gradleJarCallGraph dir = do
+  jars <- runReader (mempty :: AllFilters) $ getJarsByBuild dir
+  parsedJars <- traverse callGraphFromJar jars
+  pure $ JarAnalysis (catMaybes parsedJars)
+
+getJarsByBuild ::
+  ( Has (Lift IO) sig m
+  , Has ReadFS sig m
+  , Has Diagnostics sig m
+  , Has Exec sig m
+  , Has Logger sig m
+  , Has (Reader AllFilters) sig m
+  ) =>
+  Path Abs Dir ->
+  m [Path Abs File]
+getJarsByBuild path = do
+  discoveredProjects <- discover path
+  jars <- traverse getJarsByBuildOfaProject discoveredProjects
+  let candidateJars = concat jars
+
+  logDebug . pretty $ ("Found jars: ") <> toText (pShow candidateJars)
+  pure candidateJars
+
+getJarsByBuildOfaProject ::
+  ( Has (Lift IO) sig m
+  , Has ReadFS sig m
+  , Has Diagnostics sig m
+  , Has Exec sig m
+  , Has Logger sig m
+  ) =>
+  (DiscoveredProject GradleProject) ->
+  m [Path Abs File]
+getJarsByBuildOfaProject (DiscoveredProject _ path foundTargets _) = withSystemTempDir "fossa-gradle-reachability" $ \tmpDir -> do
+  let jarScriptFilepath = fromAbsDir tmpDir FilePath.</> "jarpath.gradle"
+  context "Writing gradle script" $ sendIO (BS.writeFile jarScriptFilepath initScript)
+
+  let cmd :: Text.Text -> Command
+      cmd = case foundTargets of
+        FoundTargets targets -> gradleJarCmdTargets jarScriptFilepath (toSet targets)
+        ProjectWithoutTargets -> gradleJarCmd jarScriptFilepath
+
+  stdout <- context "running gradle script" $ errCtx FailedToRunGradleReachabilityAnalysis $ runGradle path cmd
+  jarPathsFromScriptOutput stdout
+
+jarPathsFromScriptOutput :: (Has Logger sig m, Has ReadFS sig m) => BL.ByteString -> m [Path Abs File]
+jarPathsFromScriptOutput stdout = do
+  let rawPaths :: [Text.Text] =
+        map withoutJarFilePrefix
+          . filter hasJarFilePrefix
+          . Text.lines
+          . decodeUtf8
+          . BS.toStrict
+          $ stdout
+
+  logDebug . pretty $ ("Found candidate jars: ") <> toText (pShow rawPaths)
+  case traverse (parseAbsFile . toString) rawPaths of
+    Nothing -> pure []
+    Just absJarPaths -> filterM isValidJar absJarPaths
+
+jarFileSignifier :: Text.Text
+jarFileSignifier = "JARFILE::"
+
+hasJarFilePrefix :: Text.Text -> Bool
+hasJarFilePrefix = Text.isPrefixOf jarFileSignifier
+
+withoutJarFilePrefix :: Text.Text -> Text.Text
+withoutJarFilePrefix t = fromMaybe t $ Text.stripPrefix jarFileSignifier t
+
+initScript :: BS.ByteString
+initScript = $(embedFile' "scripts/jarpaths.gradle")
+
+-- | Run the init script on a set of subprojects. Note that this runs the
+--  `:jarPaths` task on every subproject in one command. This is helpful for
+--  performance reasons, because Gradle has a slow startup on each invocation.
+gradleJarCmdTargets :: FilePath -> Set BuildTarget -> Text.Text -> Command
+gradleJarCmdTargets initScriptFilepath targets baseCmd =
+  Command
+    { cmdName = baseCmd
+    , cmdArgs = ["-I", toText initScriptFilepath] ++ map (\target -> unBuildTarget target <> ":jarPaths") (toList targets)
+    , cmdAllowErr = Never
+    }
+
+gradleJarCmd :: FilePath -> Text.Text -> Command
+gradleJarCmd initScriptFilepath baseCmd =
+  Command
+    { cmdName = baseCmd
+    , cmdArgs = ["-I", toText initScriptFilepath, "jarPaths"]
+    , cmdAllowErr = Never
+    }
+
+data FailedToRunGradleReachabilityAnalysis = FailedToRunGradleReachabilityAnalysis deriving (Eq, Ord, Show)
+instance ToDiagnostic FailedToRunGradleReachabilityAnalysis where
+  renderDiagnostic (FailedToRunGradleReachabilityAnalysis) =
+    vsep
+      [ "Failed to perform gradle analysis."
+      , ""
+      , "Ensure your gradle project can be built successfully:"
+      , ""
+      , indent 2 "gradlew build"
+      , indent 2 "gradlew.bat build"
+      , indent 2 "gradle build"
+      , ""
+      , reportDefectWithDebugBundle
+      ]

--- a/src/App/Fossa/Reachability/Upload.hs
+++ b/src/App/Fossa/Reachability/Upload.hs
@@ -13,6 +13,7 @@ import App.Fossa.Analyze.Types (
   DiscoveredProjectScan (..),
   dpiProjectType,
  )
+import App.Fossa.Reachability.Gradle (gradleJarCallGraph)
 import App.Fossa.Reachability.Maven (mavenJarCallGraph)
 import App.Fossa.Reachability.Types (
   CallGraphAnalysis (..),
@@ -127,6 +128,11 @@ callGraphOf (Scanned dpi (Success _ projectResult)) = do
       logDebug . pretty $ "Trying to infer build jars from maven project: " <> show (projectResultPath projectResult)
       analysis <- mavenJarCallGraph (projectResultPath projectResult)
       pure . Just $ unit{callGraphAnalysis = analysis}
+    (Complete, GradleProjectType) -> context "gradle" $ do
+      logDebug . pretty $ "Trying to infer build jars from gradle project: " <> show (projectResultPath projectResult)
+      analysis <- gradleJarCallGraph (projectResultPath projectResult)
+      pure . Just $ unit{callGraphAnalysis = analysis}
+
     -- Exclude units for package manager/language we cannot support yet!
     _ -> do
       logInfo . pretty $ "FOSSA CLI does not support reachability analysis for: " <> displayId <> " yet. (skipping)"

--- a/src/Strategy/Gradle.hs
+++ b/src/Strategy/Gradle.hs
@@ -16,6 +16,7 @@
 module Strategy.Gradle (
   discover,
   GradleProject,
+  runGradle,
 ) where
 
 import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analyzeProject)

--- a/test/Reachability/GradleSpec.hs
+++ b/test/Reachability/GradleSpec.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Reachability.GradleSpec (spec) where
+
+import App.Fossa.Reachability.Gradle (
+  jarFileSignifier,
+  jarPathsFromScriptOutput,
+ )
+import Data.String.Conversion (ConvertUtf8 (..), toText)
+import Data.Text (Text)
+import Path (Abs, File, Path, mkRelFile, (</>))
+import Path.IO qualified as PIO
+import Test.Effect (it', shouldBe')
+import Test.Hspec (Spec, describe, runIO)
+import Text.RawString.QQ (r)
+
+spec :: Spec
+spec = describe "Gradle" $ describe "jarPathsFromScriptOutput" $ do
+  jarPath <- runIO sampleJar
+  it' "should get zero paths from empty" $ do
+    paths <- jarPathsFromScriptOutput . encodeUtf8 $ empty
+    paths `shouldBe'` []
+
+  it' "should get zero paths when missing jars" $ do
+    paths <- jarPathsFromScriptOutput . encodeUtf8 $ noJars
+    paths `shouldBe'` []
+
+  it' "should not include path which do not exist" $ do
+    paths <- jarPathsFromScriptOutput . encodeUtf8 $ validButMissingPath
+    paths `shouldBe'` []
+
+  it' "should get path from successful output" $ do
+    paths <- jarPathsFromScriptOutput . encodeUtf8 . toValidEntry $ jarPath
+    paths `shouldBe'` [jarPath]
+
+empty :: Text
+empty = [r||]
+
+noJars :: Text
+noJars =
+  [r|
+> Task :app:jarPaths
+  project is project ':app'
+  hasJavaPlugin is true
+  runTask is task ':app:jar'
+
+  BUILD SUCCESSFUL in 255ms
+  1 actionable task: 1 executed
+|]
+
+validButMissingPath :: Text
+validButMissingPath =
+  [r|
+  > Task :app:jarPaths
+  project is project ':app'
+  hasJavaPlugin is true
+  runTask is task ':app:jar'
+  JARFILE::/Users/dev/code/example-projects/reachability/java/vulnerable-function-used/app/build/libs/app.jar
+
+  BUILD SUCCESSFUL in 255ms
+  1 actionable task: 1 executed
+|]
+
+sampleJar :: IO (Path Abs File)
+sampleJar = do
+  cwd <- PIO.getCurrentDir
+  pure (cwd </> $(mkRelFile "test/Reachability/testdata/sample.jar"))
+
+toValidEntry :: Path Abs File -> Text
+toValidEntry p = jarFileSignifier <> toText p

--- a/test/Reachability/JarSpec.hs
+++ b/test/Reachability/JarSpec.hs
@@ -3,7 +3,7 @@
 
 module Reachability.JarSpec (spec) where
 
-import App.Fossa.Reachability.Jar (callGraphFromJar)
+import App.Fossa.Reachability.Jar (callGraphFromJar, isValidJar)
 import Control.Effect.Lift (sendIO)
 
 import Path (Abs, File, Path, mkRelFile, (</>))
@@ -11,15 +11,50 @@ import Path.IO qualified as PIO
 import Test.Effect
 import Test.Hspec (Spec, describe)
 
+spec :: Spec
+spec = do
+  describe "callGraphFromJar" $ do
+    it' "should get not get call graph from corruped jar file" $ do
+      jarFile <- sendIO malformedJarFile
+      resp <- callGraphFromJar jarFile
+
+      resp `shouldBe'` Nothing
+
+  describe "isValidJar" $ do
+    it' "should return False when jar does not exist" $ do
+      jarFile <- sendIO missingJar
+      result <- isValidJar jarFile
+      result `shouldBe'` False
+
+    it' "should return True when jar exists" $ do
+      jarFile <- sendIO sampleJar
+      result <- isValidJar jarFile
+      result `shouldBe'` True
+
+    it' "should return False when jar exists, but is test jar" $ do
+      jarFile <- sendIO sampleTestJar
+      result <- isValidJar jarFile
+      result `shouldBe'` False
+
+-- | Jar is produced from following projects:
+-- https://github.com/fossas/example-projects/tree/main/reachability/java/vulnerable-function-used
+sampleJar :: IO (Path Abs File)
+sampleJar = do
+  cwd <- PIO.getCurrentDir
+  pure (cwd </> $(mkRelFile "test/Reachability/testdata/sample.jar"))
+
+sampleTestJar :: IO (Path Abs File)
+sampleTestJar = do
+  cwd <- PIO.getCurrentDir
+  -- Jar has same content as @sampleJar@
+  pure (cwd </> $(mkRelFile "test/Reachability/testdata/sample-test.jar"))
+
+missingJar :: IO (Path Abs File)
+missingJar = do
+  cwd <- PIO.getCurrentDir
+  pure (cwd </> $(mkRelFile "test/Reachability/testdata/missing.jar"))
+
 malformedJarFile :: IO (Path Abs File)
 malformedJarFile = do
   cwd <- PIO.getCurrentDir
   pure (cwd </> $(mkRelFile "test/Reachability/testdata/malformed.jar"))
-
-spec :: Spec
-spec = describe "callGraphFromJar" $ do
-  it' "should get not get call graph from corruped jar file" $ do
-    jarFile <- sendIO malformedJarFile
-    resp <- callGraphFromJar jarFile
-
-    resp `shouldBe'` Nothing

--- a/test/Reachability/MavenSpec.hs
+++ b/test/Reachability/MavenSpec.hs
@@ -3,7 +3,7 @@
 
 module Reachability.MavenSpec (spec) where
 
-import App.Fossa.Reachability.Maven (getJarsByBuild, isValidJar)
+import App.Fossa.Reachability.Maven (getJarsByBuild)
 import Control.Effect.Lift (sendIO)
 import Path (Abs, Dir, File, Path, mkRelDir, mkRelFile, (</>))
 import Path.IO qualified as PIO
@@ -12,22 +12,6 @@ import Test.Hspec (Spec, describe)
 
 spec :: Spec
 spec = describe "Maven" $ do
-  describe "isValidJar" $ do
-    it' "should return False when jar does not exist" $ do
-      jarFile <- sendIO missingJar
-      result <- isValidJar jarFile
-      result `shouldBe'` False
-
-    it' "should return True when jar exists" $ do
-      jarFile <- sendIO sampleJar
-      result <- isValidJar jarFile
-      result `shouldBe'` True
-
-    it' "should return False when jar exists, but is test jar" $ do
-      jarFile <- sendIO sampleTestJar
-      result <- isValidJar jarFile
-      result `shouldBe'` False
-
   describe "getJarsByBuild" $ do
     it' "should get jar from defaults" $ do
       p <- sendIO defaultMavenProject
@@ -40,24 +24,6 @@ spec = describe "Maven" $ do
       jar <- sendIO mavenProjectWithCustomDistJar
       result <- getJarsByBuild p
       result `shouldBe'` [jar]
-
--- | Jar is produced from following projects:
--- https://github.com/fossas/example-projects/tree/main/reachability/java/vulnerable-function-used
-sampleJar :: IO (Path Abs File)
-sampleJar = do
-  cwd <- PIO.getCurrentDir
-  pure (cwd </> $(mkRelFile "test/Reachability/testdata/sample.jar"))
-
-sampleTestJar :: IO (Path Abs File)
-sampleTestJar = do
-  cwd <- PIO.getCurrentDir
-  -- Jar has same content as @sampleJar@
-  pure (cwd </> $(mkRelFile "test/Reachability/testdata/sample-test.jar"))
-
-missingJar :: IO (Path Abs File)
-missingJar = do
-  cwd <- PIO.getCurrentDir
-  pure (cwd </> $(mkRelFile "test/Reachability/testdata/missing.jar"))
 
 defaultMavenProject :: IO (Path Abs Dir)
 defaultMavenProject = do


### PR DESCRIPTION
# Overview

This PR, 
- Adds ability perform reachability for gradle's project and multi-project

## Acceptance criteria
- Gradle's built jar can be analyzed for reachability
 
## Testing plan
```bash
git checkout feat/reachability-in-cli-gradle && make install-dev
```

1. get example project: https://docs.gradle.org/current/samples/sample_building_java_applications_multi_project.html
```bash
./gradlew build
fossa-dev analyze -o --debug

gunzip fossa.debug.json.gz
cat fossa.debug.json | jq '.bundleReachabilityRaw' # you should see parsed jars

```

## Risks

N/A

## Metrics

N/A

## References

https://fossa.atlassian.net/browse/ANE-1413

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
