### PR TITLE
[ANE-1827] - Replace "tomland" with "toml-parser" for parsing toml files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Resolve an issue parsing toml configuration files. ([#1459](https://github.com/fossas/fossa-cli/pull/1459))
+
 ## 3.9.30
 
 - Vendored Dependencies: add support for metadata (description, and homepage) for dependencies. ([#1455](https://github.com/fossas/fossa-cli/pull/1455))

--- a/integration-test/Analysis/Python/PoetrySpec.hs
+++ b/integration-test/Analysis/Python/PoetrySpec.hs
@@ -24,4 +24,4 @@ poetry =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary poetry PoetryProjectType (DependencyResultsSummary 66 29 69 1 Complete)
+  testSuiteDepResultSummary poetry PoetryProjectType (DependencyResultsSummary 65 29 69 1 Complete)

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -149,7 +149,7 @@ common deps
     , th-lift-instances            ^>=0.1.17
     , time                         >=1.9       && <1.13
     , tls                          >=1.9       && <2.0
-    , tomland                      ^>=1.3.3.0
+    , toml-parser                  ^>=2.0.0.0
     , transformers
     , typed-process                ^>=0.2.6
     , unix-compat                  ^>=0.7

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -152,7 +152,7 @@ common deps
     , th-lift-instances            ^>=0.1.17
     , time                         >=1.9       && <1.13
     , tls                          ^>=2.0
-    , toml-parser                  ^>=2.0.0.0
+    , toml-parser                  ^>=2.0.1.0
     , transformers
     , typed-process                ^>=0.2.6
     , unix-compat                  ^>=0.7

--- a/src/Strategy/Fortran/FpmToml.hs
+++ b/src/Strategy/Fortran/FpmToml.hs
@@ -6,11 +6,10 @@ module Strategy.Fortran.FpmToml (
   FpmDependency (..),
   FpmPathDependency (..),
   FpmGitDependency (..),
+  FpmTomlExecutables (..),
   buildGraph,
-  fpmTomlCodec,
 ) where
 
-import Control.Applicative (Alternative ((<|>)))
 import Control.Effect.Diagnostics (Diagnostics, context)
 import Data.Foldable (asum)
 import Data.Map (Map, elems)
@@ -25,34 +24,62 @@ import DepTypes (
 import Effect.ReadFS (Has, ReadFS, readContentsToml)
 import Graphing (Graphing, directs, induceJust)
 import Path
-import Toml (TomlCodec, (.=))
 import Toml qualified
+import Toml.Schema qualified
 
 -- | Represents the content of the fpm manifest.
 -- Reference: https://github.com/fortran-lang/fpm/blob/main/manifest-reference.md
 data FpmToml = FpmToml
   { fpmDependencies :: Map Text FpmDependency
   , fpmDevDependencies :: Map Text FpmDependency
-  , fpmExecutables :: [Map Text FpmDependency]
+  , fpmExecutables :: [FpmTomlExecutables]
   }
   deriving (Eq, Ord, Show)
 
-fpmTomlCodec :: TomlCodec FpmToml
-fpmTomlCodec =
-  FpmToml
-    <$> Toml.tableMap Toml._KeyText fpmDependenciesCodec "dependencies" .= fpmDependencies
-    <*> Toml.tableMap Toml._KeyText fpmDependenciesCodec "dev-dependencies" .= fpmDevDependencies
-    <*> Toml.list fpmExecutableDependenciesCodec "executable" .= fpmExecutables
+instance Toml.Schema.FromValue FpmToml where
+  fromValue =
+    Toml.Schema.parseTableFromValue $
+      FpmToml
+        <$> Toml.Schema.pickKey [Toml.Schema.Key "dependencies" Toml.Schema.fromValue, Toml.Schema.Else $ pure mempty]
+        <*> Toml.Schema.pickKey [Toml.Schema.Key "dev-dependencies" Toml.Schema.fromValue, Toml.Schema.Else $ pure mempty]
+        <*> Toml.Schema.pickKey [Toml.Schema.Key "executable" Toml.Schema.fromValue, Toml.Schema.Else $ pure []]
+
+newtype FpmTomlExecutables = FpmTomlExecutables
+  { fpmExecutableDependencies :: Map Text FpmDependency
+  }
+  deriving (Eq, Ord, Show)
+
+instance Toml.Schema.FromValue FpmTomlExecutables where
+  fromValue =
+    Toml.Schema.parseTableFromValue $
+      FpmTomlExecutables
+        <$> Toml.Schema.pickKey [Toml.Schema.Key "dependencies" Toml.Schema.fromValue, Toml.Schema.Else $ pure mempty]
 
 data FpmDependency
   = FpmGitDep FpmGitDependency
   | FpmPathDep FpmPathDependency
   deriving (Eq, Ord, Show)
 
+instance Toml.Schema.FromValue FpmDependency where
+  fromValue v@(Toml.Schema.Table' l t) =
+    Toml.Schema.parseTable
+      ( Toml.Schema.pickKey
+          [ Toml.Schema.Key "git" (const (FpmGitDep <$> Toml.Schema.fromValue v))
+          , Toml.Schema.Key "path" (const (FpmPathDep <$> Toml.Schema.fromValue v))
+          , Toml.Schema.Else (Toml.Schema.failAt (Toml.valueAnn v) "Expected either 'git' or 'path' key got: ")
+          ]
+      )
+      l
+      t
+  fromValue v = Toml.Schema.failAt (Toml.valueAnn v) "Expected a table"
+
 newtype FpmPathDependency = FpmPathDependency
   { pathOf :: Text
   }
   deriving (Eq, Ord, Show)
+
+instance Toml.Schema.FromValue FpmPathDependency where
+  fromValue = Toml.Schema.parseTableFromValue $ FpmPathDependency <$> Toml.Schema.reqKey "path"
 
 data FpmGitDependency = FpmGitDependency
   { url :: Text
@@ -62,32 +89,14 @@ data FpmGitDependency = FpmGitDependency
   }
   deriving (Eq, Ord, Show)
 
-fpmExecutableDependenciesCodec :: TomlCodec (Map Text FpmDependency)
-fpmExecutableDependenciesCodec = Toml.tableMap Toml._KeyText fpmDependenciesCodec "dependencies"
-
-fpmDependenciesCodec :: Toml.Key -> TomlCodec FpmDependency
-fpmDependenciesCodec key =
-  Toml.dimatch matchFpmPathDep FpmPathDep (Toml.table fpmPathDependencyCodec key)
-    <|> Toml.dimatch matchFpmGitDep FpmGitDep (Toml.table fpmGitDependencyCodec key)
-  where
-    matchFpmPathDep :: FpmDependency -> Maybe FpmPathDependency
-    matchFpmPathDep (FpmPathDep pathDep) = Just pathDep
-    matchFpmPathDep _ = Nothing
-
-    matchFpmGitDep :: FpmDependency -> Maybe FpmGitDependency
-    matchFpmGitDep (FpmGitDep gitDep) = Just gitDep
-    matchFpmGitDep _ = Nothing
-
-    fpmPathDependencyCodec :: TomlCodec FpmPathDependency
-    fpmPathDependencyCodec = FpmPathDependency <$> Toml.text "path" .= pathOf
-
-    fpmGitDependencyCodec :: TomlCodec FpmGitDependency
-    fpmGitDependencyCodec =
+instance Toml.Schema.FromValue FpmGitDependency where
+  fromValue =
+    Toml.Schema.parseTableFromValue $
       FpmGitDependency
-        <$> Toml.text "git" .= url
-        <*> Toml.dioptional (Toml.text "branch") .= branch
-        <*> Toml.dioptional (Toml.text "tag") .= tag
-        <*> Toml.dioptional (Toml.text "rev") .= rev
+        <$> Toml.Schema.reqKey "git"
+        <*> Toml.Schema.optKey "branch"
+        <*> Toml.Schema.optKey "tag"
+        <*> Toml.Schema.optKey "rev"
 
 buildGraph :: FpmToml -> Graphing Dependency
 buildGraph fpmToml = induceJust $ foldMap directs [deps, execDeps, devDeps]
@@ -96,7 +105,7 @@ buildGraph fpmToml = induceJust $ foldMap directs [deps, execDeps, devDeps]
     deps = map toProdDependency (elems $ fpmDependencies fpmToml)
 
     execDeps :: [Maybe Dependency]
-    execDeps = map toProdDependency (foldMap elems $ fpmExecutables fpmToml)
+    execDeps = map toProdDependency (foldMap (elems . fpmExecutableDependencies) (fpmExecutables fpmToml))
 
     devDeps :: [Maybe Dependency]
     devDeps = map toDevDependency (elems $ fpmDevDependencies fpmToml)
@@ -128,5 +137,5 @@ analyzeFpmToml ::
   Path Abs File ->
   m (Graphing Dependency)
 analyzeFpmToml tomlFile = do
-  fpmTomlContent <- readContentsToml fpmTomlCodec tomlFile
+  fpmTomlContent <- readContentsToml tomlFile
   context "Building dependency graph from fpm.toml" $ pure $ buildGraph fpmTomlContent

--- a/src/Strategy/Fortran/FpmToml.hs
+++ b/src/Strategy/Fortran/FpmToml.hs
@@ -73,7 +73,7 @@ instance Toml.Schema.FromValue FpmDependency where
       l
       t
   fromValue (Toml.Schema.Text' _ t) = pure $ FpmMetaDep t
-  fromValue v = Toml.Schema.failAt (Toml.valueAnn v) "Expected a table"
+  fromValue v = Toml.Schema.failAt (Toml.valueAnn v) "Invalid dependency value, expected a table or a string"
 
 newtype FpmMetaDependency = FpmMetaDependency Text
   deriving (Eq, Ord, Show)

--- a/src/Strategy/Python/Poetry/Common.hs
+++ b/src/Strategy/Python/Poetry/Common.hs
@@ -44,7 +44,7 @@ import Strategy.Python.Poetry.PyProject (
 
 -- | Gets build backend of pyproject.
 getPoetryBuildBackend :: PyProject -> Maybe Text
-getPoetryBuildBackend project = buildBackend <$> pyprojectBuildSystem project
+getPoetryBuildBackend project = buildBackend =<< pyprojectBuildSystem project
 
 -- | Supported pyproject dependencies.
 supportedPyProjectDep :: PoetryDependency -> Bool

--- a/src/Strategy/Python/Poetry/Common.hs
+++ b/src/Strategy/Python/Poetry/Common.hs
@@ -33,8 +33,11 @@ import Strategy.Python.Poetry.PyProject (
   PyProjectPoetry (..),
   PyProjectPoetryDetailedVersionDependency (..),
   PyProjectPoetryGitDependency (..),
+  PyProjectPoetryGroup (..),
+  PyProjectPoetryGroupDependencies (..),
   PyProjectPoetryPathDependency (..),
   PyProjectPoetryUrlDependency (..),
+  PyProjectTool (..),
   allPoetryNonProductionDeps,
   toDependencyVersion,
  )
@@ -70,7 +73,10 @@ logIgnoredDeps pyproject poetryLock = for_ notSupportedDepsMsgs (logDebug . pret
     notSupportedPyProjectDeps =
       Map.keys $
         Map.filter (not . supportedPyProjectDep) $
-          maybe Map.empty dependencies (pyprojectPoetry pyproject)
+          case pyprojectTool pyproject of
+            Nothing -> mempty
+            Just (PyProjectTool{pyprojectPoetry}) ->
+              maybe Map.empty dependencies (pyprojectPoetry)
 
 -- | Not supported poetry lock package.
 supportedPoetryLockDep :: PoetryLockPackage -> Bool
@@ -89,8 +95,8 @@ pyProjectDeps project = filter notNamedPython $ map snd allDeps
     -- These are dependencies coming from dev-dependencies table
     -- which is pre 1.2.x style, understood by Poetry 1.0–1.2
     olderPoetryDevDeps :: Map Text PoetryDependency
-    olderPoetryDevDeps = case pyprojectPoetry project of
-      Just (PyProjectPoetry{devDependencies}) -> devDependencies
+    olderPoetryDevDeps = case pyprojectTool project of
+      Just (PyProjectTool{pyprojectPoetry}) -> maybe mempty devDependencies pyprojectPoetry
       _ -> mempty
 
     -- These are 'group' dependencies. All group dependencies are optional.
@@ -103,12 +109,22 @@ pyProjectDeps project = filter notNamedPython $ map snd allDeps
     -- \* https://github.com/kowainik/tomland/issues/336
     -- \* https://python-poetry.org/docs/managing-dependencies#dependency-groups
     groupDeps :: Map Text PoetryDependency
-    groupDeps = case pyprojectPoetry project of
-      Just (PyProjectPoetry{groupDevDependencies, groupTestDependencies}) -> Map.unions [groupDevDependencies, groupTestDependencies]
+    groupDeps = case pyprojectTool project of
+      Just (PyProjectTool{pyprojectPoetry}) -> case pyprojectPoetry of
+        Just (PyProjectPoetry{pyprojectPoetryGroup}) -> case pyprojectPoetryGroup of
+          Just (PyProjectPoetryGroup{groupDev, groupTest}) -> case (groupDev, groupTest) of
+            (Just devDeps, Just testDeps) -> Map.unions [groupDependencies devDeps, groupDependencies testDeps]
+            (Just devDeps, Nothing) -> groupDependencies devDeps
+            (Nothing, Just testDeps) -> groupDependencies testDeps
+            _ -> mempty
+          _ -> mempty
+        _ -> mempty
       _ -> mempty
 
     supportedProdDeps :: Map Text PoetryDependency
-    supportedProdDeps = Map.filter supportedPyProjectDep $ maybe Map.empty dependencies (pyprojectPoetry project)
+    supportedProdDeps = Map.filter supportedPyProjectDep $ case pyprojectTool project of
+      Just (PyProjectTool{pyprojectPoetry}) -> maybe Map.empty dependencies pyprojectPoetry
+      _ -> mempty
 
     toDependency :: [DepEnvironment] -> Map Text PoetryDependency -> Map Text Dependency
     toDependency depEnvs = Map.mapWithKey $ poetrytoDependency depEnvs

--- a/src/Strategy/Python/Poetry/PoetryLock.hs
+++ b/src/Strategy/Python/Poetry/PoetryLock.hs
@@ -4,18 +4,16 @@ module Strategy.Python.Poetry.PoetryLock (
   PackageName (..),
   PoetryLockPackageSource (..),
   PoetryLockDependencySpec (..),
-  poetryLockCodec,
 
   -- * for testing only
   ObjectVersion (..),
   PoetryMetadata (..),
 ) where
 
-import Control.Applicative (Alternative ((<|>)))
 import Data.Map (Map)
 import Data.Text (Text)
-import Toml (TomlCodec, (.=))
 import Toml qualified
+import Toml.Schema qualified
 
 -- | Represents the content of the poetry lock file.
 data PoetryLock = PoetryLock
@@ -24,15 +22,14 @@ data PoetryLock = PoetryLock
   }
   deriving (Eq, Ord, Show)
 
-newtype PackageName = PackageName {unPackageName :: Text} deriving (Eq, Ord, Show)
+instance Toml.Schema.FromValue PoetryLock where
+  fromValue =
+    Toml.Schema.parseTableFromValue $
+      PoetryLock
+        <$> Toml.Schema.reqKey "package"
+        <*> Toml.Schema.reqKey "metadata"
 
-poetryLockCodec :: TomlCodec PoetryLock
-poetryLockCodec =
-  PoetryLock
-    <$> Toml.list poetryLockPackageCodec "package"
-      .= poetryLockPackages
-    <*> Toml.table poetryMetadataCodec "metadata"
-      .= poetryLockMetadata
+newtype PackageName = PackageName {unPackageName :: Text} deriving (Eq, Ord, Show)
 
 -- | Metadata of poetry lock file.
 data PoetryMetadata = PoetryMetadata
@@ -42,15 +39,13 @@ data PoetryMetadata = PoetryMetadata
   }
   deriving (Eq, Ord, Show)
 
-poetryMetadataCodec :: TomlCodec PoetryMetadata
-poetryMetadataCodec =
-  PoetryMetadata
-    <$> Toml.text "lock-version"
-      .= poetryMetadataLockVersion
-    <*> Toml.text "content-hash"
-      .= poetryMetadataContentHash
-    <*> Toml.text "python-versions"
-      .= poetryMetadataPythonVersions
+instance Toml.Schema.FromValue PoetryMetadata where
+  fromValue =
+    Toml.Schema.parseTableFromValue $
+      PoetryMetadata
+        <$> Toml.Schema.reqKey "lock-version"
+        <*> Toml.Schema.reqKey "content-hash"
+        <*> Toml.Schema.reqKey "python-versions"
 
 -- | A PoetryLockPackageSource represents [package.source] field in poetry.lock.
 -- Source indicates from where the package was retrieved.
@@ -61,6 +56,15 @@ data PoetryLockPackageSource = PoetryLockPackageSource
   , poetryLockPackageSourceResolvedReference :: Maybe Text
   }
   deriving (Eq, Ord, Show)
+
+instance Toml.Schema.FromValue PoetryLockPackageSource where
+  fromValue =
+    Toml.Schema.parseTableFromValue $
+      PoetryLockPackageSource
+        <$> Toml.Schema.reqKey "type"
+        <*> Toml.Schema.reqKey "url"
+        <*> Toml.Schema.optKey "reference"
+        <*> Toml.Schema.optKey "resolved_reference"
 
 -- | Poetry package entry found in poetry lock file.
 data PoetryLockPackage = PoetryLockPackage
@@ -74,35 +78,16 @@ data PoetryLockPackage = PoetryLockPackage
   }
   deriving (Eq, Ord, Show)
 
-poetryLockPackageCodec :: TomlCodec PoetryLockPackage
-poetryLockPackageCodec =
-  PoetryLockPackage
-    <$> Toml.diwrap (Toml.text "name")
-      .= poetryLockPackageName
-    <*> Toml.text "version"
-      .= poetryLockPackageVersion
-    <*> Toml.dioptional (Toml.text "category")
-      .= poetryLockPackageCategory
-    <*> Toml.bool "optional"
-      .= poetryLockPackageOptional
-    <*> Toml.text "python-versions"
-      .= poetryLockPackagePythonVersions
-    <*> Toml.tableMap Toml._KeyText poetryLockPackagePoetryLockDependencySpecCodec "dependencies"
-      .= poetryLockPackageDependencies
-    <*> Toml.dioptional (Toml.table poetryLockPackageSourceCodec "source")
-      .= poetryLockPackageSource
-
-poetryLockPackageSourceCodec :: TomlCodec PoetryLockPackageSource
-poetryLockPackageSourceCodec =
-  PoetryLockPackageSource
-    <$> Toml.text "type"
-      .= poetryLockPackageSourceType
-    <*> Toml.text "url"
-      .= poetryLockPackageSourceUrl
-    <*> Toml.dioptional (Toml.text "reference")
-      .= poetryLockPackageSourceReference
-    <*> Toml.dioptional (Toml.text "resolved_reference")
-      .= poetryLockPackageSourceResolvedReference
+instance Toml.Schema.FromValue PoetryLockPackage where
+  fromValue =
+    Toml.Schema.parseTableFromValue $
+      (PoetryLockPackage . PackageName <$> Toml.Schema.reqKey "name")
+        <*> Toml.Schema.reqKey "version"
+        <*> Toml.Schema.optKey "category"
+        <*> Toml.Schema.reqKey "optional"
+        <*> Toml.Schema.reqKey "python-versions"
+        <*> Toml.Schema.pickKey [Toml.Schema.Key "dependencies" Toml.Schema.fromValue, Toml.Schema.Else $ pure mempty]
+        <*> Toml.Schema.optKey "source"
 
 data PoetryLockDependencySpec
   = TextVersion Text
@@ -110,31 +95,19 @@ data PoetryLockDependencySpec
   | MultipleObjectVersionSpec [ObjectVersion]
   deriving (Eq, Ord, Show)
 
+instance Toml.Schema.FromValue PoetryLockDependencySpec where
+  fromValue (Toml.Schema.Text' _ t) = pure $ TextVersion t
+  fromValue v@(Toml.Schema.Table' _ _) = ObjectVersionSpec <$> Toml.Schema.fromValue v
+  fromValue v@Toml.Schema.List'{} = MultipleObjectVersionSpec <$> Toml.Schema.fromValue v
+  fromValue v = Toml.Schema.failAt (Toml.valueAnn v) $ "invalid poetry dependency spec " <> Toml.valueType v
+
 newtype ObjectVersion = ObjectVersion
   { unObjectVersion :: Text
   }
   deriving (Eq, Ord, Show)
 
-objectVersionCodec :: TomlCodec ObjectVersion
-objectVersionCodec =
-  ObjectVersion
-    <$> Toml.text "version"
-      .= unObjectVersion
-
-matchTextVersion :: PoetryLockDependencySpec -> Maybe Text
-matchTextVersion (TextVersion version) = Just version
-matchTextVersion _ = Nothing
-
-matchObjectVersionSpec :: PoetryLockDependencySpec -> Maybe ObjectVersion
-matchObjectVersionSpec (ObjectVersionSpec version) = Just version
-matchObjectVersionSpec _ = Nothing
-
-matchMultipleObjectVersionSpec :: PoetryLockDependencySpec -> Maybe [ObjectVersion]
-matchMultipleObjectVersionSpec (MultipleObjectVersionSpec version) = Just version
-matchMultipleObjectVersionSpec _ = Nothing
-
-poetryLockPackagePoetryLockDependencySpecCodec :: Toml.Key -> TomlCodec PoetryLockDependencySpec
-poetryLockPackagePoetryLockDependencySpecCodec key =
-  Toml.dimatch matchTextVersion TextVersion (Toml.text key)
-    <|> Toml.dimatch matchObjectVersionSpec ObjectVersionSpec (Toml.table objectVersionCodec key)
-    <|> Toml.dimatch matchMultipleObjectVersionSpec MultipleObjectVersionSpec (Toml.list objectVersionCodec key)
+instance Toml.Schema.FromValue ObjectVersion where
+  fromValue =
+    Toml.Schema.parseTableFromValue $
+      ObjectVersion
+        <$> Toml.Schema.reqKey "version"

--- a/src/Strategy/Python/Poetry/PyProject.hs
+++ b/src/Strategy/Python/Poetry/PyProject.hs
@@ -126,7 +126,7 @@ data PyProjectMetadata = PyProjectMetadata
   deriving (Show, Eq, Ord)
 
 newtype PyProjectBuildSystem = PyProjectBuildSystem
-  { buildBackend :: Text
+  { buildBackend :: Maybe Text
   }
   deriving (Show, Eq, Ord)
 
@@ -134,7 +134,7 @@ instance Toml.Schema.FromValue PyProjectBuildSystem where
   fromValue =
     Toml.Schema.parseTableFromValue $
       PyProjectBuildSystem
-        <$> Toml.Schema.reqKey "build-backend"
+        <$> Toml.Schema.optKey "build-backend"
 
 data PyProjectPoetry = PyProjectPoetry
   { name :: Maybe Text

--- a/src/Strategy/Python/Poetry/PyProject.hs
+++ b/src/Strategy/Python/Poetry/PyProject.hs
@@ -230,7 +230,7 @@ instance Toml.Schema.FromValue PoetryDependency where
   fromValue (Toml.Text' _ t) = pure $ PoetryTextVersion t
   fromValue v@(Toml.Table' l t) =
     Toml.Schema.parseTable
-      ( Toml.Schema.pickKey $
+      ( Toml.Schema.pickKey
           [ Toml.Schema.Key "version" (const (PyProjectPoetryDetailedVersionDependencySpec <$> Toml.Schema.fromValue v))
           , Toml.Schema.Key "git" (const (PyProjectPoetryGitDependencySpec <$> Toml.Schema.fromValue v))
           , Toml.Schema.Key "path" (const (PyProjectPoetryPathDependencySpec <$> Toml.Schema.fromValue v))

--- a/src/Strategy/Python/Poetry/PyProject.hs
+++ b/src/Strategy/Python/Poetry/PyProject.hs
@@ -231,11 +231,12 @@ instance Toml.Schema.FromValue PoetryDependency where
   fromValue v@(Toml.Table' l t) =
     Toml.Schema.parseTable
       ( Toml.Schema.pickKey $
-          [Toml.Schema.Key "version" (const (PyProjectPoetryDetailedVersionDependencySpec <$> Toml.Schema.fromValue v))]
-            <> [Toml.Schema.Key "git" (const (PyProjectPoetryGitDependencySpec <$> Toml.Schema.fromValue v))]
-            <> [Toml.Schema.Key "path" (const (PyProjectPoetryPathDependencySpec <$> Toml.Schema.fromValue v))]
-            <> [Toml.Schema.Key "url" (const (PyProjectPoetryUrlDependencySpec <$> Toml.Schema.fromValue v))]
-            <> [Toml.Schema.Else (Toml.Schema.failAt (Toml.valueAnn v) "invalid spec")]
+          [ Toml.Schema.Key "version" (const (PyProjectPoetryDetailedVersionDependencySpec <$> Toml.Schema.fromValue v))
+          , Toml.Schema.Key "git" (const (PyProjectPoetryGitDependencySpec <$> Toml.Schema.fromValue v))
+          , Toml.Schema.Key "path" (const (PyProjectPoetryPathDependencySpec <$> Toml.Schema.fromValue v))
+          , Toml.Schema.Key "url" (const (PyProjectPoetryUrlDependencySpec <$> Toml.Schema.fromValue v))
+          , Toml.Schema.Else (Toml.Schema.failAt (Toml.valueAnn v) "invalid spec")
+          ]
       )
       l
       t

--- a/test/Go/GopkgLockSpec.hs
+++ b/test/Go/GopkgLockSpec.hs
@@ -68,11 +68,25 @@ spec = do
 
   describe "analyze" $
     it "should produce expected output" $ do
-      case Toml.decode golockCodec contents of
-        Left err -> expectationFailure ("decode failed: " <> show err)
-        Right golock -> do
+      case Toml.decode contents of
+        Toml.Failure err -> expectationFailure ("decode failed: " <> show err)
+        Toml.Success warnings golock -> do
           let result = buildGraph (lockProjects golock) & graphingGolang & run
           result `shouldBe` expected
+          warnings
+            `shouldBe` [ "5:3: unexpected key: digest in projects[0]"
+                       , "7:3: unexpected key: packages in projects[0]"
+                       , "8:3: unexpected key: pruneopts in projects[0]"
+                       , "10:3: unexpected key: version in projects[0]"
+                       , "13:3: unexpected key: digest in projects[1]"
+                       , "15:3: unexpected key: packages in projects[1]"
+                       , "23:3: unexpected key: pruneopts in projects[1]"
+                       , "25:3: unexpected key: version in projects[1]"
+                       , "29:3: unexpected key: branch in projects[2]"
+                       , "30:3: unexpected key: digest in projects[2]"
+                       , "32:3: unexpected key: packages in projects[2]"
+                       , "33:3: unexpected key: pruneopts in projects[2]"
+                       ]
 
   describe "buildGraph" $
     it "should produce expected output" $ do

--- a/test/Go/GopkgTomlSpec.hs
+++ b/test/Go/GopkgTomlSpec.hs
@@ -102,11 +102,12 @@ spec = do
 
   describe "analyze" $
     it "should produce expected output" $ do
-      case Toml.decode gopkgCodec contents of
-        Left err -> expectationFailure ("decode failed: " <> show err)
-        Right pkg -> do
+      case Toml.decode contents of
+        Toml.Failure err -> expectationFailure ("decode failed: " <> show err)
+        Toml.Success warnings pkg -> do
           let result = buildGraph pkg & graphingGolang & run
           result `shouldBe` expected
+          warnings `shouldBe` []
 
   describe "buildGraph" $
     it "should produce expected output" $ do

--- a/test/Pdm/PdmLockSpec.hs
+++ b/test/Pdm/PdmLockSpec.hs
@@ -6,7 +6,7 @@ module Pdm.PdmLockSpec (
 
 import Data.Text (Text)
 import DepTypes (DepType (..), Dependency (..), VerConstraint (..))
-import Strategy.Python.PDM.PdmLock (PdmLock (..), PdmLockPackage (..), pdmLockCodec, toDependency)
+import Strategy.Python.PDM.PdmLock (PdmLock (..), PdmLockPackage (..), toDependency)
 import Strategy.Python.Util (Req (..))
 import Test.Hspec (
   Spec,
@@ -25,11 +25,11 @@ spec = do
   describe "lockfile" $ do
     it "should parse empty lock file" $ do
       let expected = PdmLock mempty
-      Toml.decode pdmLockCodec lockNoContent `shouldBe` Right expected
+      Toml.decode lockNoContent `shouldBe` (Toml.Success [] expected)
 
     it "should parse lock file with one entry" $ do
       let expected = PdmLock [PdmLockPackage "blinker" "1.6.2" Nothing Nothing Nothing Nothing Nothing]
-      Toml.decode pdmLockCodec lockOneEntry `shouldBe` Right expected
+      Toml.decode lockOneEntry `shouldBe` (Toml.Success [] expected)
 
     it "should parse lock file with multiple entry" $ do
       let expected =
@@ -37,7 +37,7 @@ spec = do
               [ PdmLockPackage "blinker" "1.6.2" Nothing Nothing Nothing Nothing (Just [mkReq "b"])
               , PdmLockPackage "b" "1.0.0" Nothing Nothing Nothing Nothing Nothing
               ]
-      Toml.decode pdmLockCodec lockMultipleEntry `shouldBe` Right expected
+      Toml.decode lockMultipleEntry `shouldBe` (Toml.Success [] expected)
 
     it "should parse lock file, with git deps" $ do
       let expected =
@@ -51,14 +51,14 @@ spec = do
                   Nothing
                   Nothing
               ]
-      Toml.decode pdmLockCodec lockWithGitEntry `shouldBe` Right expected
+      Toml.decode lockWithGitEntry `shouldBe` (Toml.Success ["7:1: unexpected key: ref in package[0]", "5:1: unexpected key: requires_python in package[0]", "9:1: unexpected key: summary in package[0]"] expected)
 
     it "should parse lock file, with filepath deps" $ do
       let expected =
             PdmLock
               [ lockWithFilePathEntryPackage
               ]
-      Toml.decode pdmLockCodec lockWithFilePathEntry `shouldBe` Right expected
+      Toml.decode lockWithFilePathEntry `shouldBe` (Toml.Success ["5:1: unexpected key: requires_python in package[0]", "7:1: unexpected key: summary in package[0]"] expected)
 
     it "should parse lock file, with url deps" $ do
       let expected =
@@ -72,7 +72,7 @@ spec = do
                   (Just "https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.5.0/en_core_web_trf-3.5.0-py3-none-any.whl")
                   Nothing
               ]
-      Toml.decode pdmLockCodec lockWithFileUrlEntry `shouldBe` Right expected
+      Toml.decode lockWithFileUrlEntry `shouldBe` (Toml.Success [] expected)
 
   describe "toDependency" $
     it "should handle pdm's local dependency correctly" $ do

--- a/test/Python/Poetry/CommonSpec.hs
+++ b/test/Python/Poetry/CommonSpec.hs
@@ -40,7 +40,7 @@ import Toml.Schema qualified
 expectedPyProject :: PyProject
 expectedPyProject =
   PyProject
-    { pyprojectBuildSystem = Just $ PyProjectBuildSystem{buildBackend = "poetry.core.masonry.api"}
+    { pyprojectBuildSystem = Just $ PyProjectBuildSystem{buildBackend = Just "poetry.core.masonry.api"}
     , pyprojectProject = Nothing
     , pyprojectTool =
         Just $

--- a/test/Python/Poetry/PoetryLockSpec.hs
+++ b/test/Python/Poetry/PoetryLockSpec.hs
@@ -12,7 +12,6 @@ import Strategy.Python.Poetry.PoetryLock (
   PoetryLockPackage (..),
   PoetryLockPackageSource (..),
   PoetryMetadata (..),
-  poetryLockCodec,
  )
 import Test.Hspec (
   Spec,
@@ -149,6 +148,20 @@ expectedPoetryLock =
 spec :: Spec
 spec = do
   contents <- runIO (TIO.readFile "test/Python/Poetry/testdata/poetry.lock")
-  describe "poetryLockCodec" $
+  describe "decoding toml file" $
     it "should produce expected output" $
-      Toml.decode poetryLockCodec contents `shouldBe` Right expectedPoetryLock
+      Toml.decode contents
+        `shouldBe` Toml.Success
+          [ "5:1: unexpected key: description in package[0]"
+          , "21:1: unexpected key: description in package[1]"
+          , "34:1: unexpected key: description in package[2]"
+          , "54:28: unexpected key: markers in package[3].dependencies.pkgThreeChildofOne[0]"
+          , "55:28: unexpected key: markers in package[3].dependencies.pkgThreeChildofOne[1]"
+          , "57:38: unexpected key: markers in package[3].dependencies.pkgTwoChildofOne"
+          , "45:1: unexpected key: description in package[3]"
+          , "62:1: unexpected key: description in package[4]"
+          , "69:1: unexpected key: description in package[5]"
+          , "76:1: unexpected key: description in package[6]"
+          , "83:1: unexpected key: description in package[7]"
+          ]
+          expectedPoetryLock

--- a/test/Python/Poetry/PyProjectSpec.hs
+++ b/test/Python/Poetry/PyProjectSpec.hs
@@ -139,19 +139,20 @@ spec = do
       it "should parse pyrproject file with all source types" $ do
         Toml.decode nominalContents
           `shouldBe` Toml.Success
-            [ "37:1: unexpected key: requires in build-system"
-            , "24:31: unexpected key: allow-prereleases in tool.poetry.dependencies.black.version"
-            , "24:74: unexpected key: markers in tool.poetry.dependencies.black.version"
-            , "24:57: unexpected key: python in tool.poetry.dependencies.black.version"
-            , "24:31: unexpected key: allow-prereleases in tool.poetry.dependencies.black"
-            , "24:74: unexpected key: markers in tool.poetry.dependencies.black"
-            , "24:57: unexpected key: python in tool.poetry.dependencies.black"
-            , "9:56: unexpected key: rev in tool.poetry.dependencies.flask"
-            , "21:43: unexpected key: develop in tool.poetry.dependencies.my-packageDir.path"
-            , "21:43: unexpected key: develop in tool.poetry.dependencies.my-packageDir"
-            , "11:54: unexpected key: tag in tool.poetry.dependencies.numpy"
-            , "12:67: unexpected key: branch in tool.poetry.dependencies.requests"
-            , "39:15: unexpected key: source in tool.poetry"
+            [ "40:1: unexpected key: requires in build-system"
+            , "27:31: unexpected key: allow-prereleases in tool.poetry.dependencies.black.version"
+            , "27:74: unexpected key: markers in tool.poetry.dependencies.black.version"
+            , "27:57: unexpected key: python in tool.poetry.dependencies.black.version"
+            , "27:31: unexpected key: allow-prereleases in tool.poetry.dependencies.black"
+            , "27:74: unexpected key: markers in tool.poetry.dependencies.black"
+            , "27:57: unexpected key: python in tool.poetry.dependencies.black"
+            , "12:56: unexpected key: rev in tool.poetry.dependencies.flask"
+            , "24:43: unexpected key: develop in tool.poetry.dependencies.my-packageDir.path"
+            , "24:43: unexpected key: develop in tool.poetry.dependencies.my-packageDir"
+            , "14:54: unexpected key: tag in tool.poetry.dependencies.numpy"
+            , "15:67: unexpected key: branch in tool.poetry.dependencies.requests"
+            , "6:14: unexpected key: scripts in tool.poetry"
+            , "42:15: unexpected key: source in tool.poetry"
             ]
             expectedPyProject
 

--- a/test/Python/Poetry/PyProjectSpec.hs
+++ b/test/Python/Poetry/PyProjectSpec.hs
@@ -23,7 +23,6 @@ import Strategy.Python.Poetry.PyProject (
   PoetryDependency (..),
   PyProject (..),
   PyProjectBuildSystem (..),
-  PyProjectPdm (..),
   PyProjectPoetry (..),
   PyProjectPoetryDetailedVersionDependency (..),
   PyProjectPoetryGitDependency (..),

--- a/test/Python/Poetry/PyProjectSpec.hs
+++ b/test/Python/Poetry/PyProjectSpec.hs
@@ -1,7 +1,6 @@
 module Python.Poetry.PyProjectSpec (
   spec,
-)
-where
+) where
 
 import Data.Map qualified as Map
 import Data.Text (Text)
@@ -20,7 +19,21 @@ import DepTypes (
     COr
   ),
  )
-import Strategy.Python.Poetry.PyProject (PoetryDependency (..), PyProject (..), PyProjectBuildSystem (..), PyProjectPoetry (..), PyProjectPoetryDetailedVersionDependency (..), PyProjectPoetryGitDependency (..), PyProjectPoetryPathDependency (..), PyProjectPoetryUrlDependency (..), parseConstraintExpr, pyProjectCodec)
+import Strategy.Python.Poetry.PyProject (
+  PoetryDependency (..),
+  PyProject (..),
+  PyProjectBuildSystem (..),
+  PyProjectPdm (..),
+  PyProjectPoetry (..),
+  PyProjectPoetryDetailedVersionDependency (..),
+  PyProjectPoetryGitDependency (..),
+  PyProjectPoetryGroup (..),
+  PyProjectPoetryGroupDependencies (..),
+  PyProjectPoetryPathDependency (..),
+  PyProjectPoetryUrlDependency (..),
+  PyProjectTool (..),
+  parseConstraintExpr,
+ )
 import Test.Hspec (
   Expectation,
   Spec,
@@ -44,31 +57,34 @@ expectedPyProject =
   PyProject
     { pyprojectBuildSystem = Just $ PyProjectBuildSystem{buildBackend = "poetry.core.masonry.api"}
     , pyprojectProject = Nothing
-    , pyprojectPdmDevDependencies = Just mempty
-    , pyprojectPoetry =
+    , pyprojectTool =
         Just $
-          PyProjectPoetry
-            { name = Just "test_name"
-            , version = Just "test_version"
-            , description = Just "test_description"
-            , dependencies =
-                Map.fromList
-                  [ ("flake8", PoetryTextVersion "^1.1")
-                  , ("python", PoetryTextVersion "^3.9")
-                  , ("flask", PyProjectPoetryGitDependencySpec $ PyProjectPoetryGitDependency{gitUrl = "https://github.com/pallets/flask.git", gitRev = Just "38eb5d3b", gitTag = Nothing, gitBranch = Nothing})
-                  , ("networkx", PyProjectPoetryGitDependencySpec $ PyProjectPoetryGitDependency{gitUrl = "https://github.com/networkx/networkx.git", gitRev = Nothing, gitTag = Nothing, gitBranch = Nothing})
-                  , ("numpy", PyProjectPoetryGitDependencySpec $ PyProjectPoetryGitDependency{gitUrl = "https://github.com/numpy/numpy.git", gitRev = Nothing, gitTag = Just "v0.13.2", gitBranch = Nothing})
-                  , ("requests", PyProjectPoetryGitDependencySpec $ PyProjectPoetryGitDependency{gitUrl = "https://github.com/kennethreitz/requests.git", gitRev = Nothing, gitTag = Nothing, gitBranch = Just "next"})
-                  , ("my-packageUrl", PyProjectPoetryUrlDependencySpec $ PyProjectPoetryUrlDependency{sourceUrl = "https://example.com/my-package-0.1.0.tar.gz"})
-                  , ("my-packageFile", PyProjectPoetryPathDependencySpec $ PyProjectPoetryPathDependency{sourcePath = "../my-package/dist/my-package-0.1.0.tar.gz"})
-                  , ("my-packageDir", PyProjectPoetryPathDependencySpec $ PyProjectPoetryPathDependency{sourcePath = "../my-package/"})
-                  , ("black", PyProjectPoetryDetailedVersionDependencySpec $ PyProjectPoetryDetailedVersionDependency{poetryDependencyVersion = "19.10b0"})
-                  ]
-            , devDependencies =
-                Map.fromList
-                  [("pytest", PoetryTextVersion "*")]
-            , groupDevDependencies = Map.empty
-            , groupTestDependencies = Map.empty
+          PyProjectTool
+            { pyprojectPoetry =
+                Just $
+                  PyProjectPoetry
+                    { name = Just "test_name"
+                    , version = Just "test_version"
+                    , description = Just "test_description"
+                    , dependencies =
+                        Map.fromList
+                          [ ("flake8", PoetryTextVersion "^1.1")
+                          , ("python", PoetryTextVersion "^3.9")
+                          , ("flask", PyProjectPoetryGitDependencySpec $ PyProjectPoetryGitDependency{gitUrl = "https://github.com/pallets/flask.git", gitRev = Just "38eb5d3b", gitTag = Nothing, gitBranch = Nothing})
+                          , ("networkx", PyProjectPoetryGitDependencySpec $ PyProjectPoetryGitDependency{gitUrl = "https://github.com/networkx/networkx.git", gitRev = Nothing, gitTag = Nothing, gitBranch = Nothing})
+                          , ("numpy", PyProjectPoetryGitDependencySpec $ PyProjectPoetryGitDependency{gitUrl = "https://github.com/numpy/numpy.git", gitRev = Nothing, gitTag = Just "v0.13.2", gitBranch = Nothing})
+                          , ("requests", PyProjectPoetryGitDependencySpec $ PyProjectPoetryGitDependency{gitUrl = "https://github.com/kennethreitz/requests.git", gitRev = Nothing, gitTag = Nothing, gitBranch = Just "next"})
+                          , ("my-packageUrl", PyProjectPoetryUrlDependencySpec $ PyProjectPoetryUrlDependency{sourceUrl = "https://example.com/my-package-0.1.0.tar.gz"})
+                          , ("my-packageFile", PyProjectPoetryPathDependencySpec $ PyProjectPoetryPathDependency{sourcePath = "../my-package/dist/my-package-0.1.0.tar.gz"})
+                          , ("my-packageDir", PyProjectPoetryPathDependencySpec $ PyProjectPoetryPathDependency{sourcePath = "../my-package/"})
+                          , ("black", PyProjectPoetryDetailedVersionDependencySpec $ PyProjectPoetryDetailedVersionDependency{poetryDependencyVersion = "19.10b0"})
+                          ]
+                    , devDependencies =
+                        Map.fromList
+                          [("pytest", PoetryTextVersion "*")]
+                    , pyprojectPoetryGroup = Nothing
+                    }
+            , pyprojectPdm = Nothing
             }
     }
 
@@ -77,28 +93,40 @@ expectedPyProject3 =
   PyProject
     { pyprojectBuildSystem = Just $ PyProjectBuildSystem{buildBackend = "poetry.core.masonry.api"}
     , pyprojectProject = Nothing
-    , pyprojectPdmDevDependencies = Just mempty
-    , pyprojectPoetry =
+    , pyprojectTool =
         Just $
-          PyProjectPoetry
-            { name = Just "test_name"
-            , version = Just "test_version"
-            , description = Just "test_description"
-            , dependencies =
-                Map.fromList
-                  [ ("python", PoetryTextVersion "^3.12")
-                  , ("rich", PoetryTextVersion "*")
-                  ]
-            , devDependencies = Map.empty
-            , groupDevDependencies =
-                Map.fromList
-                  [ ("click", PoetryTextVersion "*")
-                  ]
-            , groupTestDependencies =
-                Map.fromList
-                  [ ("pytest", PoetryTextVersion "^6.0.0")
-                  , ("pytest-mock", PoetryTextVersion "*")
-                  ]
+          PyProjectTool
+            { pyprojectPoetry =
+                Just $
+                  PyProjectPoetry
+                    { name = Just "test_name"
+                    , version = Just "test_version"
+                    , description = Just "test_description"
+                    , dependencies =
+                        Map.fromList
+                          [ ("python", PoetryTextVersion "^3.12")
+                          , ("rich", PoetryTextVersion "*")
+                          ]
+                    , devDependencies = Map.empty
+                    , pyprojectPoetryGroup =
+                        Just $
+                          PyProjectPoetryGroup
+                            { groupDev =
+                                Just $
+                                  PyProjectPoetryGroupDependencies $
+                                    Map.fromList
+                                      [ ("click", PoetryTextVersion "*")
+                                      ]
+                            , groupTest =
+                                Just $
+                                  PyProjectPoetryGroupDependencies $
+                                    Map.fromList
+                                      [ ("pytest", PoetryTextVersion "^6.0.0")
+                                      , ("pytest-mock", PoetryTextVersion "*")
+                                      ]
+                            }
+                    }
+            , pyprojectPdm = Nothing
             }
     }
 
@@ -110,8 +138,32 @@ spec = do
   describe "pyProjectCodec" $
     describe "when provided with all possible types of dependency sources" $
       it "should parse pyrproject file with all source types" $ do
-        Toml.decode pyProjectCodec nominalContents `shouldBe` Right expectedPyProject
-        Toml.decode pyProjectCodec groupDevContents `shouldBe` Right expectedPyProject3
+        Toml.decode nominalContents
+          `shouldBe` Toml.Success
+            [ "37:1: unexpected key: requires in build-system"
+            , "24:31: unexpected key: allow-prereleases in tool.poetry.dependencies.black.version"
+            , "24:74: unexpected key: markers in tool.poetry.dependencies.black.version"
+            , "24:57: unexpected key: python in tool.poetry.dependencies.black.version"
+            , "24:31: unexpected key: allow-prereleases in tool.poetry.dependencies.black"
+            , "24:74: unexpected key: markers in tool.poetry.dependencies.black"
+            , "24:57: unexpected key: python in tool.poetry.dependencies.black"
+            , "9:56: unexpected key: rev in tool.poetry.dependencies.flask"
+            , "21:43: unexpected key: develop in tool.poetry.dependencies.my-packageDir.path"
+            , "21:43: unexpected key: develop in tool.poetry.dependencies.my-packageDir"
+            , "11:54: unexpected key: tag in tool.poetry.dependencies.numpy"
+            , "12:67: unexpected key: branch in tool.poetry.dependencies.requests"
+            , "39:15: unexpected key: source in tool.poetry"
+            ]
+            expectedPyProject
+
+        Toml.decode groupDevContents
+          `shouldBe` Toml.Success
+            [ "26:1: unexpected key: requires in build-system"
+            , "19:20: unexpected key: docs in tool.poetry.group"
+            , "5:1: unexpected key: authors in tool.poetry"
+            , "6:1: unexpected key: readme in tool.poetry"
+            ]
+            expectedPyProject3
 
   describe "parseConstraintExpr" $ do
     it "should parse equality constraint" $ do

--- a/test/Python/Poetry/PyProjectSpec.hs
+++ b/test/Python/Poetry/PyProjectSpec.hs
@@ -54,7 +54,7 @@ shouldParseInto = parseMatch parseConstraintExpr
 expectedPyProject :: PyProject
 expectedPyProject =
   PyProject
-    { pyprojectBuildSystem = Just $ PyProjectBuildSystem{buildBackend = "poetry.core.masonry.api"}
+    { pyprojectBuildSystem = Just $ PyProjectBuildSystem{buildBackend = Just "poetry.core.masonry.api"}
     , pyprojectProject = Nothing
     , pyprojectTool =
         Just $
@@ -90,7 +90,7 @@ expectedPyProject =
 expectedPyProject3 :: PyProject
 expectedPyProject3 =
   PyProject
-    { pyprojectBuildSystem = Just $ PyProjectBuildSystem{buildBackend = "poetry.core.masonry.api"}
+    { pyprojectBuildSystem = Just $ PyProjectBuildSystem{buildBackend = Just "poetry.core.masonry.api"}
     , pyprojectProject = Nothing
     , pyprojectTool =
         Just $

--- a/test/Python/Poetry/testdata/pyproject1.toml
+++ b/test/Python/Poetry/testdata/pyproject1.toml
@@ -3,6 +3,9 @@ description = "test_description"
 name = "test_name"
 version = "test_version"
 
+[tool.poetry.scripts]
+test-script = "test_script"
+
 [tool.poetry.dependencies]
 
 # git

--- a/test/Python/PoetrySpec.hs
+++ b/test/Python/PoetrySpec.hs
@@ -2,8 +2,7 @@
 
 module Python.PoetrySpec (
   spec,
-)
-where
+) where
 
 import Data.Map qualified as Map
 import Data.Set qualified as Set
@@ -29,7 +28,7 @@ import Strategy.Python.Poetry.PoetryLock (
   PoetryLockPackage (..),
   PoetryMetadata (..),
  )
-import Strategy.Python.Poetry.PyProject (PoetryDependency (..), PyProject (..), PyProjectBuildSystem (..), PyProjectPoetry (..))
+import Strategy.Python.Poetry.PyProject (PoetryDependency (..), PyProject (..), PyProjectBuildSystem (..), PyProjectPoetry (..), PyProjectTool (..))
 import Test.Effect (it')
 import Test.Hspec (Spec, describe, it, runIO, shouldBe)
 import Types (DependencyResults (dependencyGraph))
@@ -40,10 +39,15 @@ newPoetryLock pkgs = PoetryLock pkgs $ PoetryMetadata "some-version" "some-hash"
 candidatePyProject :: PyProject
 candidatePyProject =
   PyProject
-    (Just $ PyProjectBuildSystem "poetry.core.masonry.api")
-    (Just $ PyProjectPoetry Nothing Nothing Nothing (Map.fromList ([("flow_pipes", PoetryTextVersion "^1.21")])) mempty mempty mempty)
-    Nothing
-    Nothing
+    { pyprojectBuildSystem = Just $ PyProjectBuildSystem "poetry.core.masonry.api"
+    , pyprojectProject = Nothing
+    , pyprojectTool =
+        Just $
+          PyProjectTool
+            { pyprojectPdm = Nothing
+            , pyprojectPoetry = Just $ PyProjectPoetry Nothing Nothing Nothing (Map.fromList ([("flow_pipes", PoetryTextVersion "^1.21")])) mempty Nothing
+            }
+    }
 
 candidatePoetryLock :: PoetryLock
 candidatePoetryLock =

--- a/test/Python/PoetrySpec.hs
+++ b/test/Python/PoetrySpec.hs
@@ -39,7 +39,7 @@ newPoetryLock pkgs = PoetryLock pkgs $ PoetryMetadata "some-version" "some-hash"
 candidatePyProject :: PyProject
 candidatePyProject =
   PyProject
-    { pyprojectBuildSystem = Just $ PyProjectBuildSystem "poetry.core.masonry.api"
+    { pyprojectBuildSystem = Just $ PyProjectBuildSystem{buildBackend = Just "poetry.core.masonry.api"}
     , pyprojectProject = Nothing
     , pyprojectTool =
         Just $


### PR DESCRIPTION
# Overview

- This PR replaces `tomland` with `toml-parser`. The reason for the switch is because `tomland` has an issue with [handling explicit vs implicit tables](https://github.com/kowainik/tomland/issues/336#issuecomment-683406463). `toml-parser` does not have the same issue.

- The issue mainly affected poetry toml files, and as shown in ANE-1827 was cuasing CLI to believe there were no dependencies in `tool.poetry.dependencies`.

- Switching to `toml-parser` also seems to resolve an issue with `poetry.lock` files where keys wrapped in quotes contained the quotes after parsing: 
```
"backports.entry-points-selectable" = [ ... ]
```
was being recorded as `pip+"backports.entry-points-selectable"` instead of `pip+backports-entry-points-selectable`

## Acceptance criteria

- toml files are parsed correctly

## Testing plan

- download the zip file ANE-1827
- run:
`cabal run fossa -- analyze /path/to/extracted_files -o --only-target poetry | jq -c ".sourceUnits[0].Build.Dependencies"`
- there should be a list of dependencies
- running the same command using the latest fossa release report no dependencies

## Risks

- toml-parser doesn't provide a way to deal with nested values/tables, so I had to change some of the datatypes to better match the toml formats. However each of them is covered by tests.

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

https://fossa.atlassian.net/browse/ANE-1827

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
