### PR TITLE
[No Ticket] Adds attributions to release assets

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -6,14 +6,16 @@ jobs:
   add-attributions-to-release:
     name: add-attributions-to-release ${{ github.event.release.tag_name }}
     runs-on: ubuntu-latest
+
+    # release changes require contents write
     permissions:
-      contents: write # release changes require contents write
+      contents: write 
 
     steps:
       - uses: actions/checkout@v4
       - name: Install fossa-cli
         run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+          ./install-latest.sh -d
 
       # since this is only invoked after the release is published,
       # we can safely presume that fossa has ran dependency scan on the commit
@@ -22,8 +24,8 @@ jobs:
       # docs: https://cli.github.com/manual/gh_release_upload
       - name: Persist attributions to release
         run: |
-          fossa --format cyclonedx-json attribution > attributions.json
-          gh release upload ${{ github.event.release.tag_name }} attributions.json --clobber
+          fossa --format cyclonedx-json attribution > attribution.bom.json
+          gh release upload ${{ github.event.release.tag_name }} attribution.bom.json
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,0 +1,29 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  add-attributions-to-release:
+    name: add-attributions-to-release ${{ github.event.release.tag_name }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # release changes require contents write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install fossa-cli
+        run: |
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+
+      # since this is only invoked after the release is published,
+      # we can safely presume that fossa has ran dependency scan on the commit
+      # from 'dependency-scan' job!
+      #
+      # docs: https://cli.github.com/manual/gh_release_upload
+      - name: Persist attributions to release
+        run: |
+          fossa --format cyclonedx-json attribution > attributions.json
+          gh release upload ${{ github.event.release.tag_name }} attributions.json --clobber
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -24,8 +24,8 @@ jobs:
       # docs: https://cli.github.com/manual/gh_release_upload
       - name: Persist attributions to release
         run: |
-          fossa --format cyclonedx-json attribution > attribution.bom.json
-          gh release upload ${{ github.event.release.tag_name }} attribution.bom.json
+          fossa report --format cyclonedx-json attribution > fossa-cli-attribution.bom.json
+          gh release upload ${{ github.event.release.tag_name }} fossa-cli-attribution.bom.json
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Overview

This PR, 
- adds attribution report to release assets

## Acceptance criteria
- attribution report is included in release assets

## Testing plan

I don't think this can be tested end/end. 

## Risks
N/A

## Metrics

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
