### PR TITLE
update preflight check permission for test commands

### DIFF
--- a/src/App/Fossa/PreflightChecks.hs
+++ b/src/App/Fossa/PreflightChecks.hs
@@ -70,9 +70,6 @@ preflightChecks cmd = context "preflight-checks" $ do
     void $
       errSupport (renderIt reportDefectMsg) $
         case cmd of
-          TestChecks -> do
-            tokenType <- getTokenType
-            fullAccessTokenCheck tokenType
           AnalyzeChecks rev metadata -> do
             customBuildPermissions <- getCustomBuildPermissions rev metadata
             uploadBuildPermissionsCheck customBuildPermissions

--- a/test/App/Fossa/PreflightChecksSpec.hs
+++ b/test/App/Fossa/PreflightChecksSpec.hs
@@ -36,14 +36,9 @@ spec :: Spec
 spec = do
   describe "preflight checks" $ do
     it' "should pass all checks for test command" $ do
-      expectFullAccessToken
       expectOrganizationWithPreflightChecks
       res <- ignoreDebug $ preflightChecks TestChecks
       res `shouldBe'` ()
-    it' "should fail full access token check for test command" $ do
-      expectOrganizationWithPreflightChecks
-      expectPushToken
-      expectFatal' $ ignoreDebug $ preflightChecks TestChecks
     it' "should pass all check for report command" $ do
       expectOrganizationWithPremiumSubscription
       expectFullAccessToken


### PR DESCRIPTION
# Overview

Fix preflight permission checks for test commands

## Acceptance criteria

- `fossa test` should not fail with a push-only token

## Testing plan

run `fossa test` with push only token

## Risks

## Metrics


## References


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
