### PR TITLE
Don't suppress curl error messages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- install scripts: Surface curl errors and display http status code correctly. ([#1456](https://github.com/fossas/fossa-cli/pull/1456))
+
 ## 3.9.28
 
 - Container Scanning: Distroless containers will now return results for non-system dependencies. ([#1448](https://github.com/fossas/fossa-cli/pull/1448))

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -257,10 +257,10 @@ http_download_curl() {
   source_url=$2
   header=$3
   if [ -n "$header" ]; then
-    HTTP_CODE=$(curl -w '%{HTTP_CODE}' -sL -H "$header" -H "Cache-Control: no-cache" -o "$local_file" "$source_url") || (log_debug "curl command failed." && return 1)
+    HTTP_CODE=$(curl -w '%{http_code}' -sSL -H "$header" -H "Cache-Control: no-cache" -o "$local_file" "$source_url") || (log_debug "curl command failed." && return 1)
   fi
   if [ -z "$header" ]; then
-    HTTP_CODE=$(curl -w '%{HTTP_CODE}' -sL -H "Cache-Control: no-cache" -o "$local_file" "$source_url") || (log_debug "curl command failed." && return 1)
+    HTTP_CODE=$(curl -w '%{http_code}' -sSL -H "Cache-Control: no-cache" -o "$local_file" "$source_url") || (log_debug "curl command failed." && return 1)
   fi
   return 0
 }

--- a/install-v1.sh
+++ b/install-v1.sh
@@ -254,9 +254,9 @@ http_download_curl() {
   source_url=$2
   header=$3
   if [ -z "$header" ]; then
-    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+    code=$(curl -w '%{http_code}' -sSL -o "$local_file" "$source_url")
   else
-    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+    code=$(curl -w '%{http_code}' -sSL -H "$header" -o "$local_file" "$source_url")
   fi
   if [ "$code" != "200" ]; then
     log_debug "http_download_curl received HTTP status $code"

--- a/install.sh
+++ b/install.sh
@@ -254,9 +254,9 @@ http_download_curl() {
   source_url=$2
   header=$3
   if [ -z "$header" ]; then
-    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+    code=$(curl -w '%{http_code}' -sSL -o "$local_file" "$source_url")
   else
-    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+    code=$(curl -w '%{http_code}' -sSL -H "$header" -o "$local_file" "$source_url")
   fi
   if [ "$code" != "200" ]; then
     log_debug "http_download_curl received HTTP status $code"


### PR DESCRIPTION
# Overview

curl errors are not surfaced to users.
Also, the `install-latest` script was configuring the wrong setting (`HTTP_STATUS` instead of `http_status`).

This PR fixes both issues.

## Acceptance criteria
- Error messages emitted by curl are no longer suppressed when installing FOSSA CLI.
- The progress dialogue is still suppressed.

## Testing plan

I configured my hosts file:
```
127.0.0.1 github.com
```

I validated that curl's error does not appear (other than the `--write-out` error, which is unrelated):
```shell
❯ sudo ./install-latest.sh
fossas/fossa-cli info checking GitHub for latest tag
curl: unknown --write-out variable: 'HTTP_CODE'
fossas/fossa-cli crit unable to find '' - use 'latest' or see https://github.com/fossas/fossa-cli/releases for details
```

Then I applied the changes in this PR and validated that the curl error does appear (note the `curl: (7)` text):
```shell
❯ sudo ./install-latest.sh
fossas/fossa-cli info checking GitHub for latest tag
curl: (7) Failed to connect to github.com port 443 after 2 ms: Could not connect to server
fossas/fossa-cli err http_download received HTTP status 000 from https://github.com/fossas/fossa-cli/releases/latest
fossas/fossa-cli crit unable to find '' - use 'latest' or see https://github.com/fossas/fossa-cli/releases for details
```

## Risks

None

## Metrics
None
## References

https://fossa.atlassian.net/browse/ANE-1953

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
