### PR TITLE
[No Ticket] Fossa test build completion logging

### DIFF
--- a/src/App/Fossa/API/BuildWait.hs
+++ b/src/App/Fossa/API/BuildWait.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module App.Fossa.API.BuildWait (
   waitForScanCompletion,
   waitForIssues,
@@ -6,7 +8,7 @@ module App.Fossa.API.BuildWait (
 ) where
 
 import App.Fossa.Config.Test (DiffRevision)
-import App.Types (ProjectRevision)
+import App.Types (ProjectRevision, projectRevision)
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,
@@ -25,10 +27,11 @@ import Control.Effect.FossaApiClient (
   getProject,
   getRevisionDependencyCacheStatus,
  )
-import Control.Effect.StickyLogger (StickyLogger, logSticky')
+import Control.Effect.StickyLogger (StickyLogger, logSticky, logSticky')
 import Control.Monad (void, when)
 import Control.Timeout (Cancel, checkForCancel, delay)
 import Data.Error (SourceLocation, createEmptyBlock, getSourceLocation)
+import Data.String.Conversion (showText)
 import Effect.Logger (Logger, viaShow)
 import Errata (errataSimple)
 import Errata.Types (Errata)
@@ -115,7 +118,7 @@ waitForBuild revision cancelFlag = do
     StatusSucceeded -> pure ()
     StatusFailed -> fatal $ BuildFailed getSourceLocation
     otherStatus -> do
-      logSticky' $ "[ Waiting for build completion... last status: " <> viaShow otherStatus <> " ]"
+      logSticky $ "[ Waiting for build completion (revision " <> revision.projectRevision <> ")... last status: " <> showText otherStatus <> " ]"
       pauseForRetry
       waitForBuild revision cancelFlag
 

--- a/src/App/Fossa/LicenseScanner.hs
+++ b/src/App/Fossa/LicenseScanner.hs
@@ -333,7 +333,7 @@ uploadVendoredDep baseDir VendoredDependency{..} licenseSourceUnit = do
 
   signedURL <- getSignedLicenseScanUrl $ PackageRevision{packageVersion = depVersion, packageName = vendoredName}
 
-  logSticky $ "Uploading '" <> vendoredName <> "' to secure S3 bucket"
+  logSticky $ "Uploading license results for '" <> vendoredName <> "' to secure S3 bucket"
   uploadLicenseScanResult signedURL licenseSourceUnit
 
   pure $ Just $ Archive vendoredName depVersion

--- a/src/App/Fossa/Test.hs
+++ b/src/App/Fossa/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module App.Fossa.Test (
   testSubCommand,
@@ -72,10 +73,10 @@ testMain config = do
         Nothing -> logInfo ""
         Just (DiffRevision rev) -> do
           logInfo ("diffing against revision: `" <> pretty rev <> "`")
-          logSticky $ "[ Waiting for build completion of " <> rev <> "... ]"
+          logSticky $ "[ Checking build completion for " <> rev <> "... ]"
           waitForScanCompletion revision{projectRevision = rev} cancelFlag
 
-      logSticky "[ Waiting for build completion... ]"
+      logSticky $ "[ Checking build completion for " <> revision.projectRevision <> "... ]"
       waitForScanCompletion revision cancelFlag
 
       logSticky "[ Waiting for issue scan completion... ]"


### PR DESCRIPTION
# Overview

There was some ambiguity with some of our messaging around waiting for build completion. This PR:

* Changes the message from "Waiting for build completion" to "Checking for build completion" unless the CLI gets back a status indicating it needs to wait.
* Includes the revision that it's checking/waiting for in the message. 

I also specified in license scanning results upload that it's a license result we're uploading. I was viewing some debug logs and it wasn't immediately clear to me that license results were what was getting uploaded.

## References

[Slack](https://teamfossa.slack.com/archives/C0155DTGWB1/p1708962039554899)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
