### PR TITLE
Upgrade cosign installer.

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -307,7 +307,7 @@ jobs:
 
     - name: Install Cosign
       if: ${{ github.ref_type == 'tag' }}
-      uses: sigstore/cosign-installer@v3.1.1
+      uses: sigstore/cosign-installer@v3.4.0
 
     - name: Sign Release (Linux)
       if: ${{ github.ref_type == 'tag' }}


### PR DESCRIPTION
# Overview

Cosign made a new [root cert](https://blog.sigstore.dev/tuf-root-update/). The default version of cosign the installer installed was too old to pick up this change. This PR switches to a new version.

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
