### PR TITLE
[NoTicket] Fixes fossa test output

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## v3.9.10
 - Support unarchiving `tgz`, `taz`, `txz`, `tbz`, `tbz2`, and `tz2` files for `--unpack-archives` ([#1402](https://github.com/fossas/fossa-cli/pull/1402/files))
-- `fossa test`: improves diagnostic message ([#1403](https://github.com/fossas/fossa-cli/pull/1402/files))
+- `fossa test`: improves diagnostic message ([#1403](https://github.com/fossas/fossa-cli/pull/1403/files))
 
 ## v3.9.9
 - `--without-default-filters`: Users can now disable default path filters ([#1396](https://github.com/fossas/fossa-cli/pull/1396/files)).

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## v3.9.10
 - Support unarchiving `tgz`, `taz`, `txz`, `tbz`, `tbz2`, and `tz2` files for `--unpack-archives` ([#1402](https://github.com/fossas/fossa-cli/pull/1402/files))
+- `fossa test`: improves diagnostic message ([#1403](https://github.com/fossas/fossa-cli/pull/1402/files))
+
+## v3.9.9
 - `--without-default-filters`: Users can now disable default path filters ([#1396](https://github.com/fossas/fossa-cli/pull/1396/files)).
 
 ## v3.9.8

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -828,7 +828,7 @@ renderedIssues issues = rendered
         issuePolicyConflictMessage =
           "Denied by policy "
             <> fromMaybe ("(unknown policy, issueId: " <> intToText issueId <> ") ") issueLicense
-            <> "on"
+            <> " on "
             <> nameRevision
 
         issueLink :: Maybe Text

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -827,7 +827,7 @@ renderedIssues issues = rendered
         issuePolicyConflictMessage :: Text
         issuePolicyConflictMessage =
           "Denied by policy "
-            <> fromMaybe ("(unknown policy, issueId: " <> intToText issueId <> ") ") issueLicense
+            <> fromMaybe ("(unknown policy, issueId: " <> intToText issueId <> ")") issueLicense
             <> " on "
             <> nameRevision
 


### PR DESCRIPTION
# Overview

This PR, improves the legibility of diagnostic message. Previously, `fossa-cli` was not adding necessary spaces between license and dependency.

![CleanShot 2024-03-28 at 00 21 08@2x](https://github.com/fossas/fossa-cli/assets/86321858/f2186208-7a8e-4b3e-b00d-4b1336a11550)


## Acceptance criteria

- There is space between license and dependency, when policy failure occurs

## Testing plan

0. `git checkout master && git pull origin && git checkout fix/fossa-test-fmt && make install-dev`
2. Add file `fossa-deps.yml`
```yml
# sandbox/fossa-deps.yml
referenced-dependencies:
- type: npm
  name: next
  version: 14.1.0
```

```bash
echo 'numpy' > reqs.txt
fossa analyze && fossa test 
```

You should see space between license and dependency

## Risks
N/A

## Metrics
N/A

## References
N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
