### PR TITLE
Add context info about binary files that are being hashed

### DIFF
--- a/src/App/Fossa/BinaryDeps.hs
+++ b/src/App/Fossa/BinaryDeps.hs
@@ -7,7 +7,7 @@ import App.Fossa.Analyze.Project (ProjectResult (..))
 import App.Fossa.BinaryDeps.Jar (resolveJar)
 import App.Fossa.VSI.Fingerprint (Fingerprint, fingerprintRaw)
 import Control.Algebra (Has)
-import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Diagnostics (Diagnostics, context)
 import Control.Effect.Lift (Lift)
 import Control.Monad (filterM)
 import Data.String.Conversion (toText)
@@ -44,7 +44,7 @@ analyzeBinaryDeps dir filters = do
 -- if we fallback to a plain "unknown binary" strategy its name is reported as the relative path between the provided @Path Abs Dir@ and the @Path Abs File@.
 -- If the path can't be made relative, the dependency name is the absolute path of the binary.
 analyzeSingleBinary :: (Has (Lift IO) sig m, Has Logger sig m, Has ReadFS sig m, Has Diagnostics sig m) => Path Abs Dir -> Path Abs File -> m SourceUserDefDep
-analyzeSingleBinary = resolveBinary strategies
+analyzeSingleBinary root file = context ("Analyzing " <> toText file) $ resolveBinary strategies root file
 
 findBinaries :: (Has (Lift IO) sig m, Has Diagnostics sig m, Has ReadFS sig m) => PathFilters -> Path Abs Dir -> m [Path Abs File]
 findBinaries filters = walk' $ \dir _ files -> do


### PR DESCRIPTION
# Overview

We will sometimes encounter an error when fingerprinting binary files. Previously we didn't log the filename of the file being hashed in our debug bundle. This PR adds that context. 

## Acceptance criteria

* There should be filename info in the debug bundle for each file that is fingerprinted.

## Testing plan

Manual, this is a change to logging/reporting only. 

## References

- [ANE-1855](https://fossa.atlassian.net/browse/ANE-1855): Show file paths when error is throwing trying to open file

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1855]: https://fossa.atlassian.net/browse/ANE-1855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ