### PR TITLE
[ANE-1692] CLI communicates with analysis.fossa.com by default

### DIFF
--- a/docs/references/files/fossa-yml.md
+++ b/docs/references/files/fossa-yml.md
@@ -8,7 +8,7 @@ The following example is a configuration file with all available fields filled d
 ```yaml
 version: 3
 
-server: https://app.fossa.com
+server: https://platform.fossa.com
 apiKey: a1b2c3
 
 project:
@@ -16,7 +16,7 @@ project:
   id: github.com/fossas/fossa-cli
   name: fossa-cli
   team: cli-team
-  teams: 
+  teams:
     - cli-team-1
     - cli-team-2
   policy: custom-cli-policy
@@ -36,7 +36,7 @@ releaseGroup:
   releaseGroupProjects:
     - projectLocator: custom+123/git@github.com/fossas/fossa-cli
       projectRevision: "12345"
-      projectBranch: master 
+      projectBranch: master
     - projectLocator: custom+123/git@github.com/example
       projectRevision: "67890"
       projectBranch: master
@@ -97,7 +97,7 @@ Specifies the version of configuration file. Versions 1 and 2 were used by CLI v
 ### `server:`
 Sets the endpoint that the CLI will send requests to. This field should only be modified if your FOSSA account lives on a different server than app.fossa.com. This is most commonly needed with on-premise instances of FOSSA.
 
-Default: `https://app.fossa.com`
+Default: `https://platform.fossa.com`
 
 ### `apiKey:`
 Sets the [FOSSA API key](https://docs.fossa.com/docs/api-reference#api-tokens) that is required for accessing the FOSSA API and uploading data (e.g. `fossa analyze`) or retrieving information (e.g. `fossa test`) about a project.
@@ -142,7 +142,7 @@ Default:
 
 >NOTE:
     A project's ID cannot be modified after a project is created. If you change the ID,
-    you will be interacting with a different project. If the new ID does not exist, 
+    you will be interacting with a different project. If the new ID does not exist,
     a new project will be created for it.
 
 <img src="../../assets/project-id-example.png">
@@ -193,7 +193,7 @@ The releaseGroup field allows you to configure settings for the release group yo
 
 >NOTE: releaseGroup configurations are only allowed for `fossa release-group create` and `fossa release-group add-project`. This is done so that release groups are not mistakenly deleted.
 
->NOTE: release-group command line options will always take precedence over configurations set in `fossa.yml`. 
+>NOTE: release-group command line options will always take precedence over configurations set in `fossa.yml`.
 
 #### `releaseGroup.title:`
 The title of the release group which can be seen in the FOSSA dashboard.
@@ -206,7 +206,7 @@ The release associated with the release group.
 <img src="../../assets//release-example.png">
 
 #### `releaseGroup.releaseGroupProjects:`
-The projects associated with the release group's release. 
+The projects associated with the release group's release.
 
 >NOTE: At least one project must be specified upon creating a release group.
 
@@ -396,9 +396,9 @@ You can provide maven dependency scopes that you would like to filter. You can f
 
 #### scope-only:
 
-The list of `only` scopes that should by scanned. 
+The list of `only` scopes that should by scanned.
 
-When a dependency is multi-scope (i.e. [compile, runtime]) ALL of the scopes must be conatined in `scope-only` for the dependency to be included in the scan results. 
+When a dependency is multi-scope (i.e. [compile, runtime]) ALL of the scopes must be conatined in `scope-only` for the dependency to be included in the scan results.
 
 #### scope-exclude:
 
@@ -440,7 +440,7 @@ In the CLI, project ID refers to a specific portion of a project locator. When r
 
 After project ID is set, the CLI will use that value to construct a project locator on first time analysis. A project locator is a unique ID that the FOSSA API will use to reference a project across FOSSA.
 
-> NOTE: Projects uploaded through the CLI will have `custom` embedded into the project locator. 
+> NOTE: Projects uploaded through the CLI will have `custom` embedded into the project locator.
 
 <img src="../../assets/project-locator-example.png">
 
@@ -448,4 +448,4 @@ After project ID is set, the CLI will use that value to construct a project loca
 
 Project ID should be used when referencing projects uploaded via the CLI. In most cases, providing just a project ID is sufficient. However, when referencing projects uploaded through avenues outside the CLI (Quick Import, Archive Upload, etc), providing just a project ID fails. This is due to the nature of FOSSA's project naming conventions as project locators are constructed differently depending on how a project was uploaded. There is no way to tell at runtime which project a user is referencing when only given a project ID (i.e. Is this a project uploaded via the CLI or Archive Upload?).
 
-In `fossa release-group` project locator is used to reference projects that will be added to your release group's release. By using project locator, all FOSSA project upload flows are covered and the CLI is able to determine the specific project a user is trying to add to a release. 
+In `fossa release-group` project locator is used to reference projects that will be added to your release group's release. By using project locator, all FOSSA project upload flows are covered and the CLI is able to determine the specific project a user is trying to add to a release.

--- a/docs/references/files/fossa-yml.md
+++ b/docs/references/files/fossa-yml.md
@@ -8,7 +8,7 @@ The following example is a configuration file with all available fields filled d
 ```yaml
 version: 3
 
-server: https://platform.fossa.com
+server: https://analysis.fossa.com
 apiKey: a1b2c3
 
 project:
@@ -97,7 +97,7 @@ Specifies the version of configuration file. Versions 1 and 2 were used by CLI v
 ### `server:`
 Sets the endpoint that the CLI will send requests to. This field should only be modified if your FOSSA account lives on a different server than app.fossa.com. This is most commonly needed with on-premise instances of FOSSA.
 
-Default: `https://platform.fossa.com`
+Default: `https://analysis.fossa.com`
 
 ### `apiKey:`
 Sets the [FOSSA API key](https://docs.fossa.com/docs/api-reference#api-tokens) that is required for accessing the FOSSA API and uploading data (e.g. `fossa analyze`) or retrieving information (e.g. `fossa test`) about a project.

--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -17,6 +17,7 @@ import Control.Effect.FossaApiClient (
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text.Extra (showT)
+import Debug.Trace (traceM)
 import Fossa.API.Types (ApiOpts (..), Organization (..))
 import Srclib.Types (Locator (..))
 import Text.URI qualified as URI
@@ -45,11 +46,13 @@ getFossaBuildUrl :: (Has Diagnostics sig m, Has FossaApiClient sig m) => Project
 getFossaBuildUrl revision locator = do
   maybeOrg <- recover getOrganization
   apiOpts <- getApiOpts
+  traceM $ "apiOpts: " <> show apiOpts
   getBuildURLWithOrg maybeOrg revision apiOpts locator
 
 getBuildURLWithOrg :: Has Diagnostics sig m => Maybe Organization -> ProjectRevision -> ApiOpts -> Locator -> m Text
 getBuildURLWithOrg maybeOrg revision apiOpts locator = do
-  let baseURI = fromMaybe [uri|https://app.fossa.com|] (apiOptsUri apiOpts)
+  let apiURI = if (apiOptsUri apiOpts == Just ([uri|https://analysis.fossa.com|])) then Just ([uri|https://app.fossa.com|]) else (apiOptsUri apiOpts)
+  let baseURI = fromMaybe [uri|https://app.fossa.com|] apiURI
       projectPath = fossaProjectUrlPath locator revision
 
   (path, query) <- case maybeOrg of

--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -51,8 +51,7 @@ getFossaBuildUrl revision locator = do
 
 getBuildURLWithOrg :: Has Diagnostics sig m => Maybe Organization -> ProjectRevision -> ApiOpts -> Locator -> m Text
 getBuildURLWithOrg maybeOrg revision apiOpts locator = do
-  let apiURI = if (apiOptsUri apiOpts == Just ([uri|https://analysis.fossa.com|])) then Just ([uri|https://app.fossa.com|]) else (apiOptsUri apiOpts)
-  let baseURI = fromMaybe [uri|https://app.fossa.com|] apiURI
+  let baseURI = fromMaybe [uri|https://app.fossa.com|] (apiOptsUri apiOpts)
       projectPath = fossaProjectUrlPath locator revision
 
   (path, query) <- case maybeOrg of

--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -17,7 +17,6 @@ import Control.Effect.FossaApiClient (
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text.Extra (showT)
-import Debug.Trace (traceM)
 import Fossa.API.Types (ApiOpts (..), Organization (..))
 import Srclib.Types (Locator (..))
 import Text.URI qualified as URI
@@ -46,7 +45,6 @@ getFossaBuildUrl :: (Has Diagnostics sig m, Has FossaApiClient sig m) => Project
 getFossaBuildUrl revision locator = do
   maybeOrg <- recover getOrganization
   apiOpts <- getApiOpts
-  traceM $ "apiOpts: " <> show apiOpts
   getBuildURLWithOrg maybeOrg revision apiOpts locator
 
 getBuildURLWithOrg :: Has Diagnostics sig m => Maybe Organization -> ProjectRevision -> ApiOpts -> Locator -> m Text

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -560,7 +560,7 @@ endpointHelp =
   Just . formatDoc $
     vsep
       [ "The FOSSA API server base URL"
-      , boldItalicized "Default: " <> "https://platform.fossa.com"
+      , boldItalicized "Default: " <> "https://analysis.fossa.com"
       ]
 
 fossaApiKeyHelp :: Maybe (Doc AnsiStyle)

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -560,7 +560,7 @@ endpointHelp =
   Just . formatDoc $
     vsep
       [ "The FOSSA API server base URL"
-      , boldItalicized "Default: " <> "https://app.fossa.com"
+      , boldItalicized "Default: " <> "https://platform.fossa.com"
       ]
 
 fossaApiKeyHelp :: Maybe (Doc AnsiStyle)

--- a/src/App/Fossa/Init/.fossa.yml
+++ b/src/App/Fossa/Init/.fossa.yml
@@ -14,8 +14,8 @@ version: 3
 
 # # Sets the endpoint that the CLI will send requests to.
 # # Modify only if your FOSSA account lives on a different server than app.fossa.com.
-# # Default: https://app.fossa.com
-# server: https://app.fossa.com
+# # Default: https://analysis.fossa.com
+# server: https://analysis.fossa.com
 #
 #
 # # Sets the FOSSA API key required for accessing the FOSSA API and uploading/retrieving project data.
@@ -108,7 +108,7 @@ version: 3
 #   # The release associated with the release group.
 #   release: release-group-release
 #
-#   # The projects associated with the release group's release 
+#   # The projects associated with the release group's release
 #   # NOTE:
 #   #   `projectLocator` , `projectRevision`, and `projectBranch` must all be specified when providing a releaseGroupProject.
 #   releaseGroupProjects:
@@ -121,7 +121,7 @@ version: 3
 #       projectRevision:  12345
 #
 #     # The branch associated with the project
-#       projectBranch: master 
+#       projectBranch: master
 #
 #   # Name of the license policy in your FOSSA organization to associate with this release group.
 #   # See documentation for details: https://docs.fossa.com/docs/configuring-a-licensing-policy

--- a/src/Control/Carrier/Telemetry/Sink/Endpoint.hs
+++ b/src/Control/Carrier/Telemetry/Sink/Endpoint.hs
@@ -56,7 +56,7 @@ useApiOpts opts = case useURI serverURI of
   Just (Right (url, options)) -> Just (url, options <> authHeader opts)
   where
     serverURI :: URI
-    serverURI = fromMaybe [uri|https://platform.fossa.com|] (Fossa.API.Types.apiOptsUri opts)
+    serverURI = fromMaybe [uri|https://analysis.fossa.com|] (Fossa.API.Types.apiOptsUri opts)
 
     authHeader :: Fossa.API.Types.ApiOpts -> Option 'Https
     authHeader (Fossa.API.Types.ApiOpts _ (Fossa.API.Types.ApiKey key) _) = header "Authorization" $ encodeUtf8 $ "Bearer " <> key

--- a/src/Control/Carrier/Telemetry/Sink/Endpoint.hs
+++ b/src/Control/Carrier/Telemetry/Sink/Endpoint.hs
@@ -56,7 +56,7 @@ useApiOpts opts = case useURI serverURI of
   Just (Right (url, options)) -> Just (url, options <> authHeader opts)
   where
     serverURI :: URI
-    serverURI = fromMaybe [uri|https://app.fossa.com|] (Fossa.API.Types.apiOptsUri opts)
+    serverURI = fromMaybe [uri|https://platform.fossa.com|] (Fossa.API.Types.apiOptsUri opts)
 
     authHeader :: Fossa.API.Types.ApiOpts -> Option 'Https
     authHeader (Fossa.API.Types.ApiOpts _ (Fossa.API.Types.ApiKey key) _) = header "Authorization" $ encodeUtf8 $ "Bearer " <> key

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -817,7 +817,7 @@ useApiOpts opts = case useURI serverURI of
   Just (Left (url, options)) -> pure (Unsafe.unsafeCoerce url, coerce options <> authHeader (apiOptsApiKey opts))
   Just (Right (url, options)) -> pure (url, options <> authHeader (apiOptsApiKey opts))
   where
-    serverURI = fromMaybe [uri|https://app.fossa.com|] (apiOptsUri opts)
+    serverURI = fromMaybe [uri|https://platform.fossa.com|] (apiOptsUri opts)
 
 authHeader :: ApiKey -> Option 'Https
 authHeader key = header "Authorization" (encodeUtf8 ("Bearer " <> unApiKey key))

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -817,7 +817,7 @@ useApiOpts opts = case useURI serverURI of
   Just (Left (url, options)) -> pure (Unsafe.unsafeCoerce url, coerce options <> authHeader (apiOptsApiKey opts))
   Just (Right (url, options)) -> pure (url, options <> authHeader (apiOptsApiKey opts))
   where
-    serverURI = fromMaybe [uri|https://platform.fossa.com|] (apiOptsUri opts)
+    serverURI = fromMaybe [uri|https://analysis.fossa.com|] (apiOptsUri opts)
 
 authHeader :: ApiKey -> Option 'Https
 authHeader key = header "Authorization" (encodeUtf8 ("Bearer " <> unApiKey key))

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -72,7 +72,7 @@ spec = do
 
         actual `shouldBe'` simpleStandardURL
 
-    describe "Fossa URL Builder" $
+    describe "Fossa URL Builder" $ do
       it' "should render from API info" $ do
         GetApiOpts `returnsOnce` Fixtures.apiOptsWithDefaultEndpoint
         GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True True True False False False False [] False False API.Free
@@ -81,3 +81,13 @@ spec = do
         actual <- getFossaBuildUrl revision locator
 
         actual `shouldBe'` simpleSamlPath
+
+      it' "should use the overridden endpoint if it is provided" $ do
+        GetApiOpts `returnsOnce` Fixtures.apiOpts
+        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True True True False False False False [] False False API.Free
+        let locator = Locator "fetcher123" "project123" $ Just "revision123"
+            revision = ProjectRevision "" "not this revision" $ Just "master123"
+        actual <- getFossaBuildUrl revision locator
+        let expectedUrl = "https://analysis.fossa.com/account/saml/1?next=/projects/fetcher123%252bproject123/refs/branch/master123/revision123"
+
+        actual `shouldBe'` expectedUrl

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -44,7 +44,7 @@ spec = do
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
             org = Just $ Organization (OrgId 1) True False True CLILicenseScan True True True False False False False [] False False API.Free
             revision = ProjectRevision "" "not this revision" $ Just "master123"
-        actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
+        actual <- getBuildURLWithOrg org revision Fixtures.apiOptsWithDefaultEndpoint locator
 
         actual `shouldBe'` simpleSamlPath
 
@@ -52,7 +52,7 @@ spec = do
         let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
             org = Just $ Organization (OrgId 103) True False True CLILicenseScan True True True False False False False [] False False API.Free
             revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
-        actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
+        actual <- getBuildURLWithOrg org revision Fixtures.apiOptsWithDefaultEndpoint locator
 
         actual `shouldBe'` gitSamlPath
 
@@ -60,7 +60,7 @@ spec = do
         let locator = Locator "a" "b" $ Just "c"
             org = Just $ Organization (OrgId 33) True False True CLILicenseScan True True True False False False False [] False False API.Free
             revision = ProjectRevision "" "not this revision" $ Just "master"
-        actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
+        actual <- getBuildURLWithOrg org revision Fixtures.apiOptsWithDefaultEndpoint locator
 
         actual `shouldBe'` fullSamlURL
 
@@ -68,13 +68,13 @@ spec = do
       it' "should render simple links" $ do
         let locator = Locator "haskell" "89/spectrometer" $ Just "revision123"
             revision = ProjectRevision "" "not this revision" $ Just "master"
-        actual <- getBuildURLWithOrg Nothing revision Fixtures.apiOpts locator
+        actual <- getBuildURLWithOrg Nothing revision Fixtures.apiOptsWithDefaultEndpoint locator
 
         actual `shouldBe'` simpleStandardURL
 
     describe "Fossa URL Builder" $
       it' "should render from API info" $ do
-        GetApiOpts `returnsOnce` Fixtures.apiOpts
+        GetApiOpts `returnsOnce` Fixtures.apiOptsWithDefaultEndpoint
         GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True True True False False False False [] False False API.Free
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
             revision = ProjectRevision "" "not this revision" $ Just "master123"

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -40,7 +40,7 @@ expectedConfigFile :: Path Abs File -> ConfigFile
 expectedConfigFile path =
   ConfigFile
     { configVersion = 3
-    , configServer = Just "https://app.fossa.com"
+    , configServer = Just "https://platform.fossa.com"
     , configApiKey = Just "123"
     , configProject = Just expectedConfigProject
     , configReleaseGroup = Just expectedReleaseGroup

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -40,7 +40,7 @@ expectedConfigFile :: Path Abs File -> ConfigFile
 expectedConfigFile path =
   ConfigFile
     { configVersion = 3
-    , configServer = Just "https://platform.fossa.com"
+    , configServer = Just "https://analysis.fossa.com"
     , configApiKey = Just "123"
     , configProject = Just expectedConfigProject
     , configReleaseGroup = Just expectedReleaseGroup

--- a/test/App/Fossa/Configuration/testdata/valid-default-yaml/.fossa.yaml
+++ b/test/App/Fossa/Configuration/testdata/valid-default-yaml/.fossa.yaml
@@ -1,6 +1,6 @@
 version: 3
 
-server: https://app.fossa.com
+server: https://analysis.fossa.com
 apiKey: "123"
 
 project:
@@ -8,7 +8,7 @@ project:
   id: github.com/fossa-cli
   name: fossa-cli
   team: fossa-team
-  teams: 
+  teams:
     - fossa-team
   policy: license-policy
   link: fossa.com
@@ -20,7 +20,7 @@ project:
   labels:
     - project-label
     - label-2
-    
+
 releaseGroup:
   title: example-title
   release: example-release-title
@@ -31,7 +31,7 @@ releaseGroup:
   licensePolicy: example-license-policy
   securityPolicy: example-security-policy
   qualityPolicy: example-quality-policy
-  teams: 
+  teams:
     - team-1
     - team-2
 

--- a/test/App/Fossa/Configuration/testdata/valid-default/.fossa.yml
+++ b/test/App/Fossa/Configuration/testdata/valid-default/.fossa.yml
@@ -1,6 +1,6 @@
 version: 3
 
-server: https://app.fossa.com
+server: https://analysis.fossa.com
 apiKey: "123"
 
 project:
@@ -8,7 +8,7 @@ project:
   id: github.com/fossa-cli
   name: fossa-cli
   team: fossa-team
-  teams: 
+  teams:
     - fossa-team
   policy: license-policy
   link: fossa.com
@@ -31,7 +31,7 @@ releaseGroup:
   licensePolicy: example-license-policy
   securityPolicy: example-security-policy
   qualityPolicy: example-quality-policy
-  teams: 
+  teams:
     - team-1
     - team-2
 

--- a/test/App/Fossa/Configuration/testdata/ver2-default/.fossa.yml
+++ b/test/App/Fossa/Configuration/testdata/ver2-default/.fossa.yml
@@ -3,7 +3,7 @@
 
 version: 2
 cli:
-  server: https://app.fossa.com
+  server: https://analysis.fossa.com
   fetcher: custom
   project: https://github.com/fossas/fossa-cli
 analyze:

--- a/test/App/Fossa/Configuration/testdata/ver2-specified.yml
+++ b/test/App/Fossa/Configuration/testdata/ver2-specified.yml
@@ -3,7 +3,7 @@
 
 version: 2
 cli:
-  server: https://app.fossa.com
+  server: https://analysis.fossa.com
   fetcher: custom
   project: https://github.com/fossas/fossa-cli
 analyze:

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -95,7 +95,7 @@ import Types (ArchiveUploadType (..), GraphBreadth (..))
 apiOpts :: API.ApiOpts
 apiOpts =
   API.ApiOpts
-    { API.apiOptsUri = (Just [uri|https://platform.fossa.com/|])
+    { API.apiOptsUri = (Just [uri|https://analysis.fossa.com/|])
     , API.apiOptsApiKey = API.ApiKey "testApiKey"
     , API.apiOptsPollDelay = MilliSeconds 100
     }

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -4,6 +4,7 @@
 
 module Test.Fixtures (
   apiOpts,
+  apiOptsWithDefaultEndpoint,
   baseDir,
   build,
   contributors,
@@ -96,6 +97,14 @@ apiOpts :: API.ApiOpts
 apiOpts =
   API.ApiOpts
     { API.apiOptsUri = (Just [uri|https://analysis.fossa.com/|])
+    , API.apiOptsApiKey = API.ApiKey "testApiKey"
+    , API.apiOptsPollDelay = MilliSeconds 100
+    }
+
+apiOptsWithDefaultEndpoint :: API.ApiOpts
+apiOptsWithDefaultEndpoint =
+  API.ApiOpts
+    { API.apiOptsUri = Nothing
     , API.apiOptsApiKey = API.ApiKey "testApiKey"
     , API.apiOptsPollDelay = MilliSeconds 100
     }

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -95,7 +95,7 @@ import Types (ArchiveUploadType (..), GraphBreadth (..))
 apiOpts :: API.ApiOpts
 apiOpts =
   API.ApiOpts
-    { API.apiOptsUri = (Just [uri|https://app.fossa.com/|])
+    { API.apiOptsUri = (Just [uri|https://platform.fossa.com/|])
     , API.apiOptsApiKey = API.ApiKey "testApiKey"
     , API.apiOptsPollDelay = MilliSeconds 100
     }


### PR DESCRIPTION
# Overview

[Delivers ANE-1692](https://fossa.atlassian.net/browse/ANE-1692)

## Acceptance criteria

- If the endpoint is not customized, the CLI will default to communicating with analysis.fossa.com
- If the endpoint is not customized, the build URLs displayed to users will point to app.fossa.com
- If the endpoint is customized, the CLI will communicate with the custom endpoint

## Testing plan

### Setup

To test this, we need to be able to hit Sparkle, but running at http://localhost:3000. I did this by using Nginx as a reverse proxy.

- Have Sparkle running on localhost:3000 and proxying to https://app.fossa.com
- In /etc/hosts, point analysis.fossa.com at localhost
- Set up nginx to reverse proxy analysis.fossa.com to http://localhost:3000
- Set up an SSL cert and force your OS to ignore that it's self-signed

#### Point analysis.fossa.com to localhost in  /etc/hosts 
Add this to `/etc/hosts`:

```
127.0.0.1 analysis.fossa.com
```

#### Create an SSL Cert

Here's how I did it.

First, generate your key. You will need the passphrase for the next few steps, so make sure you remember it:

```
sudo openssl genrsa -des3 -out server.key 4096
passphrase: <some passphrase>
```

Now generate your CSR:

```
sudo openssl req -new -key server.key -out server.csr
```

Make sure you put `analysis.fossa.com` for the appropriate answers when you run this. Mine looked like this:

```
sudo openssl req -new -key server.key -out server.csr
Enter pass phrase for server.key:
You are about to be asked to enter information that will be incorporated
into your certificate request.
What you are about to enter is what is called a Distinguished Name or a DN.
There are quite a few fields but you can leave some blank
For some fields there will be a default value,
If you enter '.', the field will be left blank.
-----
Country Name (2 letter code) [AU]:CA
State or Province Name (full name) [Some-State]:BC
Locality Name (eg, city) []:Vancouver
Organization Name (eg, company) [Internet Widgits Pty Ltd]:analysis.fossa.com
Organizational Unit Name (eg, section) []:analysis.fossa.com
Common Name (e.g. server FQDN or YOUR name) []:analysis.fossa.com
Email Address []:scott@fossa.com

Please enter the following 'extra' attributes
to be sent with your certificate request
A challenge password []:
An optional company name []:
```

Now generate the crt file and copy things to the right spot:

```
sudo cp server.key server.key.org
sudo openssl rsa -in server.key.org -out server.key
sudo openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt
```

That will result in a server.crt and server.key file. Put those in /usr/local/nginx/conf

```
sudo mkdir -p /usr/local/nginx/conf
sudo mv server.crt /usr/local/nginx/conf
sudo mv server.key /usr/local/nginx/conf
```

#### Make your OS accept the cert even though it's self-signed

On MacOS, I followed the directions here: https://tosbourn.com/getting-os-x-to-trust-self-signed-ssl-certificates/

#### Set up nginx to reverse-proxy analysis.fossa.com to Sparkle running locally

```
brew install nginx
```


Put this in your nginx config (/opt/homebrew/etc/nginx/nginx.conf) inside the `http` block:

```
    server {
        listen       analysis.fossa.com:80;
        listen 443 ssl;
        server_name  analysis.fossa.com;
        ssl_certificate  /usr/local/nginx/conf/server.crt;
        ssl_certificate_key  /usr/local/nginx/conf/server.key;
        ssl_ciphers  HIGH:!aNULL:!MD5;
        ssl_prefer_server_ciphers  on;
        location / {
            proxy_pass http://127.0.0.1:3000;
        }
    }
```


Test that your config is working properly:

```
sudo nginx -t
nginx: the configuration file /opt/homebrew/etc/nginx/nginx.conf syntax is ok
nginx: configuration file /opt/homebrew/etc/nginx/nginx.conf test is successful
```

Start the nginx service. You're binding to port 80, so you have to do this as root:

```
sudo brew services start nginx
```

Now you should be able to go to `http://analysis.fossa.com` in your browser and see it hit Sparkle running on localhost:3000. We're using a self-signed certificate, so you'll have to click through a scary warning

### Now that you're set up, let's test that things work.

This will hit Sparkle and Sparkle will proxy to Core:

```
make install-dev
cd ~/some/project
FOSSA_API_KEY=... fossa-dev analyze 
```

Watch your Sparkle logs. Make sure that the CLI is hitting URLs. You should see a bunch of `GET api/cli/organization`, a POST to `api/builds/custom` and a POST to `/api/cli/telemetry`.

There should be no errors in the Sparkle logs.

Check that the project URL is correct and points at app.fossa.com.

Try again, but force the endpoint to Sparkle by using this flag: `-e https://analysis.fossa.com` 

Everything should work exaclty the same, except the project URL will now point at analysis.fossa.com. Make sure that the analysis.fossa.com URL redirects to the correct spot on app.fossa.com.

Run this with a normal build, a build with vendored dependencies and a container.

## Risks

This is a small change in some ways, but a big change in others.

If Sparkle is working correctly, this will be just fine.

If Sparkle is not working correctly, this will cause problems.

But the risk is not contained in this PR. This PR just exposes it.

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

_Example:_

- _[ANE-123](https://fossa.atlassian.net/browse/ANE-123): Implement X._

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
