### PR TITLE
Fix license file matches

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## 3.9.19
 - Updated the license to CPAL, an OSI-approved license similar to MPL ([#1431](https://github.com/fossas/fossa-cli/pull/1431)).
+- Fixes file matches for license scans ([#1434](https://github.com/fossas/fossa-cli/pull/1434)).
 
 ## v3.9.18
 - Resolves an issue where `vendored-dependencies` were rescanned locally, but not in the FOSSA service,

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -98,7 +98,7 @@ import App.Support (
  )
 import App.Types (
   DependencyRebuild,
-  FileUpload (FileUploadFullContent),
+  FileUpload (FileUploadMatchData),
   Policy (..),
   ProjectMetadata (..),
   ProjectRevision (..),
@@ -947,7 +947,7 @@ archiveBuildUpload' apiOpts rebuild archive = context ("archive: '" <> toText ar
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
   let opts = "dependency" =: True <> "rawLicenseScan" =: True
-  let archiveProjects = ArchiveComponents [archive] rebuild FileUploadFullContent
+  let archiveProjects = ArchiveComponents [archive] rebuild FileUploadMatchData
 
   -- The response appears to either be "Created" for new builds, or an error message for existing builds.
   -- Making the actual return value of "Created" essentially worthless.

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -98,7 +98,7 @@ import App.Support (
  )
 import App.Types (
   DependencyRebuild,
-  FileUpload (FileUploadMatchData),
+  FileUpload (FileUploadFullContent),
   Policy (..),
   ProjectMetadata (..),
   ProjectRevision (..),
@@ -947,7 +947,7 @@ archiveBuildUpload' apiOpts rebuild archive = context ("archive: '" <> toText ar
   (baseUrl, baseOpts) <- useApiOpts apiOpts
 
   let opts = "dependency" =: True <> "rawLicenseScan" =: True
-  let archiveProjects = ArchiveComponents [archive] rebuild FileUploadMatchData
+  let archiveProjects = ArchiveComponents [archive] rebuild FileUploadFullContent
 
   -- The response appears to either be "Created" for new builds, or an error message for existing builds.
   -- Making the actual return value of "Created" essentially worthless.

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -151,7 +151,9 @@ instance ToJSON ArchiveComponents where
   toJSON ArchiveComponents{..} =
     object
       [ "archives" .= archiveComponentsArchives
-      , "fullFiles" .= archiveComponentsUpload
+      , "fullFiles" .= case archiveComponentsUpload of
+          FileUploadFullContent -> True
+          FileUploadMatchData -> False
       , -- Don't use the ToJSON instance of DependencyRebuild since this endpoint has a different expectation.
         "forceRebuild" .= case archiveComponentsRebuild of
           DependencyRebuildReuseCache -> False


### PR DESCRIPTION
# Overview

The changes from pr: [Support true forced rebuilds for vendored dependencies, refactor types](https://github.com/fossas/fossa-cli/pull/1423/files) introduced a bug that caused the contents of the license file matches to be empty. 

![image-20240515-194646](https://github.com/fossas/fossa-cli/assets/28590628/7c3b6c0b-3fbc-428b-8cea-a8897f76e5ea)

Before the changes, the license file match contents appeared as: 

![Screenshot 2024-05-23 at 5 05 01 PM](https://github.com/fossas/fossa-cli/assets/28590628/453e1522-0132-471d-9a7f-618baeabe395)

After some investigation, it was discovered that the revision's license scan type was being set to `full_files` . This shouldn't have been the case because the given repro case should've had the scan type set to `match_data` 

Note: Refer to the linked ANE ticket for repro case

## Acceptance criteria

- Ensure that the contents of the license file matches are not empty

## Testing plan

- `fossa analyze`  on the project linked in the ANE ticket
- Check the license file match contents 
- Check that the license scan type is set to the proper type: `match_data`

## Risks

- No risk

## Metrics


## References

- [ANE-1769](https://fossa.atlassian.net/browse/ANE-1769)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1769]: https://fossa.atlassian.net/browse/ANE-1769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ