### PR TITLE
increase the timeouts for report API calls to 600 seconds

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Reports: Increase the timeout when hitting the report generation API endpoint
+
 ## v3.9.12
 - `--detect-dynamic`: Fix deb tatic parsing ([#1401](https://github.com/fossas/fossa-cli/pull/1401)).
 

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -1183,8 +1183,8 @@ getAttributionJson apiOpts ProjectRevision{..} = fossaReq $ do
             =: True
           <> "dependencyInfoOptions[]"
             =: packageDownloadUrl
-          -- Large reports can take over a minute to generate, so increase the timeout to 10 minutes
-          <> responseTimeoutSeconds 600
+          -- Large reports can take over a minute to generate, so increase the timeout to 5 minutes
+          <> responseTimeoutSeconds 300
   orgId <- organizationId <$> getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision)) ReportJson) NoReqBody jsonResponse opts
   pure (responseBody response)
@@ -1200,8 +1200,8 @@ getAttribution apiOpts revision ReportJson = fossaReq $ do
   pure . decodeUtf8 $ Aeson.encode jsonValue
 getAttribution apiOpts ProjectRevision{..} format = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
-  -- Large reports can take over a minute to generate, so increase the timeout to 10 minutes
-  let opts = baseOpts <> responseTimeoutSeconds 600
+  -- Large reports can take over a minute to generate, so increase the timeout to 5 minutes
+  let opts = baseOpts <> responseTimeoutSeconds 300
 
   orgId <- organizationId <$> getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision)) format) NoReqBody bsResponse opts

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -1183,6 +1183,8 @@ getAttributionJson apiOpts ProjectRevision{..} = fossaReq $ do
             =: True
           <> "dependencyInfoOptions[]"
             =: packageDownloadUrl
+          -- Large reports can take over a minute to generate, so increase the timeout to 10 minutes
+          <> responseTimeoutSeconds 600
   orgId <- organizationId <$> getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision)) ReportJson) NoReqBody jsonResponse opts
   pure (responseBody response)
@@ -1197,7 +1199,9 @@ getAttribution apiOpts revision ReportJson = fossaReq $ do
   jsonValue <- getAttributionJson apiOpts revision
   pure . decodeUtf8 $ Aeson.encode jsonValue
 getAttribution apiOpts ProjectRevision{..} format = fossaReq $ do
-  (baseUrl, opts) <- useApiOpts apiOpts
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+  -- Large reports can take over a minute to generate, so increase the timeout to 10 minutes
+  let opts = baseOpts <> responseTimeoutSeconds 600
 
   orgId <- organizationId <$> getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision)) format) NoReqBody bsResponse opts

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -1183,8 +1183,8 @@ getAttributionJson apiOpts ProjectRevision{..} = fossaReq $ do
             =: True
           <> "dependencyInfoOptions[]"
             =: packageDownloadUrl
-          -- Large reports can take over a minute to generate, so increase the timeout to 5 minutes
-          <> responseTimeoutSeconds 300
+          -- Large reports can take over a minute to generate, so increase the timeout to 10 minutes
+          <> responseTimeoutSeconds 600
   orgId <- organizationId <$> getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision)) ReportJson) NoReqBody jsonResponse opts
   pure (responseBody response)
@@ -1200,8 +1200,8 @@ getAttribution apiOpts revision ReportJson = fossaReq $ do
   pure . decodeUtf8 $ Aeson.encode jsonValue
 getAttribution apiOpts ProjectRevision{..} format = fossaReq $ do
   (baseUrl, baseOpts) <- useApiOpts apiOpts
-  -- Large reports can take over a minute to generate, so increase the timeout to 5 minutes
-  let opts = baseOpts <> responseTimeoutSeconds 300
+  -- Large reports can take over a minute to generate, so increase the timeout to 10 minutes
+  let opts = baseOpts <> responseTimeoutSeconds 600
 
   orgId <- organizationId <$> getOrganization apiOpts
   response <- req GET (attributionEndpoint baseUrl orgId (Locator "custom" projectName (Just projectRevision)) format) NoReqBody bsResponse opts


### PR DESCRIPTION
# Overview

No Ticket

See https://teamfossa.slack.com/archives/C043EM3L96Z/p1713304985656999

We were having a problem running `fossa attribution report --format html ...` for a project that was taking a long time to run the report.

The fix is to increase the timeout when we hit the reports API.

## Acceptance criteria

We can generate the report without timing out.

## Testing plan

```
make install-dev
```

Do this in an empty directory with no git repo in it or its parents:

```
fossa-dev report attribution --format html --project 'projectname from slack message' --revision 'revision from slack message'
```

Repeat with `--format json`.

Note that it takes > 30 seconds to run, but it does not take forever.

The previous behavior was that it would make the API call, timeout after 30 seconds, and then try again. I don't know if it ever gave up or if it just kept trying forever.

## Risks

The report in question takes a bit over a minute to generate. Increasing the timeout to 5 minutes should be enough, but if you think it should be larger (10 minutes?) I'm totally willing to bump it up.

## Metrics


## References

https://teamfossa.slack.com/archives/C043EM3L96Z/p1713304985656999

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
