### PR TITLE
[Ane-108] `--without-default-filters` for `fossa analyze` and `fossa container analyze`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.9.10
+- `--without-default-path-filters`: Users can now disable default path filters ([]()).
+
 ## v3.9.8
 - Reachability: Users may now provide custom locations for the JAR files emitted by projects and used for reachability analysis ([#1382](https://github.com/fossas/fossa-cli/pull/1382)).
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## v3.9.10
-- `--without-default-filters`: Users can now disable default path filters ([]()).
+- `--without-default-filters`: Users can now disable default path filters ([#1396](https://github.com/fossas/fossa-cli/pull/1396/files)).
 
 ## v3.9.8
 - Reachability: Users may now provide custom locations for the JAR files emitted by projects and used for reachability analysis ([#1382](https://github.com/fossas/fossa-cli/pull/1382)).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## v3.9.10
-- `--without-default-path-filters`: Users can now disable default path filters ([]()).
+- `--without-default-filters`: Users can now disable default path filters ([]()).
 
 ## v3.9.8
 - Reachability: Users may now provide custom locations for the JAR files emitted by projects and used for reachability analysis ([#1382](https://github.com/fossas/fossa-cli/pull/1382)).

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -38,7 +38,7 @@ The paths and targets filtering options allow you to specify the exact targets w
 | `--exclude-path`                 | Exclude these paths from scannig. See [paths.exclude](../files/fossa-yml.md#paths.exclude) in the fossa.yml spec.        |
 | `--include-unused-deps`          | Include all deps found, instead of filtering non-production deps.  Ignored by VSI.                                       |
 | `--debug-no-discovery-exclusion` | Ignore these filters during discovery phase.  This flag is for debugging only and may be removed without warning.        |
-| `--without-default-path-filters` | Ignore default path filters. See [default path filters](./analyze.md#what-are-the-default-path-filters)                  |
+| `--without-default-filters`      | Ignore default path filters. See [default path filters](./analyze.md#what-are-the-default-path-filters)                  |
 
 
 ### Printing results without uploading to FOSSA

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -164,7 +164,6 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 - (a) Target is excluded via [fossa configuration file](https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md#analysis-target-configuration) (this filtering is referred to as "exclusion filters").
 - (b) Target is excluded via [default path filters](./analyze.md#what-are-the-default-path-filters) (this filtering was previously referred to as "production path filtering").
 
-`fossa-cli` skips any target per (b), if the target is found within the [default path filters](./analyze.md#what-are-the-default-path-filters) directory.
 
 As `fossa-cli` relies on manifest and lock files provided in the project's directory, we
 intentionally skip `node_modules/` and such directories. If `fossa-cli` discovers and

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -172,7 +172,7 @@ default filters, intentionally skip `node_modules/` and such directories. If `fo
 analyzes project found in `node_modules/`: `fossa-cli` will not be able to infer
 the dependency's scope (development or production) and may double count dependencies.
 
-Specifically, `fossa-cli` by default, skips any targets, found within the following directories:
+Specifically, `fossa-cli` by default skips any targets found within the following directories:
 
 - `dist-newstyle`
 - `doc/`

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -178,6 +178,7 @@ Specifically, `fossa-cli` by default, skips any targets, found within the follow
 - `doc/`
 - `docs/`
 - `test/`
+- `tests/`
 - `example/`
 - `examples/`
 - `vendor/`

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -14,7 +14,7 @@ For supported command-line flags, use `fossa analyze --help`
 In addition to the [usual FOSSA project flags](#common-fossa-project-flags) supported by all commands, the analyze command supports the following FOSSA-project-related flags:
 
 | Name                                  | Short | Description                                                                         |
-|---------------------------------------|-------|-------------------------------------------------------------------------------------|
+| ------------------------------------- | ----- | ----------------------------------------------------------------------------------- |
 | `--title 'some title'`                | `-t`  | Set the title of the FOSSA project                                                  |
 | `--branch 'some branch'`              | `-b`  | Override the detected FOSSA project branch                                          |
 | `--project-url 'https://example.com'` | `-P`  | Add a URL to the FOSSA project                                                      |
@@ -31,13 +31,15 @@ In addition to the [usual FOSSA project flags](#common-fossa-project-flags) supp
 The paths and targets filtering options allow you to specify the exact targets which be should be scanned.
 
 | Name                             | Description                                                                                                              |
-|----------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `--only-target`                  | Only scan these targets. See [targets.only](../files/fossa-yml.md#targets.only) in the fossa.yml spec.                   |
 | `--exclude-target`               | Exclude these targets from scanning. See [targets.exclude](../files/fossa-yml.md#targets.exclude) in the fossa.yml spec. |
 | `--only-path`                    | Only scan these paths. See [paths.only](../files/fossa-yml.md#paths.only) in the fossa.yml spec.                         |
 | `--exclude-path`                 | Exclude these paths from scannig. See [paths.exclude](../files/fossa-yml.md#paths.exclude) in the fossa.yml spec.        |
 | `--include-unused-deps`          | Include all deps found, instead of filtering non-production deps.  Ignored by VSI.                                       |
 | `--debug-no-discovery-exclusion` | Ignore these filters during discovery phase.  This flag is for debugging only and may be removed without warning.        |
+| `--without-default-path-filters` | Ignore default path filters. See [default path filters](./analyze.md#what-are-the-default-path-filters)                  |
+
 
 ### Printing results without uploading to FOSSA
 
@@ -73,7 +75,7 @@ fossa analyze --fossa-deps-file /path/to/file
 The Vendored Dependencies feature allows you to scan for licenses directly in your code. For more information, please see the [Vendored Dependencies documentation](../../features/vendored-dependencies.md).
 
 | Name                                      | Description                                                                                                                                                                           |
-|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--force-vendored-dependency-scan-method` | Force the vendored dependency scan method. The options are 'CLILicenseScan' or 'ArchiveUpload'. 'CLILicenseScan' is usually the default unless your organization has overridden this. |
 | `--force-vendored-dependency-rescans`     | Force vendored dependencies to be rescanned even if the revision has been previously analyzed by FOSSA. This currently only works for CLI-side license scans.                         |
 
@@ -118,11 +120,11 @@ We support the following archive formats:
 
 In addition to the [standard flags](#specifying-fossa-project-details), the analyze command supports the following additional strategy flags:
 
-| Name                                                             | Description                                                                                                                                                              |
-|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Name                                                                              | Description                                                                                                                                                              |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [`--detect-vendored`](./analyze/detect-vendored.md)                               | Enable the vendored source identification engine. For more information, see the [C and C++ overview](../strategies/languages/c-cpp/c-cpp.md).                            |
 | [`--detect-dynamic './some-binary`](./analyze/detect-dynamic.md)                  | Analyze the binary at the provided path for dynamically linked dependencies. For more information, see the [C and C++ overview](../strategies/languages/c-cpp/c-cpp.md). |
-| [`--static-only-analysis`](../strategies/README.md#static-and-dynamic-strategies) | Do not use third-party tools when analyzing projects.
+| [`--static-only-analysis`](../strategies/README.md#static-and-dynamic-strategies) | Do not use third-party tools when analyzing projects.                                                                                                                    |
 
 
 ### Experimental Options
@@ -132,7 +134,7 @@ _Important: For support and other general information, refer to the [experimenta
 In addition to the [standard flags](#specifying-fossa-project-details), the analyze command supports the following experimental flags:
 
 | Name                                                                                     | Description                                                                                                                                                                                    |
-|------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`--experimental-enable-binary-discovery`](../experimental/binary-discovery/README.md)   | Enable reporting binary files as unlicensed dependencies. For more information, see the [binary discovery overview](../experimental/binary-discovery/README.md).                               |
 | [`--experimental-link-project-binary './some-dir'`](../experimental/msb/README.md)       | Link the provided binary files to the project being analyzed. For more information, see the [multi stage builds overview](../experimental/msb/README.md).                                      |
 | [`--experimental-skip-vsi-graph 'custom+1/some$locator'`](../experimental/msb/README.md) | Skip resolving the dependencies of the given project that was previously linked via `--experimental-link-project-binary`.                                                                      |
@@ -143,7 +145,7 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 
 ### F.A.Q.
 
-1. Why is the `fossa-cli` skipping my project?
+#### Why is the `fossa-cli` skipping my project?
 
 `fossa-cli` may sometimes report a project of interest was skipped from the analysis. For example,
 
@@ -153,16 +155,27 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 [ INFO] 3 projects scanned;  2 skipped,  1 succeeded,  0 failed,  1 analysis warning
 [ INFO]
 [ INFO] * setuptools project in "sandbox/": succeeded with 1 warning
-[ INFO] * setuptools project in "sandbox/example/": skipped (production path filtering)
+[ INFO] * setuptools project in "sandbox/example/": skipped (default path filters)
 [ INFO] * setuptools project in "sandbox/external/": skipped (exclusion filters)
 ```
 
 `fossa-cli` skips analysis, if and only if
 
 - (a) Target is excluded via [fossa configuration file](https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md#analysis-target-configuration) (this filtering is referred to as "exclusion filters").
-- (b) Target is skipped because the `fossa-cli` does not consider the target to be a production target (this filtering is referred to as "production path filtering").
+- (b) Target is excluded via [default path filters](./analyze.md#what-are-the-default-path-filters) (this filtering was previously referred to as "production path filtering").
 
-`fossa-cli` skips any target per (b), if the target is found within the following directories:
+`fossa-cli` skips any target per (b), if the target is found within the [default path filters](./analyze.md#what-are-the-default-path-filters) directory.
+
+As `fossa-cli` relies on manifest and lock files provided in the project's directory, we
+intentionally skip `node_modules/` and such directories. If `fossa-cli` discovers and
+analyzes project found in `node_modules/`: `fossa-cli` will not be able to infer
+the dependency's scope (development or production) and may double count dependencies.
+
+#### What are the default filters?
+
+Default filters are filters which `fossa-cli` applies by default. These filters,
+provide sensible non-production target exclusion. Specifically, `fossa-cli` by default,
+skips any targets, found within the following directories:
 
 - `dist-newstyle`
 - `doc/`
@@ -182,12 +195,11 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 - `Carthage/`
 - `Checkouts/`
 
-As `fossa-cli` relies on manifest and lock files provided in the project's directory, we
-intentionally skip `node_modules/` and such directories. If `fossa-cli` discovers and
-analyzes project found in `node_modules/`: `fossa-cli` will not be able to infer
-the dependency's scope (development or production) and may double count dependencies.
+To disable default filters, provide `--without-default-filters` flag when performing `fossa analyze` command. Currently,
+it is not possible to disable only a subset of default filters. If you would like to only apply a subset of default filters, you can
+use `--without-default-filters` in conjunction with [exclusion filters](./../files/fossa-yml.md#analysis-target-configuration). Refer to [exclusion filters walkthough](../../walkthroughs/analysis-target-configuration.md) for example.
 
-2. Can `fossa-cli` detect licensed/copyright content downloaded at runtime by dependencies?
+#### Can `fossa-cli` detect licensed/copyright content downloaded at runtime by dependencies?
 
 Unfortunately, as of yet, `fossa-cli` cannot discover or analyze any licensed or copyrighted
 content retrieved at runtime by dependencies when it is not referenced in manifest or lock files.
@@ -217,7 +229,7 @@ custom-dependencies:
 
 If you need more assistance, please contact [FOSSA support](https://support.fossa.com).
 
-3. How do I ensure `fossa analyze` does not exit fatally when no targets are discovered?
+#### How do I ensure `fossa analyze` does not exit fatally when no targets are discovered?
 
 In some scenarios, you may want to configure the `fossa analyze` and `fossa test` CI workflow on an empty repository or directory with 0 targets. Unfortunately, `fossa-cli` does not have a configuration yet, which will allow for successful analysis (exit code of 0) when 0 targets are discovered.
 
@@ -232,7 +244,7 @@ touch reqs.txt && fossa analyze && rm reqs.txt && fossa test
 All `fossa` commands support the following FOSSA-project-related flags:
 
 | Name                               | Short | Description                                                                                                                              |
-|------------------------------------|-------|------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `--project 'some project'`         | `-p`  | Override the detected project name                                                                                                       |
 | `--revision 'some revision'`       | `-r`  | -Override the detected project revision                                                                                                  |
 | `--fossa-api-key 'my-api-key'`     |       | An alternative to using the `FOSSA_API_KEY` environment variable to specify a FOSSA API key                                              |

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -164,17 +164,15 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 - (a) Target is excluded via [fossa configuration file](https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md#analysis-target-configuration) (this filtering is referred to as "exclusion filters").
 - (b) Target is excluded via [default path filters](./analyze.md#what-are-the-default-path-filters) (this filtering was previously referred to as "production path filtering").
 
-
-As `fossa-cli` relies on manifest and lock files provided in the project's directory, we
-intentionally skip `node_modules/` and such directories. If `fossa-cli` discovers and
-analyzes project found in `node_modules/`: `fossa-cli` will not be able to infer
-the dependency's scope (development or production) and may double count dependencies.
-
 #### What are the default filters?
 
 Default filters are filters which `fossa-cli` applies by default. These filters,
-provide sensible non-production target exclusion. Specifically, `fossa-cli` by default,
-skips any targets, found within the following directories:
+provide sensible non-production target exclusion. As `fossa-cli` relies on manifest and lock files provided in the project's directory, 
+default filters, intentionally skip `node_modules/` and such directories. If `fossa-cli` discovers and
+analyzes project found in `node_modules/`: `fossa-cli` will not be able to infer
+the dependency's scope (development or production) and may double count dependencies.
+
+Specifically, `fossa-cli` by default, skips any targets, found within the following directories:
 
 - `dist-newstyle`
 - `doc/`
@@ -196,7 +194,8 @@ skips any targets, found within the following directories:
 
 To disable default filters, provide `--without-default-filters` flag when performing `fossa analyze` command. Currently,
 it is not possible to disable only a subset of default filters. If you would like to only apply a subset of default filters, you can
-use `--without-default-filters` in conjunction with [exclusion filters](./../files/fossa-yml.md#analysis-target-configuration). Refer to [exclusion filters walkthough](../../walkthroughs/analysis-target-configuration.md) for example.
+use `--without-default-filters` in conjunction with [exclusion filters](./../files/fossa-yml.md#analysis-target-configuration). Refer to
+[exclusion filters walkthough](../../walkthroughs/analysis-target-configuration.md) for example on how to apply path and target exclusion filters.
 
 #### Can `fossa-cli` detect licensed/copyright content downloaded at runtime by dependencies?
 

--- a/docs/references/subcommands/container.md
+++ b/docs/references/subcommands/container.md
@@ -88,6 +88,7 @@ Specifically, `fossa-cli` by default, skips any targets, found within the follow
 - `doc/`
 - `docs/`
 - `test/`
+- `tests/`
 - `example/`
 - `examples/`
 - `vendor/`

--- a/docs/references/subcommands/container.md
+++ b/docs/references/subcommands/container.md
@@ -82,7 +82,7 @@ default filters, intentionally skip `node_modules/` and such directories. If `fo
 analyzes project found in `node_modules/`: `fossa-cli` will not be able to infer
 the dependency's scope (development or production) and may double count dependencies.
 
-Specifically, `fossa-cli` by default, skips any targets, found within the following directories:
+Specifically, `fossa-cli` by default skips any targets found within the following directories:
 
 - `dist-newstyle`
 - `doc/`
@@ -103,7 +103,7 @@ Specifically, `fossa-cli` by default, skips any targets, found within the follow
 - `Carthage/`
 - `Checkouts/`
 
-To disable default filters, provide `--without-default-filters` flag when performing `fossa analyze` command. Currently,
+To disable default filters, provide `--without-default-filters` flag when performing `fossa container analyze`. Currently,
 it is not possible to disable only a subset of default filters. If you would like to only apply a subset of default filters, you can
 use `--without-default-filters` in conjunction with [exclusion filters](./../files/fossa-yml.md#analysis-target-configuration). Refer to
 [exclusion filters walkthough](../../walkthroughs/analysis-target-configuration.md) for example on how to apply path and target exclusion filters.

--- a/docs/references/subcommands/container.md
+++ b/docs/references/subcommands/container.md
@@ -77,8 +77,12 @@ fossa container analyze redis:alpine --output
 ## Ignore default filters
 
 Default filters are filters which `fossa-cli` applies by default. These filters,
-provide sensible non-production target exclusion. Specifically, `fossa-cli` by default,
-skips any targets, found within the following directories:
+provide sensible non-production target exclusion. As `fossa-cli` relies on manifest and lock files provided in the project's directory, 
+default filters, intentionally skip `node_modules/` and such directories. If `fossa-cli` discovers and
+analyzes project found in `node_modules/`: `fossa-cli` will not be able to infer
+the dependency's scope (development or production) and may double count dependencies.
+
+Specifically, `fossa-cli` by default, skips any targets, found within the following directories:
 
 - `dist-newstyle`
 - `doc/`

--- a/docs/references/subcommands/container.md
+++ b/docs/references/subcommands/container.md
@@ -98,10 +98,10 @@ skips any targets, found within the following directories:
 - `Carthage/`
 - `Checkouts/`
 
-To disable default filters, provide `--without-default-filters` flag when performing `fossa container analyze` command. Currently,
+To disable default filters, provide `--without-default-filters` flag when performing `fossa analyze` command. Currently,
 it is not possible to disable only a subset of default filters. If you would like to only apply a subset of default filters, you can
-use `--without-default-filters` in conjunction with [exclusion filters](./../files/fossa-yml.md#analysis-target-configuration). Refer to [exclusion filters walkthough](../../walkthroughs/analysis-target-configuration.md) for example.
-
+use `--without-default-filters` in conjunction with [exclusion filters](./../files/fossa-yml.md#analysis-target-configuration). Refer to
+[exclusion filters walkthough](../../walkthroughs/analysis-target-configuration.md) for example on how to apply path and target exclusion filters.
 
 ### F.A.Q.
 

--- a/docs/references/subcommands/container.md
+++ b/docs/references/subcommands/container.md
@@ -74,6 +74,35 @@ The `--output` flag outputs dependency graph information to the terminal rather 
 fossa container analyze redis:alpine --output
 ```
 
+## Ignore default filters
+
+Default filters are filters which `fossa-cli` applies by default. These filters,
+provide sensible non-production target exclusion. Specifically, `fossa-cli` by default,
+skips any targets, found within the following directories:
+
+- `dist-newstyle`
+- `doc/`
+- `docs/`
+- `test/`
+- `example/`
+- `examples/`
+- `vendor/`
+- `node_modules/`
+- `.srclib-cache/`
+- `spec/`
+- `Godeps/`
+- `.git/`
+- `bower_components/`
+- `third_party/`
+- `third-party/`
+- `Carthage/`
+- `Checkouts/`
+
+To disable default filters, provide `--without-default-filters` flag when performing `fossa container analyze` command. Currently,
+it is not possible to disable only a subset of default filters. If you would like to only apply a subset of default filters, you can
+use `--without-default-filters` in conjunction with [exclusion filters](./../files/fossa-yml.md#analysis-target-configuration). Refer to [exclusion filters walkthough](../../walkthroughs/analysis-target-configuration.md) for example.
+
+
 ### F.A.Q.
 
 1. How can I only scan system dependencies?

--- a/integration-test/Analysis/ScalaSpec.hs
+++ b/integration-test/Analysis/ScalaSpec.hs
@@ -30,7 +30,7 @@ scalaExampleProject =
     $ FixtureArtifact
       "https://github.com/fossas/scala3-example-project/archive/refs/heads/main.tar.gz"
       [reldir|scala/scala-3-ex-project/|]
-      [reldir|scala3-example-project-main/target/scala-3.1.2/|]
+      [reldir|scala3-example-project-main/target/scala-3.4.0/|]
 
 spec :: Spec
 spec = do

--- a/integration-test/Container/AnalysisSpec.hs
+++ b/integration-test/Container/AnalysisSpec.hs
@@ -33,6 +33,7 @@ registrySourceCfg =
     , severity = SevInfo
     , onlySystemDeps = False
     , filterSet = mempty
+    , withoutDefaultFilters = toFlag' False
     }
 
 runAnalyze :: ContainerAnalyzeConfig -> (ContainerScan -> IO ()) -> IO ()

--- a/src/App/Docs.hs
+++ b/src/App/Docs.hs
@@ -15,6 +15,7 @@ module App.Docs (
   fossaConfigDocsUrl,
   apiTokenDocsUrl,
   fossaAnalyzeDefaultFilterDocUrl,
+  fossaContainerAnalyzeDefaultFilterDocUrl,
 ) where
 
 import App.Version (versionOrBranch)
@@ -73,3 +74,6 @@ apiTokenDocsUrl = "https://docs.fossa.com/docs/api-reference"
 
 fossaAnalyzeDefaultFilterDocUrl :: Text
 fossaAnalyzeDefaultFilterDocUrl = guidePathOf versionOrBranch "/docs/references/subcommands/analyze.md#what-are-the-default-path-filters"
+
+fossaContainerAnalyzeDefaultFilterDocUrl :: Text
+fossaContainerAnalyzeDefaultFilterDocUrl = guidePathOf versionOrBranch "/docs/references/subcommands/container.md#ignore-default-filters"

--- a/src/App/Docs.hs
+++ b/src/App/Docs.hs
@@ -14,6 +14,7 @@ module App.Docs (
   rolesDocsUrl,
   fossaConfigDocsUrl,
   apiTokenDocsUrl,
+  fossaAnalyzeDefaultFilterDocUrl,
 ) where
 
 import App.Version (versionOrBranch)
@@ -69,3 +70,6 @@ fossaConfigDocsUrl = guidePathOf versionOrBranch "/docs/references/files/fossa-y
 
 apiTokenDocsUrl :: Text
 apiTokenDocsUrl = "https://docs.fossa.com/docs/api-reference"
+
+fossaAnalyzeDefaultFilterDocUrl :: Text
+fossaAnalyzeDefaultFilterDocUrl = guidePathOf versionOrBranch "/docs/references/subcommands/analyze.md#what-are-the-default-path-filters"

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -206,16 +206,15 @@ runDependencyAnalysis ::
 runDependencyAnalysis basedir filters withoutDefaultFilters pathPrefix allowedTactics project@DiscoveredProject{..} = do
   let dpi = DiscoveredProjectIdentifier projectPath projectType
   let hasNonProductionPath =
-        if fromFlag Config.WithoutDefaultFilters $ withoutDefaultFilters
-          then False
-          else isDefaultNonProductionPath basedir projectPath
+        not (fromFlag Config.WithoutDefaultFilters withoutDefaultFilters)
+          && isDefaultNonProductionPath basedir projectPath
 
   case (applyFiltersToProject basedir filters project, hasNonProductionPath) of
     (Nothing, _) -> do
       logInfo $ "Skipping " <> pretty projectType <> " project at " <> viaShow projectPath <> ": no filters matched"
       output $ SkippedDueToProvidedFilter dpi
     (Just _, True) -> do
-      logInfo $ "Skipping " <> pretty projectType <> " project at " <> viaShow projectPath <> " (default non-production path filtering)"
+      logInfo $ "Skipping " <> pretty projectType <> " project at " <> viaShow projectPath <> " (default filtering)"
       output $ SkippedDueToDefaultFilter dpi
     (Just targets, False) -> do
       logInfo $ "Analyzing " <> pretty projectType <> " project at " <> pretty (toFilePath projectPath)

--- a/src/App/Fossa/Analyze/Filter.hs
+++ b/src/App/Fossa/Analyze/Filter.hs
@@ -32,9 +32,9 @@ checkForEmptyUpload includeAll discovered filtered additionalUnits firstPartySca
       (_, _, Just licenseSourceUnit) -> CountedScanUnits $ SourceAndLicenseUnits discoveredUnits licenseSourceUnit
       (_, _, Nothing) -> CountedScanUnits . SourceUnitOnly $ discoveredUnits
     else -- If we have a additional source units, then there's always something to upload.
-      case licensesMaybeFound of
-        Nothing -> CountedScanUnits . SourceUnitOnly $ additionalUnits ++ discoveredUnits
-        Just licenseSourceUnit -> CountedScanUnits $ SourceAndLicenseUnits (additionalUnits ++ discoveredUnits) licenseSourceUnit
+    case licensesMaybeFound of
+      Nothing -> CountedScanUnits . SourceUnitOnly $ additionalUnits ++ discoveredUnits
+      Just licenseSourceUnit -> CountedScanUnits $ SourceAndLicenseUnits (additionalUnits ++ discoveredUnits) licenseSourceUnit
   where
     discoveredLen = length discovered
     filteredLen = length filtered

--- a/src/App/Fossa/Analyze/Filter.hs
+++ b/src/App/Fossa/Analyze/Filter.hs
@@ -32,9 +32,9 @@ checkForEmptyUpload includeAll discovered filtered additionalUnits firstPartySca
       (_, _, Just licenseSourceUnit) -> CountedScanUnits $ SourceAndLicenseUnits discoveredUnits licenseSourceUnit
       (_, _, Nothing) -> CountedScanUnits . SourceUnitOnly $ discoveredUnits
     else -- If we have a additional source units, then there's always something to upload.
-    case licensesMaybeFound of
-      Nothing -> CountedScanUnits . SourceUnitOnly $ additionalUnits ++ discoveredUnits
-      Just licenseSourceUnit -> CountedScanUnits $ SourceAndLicenseUnits (additionalUnits ++ discoveredUnits) licenseSourceUnit
+      case licensesMaybeFound of
+        Nothing -> CountedScanUnits . SourceUnitOnly $ additionalUnits ++ discoveredUnits
+        Just licenseSourceUnit -> CountedScanUnits $ SourceAndLicenseUnits (additionalUnits ++ discoveredUnits) licenseSourceUnit
   where
     discoveredLen = length discovered
     filteredLen = length filtered

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -108,7 +108,7 @@ getScanCount = foldl' countOf (ScanCount 0 0 0 0 0)
   where
     countOf :: ScanCount -> DiscoveredProjectScan -> ScanCount
     countOf tsc (SkippedDueToProvidedFilter _) = tsc{numProjects = numProjects tsc + 1, numSkipped = numSkipped tsc + 1}
-    countOf tsc (SkippedDueToDefaultProductionFilter _) = tsc{numProjects = numProjects tsc + 1, numSkipped = numSkipped tsc + 1}
+    countOf tsc (SkippedDueToDefaultFilter _) = tsc{numProjects = numProjects tsc + 1, numSkipped = numSkipped tsc + 1}
     countOf tsc (Scanned _ (Failure _ _)) = tsc{numProjects = numProjects tsc + 1, numFailed = numFailed tsc + 1}
     countOf tsc (Scanned _ (Success wg _)) = tsc{numProjects = numProjects tsc + 1, numSucceeded = numSucceeded tsc + 1, numWarnings = numWarnings tsc + countWarnings wg}
 
@@ -310,7 +310,7 @@ summarizeProjectScan :: DiscoveredProjectScan -> Doc AnsiStyle
 summarizeProjectScan (Scanned dpi (Failure _ _)) = failColorCoded $ renderDiscoveredProjectIdentifier dpi <> renderFailed
 summarizeProjectScan (Scanned _ (Success wg pr)) = successColorCoded wg $ renderProjectResult pr <> renderSucceeded wg
 summarizeProjectScan (SkippedDueToProvidedFilter dpi) = renderDiscoveredProjectIdentifier dpi <> skippedDueFilter
-summarizeProjectScan (SkippedDueToDefaultProductionFilter dpi) = renderDiscoveredProjectIdentifier dpi <> skippedDueNonProductionPathFiltering
+summarizeProjectScan (SkippedDueToDefaultFilter dpi) = renderDiscoveredProjectIdentifier dpi <> skippedDueDefaultFilter
 
 summarizeReachability ::
   Doc AnsiStyle ->
@@ -361,8 +361,8 @@ failColorCoded = annotate $ color Red
 skippedDueFilter :: Doc AnsiStyle
 skippedDueFilter = ": skipped (exclusion filters)"
 
-skippedDueNonProductionPathFiltering :: Doc AnsiStyle
-skippedDueNonProductionPathFiltering = ": skipped (non-production path filtering)"
+skippedDueDefaultFilter :: Doc AnsiStyle
+skippedDueDefaultFilter = ": skipped (default filters)"
 
 skippedReachabilityDueToPartialGraph :: Doc AnsiStyle
 skippedReachabilityDueToPartialGraph = ": skipped (partial graph)"

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -99,7 +99,7 @@ instance Eq SourceUnitReachabilityAttempt where
 
 data DiscoveredProjectScan
   = SkippedDueToProvidedFilter DiscoveredProjectIdentifier
-  | SkippedDueToDefaultProductionFilter DiscoveredProjectIdentifier
+  | SkippedDueToDefaultFilter DiscoveredProjectIdentifier
   | Scanned DiscoveredProjectIdentifier (Result ProjectResult)
   deriving (Show)
 
@@ -111,10 +111,10 @@ instance Eq DiscoveredProjectScan where
 
 orderByScanStatusAndType :: DiscoveredProjectScan -> DiscoveredProjectScan -> Ordering
 orderByScanStatusAndType (SkippedDueToProvidedFilter lhs) (SkippedDueToProvidedFilter rhs) = compare lhs rhs
-orderByScanStatusAndType (SkippedDueToProvidedFilter lhs) (SkippedDueToDefaultProductionFilter rhs) = compare lhs rhs
-orderByScanStatusAndType (SkippedDueToDefaultProductionFilter lhs) (SkippedDueToProvidedFilter rhs) = compare lhs rhs
-orderByScanStatusAndType (SkippedDueToDefaultProductionFilter lhs) (SkippedDueToDefaultProductionFilter rhs) = compare lhs rhs
-orderByScanStatusAndType (SkippedDueToDefaultProductionFilter _) (Scanned _ _) = GT
+orderByScanStatusAndType (SkippedDueToProvidedFilter lhs) (SkippedDueToDefaultFilter rhs) = compare lhs rhs
+orderByScanStatusAndType (SkippedDueToDefaultFilter lhs) (SkippedDueToProvidedFilter rhs) = compare lhs rhs
+orderByScanStatusAndType (SkippedDueToDefaultFilter lhs) (SkippedDueToDefaultFilter rhs) = compare lhs rhs
+orderByScanStatusAndType (SkippedDueToDefaultFilter _) (Scanned _ _) = GT
 orderByScanStatusAndType (SkippedDueToProvidedFilter _) (Scanned _ _) = GT
 orderByScanStatusAndType (Scanned lhs (Success lhsEw _)) (Scanned rhs (Success rhsEw _)) =
   case compare (length rhsEw) (length lhsEw) of

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -103,7 +103,7 @@ analyze ::
   ContainerAnalyzeConfig ->
   m ContainerScan
 analyze cfg = do
-  scannedImage <- scanImage (filterSet cfg) (onlySystemDeps cfg) (imageLocator cfg) (dockerHost cfg) (arch cfg)
+  scannedImage <- scanImage (filterSet cfg) (withoutDefaultFilters cfg) (onlySystemDeps cfg) (imageLocator cfg) (dockerHost cfg) (arch cfg)
   let revision = extractRevision (revisionOverride cfg) scannedImage
 
   _ <- case scanDestination cfg of

--- a/src/App/Fossa/Container/Sources/DockerArchive.hs
+++ b/src/App/Fossa/Container/Sources/DockerArchive.hs
@@ -235,7 +235,7 @@ runDependencyAnalysis basedir filters project@DiscoveredProject{..} = do
       output $ SkippedDueToProvidedFilter dpi
     (Just _, True) -> do
       logInfo $ "Skipping " <> pretty projectType <> " project at " <> viaShow projectPath <> " (default non-production path filtering)"
-      output $ SkippedDueToDefaultProductionFilter dpi
+      output $ SkippedDueToDefaultFilter dpi
     (Just targets, False) -> do
       logInfo $ "Analyzing " <> pretty projectType <> " project at " <> pretty (toFilePath projectPath)
       let ctxMessage = "Project Analysis: " <> showT projectType

--- a/src/App/Fossa/Container/Sources/DockerEngine.hs
+++ b/src/App/Fossa/Container/Sources/DockerEngine.hs
@@ -6,6 +6,7 @@ module App.Fossa.Container.Sources.DockerEngine (
   revisionFromDockerEngine,
 ) where
 
+import App.Fossa.Config.Analyze (WithoutDefaultFilters)
 import App.Fossa.Container.Sources.DockerArchive (analyzeFromDockerArchive, listTargetsFromDockerArchive, revisionFromDockerArchive)
 import Container.Types (ContainerScan)
 import Control.Carrier.DockerEngineApi (runDockerEngineApi)
@@ -15,6 +16,7 @@ import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.DockerEngineApi (getDockerImage)
 import Control.Effect.Path (withSystemTempDir)
 import Control.Effect.Telemetry (Telemetry)
+import Data.Flag (Flag)
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
 import Discovery.Filters (AllFilters)
@@ -54,14 +56,15 @@ analyzeFromDockerEngine ::
   ) =>
   Bool ->
   AllFilters ->
+  Flag WithoutDefaultFilters ->
   Text ->
   Text ->
   m ContainerScan
-analyzeFromDockerEngine systemDepsOnly filters engineHost imgTag =
+analyzeFromDockerEngine systemDepsOnly filters withoutDefaultFilters engineHost imgTag =
   runFromDockerEngine
     engineHost
     imgTag
-    $ analyzeFromDockerArchive systemDepsOnly filters
+    $ analyzeFromDockerArchive systemDepsOnly filters withoutDefaultFilters
 
 listTargetsFromDockerEngine ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Container/Sources/Podman.hs
+++ b/src/App/Fossa/Container/Sources/Podman.hs
@@ -7,6 +7,7 @@ module App.Fossa.Container.Sources.Podman (
   revisionFromPodman,
 ) where
 
+import App.Fossa.Config.Analyze (WithoutDefaultFilters)
 import App.Fossa.Container.Sources.DockerArchive (analyzeFromDockerArchive, listTargetsFromDockerArchive, revisionFromDockerArchive)
 import Container.Types (ContainerScan)
 import Control.Carrier.Lift (Lift)
@@ -15,6 +16,7 @@ import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Path (withSystemTempDir)
 import Control.Effect.Telemetry (Telemetry)
 import Control.Monad (void)
+import Data.Flag (Flag)
 import Data.String.Conversion (ToText (toText), toString)
 import Data.Text (Text)
 import Discovery.Filters (AllFilters)
@@ -75,9 +77,10 @@ analyzeFromPodman ::
   ) =>
   Bool ->
   AllFilters ->
+  Flag WithoutDefaultFilters ->
   Text ->
   m ContainerScan
-analyzeFromPodman systemDepsOnly filters img = runFromPodman img $ analyzeFromDockerArchive systemDepsOnly filters
+analyzeFromPodman systemDepsOnly filters withoutDefaultFilters img = runFromPodman img $ analyzeFromDockerArchive systemDepsOnly filters withoutDefaultFilters
 
 listTargetsFromPodman ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Container/Sources/Registry.hs
+++ b/src/App/Fossa/Container/Sources/Registry.hs
@@ -4,6 +4,7 @@ module App.Fossa.Container.Sources.Registry (
   revisionFromRegistry,
 ) where
 
+import App.Fossa.Config.Analyze (WithoutDefaultFilters)
 import App.Fossa.Container.Sources.DockerArchive (analyzeFromDockerArchive, listTargetsFromDockerArchive, revisionFromDockerArchive)
 import Container.Docker.Credentials (useCredentialFromConfig)
 import Container.Docker.SourceParser (RegistryImageSource (RegistryImageSource), defaultRegistry)
@@ -15,6 +16,7 @@ import Control.Effect.Debug (Debug, Has)
 import Control.Effect.Diagnostics (Diagnostics, recover)
 import Control.Effect.Path (withSystemTempDir)
 import Control.Effect.Telemetry (Telemetry)
+import Data.Flag (Flag)
 import Data.Maybe (fromMaybe)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
@@ -76,12 +78,13 @@ analyzeFromRegistry ::
   ) =>
   Bool ->
   AllFilters ->
+  Flag WithoutDefaultFilters ->
   RegistryImageSource ->
   m ContainerScan
-analyzeFromRegistry systemDepsOnly filters img =
+analyzeFromRegistry systemDepsOnly filters withoutDefaultFilters img =
   runFromRegistry
     img
-    $ analyzeFromDockerArchive systemDepsOnly filters
+    $ analyzeFromDockerArchive systemDepsOnly filters withoutDefaultFilters
 
 listTargetsFromRegistry ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Reachability/Upload.hs
+++ b/src/App/Fossa/Reachability/Upload.hs
@@ -168,7 +168,7 @@ callGraphOf (Scanned dpi (Success _ projectResult)) = do
 -- which were not scanned (skipped due to filter), as we do not
 -- complete dependency graph for them
 callGraphOf (SkippedDueToProvidedFilter dpi) = pure . SourceUnitReachabilitySkippedMissingDependencyAnalysis $ dpi
-callGraphOf (SkippedDueToDefaultProductionFilter dpi) = pure . SourceUnitReachabilitySkippedMissingDependencyAnalysis $ dpi
+callGraphOf (SkippedDueToDefaultFilter dpi) = pure . SourceUnitReachabilitySkippedMissingDependencyAnalysis $ dpi
 callGraphOf (Scanned dpi (Failure _ _)) = pure . SourceUnitReachabilitySkippedMissingDependencyAnalysis $ dpi
 
 -- | Unique locators from SourceUnit

--- a/src/Discovery/Filters.hs
+++ b/src/Discovery/Filters.hs
@@ -211,6 +211,7 @@ ignoredPaths =
   , "doc/"
   , "docs/"
   , "test/"
+  , "tests/"
   , "example/"
   , "examples/"
   , "vendor/"

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -2,7 +2,7 @@ module App.DocsSpec (
   spec,
 ) where
 
-import App.Docs (fossaAnalyzeDefaultFilterDocUrl, fossaContainerScannerUrl, fossaDepsDocUrl, fossaYmlDocUrl, newIssueUrl, pathDependencyDocsUrl, userGuideUrl)
+import App.Docs (fossaAnalyzeDefaultFilterDocUrl, fossaContainerAnalyzeDefaultFilterDocUrl, fossaContainerScannerUrl, fossaDepsDocUrl, fossaYmlDocUrl, newIssueUrl, pathDependencyDocsUrl, userGuideUrl)
 import Data.Foldable (for_)
 import Data.Maybe (fromJust)
 import Data.String.Conversion (toString)
@@ -70,6 +70,7 @@ urlsToCheck =
   , pathDependencyDocsUrl
   , fossaDepsDocUrl
   , fossaAnalyzeDefaultFilterDocUrl
+  , fossaContainerAnalyzeDefaultFilterDocUrl
   ]
 
 spec :: Spec

--- a/test/App/DocsSpec.hs
+++ b/test/App/DocsSpec.hs
@@ -2,7 +2,7 @@ module App.DocsSpec (
   spec,
 ) where
 
-import App.Docs (fossaContainerScannerUrl, fossaDepsDocUrl, fossaYmlDocUrl, newIssueUrl, pathDependencyDocsUrl, userGuideUrl)
+import App.Docs (fossaAnalyzeDefaultFilterDocUrl, fossaContainerScannerUrl, fossaDepsDocUrl, fossaYmlDocUrl, newIssueUrl, pathDependencyDocsUrl, userGuideUrl)
 import Data.Foldable (for_)
 import Data.Maybe (fromJust)
 import Data.String.Conversion (toString)
@@ -69,6 +69,7 @@ urlsToCheck =
   , sbtDepsGraphPluginUrl
   , pathDependencyDocsUrl
   , fossaDepsDocUrl
+  , fossaAnalyzeDefaultFilterDocUrl
   ]
 
 spec :: Spec

--- a/test/App/Fossa/Container/AnalyzeNativeSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeSpec.hs
@@ -19,6 +19,7 @@ import Control.Carrier.Telemetry (IgnoreTelemetryC, withoutTelemetry)
 import Control.Effect.DockerEngineApi (
   DockerEngineApiF (GetImageSize, IsDockerEngineAccessible),
  )
+import Data.Flag (toFlag')
 import Data.Maybe (mapMaybe)
 import Data.String.Conversion (toText)
 import Data.Text (Text)
@@ -56,7 +57,6 @@ import Types (
   DiscoveredProjectType (SetuptoolsProjectType),
   TargetFilter (TypeDirTarget, TypeTarget),
  )
-import Data.Flag (toFlag')
 
 spec :: Spec
 spec = do

--- a/test/App/Fossa/Container/AnalyzeNativeSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeSpec.hs
@@ -56,6 +56,7 @@ import Types (
   DiscoveredProjectType (SetuptoolsProjectType),
   TargetFilter (TypeDirTarget, TypeTarget),
  )
+import Data.Flag (toFlag')
 
 spec :: Spec
 spec = do
@@ -84,27 +85,31 @@ spec = do
     let imageArchive = currDir </> appDepsImage
 
     it' "should not analyze application dependencies when only-system-dependencies are requested" $ do
-      containerScan <- analyzeFromDockerArchive True mempty imageArchive
+      containerScan <- analyzeFromDockerArchive True mempty (toFlag' False) imageArchive
       buildImportsOf containerScan `shouldNotContain'` [numpy, scipy, black]
 
     it' "should analyze application dependencies" $ do
-      containerScan <- analyzeFromDockerArchive False mempty imageArchive
+      containerScan <- analyzeFromDockerArchive False mempty (toFlag' False) imageArchive
       buildImportsOf containerScan `shouldBeSupersetOf'` [numpy, scipy, black]
       buildImportsOf containerScan `shouldNotContain'` [networkX]
 
     it' "should apply tool exclusion filter" $ do
-      containerScan <- analyzeFromDockerArchive False (excludeTool SetuptoolsProjectType) imageArchive
+      containerScan <- analyzeFromDockerArchive False (excludeTool SetuptoolsProjectType) (toFlag' False) imageArchive
       buildImportsOf containerScan `shouldNotContain'` [numpy, scipy, black]
 
     it' "should apply project exclusion filter" $ do
       let appAPath = $(mkRelDir "app/services/b/")
-      containerScan <- analyzeFromDockerArchive False (excludeProject SetuptoolsProjectType appAPath) imageArchive
+      containerScan <- analyzeFromDockerArchive False (excludeProject SetuptoolsProjectType appAPath) (toFlag' False) imageArchive
       buildImportsOf containerScan `shouldNotContain'` [scipy]
       buildImportsOf containerScan `shouldBeSupersetOf'` [numpy, black]
 
+    it' "should analyze all targets, if default filter is disabled" $ do
+      containerScan <- analyzeFromDockerArchive False mempty (toFlag' True) imageArchive
+      buildImportsOf containerScan `shouldBeSupersetOf'` [numpy, scipy, black, networkX]
+
     it' "should apply path exclusion filter" $ do
       let appAPath = $(mkRelDir "app/services/b/internal/")
-      containerScan <- analyzeFromDockerArchive False (excludePath appAPath) imageArchive
+      containerScan <- analyzeFromDockerArchive False (excludePath appAPath) (toFlag' False) imageArchive
       buildImportsOf containerScan `shouldNotContain'` [black]
       buildImportsOf containerScan `shouldBeSupersetOf'` [numpy, scipy]
 

--- a/test/Reachability/UploadSpec.hs
+++ b/test/Reachability/UploadSpec.hs
@@ -161,7 +161,7 @@ skippedProject dir =
 
 skippedProjectByDefaultFilter :: Path Abs Dir -> (DiscoveredProjectScan, DiscoveredProjectIdentifier)
 skippedProjectByDefaultFilter dir =
-  ( SkippedDueToDefaultProductionFilter dpi
+  ( SkippedDueToDefaultFilter dpi
   , dpi
   )
   where

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -84,6 +84,7 @@ import System.Directory (getTemporaryDirectory)
 import Text.RawString.QQ (r)
 import Text.URI.QQ (uri)
 import Types (ArchiveUploadType (..), GraphBreadth (..))
+import App.Fossa.Config.Analyze (WithoutDefaultFilters(..))
 
 apiOpts :: API.ApiOpts
 apiOpts =
@@ -526,6 +527,7 @@ standardAnalyzeConfig =
     , ANZ.customFossaDepsFile = customFossaDepsFile
     , ANZ.allowedTacticTypes = Any
     , ANZ.reachabilityConfig = mempty
+    , ANZ.withoutDefaultFilters = toFlag WithoutDefaultFilters False
     }
 
 sampleJarParsedContent :: Text

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -53,7 +53,7 @@ module Test.Fixtures (
   organizationWithPreflightChecks,
 ) where
 
-import App.Fossa.Config.Analyze (AnalysisTacticTypes (Any), AnalyzeConfig (AnalyzeConfig), ExperimentalAnalyzeConfig (..), GoDynamicTactic (..), IncludeAll (..), JsonOutput (JsonOutput), NoDiscoveryExclusion (..), ScanDestination (..), UnpackArchives (..), VSIModeOptions (..), VendoredDependencyOptions (..))
+import App.Fossa.Config.Analyze (AnalysisTacticTypes (Any), AnalyzeConfig (AnalyzeConfig), ExperimentalAnalyzeConfig (..), GoDynamicTactic (..), IncludeAll (..), JsonOutput (JsonOutput), NoDiscoveryExclusion (..), ScanDestination (..), UnpackArchives (..), VSIModeOptions (..), VendoredDependencyOptions (..), WithoutDefaultFilters (..))
 import App.Fossa.Config.Analyze qualified as ANZ
 import App.Fossa.Config.Analyze qualified as VSI
 import App.Fossa.Config.Test (DiffRevision (DiffRevision))
@@ -84,7 +84,6 @@ import System.Directory (getTemporaryDirectory)
 import Text.RawString.QQ (r)
 import Text.URI.QQ (uri)
 import Types (ArchiveUploadType (..), GraphBreadth (..))
-import App.Fossa.Config.Analyze (WithoutDefaultFilters(..))
 
 apiOpts :: API.ApiOpts
 apiOpts =


### PR DESCRIPTION
# Overview

This PR, adds `--without-default-filters` option for,
- `fossa analyze`
- `fossa container analyze`

## Acceptance criteria

- When, `--without-default-filters` is used default filters are not used in `fossa analyze`
- When, `--without-default-filters` is used default filters are not used in `fossa container analyze`

## Testing plan

```bash
# install and prep
git checkout feat/include-no-default-option
make install-dev

# create test data
>> mkdir sandbox && cd sandbox 
>> echo 'numpy' > reqs.txt
>> mkdir test && cd test
>> echo 'numpy' > reqs.txt

# test
fossa-dev analyze -o --without-default-filter # should include setuptools@test target
fossa-dev analyze -o # should not include setuptools@test target

```

## Risks
N/A

## Metrics
N/A

## References
https://fossa.atlassian.net/browse/ANE-108

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
