### PR TITLE
include projectId in --json output

### DIFF
--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -59,7 +59,7 @@ fossa analyze --json
 ```
 
 ```json
-{"branch":"master", "id":"custom+<org-id>/new-project$123", "project":"org-id/new-project", "projectId":"custom+<org-id>/new-project", "revision":"123", "url":"https://app.fossa.com/projects/custom+<org-id>/new-project/refs/branch/master/123"}
+{"branch":"master", "id":"custom+<org-id>/new-project$123", "project":"<org-id>/new-project", "projectId":"custom+<org-id>/new-project", "revision":"123", "url":"https://app.fossa.com/projects/custom+<org-id>/new-project/refs/branch/master/123"}
 ```
 
 ### Running a specific fossa-deps file

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -59,7 +59,7 @@ fossa analyze --json
 ```
 
 ```json
-{"branch":"master", "id":"custom+<org-id>/new-project$123", "project":"<org-id>/new-project", "projectId":"custom+<org-id>/new-project", "revision":"123", "url":"https://app.fossa.com/projects/custom+<org-id>/new-project/refs/branch/master/123"}
+{"branch":"master", "id":"custom+<org-id>/new-project$123", "project":"<org-id>/new-project", "projectId":"custom+<org-id>/new-project", "revision":"123", "url":"https://app.fossa.com/projects/custom%2b+<org-id>$2fnew-project/refs/branch/master/123"}
 ```
 
 ### Running a specific fossa-deps file

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -57,8 +57,9 @@ The `--json` flag can be used to print project metadata after running `fossa ana
 ```sh
 fossa analyze --json
 ```
+
 ```json
-{"project":{"name":"custom@new-project","branch":"master","revision":"123","url":"https://app.fossa.com/projects/custom+<org-id>/new-project/refs/branch/master/123","id":"custom+<org-id>/new-project$123"}}
+{"branch":"master", "id":"custom+<org-id>/new-project$123", "project":"org-id/new-project", "projectId":"custom+<org-id>/new-project", "revision":"123", "url":"https://app.fossa.com/projects/custom+<org-id>/new-project/refs/branch/master/123"}
 ```
 
 ### Running a specific fossa-deps file
@@ -181,7 +182,7 @@ Note that the `MY_RG` release group must already exist, as well as `MY_RELEASE_V
 #### What are the default filters?
 
 Default filters are filters which `fossa-cli` applies by default. These filters,
-provide sensible non-production target exclusion. As `fossa-cli` relies on manifest and lock files provided in the project's directory, 
+provide sensible non-production target exclusion. As `fossa-cli` relies on manifest and lock files provided in the project's directory,
 default filters, intentionally skip `node_modules/` and such directories. If `fossa-cli` discovers and
 analyzes project found in `node_modules/`: `fossa-cli` will not be able to infer
 the dependency's scope (development or production) and may double count dependencies.

--- a/src/App/Fossa/API/BuildLink.hs
+++ b/src/App/Fossa/API/BuildLink.hs
@@ -18,7 +18,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text.Extra (showT)
 import Fossa.API.Types (ApiOpts (..), Organization (..))
-import Srclib.Types (Locator (..))
+import Srclib.Types (Locator (..), projectId)
 import Text.URI qualified as URI
 import Text.URI.Builder (
   PathComponent (PathComponent),
@@ -31,10 +31,10 @@ import Text.URI.Builder (
 import Text.URI.QQ (uri)
 
 fossaProjectUrlPath :: Locator -> ProjectRevision -> [PathComponent]
-fossaProjectUrlPath Locator{..} ProjectRevision{..} = map PathComponent components
+fossaProjectUrlPath loc@Locator{..} ProjectRevision{..} = map PathComponent components
   where
     components = ["projects", project, "refs", "branch", branch, revision]
-    project = locatorFetcher <> "+" <> locatorProject
+    project = projectId loc
     revision = fromMaybe projectRevision locatorRevision
     -- We default to master because core does, and we need a branch to allow us to
     -- create links directly to builds.  If this changes, then a core change should

--- a/src/App/Fossa/Analyze/Upload.hs
+++ b/src/App/Fossa/Analyze/Upload.hs
@@ -210,6 +210,7 @@ buildProjectSummary project locator projectUrl = do
   pure $
     Aeson.object
       [ "project" .= locatorProject locator
+      , "projectId" .= (locatorFetcher locator <> "+" <> locatorProject locator)
       , "revision" .= revision
       , "branch" .= projectBranch project
       , "url" .= projectUrl

--- a/src/App/Fossa/Analyze/Upload.hs
+++ b/src/App/Fossa/Analyze/Upload.hs
@@ -70,6 +70,7 @@ import Srclib.Types (
   Locator (..),
   SourceUnit,
   licenseUnitToFullSourceUnit,
+  projectId,
   renderLocator,
   sourceUnitToFullSourceUnit,
  )
@@ -210,7 +211,7 @@ buildProjectSummary project locator projectUrl = do
   pure $
     Aeson.object
       [ "project" .= locatorProject locator
-      , "projectId" .= (locatorFetcher locator <> "+" <> locatorProject locator)
+      , "projectId" .= projectId locator
       , "revision" .= revision
       , "branch" .= projectBranch project
       , "url" .= projectUrl

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -411,6 +411,7 @@ renderLocator :: Locator -> Text
 renderLocator Locator{..} =
   locatorFetcher <> "+" <> locatorProject <> "$" <> fromMaybe "" locatorRevision
 
+-- The projectId is the full locator of the project. E.g. custom+123/someProject (<fetcher>+<orgId>/<project-name>)
 projectId :: Locator -> Text
 projectId Locator{..} =
   locatorFetcher <> "+" <> locatorProject

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -20,6 +20,7 @@ module Srclib.Types (
   renderLocator,
   parseLocator,
   pathToOriginPath,
+  projectId,
   someBaseToOriginPath,
   somePathToOriginPath,
   emptyLicenseUnit,
@@ -409,6 +410,10 @@ instance ToText Locator where
 renderLocator :: Locator -> Text
 renderLocator Locator{..} =
   locatorFetcher <> "+" <> locatorProject <> "$" <> fromMaybe "" locatorRevision
+
+projectId :: Locator -> Text
+projectId Locator{..} =
+  locatorFetcher <> "+" <> locatorProject
 
 parseLocator :: Text -> Locator
 parseLocator raw = Locator fetcher project (if Text.null revision then Nothing else Just revision)


### PR DESCRIPTION
# Overview

Delivers [ANE-2002](https://fossa.atlassian.net/browse/ANE-2002)

When you run `fossa analyze --json`, we want to also include the full project ID in the output. the project ID is typically just the existing project field with `custom+` prepended to it:

```
fossa analyze --json
{
  "branch": null,
  "id": "custom+24987/ane-1993-missing-preview$2024-08-29T21:53:33Z",
  "project": "24987/ane-1993-missing-preview",
  "projectId": "custom+24987/ane-1993-missing-preview",
  "revision": "2024-08-29T21:53:33Z",
  "url": "https://app.fossa.com/projects/custom%2b24987%2fane-1993-missing-preview/refs/branch/master/2024-08-29T21:53:33Z"
}
```


## Acceptance criteria

When you run `fossa analyze --json` we include the full projectId in the output

## Testing plan

Run `fossa analyze --json` on a project and take a look at the output

## Risks
This is low risk

## References


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2002]: https://fossa.atlassian.net/browse/ANE-2002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ