### PR TITLE
Fix: Treat issue summary targets optional

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Treat `targets` field in the issue summary loaded from Core as optional ([#1422](https://github.com/fossas/fossa-cli/pull/1422)).
+
 ## v3.9.15
 - Change TLS to a version that takes advantage of but does not require 1.2 with EMS.
   This will be reverted in six months.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,7 @@
 # FOSSA CLI Changelog
 
-## Unreleased
-
-- Treat `targets` field in the issue summary loaded from Core as optional ([#1422](https://github.com/fossas/fossa-cli/pull/1422)).
 ## v3.9.16
+- Treat `targets` field in the issue summary loaded from Core as optional ([#1422](https://github.com/fossas/fossa-cli/pull/1422)).
 - Updates parallel embedded binary extractions to be more properly isolated ([#1425](https://github.com/fossas/fossa-cli/pull/1425)).
 
 ## v3.9.15

--- a/src/App/Fossa/Lernie/Types.hs
+++ b/src/App/Fossa/Lernie/Types.hs
@@ -66,10 +66,8 @@ instance ToJSON GrepEntry where
 instance FromJSON GrepEntry where
   parseJSON = withObject "GrepEntry" $ \obj ->
     GrepEntry
-      <$> obj
-        .: "matchCriteria"
-      <*> obj
-        .: "name"
+      <$> obj .: "matchCriteria"
+      <*> obj .: "name"
 
 data LernieConfig = LernieConfig
   { rootDir :: Path Abs Dir

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -513,8 +513,7 @@ instance FromJSON CustomDependency where
       <$> (obj `neText` "name")
       <*> (unTextLike <$> obj `neText` "version")
       <*> (obj `neText` "license")
-      <*> obj
-        .:? "metadata"
+      <*> obj .:? "metadata"
       <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
 
 instance FromJSON RemoteDependency where
@@ -523,8 +522,7 @@ instance FromJSON RemoteDependency where
       <$> (obj `neText` "name")
       <*> (unTextLike <$> obj `neText` "version")
       <*> (obj `neText` "url")
-      <*> obj
-        .:? "metadata"
+      <*> obj .:? "metadata"
       <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
 
 validateRemoteDep :: (Has Diagnostics sig m) => RemoteDependency -> Organization -> m RemoteDependency
@@ -582,10 +580,8 @@ instance ToDiagnostic RemoteDepLengthIsGtThanAllowed where
 instance FromJSON DependencyMetadata where
   parseJSON = withObject "metadata" $ \obj ->
     DependencyMetadata
-      <$> obj
-        .:? "description"
-      <*> obj
-        .:? "homepage"
+      <$> obj .:? "description"
+      <*> obj .:? "homepage"
       <* forbidMembers "metadata" ["url"] obj
 
 -- Parse supported dependency types into their respective type or return Nothing.

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -74,10 +74,8 @@ instance ToJSON ReleaseGroupMetadata where
 instance FromJSON ReleaseGroupMetadata where
   parseJSON = withObject "ReleaseGroupMetadata" $ \obj ->
     ReleaseGroupMetadata
-      <$> obj
-        .: "name"
-      <*> obj
-        .: "release"
+      <$> obj .: "name"
+      <*> obj .: "release"
 
 data ProjectRevision = ProjectRevision
   { projectName :: Text

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -240,10 +240,8 @@ data FossaPublicFacingError = FossaPublicFacingError
 instance FromJSON FossaPublicFacingError where
   parseJSON = withObject "FossaPublicFacingError" $ \v ->
     FossaPublicFacingError
-      <$> v
-        .: "message"
-      <*> v
-        .: "uuid"
+      <$> v .: "message"
+      <*> v .: "uuid"
 
 newtype FossaReq m a = FossaReq {unFossaReq :: m a}
   deriving (Functor, Applicative, Monad, Algebra sig)

--- a/src/Effect/Exec.hs
+++ b/src/Effect/Exec.hs
@@ -139,10 +139,8 @@ instance RecordableValue CmdFailure
 instance FromJSON CmdFailure where
   parseJSON = withObject "CmdFailure" $ \obj ->
     CmdFailure
-      <$> obj
-        .: "cmdFailureCmd"
-      <*> obj
-        .: "cmdFailureDir"
+      <$> obj .: "cmdFailureCmd"
+      <*> obj .: "cmdFailureDir"
       <*> (obj .: "cmdFailureExit" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStdout" >>= fromRecordedValue)
       <*> (obj .: "cmdFailureStderr" >>= fromRecordedValue)

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -191,12 +191,9 @@ newtype BuildTask = BuildTask
 instance FromJSON Build where
   parseJSON = withObject "Build" $ \obj ->
     Build
-      <$> obj
-        .: "id"
-      <*> obj
-        .:? "error"
-      <*> obj
-        .: "task"
+      <$> obj .: "id"
+      <*> obj .:? "error"
+      <*> obj .: "task"
 
 instance FromJSON BuildTask where
   parseJSON = withObject "BuildTask" $ \obj ->
@@ -331,15 +328,10 @@ newtype IssueRule = IssueRule
 instance FromJSON Issues where
   parseJSON = withObject "Issues" $ \obj ->
     Issues
-      <$> obj
-        .: "count"
-      <*> obj
-        .:? "issues"
-        .!= []
-      <*> obj
-        .: "status"
-      <*> obj
-        .:? "summary"
+      <$> obj .: "count"
+      <*> obj .:? "issues" .!= []
+      <*> obj .: "status"
+      <*> obj .:? "summary"
 
 instance ToJSON Issues where
   toJSON Issues{..} =
@@ -353,11 +345,8 @@ instance ToJSON Issues where
 instance FromJSON IssuesSummary where
   parseJSON = withObject "IssuesSummary" $ \obj ->
     IssuesSummary
-      <$> obj
-        .: "revision"
-      <*> obj
-        .:? "targets"
-        .!= []
+      <$> obj .: "revision"
+      <*> obj .:? "targets" .!= []
 
 instance ToJSON IssuesSummary where
   toJSON IssuesSummary{..} =
@@ -369,12 +358,9 @@ instance ToJSON IssuesSummary where
 instance FromJSON IssueSummaryRevision where
   parseJSON = withObject "IssueSummaryRevision" $ \obj ->
     IssueSummaryRevision
-      <$> obj
-        .: "projectTitle"
-      <*> obj
-        .: "projectRevision"
-      <*> obj
-        .:? "isPublic"
+      <$> obj .: "projectTitle"
+      <*> obj .: "projectRevision"
+      <*> obj .:? "isPublic"
 
 instance ToJSON IssueSummaryRevision where
   toJSON IssueSummaryRevision{..} =
@@ -387,10 +373,8 @@ instance ToJSON IssueSummaryRevision where
 instance FromJSON IssueSummaryTarget where
   parseJSON = withObject "IssueSummaryTarget" $ \obj ->
     IssueSummaryTarget
-      <$> obj
-        .: "type"
-      <*> obj
-        .: "originPaths"
+      <$> obj .: "type"
+      <*> obj .: "originPaths"
 
 instance ToJSON IssueSummaryTarget where
   toJSON IssueSummaryTarget{..} =
@@ -402,27 +386,16 @@ instance ToJSON IssueSummaryTarget where
 instance FromJSON Issue where
   parseJSON = withObject "Issue" $ \obj ->
     Issue
-      <$> obj
-        .: "id"
-      <*> obj
-        .:? "priorityString"
-      <*> obj
-        .: "resolved"
-      <*> obj
-        .:? "revisionId"
-        .!= "unknown project"
-      <*> obj
-        .: "type"
-      <*> obj
-        .:? "rule"
-      <*> obj
-        .:? "license"
-      <*> obj
-        .:? "issueDashURL"
-      <*> obj
-        .:? "cve"
-      <*> obj
-        .:? "fixedIn"
+      <$> obj .: "id"
+      <*> obj .:? "priorityString"
+      <*> obj .: "resolved"
+      <*> obj .:? "revisionId" .!= "unknown project"
+      <*> obj .: "type"
+      <*> obj .:? "rule"
+      <*> obj .:? "license"
+      <*> obj .:? "issueDashURL"
+      <*> obj .:? "cve"
+      <*> obj .:? "fixedIn"
 
 instance ToJSON Issue where
   toJSON Issue{..} =
@@ -530,53 +503,22 @@ blankOrganization =
 instance FromJSON Organization where
   parseJSON = withObject "Organization" $ \obj ->
     Organization
-      <$> obj
-        .: "organizationId"
-      <*> obj
-        .:? "usesSAML"
-        .!= False
-      <*> obj
-        .:? "supportsCliLicenseScanning"
-        .!= False
-      <*> obj
-        .:? "supportsAnalyzedRevisionsQuery"
-        .!= False
-      <*> obj
-        .:? "defaultVendoredDependencyScanType"
-        .!= CLILicenseScan
-      <*> obj
-        .:? "supportsIssueDiffs"
-        .!= False
-      <*> obj
-        .:? "supportsNativeContainerScans"
-        .!= False
-      <*> obj
-        .:? "supportsDependenciesCachePolling"
-        .!= False
-      <*> obj
-        .:? "requireFullFileUploads"
-        .!= False
-      <*> obj
-        .:? "defaultToFirstPartyScans"
-        .!= False
-      <*> obj
-        .:? "supportsPathDependency"
-        .!= False
-      <*> obj
-        .:? "supportsFirstPartyScans"
-        .!= False
-      <*> obj
-        .:? "customLicenseScanConfigs"
-        .!= []
-      <*> obj
-        .:? "supportsReachability"
-        .!= False
-      <*> obj
-        .:? "supportsPreflightChecks"
-        .!= False
-      <*> obj
-        .:? "subscription"
-        .!= Free
+      <$> obj .: "organizationId"
+      <*> obj .:? "usesSAML" .!= False
+      <*> obj .:? "supportsCliLicenseScanning" .!= False
+      <*> obj .:? "supportsAnalyzedRevisionsQuery" .!= False
+      <*> obj .:? "defaultVendoredDependencyScanType" .!= CLILicenseScan
+      <*> obj .:? "supportsIssueDiffs" .!= False
+      <*> obj .:? "supportsNativeContainerScans" .!= False
+      <*> obj .:? "supportsDependenciesCachePolling" .!= False
+      <*> obj .:? "requireFullFileUploads" .!= False
+      <*> obj .:? "defaultToFirstPartyScans" .!= False
+      <*> obj .:? "supportsPathDependency" .!= False
+      <*> obj .:? "supportsFirstPartyScans" .!= False
+      <*> obj .:? "customLicenseScanConfigs" .!= []
+      <*> obj .:? "supportsReachability" .!= False
+      <*> obj .:? "supportsPreflightChecks" .!= False
+      <*> obj .:? "subscription" .!= Free
 
 data TokenType
   = Push
@@ -589,8 +531,7 @@ newtype TokenTypeResponse = TokenTypeResponse {tokenType :: TokenType}
 instance FromJSON TokenTypeResponse where
   parseJSON = withObject "TokenTypeResponse" $ \obj ->
     TokenTypeResponse
-      <$> obj
-        .: "tokenType"
+      <$> obj .: "tokenType"
 
 instance FromJSON TokenType where
   parseJSON = withText "TokenType" $ \case
@@ -651,12 +592,9 @@ data Project = Project
 instance FromJSON Project where
   parseJSON = withObject "Project" $ \obj ->
     Project
-      <$> obj
-        .: "id"
-      <*> obj
-        .: "title"
-      <*> obj
-        .: "isMonorepo"
+      <$> obj .: "id"
+      <*> obj .: "title"
+      <*> obj .: "isMonorepo"
 
 data UploadResponse = UploadResponse
   { uploadLocator :: Locator
@@ -684,8 +622,7 @@ newtype RevisionDependencyCache = RevisionDependencyCache {status :: RevisionDep
 instance FromJSON RevisionDependencyCache where
   parseJSON = withObject "RevisionDependencyCache" $ \obj ->
     RevisionDependencyCache
-      <$> obj
-        .: "status"
+      <$> obj .: "status"
 
 instance FromJSON RevisionDependencyCacheStatus where
   parseJSON = withText "RevisionDependencyCacheStatus" $ \txt -> case Text.toUpper txt of

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -225,7 +225,7 @@ data Issues = Issues
 
 data IssuesSummary = IssuesSummary
   { revision :: IssueSummaryRevision
-  , targets :: Maybe [IssueSummaryTarget]
+  , targets :: [IssueSummaryTarget]
   }
   deriving (Eq, Ord, Show)
 
@@ -356,7 +356,8 @@ instance FromJSON IssuesSummary where
       <$> obj
         .: "revision"
       <*> obj
-        .: "targets"
+        .:? "targets"
+        .!= []
 
 instance ToJSON IssuesSummary where
   toJSON IssuesSummary{..} =
@@ -739,14 +740,12 @@ renderedIssues issues = rendered
           , line
           ]
 
-    renderRevisionTargets :: Maybe [IssueSummaryTarget] -> Doc ann
-    renderRevisionTargets issueRevisionTargets = case issueRevisionTargets of
-      Nothing -> mempty
-      Just [] -> mempty
-      Just targets ->
-        vsep $
-          ["Project Targets:"]
-            <> map (\target -> "- " <> renderedTarget target) (sort targets)
+    renderRevisionTargets :: [IssueSummaryTarget] -> Doc ann
+    renderRevisionTargets [] = mempty
+    renderRevisionTargets targets =
+      vsep $
+        ["Project Targets:"]
+          <> map (\target -> "- " <> renderedTarget target) (sort targets)
 
     renderProjectVisibility :: Maybe Bool -> Doc ann
     renderProjectVisibility Nothing = "unknown"

--- a/src/Strategy/Conda/CondaEnvCreate.hs
+++ b/src/Strategy/Conda/CondaEnvCreate.hs
@@ -94,8 +94,7 @@ data CondaEnvDep = CondaEnvDep
 instance FromJSON CondaEnvCreateOut where
   parseJSON = withObject "CondaEnvOutput" $ \obj ->
     CondaEnvCreateOut
-      <$> obj
-        .: "dependencies"
+      <$> obj .: "dependencies"
 
 type Parser = Parsec Void Text
 

--- a/test/Fossa/API/TypesSpec.hs
+++ b/test/Fossa/API/TypesSpec.hs
@@ -29,7 +29,7 @@ genIssueRevisionSummary :: Gen IssuesSummary
 genIssueRevisionSummary =
   IssuesSummary
     <$> genIssueRevision
-    <*> Gen.maybe (Gen.list (Range.linear 0 100) genIssueRevisionTargets)
+    <*> Gen.list (Range.linear 0 100) genIssueRevisionTargets
 
 genIssueRevision :: Gen IssueSummaryRevision
 genIssueRevision =


### PR DESCRIPTION
# Overview

Companion PR to https://github.com/fossas/FOSSA/pull/12559, fixes https://fossa.atlassian.net/browse/ANE-1738 but in a different way.

Updates the issue summary datatype to treat targets as optional.

Note: I put this in "unreleased" because, since we're also doing the Core-side change, I don't think this is worth the time of going through the release process on its own, and can just go in the next release we perform.

Mostly I just integrated this change on this end for on-premise users and for completeness (if we consider it optional, we should consider it optional on the client side too).

## Acceptance criteria

`fossa test` and `fossa report` are able to work on first-party-license-scanned builds, without the changes in the linked Core PR.

## Testing plan

I tested manually against the current production version of FOSSA:
```
; fossa test -p {project} --revision {revision} --debug
[DEBUG] Loading configuration file from "/Users/jessica/projects/fossa-cli/"

Using project name: {project}
Using revision: {revision}

[DEBUG] [ Checking build completion for {revision}... ]
[DEBUG] [ Waiting for issue scan completion... ]
[DEBUG] An issue occurred

  *** Relevant Errors ***

      Error: An error occurred when deserializing a response from the FOSSA API:Error in $.summary: key "targets" not found

      Traceback:
        - Calling FOSSA API

[ERROR] An issue occurred

  *** Relevant Errors ***

      Error: An error occurred when deserializing a response from the FOSSA API:Error in $.summary: key "targets" not found
```

After this change:
```
; cabal run fossa -- test -p {project} --revision {revision} --debug
[DEBUG] Loading configuration file from "/Users/jessica/projects/fossa-cli/"

Using project name: `{project}`
Using revision: `{revision}`

[DEBUG] [ Checking build completion for {revision}... ]
[DEBUG] [ Waiting for issue scan completion... ]
[DEBUG]

[ERROR]

  ========================================================================
  Tested Following Project:
  ========================================================================


  Project Title: {project}
  Project Revision: {revision}
  Project Visibility: public



  COMPLIANCE ISSUES (Total 4)

  ========================================================================
  Flagged by Policy (Total 4)
  ========================================================================
  { ... omitted project specific details ... }


[DEBUG] An issue occurred

  *** Relevant Errors ***

      Error: The scan has revealed issues. Number of issues found: 4

      Traceback:
        (none)

[ERROR] An issue occurred

  *** Relevant Errors ***

      Error: The scan has revealed issues. Number of issues found: 4

```


## Risks

None

## Metrics

None

## References

Fixes https://fossa.atlassian.net/browse/ANE-1738

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
