### PR TITLE
Add --release-group-release to docs

### DIFF
--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -24,7 +24,8 @@ In addition to the [usual FOSSA project flags](#common-fossa-project-flags) supp
 | `--policy 'some policy'`              |       | Assign a specific FOSSA policy to this project. Mutually excludes `--policy-id`.    |
 | `--policy-id 'some policy id'`        |       | Assign a specific FOSSA policy to this project by id. Mutually excludes `--policy`. |
 | `--project-label`                     |       | assign up to 5 labels to the project                                                |
-| `--release-group-name`                |       | the name of the release group to add this project to                                |
+| `--release-group-name 'MY_RG'`        |       | add the project to this release group (also requires `--release-group-release`)     |
+| `--release-group-release 'MY_RELEASE` |       | add the project to this release version within the release group                    |
 
 ### Filtering Paths and Targets
 

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -25,7 +25,7 @@ In addition to the [usual FOSSA project flags](#common-fossa-project-flags) supp
 | `--policy-id 'some policy id'`        |       | Assign a specific FOSSA policy to this project by id. Mutually excludes `--policy`. |
 | `--project-label`                     |       | assign up to 5 labels to the project                                                |
 | `--release-group-name 'MY_RG'`        |       | add the project to this release group (also requires `--release-group-release`)     |
-| `--release-group-release 'MY_RELEASE` |       | add the project to this release version within the release group                    |
+| `--release-group-release 'MY_RELEASE'`|       | add the project to this release version within the release group                    |
 
 ### Filtering Paths and Targets
 

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -152,6 +152,13 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 
 ### F.A.Q.
 
+#### How do I add a project to a release group when it is analyzed?
+
+To add the project you're analyzing to a [release group](https://docs.fossa.com/docs/release-groups), use
+`fossa analyze --release-group-name 'MY_RG' --release-group-release 'MY_RELEASE_VERSION'`
+
+Note that the `MY_RG` release group must already exist, as well as `MY_RELEASE_VERSION` within it. You may use the `release-group` [subcommand](https://github.com/fossas/fossa-cli/blob/master/docs/references/subcommands/release-group.md) in advance to create these or do so [within the FOSSA UI](https://docs.fossa.com/docs/release-groups).
+
 #### Why is the `fossa-cli` skipping my project?
 
 `fossa-cli` may sometimes report a project of interest was skipped from the analysis. For example,


### PR DESCRIPTION
# Overview

_Provide an overview of this change. Describe the intent of this change, and how it implements that intent._

The `--release-group-release` flag was missing from the analyze subcommand docs. This adds it and reformats the text a bit.

## Acceptance criteria

Documentation is clear for flag that is required when using `--release-group-name`.

## Testing plan

_How did you validate that this PR works? What literal steps did you take when manually checking that your code works?_

_Example:_

n/a

## Risks

n/a

## Metrics

n/a

## References

Nexthink Teams chat

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
