### PR TITLE
[No Ticket]: Change GitHub actions to use macos-12

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        os: ['windows-latest', 'ubuntu-latest', 'macos-12']
         include:
         - os: ubuntu-latest
           os-name: Linux
@@ -27,7 +27,7 @@ jobs:
           project-file: cabal.project.ci.linux
           ghc: '9.4.8'
 
-        - os: macos-latest
+        - os: macos-12
           os-name: macOS
           project-file: cabal.project.ci.macos
           ghc: '9.4.8'

--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-12]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Overview

Previously we were using macos-latest for our macos runners. However, there are migrations to use ARM instead of AMD for macos-latest.

It has caused this test to fail:

- https://github.com/fossas/fossa-cli/actions/runs/8852343990

You can see that github has updated macos-latest here:
- https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

Changing to macos-12 to be conservative and based on the suggestion here:
- https://github.com/actions/runner-images/blob/main/README.md#latest-migration-process

## Testing plan

- Test via GH actions

## Risks


## Metrics


## References


## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
