### PR TITLE
Surface build warnings in fossa analyze

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.9.6
+- Add debug logs for build warnings in `analyze` commands [#1386](https://github.com/fossas/fossa-cli/pull/1386)
+
 ## v3.9.5
 - Maven: Fix hanging maven analysis [#1381](https://github.com/fossas/fossa-cli/pull/1381)
 

--- a/src/App/Fossa/Analyze/Upload.hs
+++ b/src/App/Fossa/Analyze/Upload.hs
@@ -56,11 +56,9 @@ import Effect.Logger (
   Logger,
   Pretty (pretty),
   Severity (SevInfo),
-  logDebug,
   logError,
   logInfo,
   logStdout,
-  logWarn,
   viaShow,
  )
 import Fossa.API.Types (Organization (orgRequiresFullFileUploads, orgSupportsReachability, organizationId), Project (projectIsMonorepo), UploadResponse (..))
@@ -74,7 +72,6 @@ import Srclib.Types (
   renderLocator,
   sourceUnitToFullSourceUnit,
  )
-import Text.Pretty.Simple (pShow)
 
 data ScanUnits
   = SourceUnitOnly [SourceUnit]

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -8,7 +8,7 @@ module App.Fossa.Container.AnalyzeNative (
 
 import App.Fossa.API.BuildLink (getFossaBuildUrl)
 import App.Fossa.Analyze.Debug (collectDebugBundle)
-import App.Fossa.Analyze.Upload (checkUploadResponseForWarnings)
+import App.Fossa.Analyze.Upload (emitBuildWarnings)
 import App.Fossa.Config.Common (
   ScanDestination (OutputStdout, UploadScan),
  )
@@ -141,7 +141,7 @@ uploadScan revision projectMeta jsonOutput containerScan =
       then fatal (EndpointDoesNotSupportNativeContainerScan getSourceLocation)
       else do
         resp <- uploadNativeContainerScan revision projectMeta containerScan
-        checkUploadResponseForWarnings resp
+        emitBuildWarnings resp
         let locator = uploadLocator resp
         buildUrl <- getFossaBuildUrl revision locator
 

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -8,6 +8,7 @@ module App.Fossa.Container.AnalyzeNative (
 
 import App.Fossa.API.BuildLink (getFossaBuildUrl)
 import App.Fossa.Analyze.Debug (collectDebugBundle)
+import App.Fossa.Analyze.Upload (checkUploadResponseForWarnings)
 import App.Fossa.Config.Common (
   ScanDestination (OutputStdout, UploadScan),
  )
@@ -140,6 +141,7 @@ uploadScan revision projectMeta jsonOutput containerScan =
       then fatal (EndpointDoesNotSupportNativeContainerScan getSourceLocation)
       else do
         resp <- uploadNativeContainerScan revision projectMeta containerScan
+        checkUploadResponseForWarnings resp
         let locator = uploadLocator resp
         buildUrl <- getFossaBuildUrl revision locator
 

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -579,6 +579,7 @@ instance FromJSON Project where
 data UploadResponse = UploadResponse
   { uploadLocator :: Locator
   , uploadError :: Maybe Text
+  , uploadWarnings :: Maybe [Text]
   }
   deriving (Eq, Ord, Show)
 
@@ -587,6 +588,7 @@ instance FromJSON UploadResponse where
     UploadResponse
       <$> (parseLocator <$> obj .: "locator")
       <*> obj .:? "error"
+      <*> obj .:? "warnings"
 
 data RevisionDependencyCacheStatus
   = Ready

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -106,6 +106,7 @@ uploadResponse =
   API.UploadResponse
     { API.uploadLocator = locator
     , API.uploadError = Nothing
+    , API.uploadWarnings = Nothing
     }
 
 projectMetadata :: App.ProjectMetadata


### PR DESCRIPTION
# Overview

- When builds are sent to the [customUploadBuildHandler](https://github.com/fossas/FOSSA/blob/develop/modules/customBuildUploadHandler.ts) sometimes errors are returned under build.warnings as [pointed out by Andrew](https://teamfossa.slack.com/archives/C043EM3L96Z/p1708717893834989?thread_ts=1708712806.856329&cid=C043EM3L96Z). However, these errors aren’t being surfaced to the user in any way.

- Alex [demonstrated](https://teamfossa.slack.com/archives/CTN0VM59S/p1708718846798719?thread_ts=1708714534.565389&cid=CTN0VM59S) that these errors are present in the response 


Deserialize the warnings from the response [here ](https://github.com/fossas/fossa-cli/blob/24ed7b9bdda580c04c6bb840e92fda29eb28138c/src/Fossa/API/Types.hs#L579)

[slack thread](https://teamfossa.slack.com/archives/C043EM3L96Z/p1708718725618439?thread_ts=1708712806.856329&cid=C043EM3L96Z)

## Acceptance criteria

Surface these warnings when we do fossa analyze and include them in our debug logs

## Testing plan

fossa analyze --project-label “super long project label ….” --debug 

![Screenshot 2024-02-26 at 3 16 36 PM](https://github.com/fossas/fossa-cli/assets/28590628/f59a5634-42ef-4123-8864-dd4b0de99797)


## Risks

## Metrics

## References

- [ANE-1500](https://fossa.atlassian.net/browse/ANE-1500)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1500]: https://fossa.atlassian.net/browse/ANE-1500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ