### PR TITLE
Update issueDashURL to contain correct revision branch

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## 3.9.19
 - Updated the license to CPAL, an OSI-approved license similar to MPL ([#1431](https://github.com/fossas/fossa-cli/pull/1431)).
+- `fossa test`: Update `issueDashURL` to contain correct branch [#1433](https://github.com/fossas/fossa-cli/pull/1433).
 
 ## v3.9.18
 - Resolves an issue where `vendored-dependencies` were rescanned locally, but not in the FOSSA service,


### PR DESCRIPTION
# Overview

`fossa test` reports the issue URLs incorrectly. It points to the master branch even when last analysis was performed on a different branch. 

## Acceptance criteria

issueDashURL should contain the correct branch. 

## Testing plan
To view current state of our issue urls in `fossa test`

- `fossa analyze /path/to/project/` a project on a branch that is NOT `master`
- `fossa test /path/to/project/` 
- You will see that the issueDashURL will contain `/refs/branch/master` 

To view updated issue urls

- `git checkout fix-issueUrl` 
- `fossa test /path/to/project/` 


## Risks

I have decided to update the `issueDashURL` in the CLI rather than in Core's /api/cli/:locator/issues endpoint for the following reasons:
- There is no way to generate the `issueDashURL` with the correct branch in the /api/cli/:locator/issues endpoint without breaking backwards compatibility.
    - Updating the API to accept the project's branch would be necessary to ensure all users generate URLs with correct branch info. Without explicitly passing the project's branch to the API, it would be impossible to associate a revision's scan with the correct branch.

## Metrics


## References

[ANE-1771](https://fossa.atlassian.net/jira/software/c/projects/ANE/boards/66?selectedIssue=ANE-1771)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1771]: https://fossa.atlassian.net/browse/ANE-1771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ