### PR TITLE
Ane 1808 suppress reachability notice

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Reachability: For organizations that don't have reachability turned on suppress messages about it. ([#1440](https://github.com/fossas/fossa-cli/pull/1440))
+
 ## 3.9.22
 - Fixes release group flags for `fossa analyze` and `fossa container analyze`  ([#1439](https://github.com/fossas/fossa-cli/pull/1439))
 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -302,9 +302,10 @@ analyze cfg = Diag.context "fossa-analyze" $ do
           pure Nothing
         else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir customFossaDepsFile maybeApiOpts vendoredDepsOptions
 
-  _ <- case destination of
-    OutputStdout -> pure ()
-    UploadScan apiOpts metadata -> runFossaApiClient apiOpts $ preflightChecks $ AnalyzeChecks revision metadata
+  orgInfo <- case destination of
+    OutputStdout -> pure Nothing
+    UploadScan apiOpts metadata ->
+      fmap Just . runFossaApiClient apiOpts . preflightChecks $ AnalyzeChecks revision metadata
 
   -- additional source units are built outside the standard strategy flow, because they either
   -- require additional information (eg API credentials), or they return additional information (eg user deps).
@@ -410,7 +411,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   let reachabilityUnits = onlyFoundUnits reachabilityUnitsResult
 
   let analysisResult = AnalysisScanResult projectScans vsiResults binarySearchResults manualSrcUnits dynamicLinkedResults maybeLernieResults reachabilityUnitsResult
-  renderScanSummary (severity cfg) maybeEndpointAppVersion analysisResult cfg
+  renderScanSummary (severity cfg) maybeEndpointAppVersion analysisResult cfg orgInfo
 
   -- Need to check if vendored is empty as well, even if its a boolean that vendoredDeps exist
   let licenseSourceUnits =

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -415,7 +415,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   let reachabilityUnits = onlyFoundUnits reachabilityUnitsResult
 
   let analysisResult = AnalysisScanResult projectScans vsiResults binarySearchResults manualSrcUnits dynamicLinkedResults maybeLernieResults reachabilityUnitsResult
-  renderScanSummary (severity cfg) maybeEndpointAppVersion analysisResult cfg orgInfo
+  renderScanSummary (severity cfg) maybeEndpointAppVersion analysisResult cfg
 
   -- Need to check if vendored is empty as well, even if its a boolean that vendoredDeps exist
   let licenseSourceUnits =

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -44,7 +44,6 @@ import Effect.Logger (
   hsep,
   logInfo,
  )
-import Fossa.API.Types (Organization (Organization, orgSupportsReachability))
 import Path (
   Abs,
   Dir,
@@ -149,12 +148,12 @@ staticOnlyAnalysisMessage =
 -- * __poetry__ project in path: succeeded
 -- * __fpm__ project in path: skipped
 -- * __setuptools__ project in path: skipped
-renderScanSummary :: (Has Diag.Diagnostics sig m, Has Logger sig m, Has (Lift IO) sig m) => Severity -> (Maybe Text) -> AnalysisScanResult -> Config.AnalyzeConfig -> Maybe Organization -> m ()
-renderScanSummary severity maybeEndpointVersion analysisResults cfg orgInfo = do
+renderScanSummary :: (Has Diag.Diagnostics sig m, Has Logger sig m, Has (Lift IO) sig m) => Severity -> (Maybe Text) -> AnalysisScanResult -> Config.AnalyzeConfig -> m ()
+renderScanSummary severity maybeEndpointVersion analysisResults cfg = do
   let endpointVersion = fromMaybe "N/A" maybeEndpointVersion
   let hasDefaultFilters = (not $ fromFlag Config.WithoutDefaultFilters $ Config.withoutDefaultFilters cfg)
 
-  case summarize cfg orgInfo endpointVersion analysisResults of
+  case summarize cfg endpointVersion analysisResults of
     Nothing -> pure ()
     Just summary -> do
       let someFilters = isMempty cfg.filterSet
@@ -163,7 +162,7 @@ renderScanSummary severity maybeEndpointVersion analysisResults cfg orgInfo = do
       logInfo "-----"
       logInfoVsep $ renderNotes someFilters hasDefaultFilters (severity /= SevDebug)
 
-      summaryWithWarnErrorsTmpFile <- dumpResultLogsToTempFile cfg orgInfo endpointVersion analysisResults
+      summaryWithWarnErrorsTmpFile <- dumpResultLogsToTempFile cfg endpointVersion analysisResults
       logInfo . pretty $ "You can also view analysis summary with warning and error messages at: " <> show summaryWithWarnErrorsTmpFile
       logInfo "------------"
 
@@ -193,8 +192,8 @@ renderDefaultSkippedTargetHelp =
   , ""
   ]
 
-summarize :: Config.AnalyzeConfig -> Maybe Organization -> Text -> AnalysisScanResult -> Maybe ([Doc AnsiStyle])
-summarize cfg orgInfo endpointVersion (AnalysisScanResult dps vsi binary manualDeps dynamicLinkingDeps lernie reachabilityAttempts) =
+summarize :: Config.AnalyzeConfig -> Text -> AnalysisScanResult -> Maybe ([Doc AnsiStyle])
+summarize cfg endpointVersion (AnalysisScanResult dps vsi binary manualDeps dynamicLinkingDeps lernie reachabilityAttempts) =
   if (numProjects totalScanCount <= 0)
     then Nothing
     else
@@ -221,9 +220,11 @@ summarize cfg orgInfo endpointVersion (AnalysisScanResult dps vsi binary manualD
           <> reachabilitySummary
           <> [""]
   where
-    reachabilitySummary = case orgInfo of
-      (Just Organization{orgSupportsReachability = False}) -> []
-      _ -> summarizeReachability "Reachability analysis" reachabilityAttempts
+    reachabilitySummary =
+      if null reachabilityAttempts
+        then
+          []
+        else summarizeReachability "Reachability analysis" reachabilityAttempts
     vsiResults = summarizeSrcUnit "vsi analysis" (Just (join . map vsiSourceUnits)) vsi
     projects = sort dps
     totalScanCount =
@@ -425,8 +426,8 @@ countWarnings ws =
     isIgnoredErrGroup IgnoredErrGroup{} = True
     isIgnoredErrGroup _ = False
 
-dumpResultLogsToTempFile :: (Has (Lift IO) sig m) => Config.AnalyzeConfig -> Maybe Organization -> Text -> AnalysisScanResult -> m (Path Abs File)
-dumpResultLogsToTempFile cfg orgInfo endpointVersion (AnalysisScanResult projects vsi binary manualDeps dynamicLinkingDeps lernieResults reachabilityAttempts) = do
+dumpResultLogsToTempFile :: (Has (Lift IO) sig m) => Config.AnalyzeConfig -> Text -> AnalysisScanResult -> m (Path Abs File)
+dumpResultLogsToTempFile cfg endpointVersion (AnalysisScanResult projects vsi binary manualDeps dynamicLinkingDeps lernieResults reachabilityAttempts) = do
   let doc =
         stripAnsiEscapeCodes
           . renderStrict
@@ -449,7 +450,7 @@ dumpResultLogsToTempFile cfg orgInfo endpointVersion (AnalysisScanResult project
   pure (tmpDir </> scanSummaryFileName)
   where
     scanSummary :: [Doc AnsiStyle]
-    scanSummary = maybeToList (vsep <$> summarize cfg orgInfo endpointVersion (AnalysisScanResult projects vsi binary manualDeps dynamicLinkingDeps lernieResults reachabilityAttempts))
+    scanSummary = maybeToList (vsep <$> summarize cfg endpointVersion (AnalysisScanResult projects vsi binary manualDeps dynamicLinkingDeps lernieResults reachabilityAttempts))
 
     renderSourceUnit :: Doc AnsiStyle -> Result (Maybe a) -> Maybe (Doc AnsiStyle)
     renderSourceUnit header (Failure ws eg) = Just $ renderFailure ws eg $ vsep $ summarizeSrcUnit header Nothing (Failure ws eg)

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -109,7 +109,11 @@ analyze cfg = do
 
   _ <- case scanDestination cfg of
     OutputStdout -> pure ()
-    UploadScan apiOpts projectMetadata -> runFossaApiClient apiOpts $ preflightChecks $ AnalyzeChecks revision projectMetadata
+    UploadScan apiOpts projectMetadata ->
+      void
+        . runFossaApiClient apiOpts
+        . preflightChecks
+        $ AnalyzeChecks revision projectMetadata
 
   logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")
   logInfo ("Using project revision: `" <> pretty (projectRevision revision) <> "`")

--- a/src/App/Fossa/Lernie/Analyze.hs
+++ b/src/App/Fossa/Lernie/Analyze.hs
@@ -91,8 +91,9 @@ analyzeWithLernieWithOrgInfo ::
   GrepOptions ->
   m (Maybe LernieResults)
 analyzeWithLernieWithOrgInfo rootDir grepOptions = do
-  orgWideCustomLicenses <- orgCustomLicenseScanConfigs <$> getOrganization
-  uploadKind <- orgFileUpload <$> getOrganization
+  org <- getOrganization
+  let orgWideCustomLicenses = orgCustomLicenseScanConfigs org
+      uploadKind = orgFileUpload org
 
   let options = grepOptions{customLicenseSearch = nub $ orgWideCustomLicenses <> customLicenseSearch grepOptions}
   analyzeWithLernieMain rootDir options uploadKind

--- a/src/App/Fossa/PreflightChecks.hs
+++ b/src/App/Fossa/PreflightChecks.hs
@@ -41,22 +41,24 @@ data PreflightCommandChecks
   | ReportChecks
   | AssertUserDefinedBinariesChecks
 
+-- | Returns the Organization used to decide pass or fail for the checks.
 guardWithPreflightChecks ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
   ) =>
   ApiOpts ->
   PreflightCommandChecks ->
-  m ()
+  m Organization
 guardWithPreflightChecks apiOpts cmd = ignoreDebug $ runFossaApiClient apiOpts $ preflightChecks cmd
 
+-- | Returns the Organization used to decide pass or fail for the checks.
 preflightChecks ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
   , Has FossaApiClient sig m
   ) =>
   PreflightCommandChecks ->
-  m ()
+  m Organization
 preflightChecks cmd = context "preflight-checks" $ do
   -- Check for writing to temp dir
   tmpDir <- sendIO getTempDir
@@ -78,6 +80,7 @@ preflightChecks cmd = context "preflight-checks" $ do
             fullAccessTokenCheck tokenType
             premiumSubscriptionCheck org
           _ -> pure ()
+  pure org
 
 uploadBuildPermissionsCheck :: Has Diagnostics sig m => CustomBuildUploadPermissions -> m ()
 uploadBuildPermissionsCheck CustomBuildUploadPermissions{..} =

--- a/src/App/Fossa/PreflightChecks.hs
+++ b/src/App/Fossa/PreflightChecks.hs
@@ -41,7 +41,7 @@ data PreflightCommandChecks
   | ReportChecks
   | AssertUserDefinedBinariesChecks
 
--- | Returns the Organization used to decide pass or fail for the checks.
+-- | Returns the Organization fetched as part of the checks.
 guardWithPreflightChecks ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
@@ -51,7 +51,7 @@ guardWithPreflightChecks ::
   m Organization
 guardWithPreflightChecks apiOpts cmd = ignoreDebug $ runFossaApiClient apiOpts $ preflightChecks cmd
 
--- | Returns the Organization used to decide pass or fail for the checks.
+-- | Returns the Organization fetched as part of the checks.
 preflightChecks ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m

--- a/src/App/Fossa/SBOM/Analyze.hs
+++ b/src/App/Fossa/SBOM/Analyze.hs
@@ -37,7 +37,7 @@ analyze config = do
   let emptyMetadata = ProjectMetadata Nothing Nothing Nothing Nothing Nothing Nothing [] Nothing
   let apiOpts = sbomApiOpts config
   trackUsage SBOMAnalyzeUsage
-  runFossaApiClient apiOpts . preflightChecks $ AnalyzeChecks (sbomRevision config) emptyMetadata
+  void . runFossaApiClient apiOpts . preflightChecks $ AnalyzeChecks (sbomRevision config) emptyMetadata
   runFossaApiClient apiOpts . runStickyLogger (severity config) $ analyzeInternal config
 
 analyzeInternal ::

--- a/test/App/Fossa/PreflightChecksSpec.hs
+++ b/test/App/Fossa/PreflightChecksSpec.hs
@@ -4,6 +4,10 @@ import App.Fossa.PreflightChecks (PreflightCommandChecks (..), preflightChecks)
 import Control.Algebra (Has)
 import Control.Carrier.Debug (ignoreDebug)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
+import Fossa.API.Types (
+  Organization (orgSubscription, orgSupportsPreflightChecks),
+  Subscription (Premium),
+ )
 import Test.Effect (expectFatal', it', shouldBe')
 import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec)
@@ -40,10 +44,11 @@ spec = do
       res <- ignoreDebug $ preflightChecks TestChecks
       res `shouldBe'` Fixtures.organizationWithPreflightChecks
     it' "should pass all check for report command" $ do
+      let expected = Fixtures.organizationWithPreflightChecks{orgSubscription = Premium}
       expectOrganizationWithPremiumSubscription
       expectFullAccessToken
       res <- preflightChecks ReportChecks
-      res `shouldBe'` Fixtures.organizationWithPreflightChecks
+      res `shouldBe'` expected
     it' "should fail full access token check for report command" $ do
       expectOrganizationWithPremiumSubscription
       expectPushToken
@@ -58,9 +63,10 @@ spec = do
       res <- ignoreDebug $ preflightChecks analyzeChecks
       res `shouldBe'` Fixtures.organizationWithPreflightChecks
     it' "should pass all checks while skipping permission checks for analyze command" $ do
+      let expected = Fixtures.organizationWithPreflightChecks{orgSupportsPreflightChecks = False}
       expectOrganization
       res <- ignoreDebug $ preflightChecks analyzeChecks
-      res `shouldBe'` Fixtures.organizationWithPreflightChecks
+      res `shouldBe'` expected
     it' "should fail edit project check for analyze command" $ do
       expectOrganizationWithPreflightChecks
       (GetCustomBuildPermissons Fixtures.projectRevision Fixtures.projectMetadata) `returnsOnce` Fixtures.invalidEditProjectPermission

--- a/test/App/Fossa/PreflightChecksSpec.hs
+++ b/test/App/Fossa/PreflightChecksSpec.hs
@@ -38,12 +38,12 @@ spec = do
     it' "should pass all checks for test command" $ do
       expectOrganizationWithPreflightChecks
       res <- ignoreDebug $ preflightChecks TestChecks
-      res `shouldBe'` ()
+      res `shouldBe'` Fixtures.organizationWithPreflightChecks
     it' "should pass all check for report command" $ do
       expectOrganizationWithPremiumSubscription
       expectFullAccessToken
       res <- preflightChecks ReportChecks
-      res `shouldBe'` ()
+      res `shouldBe'` Fixtures.organizationWithPreflightChecks
     it' "should fail full access token check for report command" $ do
       expectOrganizationWithPremiumSubscription
       expectPushToken
@@ -56,11 +56,11 @@ spec = do
       expectOrganizationWithPreflightChecks
       (GetCustomBuildPermissons Fixtures.projectRevision Fixtures.projectMetadata) `returnsOnce` Fixtures.validCustomUploadPermissions
       res <- ignoreDebug $ preflightChecks analyzeChecks
-      res `shouldBe'` ()
+      res `shouldBe'` Fixtures.organizationWithPreflightChecks
     it' "should pass all checks while skipping permission checks for analyze command" $ do
       expectOrganization
       res <- ignoreDebug $ preflightChecks analyzeChecks
-      res `shouldBe'` ()
+      res `shouldBe'` Fixtures.organizationWithPreflightChecks
     it' "should fail edit project check for analyze command" $ do
       expectOrganizationWithPreflightChecks
       (GetCustomBuildPermissons Fixtures.projectRevision Fixtures.projectMetadata) `returnsOnce` Fixtures.invalidEditProjectPermission


### PR DESCRIPTION
# Overview

Reachability analysis is quite noisy, and many customers don't have it enabled for their organization anyways. This PR changes it so that:

1. Reachability analysis is skipped when the organization doesn't have reachability enabled. This means that "reachability not supported" messages as well as the entire reachability summary isn't printed out.
2. For an organization that does have it enabled, the messages will be the same. These are noisy, but we can refine them a bit in the future.
3. It still outputs a single message about reachability being turned off at the end of analysis regardless of whether reachability is enabled or not.
4. It will still try to do analysis and print out the analysis log messages with the `-o` option. We have no way of knowing if reachability is enabled in that case so it defaults to doing it. 

## Acceptance criteria

The output isn't nearly as noisy.

## Testing plan

I tested by analyzing projects while having reachability analysis enabled or disabled in my organization.

## Risks

None.

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

[ANE-1808](https://fossa.atlassian.net/browse/ANE-1808)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1808]: https://fossa.atlassian.net/browse/ANE-1808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ