### PR TITLE
Don't put files in subdir when extracting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## v3.9.16
+- Updates parallel embedded binary extractions to be more properly isolated ([#1425](https://github.com/fossas/fossa-cli/pull/1425)).
+
 ## v3.9.15
 - Change TLS to a version that takes advantage of but does not require 1.2 with EMS.
   This will be reverted in six months.


### PR DESCRIPTION
# Overview

Updates the `EmbeddedBinary` logic to suffix the `fossa-vendor` directory name with a UUID instead of nesting a UUID folder inside.

This provides complete isolation to multiple callers, such that even if they (or a system process) cleans up the parent after they're done they don't mess with other callers.

## Acceptance criteria

Integration tests pass again

## Testing plan

Relying on integration tests- if this breaks anything with extraction we'll get way more errors, if this fixes the issue observed in other PRs we'll get none.

## Risks

None

## Metrics

None

## References

Resolves https://fossa.atlassian.net/browse/ANE-1742

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
