### PR TITLE
Use the name of the runner for integration tests.

### DIFF
--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -11,8 +11,7 @@ on:
 jobs:
   integration-test:
     name: integration-test
-    runs-on:
-      group: "FOSSA CLI Runner"
+    runs-on: "fossa-cli-integration-runner"
     # Be sure to update the env below too
     container: fossa/haskell-static-alpine:ghc-9.4.8
 


### PR DESCRIPTION
# Overview

We added an additional runner to our runner group and now need to specify by name which runner to use for integration tests. 

## Acceptance criteria

This is purely to fix CI.
