### PR TITLE
Support .tgz extensions for --unpack-archives

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## v3.9.10
-- Support unarchiving `tgz`, `txz`, `tbz2`, and `tz2` files for `--unpack-archives` ([#1402](https://github.com/fossas/fossa-cli/pull/1402/files))
+- Support unarchiving `tgz`, `taz`, `txz`, `tbz`, `tbz2`, and `tz2` files for `--unpack-archives` ([#1402](https://github.com/fossas/fossa-cli/pull/1402/files))
 - `--without-default-filters`: Users can now disable default path filters ([#1396](https://github.com/fossas/fossa-cli/pull/1396/files)).
 
 ## v3.9.8

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,11 +1,7 @@
 # FOSSA CLI Changelog
 
-
-## Unreleased
-
-- Support unarchiving .tgz files for `--unpack-archives` ([#1402](https://github.com/fossas/fossa-cli/pull/1402/files))
-
 ## v3.9.10
+- Support unarchiving .tgz files for `--unpack-archives` ([#1402](https://github.com/fossas/fossa-cli/pull/1402/files))
 - `--without-default-filters`: Users can now disable default path filters ([#1396](https://github.com/fossas/fossa-cli/pull/1396/files)).
 
 ## v3.9.8

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # FOSSA CLI Changelog
 
+
+## Unreleased
+
+- Support unarchiving .tgz files for `--unpack-archives` ([#1402](https://github.com/fossas/fossa-cli/pull/1402/files))
+
 ## v3.9.10
 - `--without-default-filters`: Users can now disable default path filters ([#1396](https://github.com/fossas/fossa-cli/pull/1396/files)).
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## v3.9.10
-- Support unarchiving .tgz files for `--unpack-archives` ([#1402](https://github.com/fossas/fossa-cli/pull/1402/files))
+- Support unarchiving `tgz`, `txz`, `tbz2`, and `tz2` files for `--unpack-archives` ([#1402](https://github.com/fossas/fossa-cli/pull/1402/files))
 - `--without-default-filters`: Users can now disable default path filters ([#1396](https://github.com/fossas/fossa-cli/pull/1396/files)).
 
 ## v3.9.8

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -106,9 +106,13 @@ We support the following archive formats:
 - `.zip`
 - `.tar`
 - `.tar.gz`
+- `.taz`
 - `.tgz`
 - `.tar.xz`
+- `.txz`
 - `.tar.bz2`
+- `.tbz2`
+- `.tz2`
 - `.jar`
 - `.aar`
 - `.rpm`, with...

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -106,6 +106,7 @@ We support the following archive formats:
 - `.zip`
 - `.tar`
 - `.tar.gz`
+- `.tgz`
 - `.tar.xz`
 - `.tar.bz2`
 - `.jar`

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -111,6 +111,7 @@ We support the following archive formats:
 - `.tar.xz`
 - `.txz`
 - `.tar.bz2`
+- `.tbz`
 - `.tbz2`
 - `.tz2`
 - `.jar`

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -111,8 +111,13 @@ selectUnarchiver file
   | ".tar" `isSuffixOf` file = Just extractTar
   | ".tar.gz" `isSuffixOf` file = Just extractTarGz
   | ".tgz" `isSuffixOf` file = Just extractTarGz
+  | ".taz" `isSuffixOf` file = Just extractTarGz
   | ".tar.xz" `isSuffixOf` file = Just extractTarXz
+  | ".txz" `isSuffixOf` file = Just extractTarXz
   | ".tar.bz2" `isSuffixOf` file = Just extractTarBz2
+  | ".tbz" `isSuffixOf` file = Just extractTarBz2
+  | ".tbz2" `isSuffixOf` file = Just extractTarBz2
+  | ".tz2" `isSuffixOf` file = Just extractTarBz2
   | ".zip" `isSuffixOf` file = Just extractZip
   | ".jar" `isSuffixOf` file = Just extractZip
   | ".rpm" `isSuffixOf` file = Just extractRpm

--- a/src/Discovery/Archive.hs
+++ b/src/Discovery/Archive.hs
@@ -110,6 +110,7 @@ selectUnarchiver :: Has (Lift IO) sig m => String -> Maybe (Path Abs Dir -> Path
 selectUnarchiver file
   | ".tar" `isSuffixOf` file = Just extractTar
   | ".tar.gz" `isSuffixOf` file = Just extractTarGz
+  | ".tgz" `isSuffixOf` file = Just extractTarGz
   | ".tar.xz" `isSuffixOf` file = Just extractTarXz
   | ".tar.bz2" `isSuffixOf` file = Just extractTarBz2
   | ".zip" `isSuffixOf` file = Just extractZip


### PR DESCRIPTION
# Overview

This PR adds support for `.tgz`, `taz`, `tb2`, and `tbz2` files through `--unpack-archives`, which are identical to tar.gz files. The best I could find is that they are named tgz because [DOS floppy disks only supported 3 letter file extensions](https://stackoverflow.com/questions/11534918/are-tar-gz-and-tgz-the-same-thing).

## Acceptance criteria

Files with the `.tgz`, `taz`, `tb2`, and `tbz2` extensions are scanned when `--unpack-archives` is used.

## Testing plan

1. I had a Python test project, `torchpack-0.3.1`, in a directory
2. I ran `tar -cvzf torch.tgz torchpack-0.3.1` to create a `.tgz` file
3. I ran `fossa analyze --unpack-archives` and saw 0 results
4. I compiled this PR and repeated step 3. I then saw the results I would expect for scanning torchpack if it was not compressed.

I then repeated this process identically for `taz`,`tb2`, and `tbz2`


## Risks

The largest risk I can think of is that .tgz for some reason introduces us to types of tar.gz files that we can't as easily support, but I think that is incredibly small.

Another risk is that I haven't added `.tgz` support to everywhere it needs to be added in the CLI.

## References

- [ANE-1272](https://fossa.atlassian.net/browse/ANE-1272): .tgz support

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1272]: https://fossa.atlassian.net/browse/ANE-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ