### PR TITLE
Ane 793 yarn lock descriptors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## 3.9.21
+- Yarn: Don't fail analysis if a dependency cannot be found. ([1436](https://github.com/fossas/fossa-cli/pull/1436))
+
 ## 3.9.20 
 - Fixes file matches for license scans ([#1434](https://github.com/fossas/fossa-cli/pull/1434)).
 

--- a/src/Control/Effect/Diagnostics.hs
+++ b/src/Control/Effect/Diagnostics.hs
@@ -46,6 +46,7 @@ module Control.Effect.Diagnostics (
   ToDiagnostic (..),
   SomeDiagnostic (..),
   module Diagnostic,
+  warnLeft,
 ) where
 
 import Control.Algebra as X -- intentionally implicit
@@ -53,6 +54,7 @@ import Control.Effect.Lift (Lift)
 import Control.Effect.Stack (Stack, context)
 import Control.Exception (Exception, IOException, SomeException (..))
 import Control.Exception.Extra (safeCatch)
+import Data.Functor (($>))
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (catMaybes)
 import Data.Semigroup (sconcat)
@@ -156,6 +158,11 @@ fatalText = fatal
 -- | Lift an Either result into the Diagnostics effect, given a ToDiagnostic instance for the error type
 fromEither :: (ToDiagnostic err, Has Diagnostics sig m) => Either err a -> m a
 fromEither = either fatal pure
+
+-- | Sometimes the only thing to do with the @Left@ part of an @Either a b@ is emit it as a warning.
+-- This function does that and eliminates the error value.
+warnLeft :: (ToDiagnostic warn, Has Diagnostics sig m) => Either warn a -> m (Maybe a)
+warnLeft = either (\e -> warn e $> Nothing) (pure . Just)
 
 -- | Lift an Either result into the Diagnostics effect, given a Show instance for the error type
 fromEitherShow :: (Show err, Has Diagnostics sig m) => Either err a -> m a

--- a/src/Strategy/Node/PackageJson.hs
+++ b/src/Strategy/Node/PackageJson.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -42,6 +43,7 @@ import Data.Glob (Glob)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
+import Data.String.Conversion (ToText)
 import Data.Tagged (Tagged)
 import Data.Text (Text)
 import DepTypes (
@@ -187,7 +189,9 @@ instance ToJSON PackageJson where
       , "peerDependencies" .= packagePeerDeps
       ]
 
-newtype Manifest = Manifest {unManifest :: Path Abs File} deriving (Eq, Show, Ord, Generic, ToJSONKey, ToJSON)
+newtype Manifest = Manifest {unManifest :: Path Abs File}
+  deriving (Eq, Show, Ord, Generic, ToJSONKey, ToJSON)
+  deriving (ToText) via (Path Abs File)
 
 data PkgJsonGraph = PkgJsonGraph
   { jsonGraph :: AM.AdjacencyMap Manifest

--- a/src/Strategy/Node/PackageJson.hs
+++ b/src/Strategy/Node/PackageJson.hs
@@ -43,7 +43,7 @@ import Data.Glob (Glob)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
-import Data.String.Conversion (ToText)
+import Data.String.Conversion (ToText (toText))
 import Data.Tagged (Tagged)
 import Data.Text (Text)
 import DepTypes (
@@ -232,3 +232,7 @@ data NodePackage = NodePackage
   , pkgConstraint :: Text
   }
   deriving (Eq, Ord, Show)
+
+instance ToText NodePackage where
+  toText NodePackage{pkgName, pkgConstraint} =
+    pkgName <> "@" <> pkgConstraint

--- a/src/Strategy/Node/YarnV2/Resolvers.hs
+++ b/src/Strategy/Node/YarnV2/Resolvers.hs
@@ -67,7 +67,7 @@ data Package
 
 -- | Search for a resolver that supports the Locator, and turn it into a Package
 resolveLocatorToPackage :: Has Diagnostics sig m => Locator -> m Package
-resolveLocatorToPackage locator = context ("Resolving locator " <> showT locator) $ do
+resolveLocatorToPackage locator = context ("Resolving " <> showT locator) $ do
   resolver <-
     fromMaybe @Text "Unsupported locator (no resolver found)" $
       find (`resolverSupportsLocator` locator) allResolvers

--- a/src/Strategy/Node/YarnV2/YarnLock.hs
+++ b/src/Strategy/Node/YarnV2/YarnLock.hs
@@ -107,7 +107,7 @@ resolveSingle (YarnLockfile lockfileMap) nodePkg =
       Diag.fromMaybe (DescriptorParse nodePkg) $
         tryParseDescriptor nodePkg
     let lookupRes = lookupPackage descriptor $ remap lockfileMap
-    res <- context ("Resolve " <> toText nodePkg) $ warnLeft lookupRes
+    res <- warnLeft lookupRes
     traverse (resolveLocatorToPackage . descResolution) res
 
 remap :: Ord k => Map [k] a -> Map k a


### PR DESCRIPTION
# Overview

Some customers have encountered issues where the CLI fails to resolve one of their transitive dependencies and then fails analysis for that whole project. I haven't been able to track down under exactly what conditions this happens and how to patch it, so for now this PR changes the behavior to emit a warning rather than failing analysis. 

## Acceptance criteria

* The CLI no longer fails when it gets a `Can't find package for descriptor...` error.

## Testing plan

I used as an example [backstage](https://github.com/backstage/backstage).

Scanning with the current master version of `fossa` results in failed projects and no dependencies.
Scanning with the version of the CLI on this branch will return results and warn about the missing dependencies.

## Risks

None.

## Metrics

## References

- [ANE-793](https://fossa.atlassian.net/browse/ANE-793).

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-793]: https://fossa.atlassian.net/browse/ANE-793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ