### PR TITLE
add includeCopyrightList query param to JSON attribution report request

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.9.26
+
+- Reports: Add `includeCopyrightList` to JSON attribution report request. This will ensure that all copyrights are included in the JSON attribution report once the FOSSA API starts including them. All other formats of attribution reports will receive all copyrights without needing to add this query param. [#1450](https://github.com/fossas/fossa-cli/pull/1450)
+
 ## 3.9.25
 
 - Update jar-callgraph version [#1447](https://github.com/fossas/fossa-cli/pull/1447)
@@ -20,7 +24,7 @@
 - License Scanning: Add the Llama-3-community license (No PR)
 - Yarn: Don't fail analysis if a dependency cannot be found. ([1436](https://github.com/fossas/fossa-cli/pull/1436))
 
-## 3.9.20 
+## 3.9.20
 - Fixes file matches for license scans ([#1434](https://github.com/fossas/fossa-cli/pull/1434)).
 
 ## v3.9.19

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -1248,6 +1248,8 @@ getAttributionJson apiOpts ProjectRevision{..} = fossaReq $ do
             =: True
           <> "dependencyInfoOptions[]"
             =: packageDownloadUrl
+          <> "includeCopyrightList"
+            =: True
           -- Large reports can take over a minute to generate, so increase the timeout to 10 minutes
           <> responseTimeoutSeconds 600
   orgId <- organizationId <$> getOrganization apiOpts


### PR DESCRIPTION
# Overview

https://teamfossa.slack.com/archives/C0155DTGWB1/p1721159453386859

As part of https://fossa.atlassian.net/browse/CORE-3105, we need to include a `includeCopyrightList=true` query param when we're getting a JSON attribution report.

This PR adds that.

## Acceptance criteria

- The report still works and is unchanged for current Core
- The report adds all copyrights when you test it against Core with the fixes for CORE-3105: https://github.com/fossas/FOSSA/pull/13269

## Testing plan

Use the fossa-deps.yml from the ticket:

```yaml
referenced-dependencies:
 - type: pypi
   name: cffi
   version: 1.14.4
```

Run `fossa analyze` and then `fossa report attribution --format json` against current core. Compare the output to the results from this branch.

```
fossa analyze
fossa report attribution --format json > ~/tmp/report-cli-master-core-master.json
```

```
# In fossa-cli, with this branch checked out:
make install-dev
# in the directory with the fossa-deps file from above:
fossa-dev report attribution --format json > ~/tmp/report-cli-dev-core-master.json
# Compare the two. There should be no changes
diff ~/tmp/report-cli-master-core-master.json ~/tmp/report-cli-dev-core-master.json 
```

Now run against core locally, but with the branch from https://github.com/fossas/FOSSA/pull/13269 checked out:

```
fossa-dev analyze -e http://localhost:9578
fossa-dev report attribution --format json -e http://localhost:9578 > ~/tmp/report-cli-dev-core-dev.json
```

Note the difference in the copyrights.

Before:

```
  "copyrightsByLicense": {
    "MIT": [
      "1996, 1998, 1999, 2001 Red Hat, Inc."
    ]
  },
```

After:

```
  "copyrightsByLicense": {
    "MIT": [
      "1996, 1998, 1999, 2001 Red Hat, Inc.",
      "1996, 1998, 2001, 2002 Red Hat, Inc.",
      "2001 John Beniton",
      "2002 Ranjit Mathew",
      "1996, 1998 Red Hat, Inc.",
      "1996-2003 Red Hat, Inc.",
      "2002 Bo Thorsen",
      "2002 Roger Sayle"
    ]
```

## Risks

This is very low risk

## Metrics

N/A

## References

- https://teamfossa.slack.com/archives/C0155DTGWB1/p1721159453386859
- https://fossa.atlassian.net/browse/CORE-3105

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
