### PR TITLE
Revert "Add Mac arm64 executable (#1426)"

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-12', 'macos-latest']
+        os: ['windows-latest', 'ubuntu-latest', 'macos-12']
         include:
         - os: ubuntu-latest
           os-name: Linux
@@ -27,20 +27,14 @@ jobs:
           project-file: cabal.project.ci.linux
           ghc: '9.4.8'
 
-        # macos-latest pointed at macos-12 this before it was changed to ARM.
         - os: macos-12
-          os-name: macOS-intel
+          os-name: macOS
           project-file: cabal.project.ci.macos
           ghc: '9.4.8'
 
         - os: windows-latest
           os-name: Windows
           project-file: cabal.project.ci.windows
-          ghc: '9.4.8'
-
-        - os: macos-latest
-          os-name: macOS-arm64
-          project-file: cabal.project.ci.macos
           ghc: '9.4.8'
 
     steps:
@@ -140,22 +134,22 @@ jobs:
       name: Cache cabal store
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.local/state/cabal' }}
-        key: ${{ matrix.os-name }}-${{ matrix.ghc }}-cabal-cache-${{ steps.compute-cache-key.outputs.cabal-cache-key }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-${{ steps.compute-cache-key.outputs.cabal-cache-key }}
         restore-keys: |
-          ${{ matrix.os-name }}-${{ matrix.ghc }}-cabal-cache-
-          ${{ matrix.os-name }}-${{ matrix.ghc }}-
-          ${{ matrix.os-name }}-
+          ${{ runner.os }}-${{ matrix.ghc }}-cabal-cache-
+          ${{ runner.os }}-${{ matrix.ghc }}-
+          ${{ runner.os }}-
 
     - uses: actions/cache@v4
       name: Cache dist-newstyle
       with:
         path: ${{ github.workspace }}/dist-newstyle
-        key: ${{ matrix.os-name }}-${{ env.GHC_VERSION }}-dist-newstyle-${{ github.sha }}
+        key: ${{ runner.os }}-${{ env.GHC_VERSION }}-dist-newstyle-${{ github.sha }}
         restore-keys: |
-          ${{ matrix.os-name }}-${{ env.GHC_VERSION }}-dist-newstyle-${{ env.parent_commit }}
-          ${{ matrix.os-name }}-${{ env.GHC_VERSION }}-dist-newstyle-
-          ${{ matrix.os-name }}-${{ env.GHC_VERSION }}-
-          ${{ matrix.os-name }}-
+          ${{ runner.os }}-${{ env.GHC_VERSION }}-dist-newstyle-${{ env.parent_commit }}
+          ${{ runner.os }}-${{ env.GHC_VERSION }}-dist-newstyle-
+          ${{ runner.os }}-${{ env.GHC_VERSION }}-
+          ${{ runner.os }}-
 
     - name: Update vendored binaries
       run: |
@@ -266,7 +260,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.os-name }}-binaries
+        name: ${{ runner.os }}-binaries
         path: release
 
   create-release:
@@ -373,14 +367,10 @@ jobs:
         gzip "$LINUX_DIAGNOSE_TAR_PATH"
         gzip "$LINUX_MILLHONE_TAR_PATH"
 
-        chmod +x macOS-intel-binaries/*
-        zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-intel-binaries/fossa
-        zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-intel-binaries/diagnose
-        zip -j release/millhone_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-intel-binaries/millhone
-        chmod +x macOS-arm64-binaries/*
-        zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_arm64.zip macOS-intel-binaries/fossa
-        zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_darwin_arm64.zip macOS-intel-binaries/diagnose
-        zip -j release/millhone_${{ steps.get-version.outputs.VERSION }}_darwin_arm64.zip macOS-intel-binaries/millhone
+        chmod +x macOS-binaries/*
+        zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/fossa
+        zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/diagnose
+        zip -j release/millhone_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-binaries/millhone
 
         chmod +x Windows-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/fossa.exe
@@ -394,7 +384,6 @@ jobs:
         sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip.sha256"
         sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz" > "fossa_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar.gz.sha256"
         sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip.sha256"
-        sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_arm64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_darwin_arm64.zip.sha256"
         sha256sum --binary "fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip" > "fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip.sha256"
 
         echo "Sanity-checking the checksums."

--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -55,28 +55,6 @@ jobs:
           fossa --version
           brew uninstall fossa
 
-  # These are run separately from the Matrix above because:
-  # 1. There is no Mac ARM fossa v1.
-  # 2. Earlier versions of cli v3 did not have ARM releases.
-  test-macos-arm:
-    runs-on: "macos-latest"
-    steps:
-      - uses: actions/checkout@v4
-      - name: install latest script can install a specific version
-        shell: bash
-        run: |
-          # 3.9.19 is the first version with native Mac ARM builds.
-          ./install-latest.sh -b . v3.9.19
-          ./fossa --version | grep -q "3.9.19"
-          rm fossa
-
-      - name: install latest script performs installation
-        shell: bash
-        run: |
-          ./install-latest.sh -b .
-          ./fossa --version
-          rm fossa
-
   test-windows:
     runs-on: "windows-latest"
     steps:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,5 @@
 # FOSSA CLI Changelog
 
-## v3.9.19
-- Release a Mac arm64 binary. ([#1426](https://github.com/fossas/fossa-cli/pull/1426))
-
 ## v3.9.18
 - Resolves an issue where `vendored-dependencies` were rescanned locally, but not in the FOSSA service,
   when `forceRescans` was set to `true` ([#1423](https://github.com/fossas/fossa-cli/pull/1423)).

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -393,10 +393,9 @@ get_binary_name() {
   name=${PROJECT_NAME}_${VERSION}_${OS}_${ARCH}
   case ${PLATFORM} in
     darwin/arm64)
-      if version_less_than "$VERSION" "3.9.19"; then
-        log_info "Platform ${PLATFORM} (m1 silicon) detected and requested version < 3.9.19, using compatible darwin/amd64 binary instead."
-        name=${PROJECT_NAME}_${VERSION}_${OS}_amd64
-      fi ;;
+      log_info "Platform ${PLATFORM} (m1 silicon) detected, using compatible darwin/amd64 binary instead."
+      name=${PROJECT_NAME}_${VERSION}_${OS}_amd64
+      ;;
   esac
   echo "$name"
 }

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -35,17 +35,15 @@ THEMIS_ASSET_POSTFIX=""
 LERNIE_ASSET_POSTFIX=""
 case "$(uname -s)" in
   Darwin)
+    ASSET_POSTFIX="darwin"
+    THEMIS_ASSET_POSTFIX="darwin-amd64"
     case "$(uname -m)" in
       arm64)
-        ASSET_POSTFIX="darwin-arm64"
         LERNIE_ASSET_POSTFIX="aarch64-macos"
-        THEMIS_ASSET_POSTFIX="darwin-arm64"
         ;;
 
       *)
-        ASSET_POSTFIX="darwin-amd64"
         LERNIE_ASSET_POSTFIX="x86_64-macos"
-        THEMIS_ASSET_POSTFIX="darwin-amd64"
         ;;
     esac
     ;;


### PR DESCRIPTION
This reverts commit 75363fc11aa959ffed8cc7c879382d0e3533c9a3.

# Overview

During the initial go of implementing this I missed some issues with codesigning and notarization on Mac that need to be resolved. This PR reverts the mac arm release so that it doesn't get in the way of any other releases.
