### PR TITLE
[No ticket] add a link to the release-group subcommand in the readme

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.9.11
+- Licensing: Add new rules for unity licenses. Add the Redis Source Available License.
+
 ## v3.9.10
 - Support unarchiving `tgz`, `taz`, `txz`, `tbz`, `tbz2`, and `tz2` files for `--unpack-archives` ([#1402](https://github.com/fossas/fossa-cli/pull/1402/files))
 - `fossa test`: improves diagnostic message ([#1403](https://github.com/fossas/fossa-cli/pull/1403/files))

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,6 +133,7 @@ Concept guides explain the nuances behind how basic FOSSA primitives work. If yo
 - [`fossa report`](./references/subcommands/report.md): Download a report of the most recent scan of a project.
 - [`fossa snippets`](./references/subcommands/snippets.md): Analyze snippets of a project and check if they exist in other open source projects FOSSA knows about.
 - [`fossa test`](./references/subcommands/test.md): View the results of the most recent scan of a project.
+- [`fossa release-group`](./references/subcommands/release-group.md): Interact with FOSSA release groups.
 
 #### Configuration
 


### PR DESCRIPTION
# Overview

Steven [pointed out](https://teamfossa.slack.com/archives/CCPE2LSRL/p1712855324715489?thread_ts=1712854040.952919&cid=CCPE2LSRL) that there was no link to the release group subcommand docs, so I added it.

I also took the opportunity to prep for a release that will include two Themis changes.

## Acceptance criteria

The link is to the right spot. Here's the rendered file: https://github.com/fossas/fossa-cli/blob/028ef47194eb2e4088c9d6d788b73b5e2af30e11/docs/README.md

## Testing plan

Click on the link.

## Risks



## Metrics



## References

_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

_Example:_

- _[ANE-123](https://fossa.atlassian.net/browse/ANE-123): Implement X._

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
