### PR TITLE
Fix release group options on analyze commands

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## 3.9.22
+- Fixes release group flags for `fossa analyze` and `fossa container analyze`  ([#1439](https://github.com/fossas/fossa-cli/pull/1439))
+
 ## 3.9.21
 - Add support for analyzing SBOM files ([#1435](https://github.com/fossas/fossa-cli/pull/1435))
 - License Scanning: Add the Llama-3-community license (No PR)

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -36,6 +36,7 @@ import App.Fossa.Config.Common (
   CacheAction (WriteOnly),
   CommonOpts (..),
   ScanDestination (..),
+  applyReleaseGroupDeprecationWarning,
   baseDirArg,
   collectApiOpts,
   collectBaseDir,
@@ -43,7 +44,6 @@ import App.Fossa.Config.Common (
   collectConfigMavenScopeFilters,
   collectRevisionData',
   commonOpts,
-  deprecateReleaseGroupMetadata,
   metadataOpts,
   pathOpt,
   targetOpt,
@@ -84,7 +84,7 @@ import Control.Effect.Diagnostics (
   recover,
  )
 import Control.Effect.Lift (Lift)
-import Control.Monad (when)
+import Control.Monad (void, when)
 import Data.Aeson (ToJSON (toEncoding), defaultOptions, genericToEncoding)
 import Data.Flag (Flag, flagOpt, fromFlag)
 import Data.Map qualified as Map
@@ -639,9 +639,9 @@ collectScanDestination maybeCfgFile envvars AnalyzeCliOpts{..} =
     else do
       apiOpts <- collectApiOpts maybeCfgFile envvars commons
       metaMerged <- maybe (pure analyzeMetadata) (mergeFileCmdMetadata analyzeMetadata) (maybeCfgFile)
-      projectMetadataWithoutReleaseGroup <- deprecateReleaseGroupMetadata metaMerged
+      void $ applyReleaseGroupDeprecationWarning metaMerged
       when (length (projectLabel metaMerged) > 5) $ fatalText "Projects are only allowed to have 5 associated project labels"
-      pure $ UploadScan apiOpts projectMetadataWithoutReleaseGroup
+      pure $ UploadScan apiOpts metaMerged
 
 collectModeOptions ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -336,32 +336,6 @@ validateApiKey maybeConfigFile EnvVars{envApiKey} CommonOpts{optAPIKey} = do
   textkey <-
     fromMaybeText "A FOSSA API key is required to run this command" $
       -- API key precedence is strictly defined:
-      -- API key precedence is strictly defined:
-      -- API key precedence is strictly defined:
-      -- API key precedence is strictly defined:
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 2. Config file (maybe used)
-      -- 2. Config file (maybe used)
-      -- 2. Config file (maybe used)
-      -- 2. Config file (maybe used)
-      -- 3. Environment Variable (most common)
-      -- 3. Environment Variable (most common)
-      -- 3. Environment Variable (most common)
-      -- 3. Environment Variable (most common)
-
-      -- API key precedence is strictly defined:
-      -- API key precedence is strictly defined:
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 2. Config file (maybe used)
-      -- 2. Config file (maybe used)
-      -- 3. Environment Variable (most common)
-      -- 3. Environment Variable (most common)
-
-      -- API key precedence is strictly defined:
       -- 1. Cmd-line option (rarely used, not encouraged)
       -- 2. Config file (maybe used)
       -- 3. Environment Variable (most common)
@@ -382,32 +356,6 @@ validateApiKeyGeneric ::
 validateApiKeyGeneric maybeConfigFile maybeEnvApiKey maybeOptAPIKey = do
   textkey <-
     fromMaybeText "A FOSSA API key is required to run this command" $
-      -- API key precedence is strictly defined:
-      -- API key precedence is strictly defined:
-      -- API key precedence is strictly defined:
-      -- API key precedence is strictly defined:
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 2. Config file (maybe used)
-      -- 2. Config file (maybe used)
-      -- 2. Config file (maybe used)
-      -- 2. Config file (maybe used)
-      -- 3. Environment Variable (most common)
-      -- 3. Environment Variable (most common)
-      -- 3. Environment Variable (most common)
-      -- 3. Environment Variable (most common)
-
-      -- API key precedence is strictly defined:
-      -- API key precedence is strictly defined:
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 1. Cmd-line option (rarely used, not encouraged)
-      -- 2. Config file (maybe used)
-      -- 2. Config file (maybe used)
-      -- 3. Environment Variable (most common)
-      -- 3. Environment Variable (most common)
-
       -- API key precedence is strictly defined:
       -- 1. Cmd-line option (rarely used, not encouraged)
       -- 2. Config file (maybe used)

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -47,7 +47,7 @@ module App.Fossa.Config.Common (
   configHelp,
   titleHelp,
   -- Deprecation
-  deprecateReleaseGroupMetadata,
+  applyReleaseGroupDeprecationWarning,
 ) where
 
 import App.Fossa.Config.ConfigFile (
@@ -126,7 +126,6 @@ import Options.Applicative (
   argument,
   auto,
   eitherReader,
-  internal,
   long,
   metavar,
   option,
@@ -144,7 +143,7 @@ import Options.Applicative.Help (AnsiStyle)
 import Path (Abs, Dir, File, Path, Rel, SomeBase (..), parseRelDir)
 import Path.Extra (SomePath (..))
 import Path.IO (resolveDir', resolveFile')
-import Prettyprinter (Doc, annotate)
+import Prettyprinter (Doc, Pretty (pretty), annotate)
 import Prettyprinter.Render.Terminal (Color (Green, Red), color)
 import Style (applyFossaStyle, boldItalicized, coloredBoldItalicized, formatDoc, stringToHelpDoc)
 import Text.Megaparsec (errorBundlePretty, runParser)
@@ -221,25 +220,38 @@ policyIdHelp =
 releaseGroupMetadataOpts :: Parser ReleaseGroupMetadata
 releaseGroupMetadataOpts =
   ReleaseGroupMetadata
-    <$> strOption (applyFossaStyle <> long "release-group-name" <> stringToHelpDoc "The name of the release group to add this project to" <> internal)
-    <*> strOption (applyFossaStyle <> long "release-group-release" <> stringToHelpDoc "The release of the release group to add this project to" <> internal)
+    <$> strOption (applyFossaStyle <> long "release-group-name" <> helpDoc releaseGroupNameHelp)
+    <*> strOption (applyFossaStyle <> long "release-group-release" <> helpDoc releaseGroupReleaseHelp)
 
-deprecateReleaseGroupMetadata :: Has Diagnostics sig m => ProjectMetadata -> m ProjectMetadata
-deprecateReleaseGroupMetadata projectMetadata = do
+releaseGroupNameHelp :: Maybe (Doc AnsiStyle)
+releaseGroupNameHelp =
+  Just . formatDoc $
+    vsep
+      [ "The name of the release group to add this project to"
+      , boldItalicized "Note: " <> pretty releaseGroupDeprecationMessage
+      ]
+
+releaseGroupReleaseHelp :: Maybe (Doc AnsiStyle)
+releaseGroupReleaseHelp =
+  Just . formatDoc $
+    vsep
+      [ "The release of the release group to add this project to"
+      , boldItalicized "Note: " <> pretty releaseGroupDeprecationMessage
+      ]
+
+applyReleaseGroupDeprecationWarning :: Has Diagnostics sig m => ProjectMetadata -> m ()
+applyReleaseGroupDeprecationWarning projectMetadata = do
   case (projectReleaseGroup projectMetadata) of
-    Nothing -> pure projectMetadata
+    Nothing -> pure ()
     Just _ -> do
-      warn deprecationMessage
-      pure $ removeReleaseGroupMetadata projectMetadata
-  where
-    removeReleaseGroupMetadata :: ProjectMetadata -> ProjectMetadata
-    removeReleaseGroupMetadata project = project{projectReleaseGroup = Nothing}
+      warn releaseGroupDeprecationMessage
+      pure ()
 
-    deprecationMessage :: Text
-    deprecationMessage =
-      renderIt $
-        vsep
-          [annotate (color Red) "Release group options for this command have been deprecated. Refer to `fossa release-group` subcommands to interact with FOSSA release groups."]
+releaseGroupDeprecationMessage :: Text
+releaseGroupDeprecationMessage =
+  renderIt $
+    vsep
+      [annotate (color Red) "Release group options for this command will soon be deprecated. Refer to `fossa release-group` subcommands to interact with FOSSA release groups."]
 
 pathOpt :: String -> Either String (Path Rel Dir)
 pathOpt = first show . parseRelDir
@@ -324,6 +336,32 @@ validateApiKey maybeConfigFile EnvVars{envApiKey} CommonOpts{optAPIKey} = do
   textkey <-
     fromMaybeText "A FOSSA API key is required to run this command" $
       -- API key precedence is strictly defined:
+      -- API key precedence is strictly defined:
+      -- API key precedence is strictly defined:
+      -- API key precedence is strictly defined:
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 2. Config file (maybe used)
+      -- 2. Config file (maybe used)
+      -- 2. Config file (maybe used)
+      -- 2. Config file (maybe used)
+      -- 3. Environment Variable (most common)
+      -- 3. Environment Variable (most common)
+      -- 3. Environment Variable (most common)
+      -- 3. Environment Variable (most common)
+
+      -- API key precedence is strictly defined:
+      -- API key precedence is strictly defined:
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 2. Config file (maybe used)
+      -- 2. Config file (maybe used)
+      -- 3. Environment Variable (most common)
+      -- 3. Environment Variable (most common)
+
+      -- API key precedence is strictly defined:
       -- 1. Cmd-line option (rarely used, not encouraged)
       -- 2. Config file (maybe used)
       -- 3. Environment Variable (most common)
@@ -344,6 +382,32 @@ validateApiKeyGeneric ::
 validateApiKeyGeneric maybeConfigFile maybeEnvApiKey maybeOptAPIKey = do
   textkey <-
     fromMaybeText "A FOSSA API key is required to run this command" $
+      -- API key precedence is strictly defined:
+      -- API key precedence is strictly defined:
+      -- API key precedence is strictly defined:
+      -- API key precedence is strictly defined:
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 2. Config file (maybe used)
+      -- 2. Config file (maybe used)
+      -- 2. Config file (maybe used)
+      -- 2. Config file (maybe used)
+      -- 3. Environment Variable (most common)
+      -- 3. Environment Variable (most common)
+      -- 3. Environment Variable (most common)
+      -- 3. Environment Variable (most common)
+
+      -- API key precedence is strictly defined:
+      -- API key precedence is strictly defined:
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 1. Cmd-line option (rarely used, not encouraged)
+      -- 2. Config file (maybe used)
+      -- 2. Config file (maybe used)
+      -- 3. Environment Variable (most common)
+      -- 3. Environment Variable (most common)
+
       -- API key precedence is strictly defined:
       -- 1. Cmd-line option (rarely used, not encouraged)
       -- 2. Config file (maybe used)

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -11,7 +11,7 @@ import App.Fossa.Analyze.Debug (collectDebugBundle)
 import App.Fossa.Analyze.Upload (emitBuildWarnings)
 import App.Fossa.Config.Common (
   ScanDestination (OutputStdout, UploadScan),
-  deprecateReleaseGroupMetadata,
+  applyReleaseGroupDeprecationWarning,
  )
 import App.Fossa.Config.Container.Analyze (
   ContainerAnalyzeConfig (..),
@@ -141,8 +141,8 @@ uploadScan revision projectMeta jsonOutput containerScan =
     if not supportsNativeScan
       then fatal (EndpointDoesNotSupportNativeContainerScan getSourceLocation)
       else do
-        projectMetadataWithoutReleaseGroup <- deprecateReleaseGroupMetadata projectMeta
-        resp <- uploadNativeContainerScan revision projectMetadataWithoutReleaseGroup containerScan
+        void $ applyReleaseGroupDeprecationWarning projectMeta
+        resp <- uploadNativeContainerScan revision projectMeta containerScan
         emitBuildWarnings resp
         let locator = uploadLocator resp
         buildUrl <- getFossaBuildUrl revision locator


### PR DESCRIPTION
# Overview

These flags are being superseded by fossa release-group commands, but for backwards compatibility they should still work with analyze. They do not, even though we document them as existing.


## Acceptance criteria

- These flags work again.

- The CLI prints the deprecation message in  when either option is used.

## Testing plan

- `git checkout fix-analyze`

Shows the help message for release group options of `fossa analyze`
- `cabal run fossa -- analyze -h `

Fossa analyze with release group options. This will show a warning message when the release group options are used

- `cabal run fossa -- analyze --debug --release-group-name <name> --release-group-release <release>   /path/`

## Risks

## Metrics

## References

_Example:_

- [ANE-1804](https://fossa.atlassian.net/browse/ANE-1804)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1804]: https://fossa.atlassian.net/browse/ANE-1804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ