### PR TITLE
Explain why test deps may not be removed using go mod tidy.

### DIFF
--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -235,3 +235,24 @@ not using backoff!
 
 As a concrete step towards resolving this sort of discrepancy, we recommend running `go mod tidy` on projects regularly;
 this command should synchronize the `go.mod` file with the actual state of the project.
+
+#### Test Dependencies
+
+Sometimes the above procedure may uncover a dependency that is not reported by FOSSA but that is also not removed by `go mod tidy`.
+The other reason that a dependency may appear in `go.mod` but not in FOSSA is that it is a test dependency.
+`go.mod` itself does not label dependencies as being used only in tests, but FOSSA's Go module strategy can identify these and will exclude them.
+To verify that a direct dependency is not a test-only dependency, we recommend searching the project source code for where a package from the module is imported.
+Generally, for a declaration in `go.mod` like:
+
+```
+	github.com/prometheus/client_golang v1.12.2
+```
+
+You can search for its imports using a command like:
+
+```sh
+$ find <project_directory> -name \*.go -exec grep -Hn "github.com/prometheus/client_golang" {} \;
+```
+
+Then verify that it appears in at least one Go source file _not_ ending in `_test.go`.
+You can read more about how tests are defined in Go [here](https://go.dev/doc/tutorial/add-a-test).


### PR DESCRIPTION
# Overview

FOSSA will generally not report Go module test deps. This scenario isn't called out specifically in our documentation about how `go.mod` is advisory rather than defines the exact set of deps a go modules project will use. I added a quick paragraph. 

## Acceptance criteria

* We have some guidance ready and available for when a test dep doesn't appear in a Go modules project.


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
