### PR TITLE
[ANE-1861] strip auth from git projects cloned via url 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## 3.9.26
 
 - Reports: Add `includeCopyrightList` to JSON attribution report request. This will ensure that all copyrights are included in the JSON attribution report once the FOSSA API starts including them. All other formats of attribution reports will receive all copyrights without needing to add this query param. [#1450](https://github.com/fossas/fossa-cli/pull/1450)
-- Resolves an issue where git projects cloned with an url including a username were unable to found running `fossa analyze`. [#1451](https://github.com/fossas/fossa-cli/pull/1451)
+- Resolves an issue where git projects cloned with an url including a username were unable to be found running when `fossa test`. [#1451](https://github.com/fossas/fossa-cli/pull/1451)
 
 ## 3.9.25
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.9.27
+
+- Resolves an issue where git projects cloned with an url including a username were unable to found running `fossa analyze`. [#1451](https://github.com/fossas/fossa-cli/pull/1451)
+
 ## 3.9.26
 
 - Reports: Add `includeCopyrightList` to JSON attribution report request. This will ensure that all copyrights are included in the JSON attribution report once the FOSSA API starts including them. All other formats of attribution reports will receive all copyrights without needing to add this query param. [#1450](https://github.com/fossas/fossa-cli/pull/1450)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,12 +1,9 @@
 # FOSSA CLI Changelog
 
-## 3.9.27
-
-- Resolves an issue where git projects cloned with an url including a username were unable to found running `fossa analyze`. [#1451](https://github.com/fossas/fossa-cli/pull/1451)
-
 ## 3.9.26
 
 - Reports: Add `includeCopyrightList` to JSON attribution report request. This will ensure that all copyrights are included in the JSON attribution report once the FOSSA API starts including them. All other formats of attribution reports will receive all copyrights without needing to add this query param. [#1450](https://github.com/fossas/fossa-cli/pull/1450)
+- Resolves an issue where git projects cloned with an url including a username were unable to found running `fossa analyze`. [#1451](https://github.com/fossas/fossa-cli/pull/1451)
 
 ## 3.9.25
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## 3.9.26
 
 - Reports: Add `includeCopyrightList` to JSON attribution report request. This will ensure that all copyrights are included in the JSON attribution report once the FOSSA API starts including them. All other formats of attribution reports will receive all copyrights without needing to add this query param. [#1450](https://github.com/fossas/fossa-cli/pull/1450)
-- Resolves an issue where git projects cloned with an url including a username were unable to be found running when `fossa test`. [#1451](https://github.com/fossas/fossa-cli/pull/1451)
+- Resolves an issue where git projects cloned with an url including a username were unable to be found when running `fossa test`. [#1451](https://github.com/fossas/fossa-cli/pull/1451)
 
 ## 3.9.25
 

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -36,6 +36,7 @@ import Data.Time.Format.ISO8601 (iso8601Show)
 import Effect.Exec
 import Effect.ReadFS
 import Errata (Errata (..))
+import Network.URI (URI (..), URIAuth (..), parseURI, uriToString, isURI)
 import Path
 import Path.IO (getTempDir)
 import System.FilePath.Posix qualified as FP
@@ -203,12 +204,21 @@ parseGitProjectName dir = do
         Nothing -> fatal InvalidRemote
         Just (Section _ properties) ->
           case HM.lookup "url" properties of
-            Just url -> pure url
+            Just url ->
+              pure $
+                if isURI (toString url) then stripAuthFromHttp url else url
             Nothing -> fatal InvalidRemote
   where
     isOrigin :: Section -> Bool
     isOrigin (Section ["remote", "origin"] _) = True
     isOrigin _ = False
+
+    stripAuthFromHttp :: Text -> Text
+    stripAuthFromHttp url = case parseURI (toString url) of
+      Just uri -> case uriAuthority uri of
+        Just auth -> toText $ uriToString id uri{uriAuthority = Just auth{uriUserInfo = ""}} ""
+        Nothing -> url
+      Nothing -> url
 
 parseGitProjectRevision ::
   ( Has ReadFS sig m

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -206,15 +206,15 @@ parseGitProjectName dir = do
           case HM.lookup "url" properties of
             Just url ->
               pure $
-                if isURI (toString url) then stripAuthFromHttp url else url
+                if isURI (toString url) then stripAuthFromURL url else url
             Nothing -> fatal InvalidRemote
   where
     isOrigin :: Section -> Bool
     isOrigin (Section ["remote", "origin"] _) = True
     isOrigin _ = False
 
-    stripAuthFromHttp :: Text -> Text
-    stripAuthFromHttp url = case parseURI (toString url) of
+    stripAuthFromURL :: Text -> Text
+    stripAuthFromURL url = case parseURI (toString url) of
       Just uri -> case uriAuthority uri of
         Just auth -> toText $ uriToString id uri{uriAuthority = Just auth{uriUserInfo = ""}} ""
         Nothing -> url

--- a/src/App/Fossa/ProjectInference.hs
+++ b/src/App/Fossa/ProjectInference.hs
@@ -36,7 +36,7 @@ import Data.Time.Format.ISO8601 (iso8601Show)
 import Effect.Exec
 import Effect.ReadFS
 import Errata (Errata (..))
-import Network.URI (URI (..), URIAuth (..), parseURI, uriToString, isURI)
+import Network.URI (URI (..), URIAuth (..), isURI, parseURI, uriToString)
 import Path
 import Path.IO (getTempDir)
 import System.FilePath.Posix qualified as FP


### PR DESCRIPTION
# Overview

This PR wont affect current locators as core already strips auth when generating a custom locator, however the CLI will send a locator of `custom+{orgId}/username@bitbucket.org/owner/repo` for all other endpoints. This was only happening to projects cloned from a bitbucket url with a username.

Changes: 
- PR removes auth from projects cloned via a url

## Acceptance criteria

- locators do not have auth in them in a URL

## Testing plan

- if you dont have a bitbucket project then just modify `.git/config` for testing:
- under `[remote "origin"]` change the url to `https://user@bitbucket.org/owner/repo.git`
- ensure `FOSSA_API_KEY` is set
- run `cabal run fossa -- analyze /path/to/local_repo/` 
- you should see a new project for `custom+{orgId}/bitbucket.org/owner/repo`
- run `cabal run fossa -- test /path/to/local_repo` and the command works
- repeat for `https://bitbucket.org/owner/repo.git`
- for `git@github.com:repo/owner` the "url" is unchanged.

Here's the debug logs for the urls:

```
// ssh url
{
  "projectName": "git@bitbucket.org:jeremygonzalez/test.git",
  "projectRevision": "51f90e00d46d273b5cacb4ff3a7a75170bd14c95",
  "projectBranch": "main"
}
```
```
// https://user@bitbucket.org/jeremygonzalez/test.git
{
  "projectName": "https://bitbucket.org/jeremygonzalez/test.git",
  "projectRevision": "51f90e00d46d273b5cacb4ff3a7a75170bd14c95",
  "projectBranch": "main"
}
```
## Risks

Minimal risks, we're already stripping the auth part in core when creating the locator. 

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

See https://fossa.atlassian.net/browse/ANE-1864 for more info

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
