### PR TITLE
Swift: Support v3 file format, downgrade version mismatch to warning in the future

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,10 +5,6 @@
   Future SwiftPM file formats will be accepted automatically if they remain backwards compatible with the current parser.
 - Updates parallel embedded binary extractions to be more properly isolated ([#1425](https://github.com/fossas/fossa-cli/pull/1425)).
 
-## v3.9.16
-- Adds support for SwiftPM v3 files ([#1424](https://github.com/fossas/fossa-cli/pull/1424)).
-  Future SwiftPM file formats will be accepted automatically if they remain backwards compatible with the current parser.
-
 ## v3.9.15
 - Change TLS to a version that takes advantage of but does not require 1.2 with EMS.
   This will be reverted in six months.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## v3.9.16
+- Adds support for SwiftPM v3 files ([#1424](https://github.com/fossas/fossa-cli/pull/1424)).
+  Future SwiftPM file formats will be accepted automatically if they remain backwards compatible with the current parser.
+
 ## v3.9.15
 - Change TLS to a version that takes advantage of but does not require 1.2 with EMS.
   This will be reverted in six months.

--- a/src/Strategy/Swift/PackageResolved.hs
+++ b/src/Strategy/Swift/PackageResolved.hs
@@ -51,7 +51,6 @@ data SwiftResolvedPackage = SwiftResolvedPackage
   }
   deriving (Show, Eq, Ord)
 
--- | If you update this, make sure to update warnAssumedVersion with the new assumed version.
 instance FromJSON SwiftPackageResolvedFile where
   parseJSON = withObject "Package.resolved content" $ \obj -> do
     version :: Integer <- obj .: "version"

--- a/src/Strategy/Swift/PackageResolved.hs
+++ b/src/Strategy/Swift/PackageResolved.hs
@@ -2,8 +2,11 @@ module Strategy.Swift.PackageResolved (
   SwiftPackageResolvedFile (..),
   SwiftResolvedPackage (..),
   resolvedDependenciesOf,
+  parsePackageResolved,
 ) where
 
+import Control.Carrier.Diagnostics (Diagnostics, Has, context, warn)
+import Control.Monad (when)
 import Data.Aeson (
   FromJSON (parseJSON),
   Key,
@@ -14,8 +17,24 @@ import Data.Aeson (
  )
 import Data.Aeson.Types (Parser)
 import Data.Foldable (asum)
+import Data.List (find)
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import DepTypes (DepType (GitType), Dependency (..), VerConstraint (CEq))
+import Effect.ReadFS (ReadFS, readContentsJson)
+import Path (Abs, File, Path)
+
+parsePackageResolved :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m SwiftPackageResolvedFile
+parsePackageResolved path = context "read and parse Package.resolved" $ do
+  packageResolved <- readContentsJson path
+
+  let fileVersion = version packageResolved
+  let parsedVersion = parserVersion $ parserForVersion fileVersion
+  when (parsedVersion /= fileVersion) $ warn $ "Package.resolved file is version '" <> show fileVersion <> "', but was parsed as version '" <> show parsedVersion <> "'"
+
+  pure packageResolved
 
 data SwiftPackageResolvedFile = SwiftPackageResolvedFile
   { version :: Integer
@@ -32,13 +51,11 @@ data SwiftResolvedPackage = SwiftResolvedPackage
   }
   deriving (Show, Eq, Ord)
 
+-- | If you update this, make sure to update warnAssumedVersion with the new assumed version.
 instance FromJSON SwiftPackageResolvedFile where
   parseJSON = withObject "Package.resolved content" $ \obj -> do
     version :: Integer <- obj .: "version"
-    case version of
-      1 -> SwiftPackageResolvedFile version <$> ((obj .: "object" |> "pins") >>= traverse (withObject "Package.resolved v1 pin" parseV1Pin))
-      2 -> SwiftPackageResolvedFile version <$> ((obj .: "pins") >>= traverse (withObject "Package.resolved v2 pin" parseV2Pin))
-      _ -> fail $ "unknown Package.resolved version: " <> show version
+    (parserFunction $ parserForVersion version) version obj
 
 (|>) :: FromJSON a => Parser Object -> Key -> Parser a
 (|>) parser key = do
@@ -52,6 +69,27 @@ instance FromJSON SwiftPackageResolvedFile where
     Nothing -> pure Nothing
     Just o -> o .:? key
 
+data PackageResolvedParser = PackageResolvedParser
+  { parserVersion :: Integer
+  , parserFunction :: (Integer -> Object -> Parser SwiftPackageResolvedFile)
+  }
+
+-- | Select the appropriate parser based on the file version.
+-- Defaults to the parser with the latest version if none is specified.
+parserForVersion :: Integer -> PackageResolvedParser
+parserForVersion version = fromMaybe (NE.head allParsers) findVersion
+  where
+    findVersion :: Maybe PackageResolvedParser
+    findVersion = find (\p -> version == parserVersion p) $ NE.toList allParsers
+
+    -- Rather than paying the cost of sorting at runtime, the parent function assumes the "default" parser is the first in the list.
+    -- Ensure when adding new parsers that the new parser is added in the appropriate place based on this.
+    allParsers :: NonEmpty PackageResolvedParser
+    allParsers = PackageResolvedParser 2 parseV2 :| [PackageResolvedParser 1 parseV1]
+
+parseV1 :: Integer -> Object -> Parser SwiftPackageResolvedFile
+parseV1 version obj = SwiftPackageResolvedFile version <$> ((obj .: "object" |> "pins") >>= traverse (withObject "Package.resolved v1 pin" parseV1Pin))
+
 parseV1Pin :: Object -> Parser SwiftResolvedPackage
 parseV1Pin obj =
   SwiftResolvedPackage
@@ -60,6 +98,9 @@ parseV1Pin obj =
     <*> (obj .:? "state" |?> "branch")
     <*> (obj .:? "state" |?> "revision")
     <*> (obj .:? "state" |?> "version")
+
+parseV2 :: Integer -> Object -> Parser SwiftPackageResolvedFile
+parseV2 version obj = SwiftPackageResolvedFile version <$> ((obj .: "pins") >>= traverse (withObject "Package.resolved v2 pin" parseV2Pin))
 
 parseV2Pin :: Object -> Parser SwiftResolvedPackage
 parseV2Pin obj =

--- a/test/Swift/PackageResolvedSpec.hs
+++ b/test/Swift/PackageResolvedSpec.hs
@@ -69,6 +69,21 @@ expectedV2ResolvedContent =
         ]
     }
 
+expectedV3ResolvedContent :: SwiftPackageResolvedFile
+expectedV3ResolvedContent =
+  SwiftPackageResolvedFile
+    { version = 3
+    , pinnedPackages =
+        [ SwiftResolvedPackage
+            { package = "vonage-client-sdk-video"
+            , repositoryURL = "https://github.com/opentok/vonage-client-sdk-video.git"
+            , repositoryBranch = Nothing
+            , repositoryRevision = Just "e4b1af1808067f0c0a66fa85aaf99915b542a579"
+            , repositoryVersion = Just "2.27.2"
+            }
+        ]
+    }
+
 spec :: Spec
 spec = do
   describe "parse Package.resolved file" $ do
@@ -78,3 +93,6 @@ spec = do
     it "should parse v2 content correctly" $ do
       resolvedFile <- decodeFileStrict' "test/Swift/testdata/v2/Package.resolved"
       resolvedFile `shouldBe` Just expectedV2ResolvedContent
+    it "should parse v3 content correctly" $ do
+      resolvedFile <- decodeFileStrict' "test/Swift/testdata/v3/Package.resolved"
+      resolvedFile `shouldBe` Just expectedV3ResolvedContent

--- a/test/Swift/PackageResolvedSpec.hs
+++ b/test/Swift/PackageResolvedSpec.hs
@@ -84,15 +84,40 @@ expectedV3ResolvedContent =
         ]
     }
 
+-- | Not a true v4; we'll need to rename this test in the future.
+-- The point here is just to test "a version that is not explicitly supported but still parses".
+expectedHypotheticalV4ResolvedContent :: SwiftPackageResolvedFile
+expectedHypotheticalV4ResolvedContent =
+  SwiftPackageResolvedFile
+    { version = 4
+    , pinnedPackages =
+        [ SwiftResolvedPackage
+            { package = "vonage-client-sdk-video"
+            , repositoryURL = "https://github.com/opentok/vonage-client-sdk-video.git"
+            , repositoryBranch = Nothing
+            , repositoryRevision = Just "e4b1af1808067f0c0a66fa85aaf99915b542a579"
+            , repositoryVersion = Just "2.27.2"
+            }
+        ]
+    }
+
 spec :: Spec
 spec = do
   describe "parse Package.resolved file" $ do
     it "should parse v1 content correctly" $ do
       resolvedFile <- decodeFileStrict' "test/Swift/testdata/v1/Package.resolved"
       resolvedFile `shouldBe` Just expectedV1ResolvedContent
+
     it "should parse v2 content correctly" $ do
       resolvedFile <- decodeFileStrict' "test/Swift/testdata/v2/Package.resolved"
       resolvedFile `shouldBe` Just expectedV2ResolvedContent
+
     it "should parse v3 content correctly" $ do
       resolvedFile <- decodeFileStrict' "test/Swift/testdata/v3/Package.resolved"
       resolvedFile `shouldBe` Just expectedV3ResolvedContent
+
+    -- Not a true v4; we'll need to rename this test in the future.
+    -- The point here is just to test "a version that is not explicitly supported but still parses".
+    it "should parse hypothetical v4 content correctly" $ do
+      resolvedFile <- decodeFileStrict' "test/Swift/testdata/v4/Package.resolved"
+      resolvedFile `shouldBe` Just expectedHypotheticalV4ResolvedContent

--- a/test/Swift/testdata/v3/Package.resolved
+++ b/test/Swift/testdata/v3/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "fbfc6b659421b42ead4ad2cfb780bcd9992922da94fe0df8024fd7086598dc08",
+  "pins" : [
+    {
+      "identity" : "vonage-client-sdk-video",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/opentok/vonage-client-sdk-video.git",
+      "state" : {
+        "revision" : "e4b1af1808067f0c0a66fa85aaf99915b542a579",
+        "version" : "2.27.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/test/Swift/testdata/v4/Package.resolved
+++ b/test/Swift/testdata/v4/Package.resolved
@@ -12,5 +12,5 @@
       "extra": "some extra field that didn't exist in v3"
     }
   ],
-  "version" : 3
+  "version" : 4
 }

--- a/test/Swift/testdata/v4/Package.resolved
+++ b/test/Swift/testdata/v4/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "originHash" : "fbfc6b659421b42ead4ad2cfb780bcd9992922da94fe0df8024fd7086598dc08",
+  "pins" : [
+    {
+      "identity" : "vonage-client-sdk-video",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/opentok/vonage-client-sdk-video.git",
+      "state" : {
+        "revision" : "e4b1af1808067f0c0a66fa85aaf99915b542a579",
+        "version" : "2.27.2"
+      },
+      "extra": "some extra field that didn't exist in v3"
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
# Overview

Resolves ANE-1739:
- Downgrades version mismatch in the `Package.resolved` file to a warning, if parsing otherwise succeeds. If parsing fails because the actual shape of the data changes in a backwards-incompatible way, that will still be an error.
- Adds explicit support for v3, [which is not different from v2 for our purposes](https://github.com/apple/swift-package-manager/blob/9aa348e8eecc44fb6f93e1ef46e6dbd29947f4e7/Sources/PackageGraph/PinsStore.swift#L470).

## Acceptance criteria

SwiftPM v3 files can be parsed.

## Testing plan

I added an automated test for this and I am relying on that.

## Risks

None

## Metrics

None

## References

Resolves: https://fossa.atlassian.net/browse/ANE-1739

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
