### PR TITLE
Refactor Gradle documentation

### DIFF
--- a/docs/references/strategies/languages/gradle/plugin.md
+++ b/docs/references/strategies/languages/gradle/plugin.md
@@ -1,0 +1,80 @@
+
+# Gradle build plugin
+
+> [!WARNING]
+> This tactic does not support static analysis, which means it requires a CI integration executing FOSSA CLI.
+
+> [!NOTE]
+> Gradle analysis is not supported in Container Scanning.
+
+This tactic runs a [Gradle init script](https://docs.gradle.org/current/userguide/init_scripts.html) to output the dependencies in each Gradle subproject. Mechanically, this tactic:
+
+1. Unpacks an [init script] to a temporary directory. Elsewhere in this document, we refer to this as "the plugin".
+2. Invokes the plugin with `gradle jsonDeps -Ipath/to/init.gradle`.
+3. Parses the JSON output of the plugin.
+
+The plugin works by iterating through configurations, getting resolution result for the configuration, and then serializing those dependencies into JSON.
+
+> [!WARNING]
+> The plugin requires Gradle v3.3 or greater.
+
+## Debugging
+
+### Manually view plugin output
+
+If the plugin doesn't appear to be working correctly, you can perform the following steps to run it directly:
+
+1. [Download it from this repository.][init script]
+2. Run the command `gradle -I$PATH_TO_SCRIPT jsonDeps`, where `$PATH_TO_SCRIPT` is the location to which the plugin was downloaded.
+
+For example, with the plugin downloaded to `/tmp/jsondeps.gradle`, you should run (from within your project's working directory):
+
+```
+gradle -I/tmp/jsondeps.gradle jsonDeps
+```
+
+Usually, this output provides additional information on what is causing the build to fail.
+This information is provided by Gradle and is not related to FOSSA.
+
+### Debugging the plugin
+
+If the plugin itself appears to not be working based on its output, please send in a support request with the following information:
+
+1. If available, the "complete report" written by Gradle when you ran the script directly.
+   This is usually linked in the Gradle output with the message "See the complete report at {file path}".
+2. Send in the commands you executed to run the plugin directly, and the verbatim output of those commands.
+3. Create a minimal reproduction case for us to run locally on our machines so we can debug the script on our systems.
+
+> [!TIP]
+> Support requests can be initiated at https://support.fossa.com.
+
+### "Configuration cache problems found in this build"
+
+The plugin may contain text like the below:
+
+```
+FAILURE: Build failed with an exception.
+
+* Where:
+Initialization script 'jsondeps.gradle' line: 190
+
+* What went wrong:
+Configuration cache problems found in this build.
+```
+
+This is a Gradle specific issue with the "[configuration cache]" feature.
+When the document you're reading was written, the Gradle documentation had this to say about this feature:
+
+> This feature [Gradle's configuration cache] is currently not enabled by default. This feature has the following limitations:
+>
+> - The configuration cache does not support all core Gradle plugins and features. Full support is a work in progress.
+> - Your build and the plugins you depend on might require changes to fulfil the requirements.
+> - IDE imports and syncs do not yet use the configuration cache.
+
+Specific resolution steps depend on your project and Gradle version, but a possible resolution is to set `org.gradle.unsafe.configuration-cache-problems=warn` in your `gradle.properties`. This modifies configuration cache problems such that they become warnings instead of errors.
+
+> [!TIP]
+> You can read more about the [Gradle configuration cache here][configuration cache].
+
+[init script](https://github.com/fossas/fossa-cli/blob/master/scripts/jsondeps.gradle)
+[configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html)

--- a/docs/references/strategies/languages/gradle/plugin.md
+++ b/docs/references/strategies/languages/gradle/plugin.md
@@ -9,7 +9,7 @@
 
 This tactic runs a [Gradle init script](https://docs.gradle.org/current/userguide/init_scripts.html) to output the dependencies in each Gradle subproject. Mechanically, this tactic:
 
-1. Unpacks an [init script] to a temporary directory. Elsewhere in this document, we refer to this as "the plugin".
+1. Unpacks an [init script](https://github.com/fossas/fossa-cli/blob/master/scripts/jsondeps.gradle) to a temporary directory. Elsewhere in this document, we refer to this as "the plugin".
 2. Invokes the plugin with `gradle jsonDeps -Ipath/to/init.gradle`.
 3. Parses the JSON output of the plugin.
 
@@ -24,7 +24,7 @@ The plugin works by iterating through configurations, getting resolution result 
 
 If the plugin doesn't appear to be working correctly, you can perform the following steps to run it directly:
 
-1. [Download it from this repository.][init script]
+1. [Download it from this repository](https://github.com/fossas/fossa-cli/blob/master/scripts/jsondeps.gradle).
 2. Run the command `gradle -I$PATH_TO_SCRIPT jsonDeps`, where `$PATH_TO_SCRIPT` is the location to which the plugin was downloaded.
 
 For example, with the plugin downloaded to `/tmp/jsondeps.gradle`, you should run (from within your project's working directory):
@@ -62,19 +62,16 @@ Initialization script 'jsondeps.gradle' line: 190
 Configuration cache problems found in this build.
 ```
 
-This is a Gradle specific issue with the "[configuration cache]" feature.
-When the document you're reading was written, the Gradle documentation had this to say about this feature:
+This is a Gradle specific issue with the "configuration cache" feature in relation to the plugin FOSSA uses.
+When the document you're reading was written, the Gradle documentation had this to say about the Gradle configuration cache:
 
-> This feature [Gradle's configuration cache] is currently not enabled by default. This feature has the following limitations:
+> This feature is currently not enabled by default. This feature has the following limitations:
 >
 > - The configuration cache does not support all core Gradle plugins and features. Full support is a work in progress.
 > - Your build and the plugins you depend on might require changes to fulfil the requirements.
 > - IDE imports and syncs do not yet use the configuration cache.
 
-Specific resolution steps depend on your project and Gradle version, but a possible resolution is to set `org.gradle.unsafe.configuration-cache-problems=warn` in your `gradle.properties`. This modifies configuration cache problems such that they become warnings instead of errors.
-
 > [!TIP]
-> You can read more about the [Gradle configuration cache here][configuration cache].
+> You can read more about the [Gradle configuration cache here](https://docs.gradle.org/current/userguide/configuration_cache.html).
 
-[init script](https://github.com/fossas/fossa-cli/blob/master/scripts/jsondeps.gradle)
-[configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html)
+Specific resolution steps depend on your project and Gradle version, but a possible resolution is to set `org.gradle.unsafe.configuration-cache-problems=warn` in your `gradle.properties`. This modifies configuration cache problems such that they become warnings instead of errors.

--- a/docs/references/strategies/languages/gradle/plugin.md
+++ b/docs/references/strategies/languages/gradle/plugin.md
@@ -63,15 +63,11 @@ Configuration cache problems found in this build.
 ```
 
 This is a Gradle specific issue with the "configuration cache" feature in relation to the plugin FOSSA uses.
-When the document you're reading was written, the Gradle documentation had this to say about the Gradle configuration cache:
+The Gradle configuration cache is enabled by setting `org.gradle.unsafe.configuration-cache=true` in your `gradle.properties`.
 
-> This feature is currently not enabled by default. This feature has the following limitations:
->
-> - The configuration cache does not support all core Gradle plugins and features. Full support is a work in progress.
-> - Your build and the plugins you depend on might require changes to fulfil the requirements.
-> - IDE imports and syncs do not yet use the configuration cache.
+According to the Gradle documentation, the Gradle configuration cache is not compatible with all "Gradle plugins and features"; the plugin used by FOSSA CLI appears to be one of them.
 
 > [!TIP]
 > You can read more about the [Gradle configuration cache here](https://docs.gradle.org/current/userguide/configuration_cache.html).
 
-Specific resolution steps depend on your project and Gradle version, but a possible resolution is to set `org.gradle.unsafe.configuration-cache-problems=warn` in your `gradle.properties`. This modifies configuration cache problems such that they become warnings instead of errors.
+Specific resolution steps depend on your project and Gradle version, but a possible resolution is to set `org.gradle.unsafe.configuration-cache-problems=warn` in your `gradle.properties`. This modifies configuration cache problems such that they become warnings instead of errors, and stop preventing the project from building when FOSSA CLI attempts to analyze it.


### PR DESCRIPTION
# Overview

Refactors Gradle documentation:

- Cleans it up and modernizes it.
- Removes references to unimplemented tactics.
- Updates the wording used.
- Adds documentation for the "configuration cache" issue observed in https://fossa.atlassian.net/browse/ANE-1733.

Rendered:
- [Gradle documentation root](https://github.com/fossas/fossa-cli/blob/gradle/document-cache-control/docs/references/strategies/languages/gradle/gradle.md)
- [Plugin tactic](https://github.com/fossas/fossa-cli/blob/gradle/document-cache-control/docs/references/strategies/languages/gradle/plugin.md)

## Acceptance criteria

Gradle documentation is more clear and users are more easily able to debug their Gradle integration.

## Testing plan

Doc-only change.

## Risks

None.

## Metrics

None.

## References

https://fossa.atlassian.net/browse/ANE-1733

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
