### PR TITLE
Add NOTICE files to source units

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## 3.9.37
 
-- License Scanning: Update Themis to include NOTICE files, and parse the additional NOTICE file fields in Themis's output.
+- License Scanning: Update Themis to include NOTICE files, and parse the additional NOTICE file fields in Themis's output. ([#1466](https://github.com/fossas/fossa-cli/pull/1466))
 
 ## 3.9.36
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,13 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- License Scanning: Update Themis to include NOTICE files, and parse the additional NOTICE file fields in Themis's output.
+
 ## 3.9.36
 
-- fossa-deps: Fixed an issue where Rocky Linux deps were not supported in the fossa-deps file ([#1473](https://github.com/fossas/fossa-cli/pull/1473))  
-- `fossa report`: Remove subscription type check in preflight checks ([#1474](https://github.com/fossas/fossa-cli/pull/1474))  
+- fossa-deps: Fixed an issue where Rocky Linux deps were not supported in the fossa-deps file ([#1473](https://github.com/fossas/fossa-cli/pull/1473))
+- `fossa report`: Remove subscription type check in preflight checks ([#1474](https://github.com/fossas/fossa-cli/pull/1474))
 
 ## 3.9.35
 

--- a/src/App/Fossa/Lernie/Analyze.hs
+++ b/src/App/Fossa/Lernie/Analyze.hs
@@ -304,5 +304,6 @@ createLicenseUnitSingles ((path, title), licenseUnitData) =
         , licenseUnitDir = ""
         , licenseUnitFiles = NE.singleton (unCustomLicensePath path)
         , licenseUnitData = NE.singleton licenseUnitData
+        , licenseUnitNoticeFiles = Nothing
         , licenseUnitInfo = LicenseUnitInfo{licenseUnitInfoDescription = Just $ "custom license search " <> unCustomLicenseTitle title}
         }

--- a/src/App/Fossa/Lernie/Analyze.hs
+++ b/src/App/Fossa/Lernie/Analyze.hs
@@ -304,6 +304,6 @@ createLicenseUnitSingles ((path, title), licenseUnitData) =
         , licenseUnitDir = ""
         , licenseUnitFiles = NE.singleton (unCustomLicensePath path)
         , licenseUnitData = NE.singleton licenseUnitData
-        , licenseUnitNoticeFiles = Nothing
+        , licenseUnitNoticeFiles = []
         , licenseUnitInfo = LicenseUnitInfo{licenseUnitInfoDescription = Just $ "custom license search " <> unCustomLicenseTitle title}
         }

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -206,6 +206,7 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendor
       , sourceUnitType = "user-specific-yaml"
       , sourceUnitBuild = build
       , sourceUnitGraphBreadth = Complete
+      , sourceUnitNoticeFiles = Nothing
       , sourceUnitOriginPaths = [someBaseToOriginPath originPath]
       , additionalData = additional
       }
@@ -426,24 +427,24 @@ instance FromJSON ReferencedDependency where
                   <$> (obj `neText` "name")
                   <*> pure depType
                   <*> (unTextLike <$$> obj .:? "version")
-                  <* forbidNonRefDepFields obj
-                  <* forbidLinuxFields depType obj
-                  <* forbidEpoch depType obj
+                    <* forbidNonRefDepFields obj
+                    <* forbidLinuxFields depType obj
+                    <* forbidEpoch depType obj
               )
 
       parseApkOrDebDependency :: Object -> DepType -> Parser ReferencedDependency
       parseApkOrDebDependency obj depType =
         LinuxApkDebDep
           <$> parseLinuxDependency obj depType
-          <* forbidNonRefDepFields obj
-          <* forbidEpoch depType obj
+            <* forbidNonRefDepFields obj
+            <* forbidEpoch depType obj
 
       parseRpmDependency :: Object -> DepType -> Parser ReferencedDependency
       parseRpmDependency obj depType =
         LinuxRpmDep
           <$> parseLinuxDependency obj depType
           <*> (unTextLike <$$> obj .:? "epoch")
-          <* forbidNonRefDepFields obj
+            <* forbidNonRefDepFields obj
 
       parseLinuxDependency :: Object -> DepType -> Parser LinuxReferenceDependency
       parseLinuxDependency obj depType =
@@ -508,8 +509,9 @@ instance FromJSON CustomDependency where
       <$> (obj `neText` "name")
       <*> (unTextLike <$> obj `neText` "version")
       <*> (obj `neText` "license")
-      <*> obj .:? "metadata"
-      <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
+      <*> obj
+        .:? "metadata"
+        <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
 
 instance FromJSON RemoteDependency where
   parseJSON = withObject "RemoteDependency" $ \obj -> do
@@ -517,8 +519,9 @@ instance FromJSON RemoteDependency where
       <$> (obj `neText` "name")
       <*> (unTextLike <$> obj `neText` "version")
       <*> (obj `neText` "url")
-      <*> obj .:? "metadata"
-      <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
+      <*> obj
+        .:? "metadata"
+        <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
 
 validateRemoteDep :: (Has Diagnostics sig m) => RemoteDependency -> Organization -> m RemoteDependency
 validateRemoteDep r org =

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -521,7 +521,7 @@ instance FromJSON RemoteDependency where
       <*> (obj `neText` "url")
       <*> obj
         .:? "metadata"
-        <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
+      <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
 
 validateRemoteDep :: (Has Diagnostics sig m) => RemoteDependency -> Organization -> m RemoteDependency
 validateRemoteDep r org =

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -427,24 +427,24 @@ instance FromJSON ReferencedDependency where
                   <$> (obj `neText` "name")
                   <*> pure depType
                   <*> (unTextLike <$$> obj .:? "version")
-                    <* forbidNonRefDepFields obj
-                    <* forbidLinuxFields depType obj
-                    <* forbidEpoch depType obj
+                  <* forbidNonRefDepFields obj
+                  <* forbidLinuxFields depType obj
+                  <* forbidEpoch depType obj
               )
 
       parseApkOrDebDependency :: Object -> DepType -> Parser ReferencedDependency
       parseApkOrDebDependency obj depType =
         LinuxApkDebDep
           <$> parseLinuxDependency obj depType
-            <* forbidNonRefDepFields obj
-            <* forbidEpoch depType obj
+          <* forbidNonRefDepFields obj
+          <* forbidEpoch depType obj
 
       parseRpmDependency :: Object -> DepType -> Parser ReferencedDependency
       parseRpmDependency obj depType =
         LinuxRpmDep
           <$> parseLinuxDependency obj depType
           <*> (unTextLike <$$> obj .:? "epoch")
-            <* forbidNonRefDepFields obj
+          <* forbidNonRefDepFields obj
 
       parseLinuxDependency :: Object -> DepType -> Parser LinuxReferenceDependency
       parseLinuxDependency obj depType =
@@ -511,7 +511,7 @@ instance FromJSON CustomDependency where
       <*> (obj `neText` "license")
       <*> obj
         .:? "metadata"
-        <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
+      <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
 
 instance FromJSON RemoteDependency where
   parseJSON = withObject "RemoteDependency" $ \obj -> do
@@ -521,7 +521,7 @@ instance FromJSON RemoteDependency where
       <*> (obj `neText` "url")
       <*> obj
         .:? "metadata"
-        <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
+      <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
 
 validateRemoteDep :: (Has Diagnostics sig m) => RemoteDependency -> Organization -> m RemoteDependency
 validateRemoteDep r org =

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -519,8 +519,7 @@ instance FromJSON RemoteDependency where
       <$> (obj `neText` "name")
       <*> (unTextLike <$> obj `neText` "version")
       <*> (obj `neText` "url")
-      <*> obj
-        .:? "metadata"
+      <*> obj .:? "metadata"
       <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
 
 validateRemoteDep :: (Has Diagnostics sig m) => RemoteDependency -> Organization -> m RemoteDependency

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -427,24 +427,24 @@ instance FromJSON ReferencedDependency where
                   <$> (obj `neText` "name")
                   <*> pure depType
                   <*> (unTextLike <$$> obj .:? "version")
-                    <* forbidNonRefDepFields obj
-                    <* forbidLinuxFields depType obj
-                    <* forbidEpoch depType obj
+                  <* forbidNonRefDepFields obj
+                  <* forbidLinuxFields depType obj
+                  <* forbidEpoch depType obj
               )
 
       parseApkOrDebDependency :: Object -> DepType -> Parser ReferencedDependency
       parseApkOrDebDependency obj depType =
         LinuxApkDebDep
           <$> parseLinuxDependency obj depType
-            <* forbidNonRefDepFields obj
-            <* forbidEpoch depType obj
+          <* forbidNonRefDepFields obj
+          <* forbidEpoch depType obj
 
       parseRpmDependency :: Object -> DepType -> Parser ReferencedDependency
       parseRpmDependency obj depType =
         LinuxRpmDep
           <$> parseLinuxDependency obj depType
           <*> (unTextLike <$$> obj .:? "epoch")
-            <* forbidNonRefDepFields obj
+          <* forbidNonRefDepFields obj
 
       parseLinuxDependency :: Object -> DepType -> Parser LinuxReferenceDependency
       parseLinuxDependency obj depType =
@@ -511,7 +511,7 @@ instance FromJSON CustomDependency where
       <*> (obj `neText` "license")
       <*> obj
         .:? "metadata"
-        <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
+      <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
 
 instance FromJSON RemoteDependency where
   parseJSON = withObject "RemoteDependency" $ \obj -> do

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -206,7 +206,7 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendor
       , sourceUnitType = "user-specific-yaml"
       , sourceUnitBuild = build
       , sourceUnitGraphBreadth = Complete
-      , sourceUnitNoticeFiles = Nothing
+      , sourceUnitNoticeFiles = []
       , sourceUnitOriginPaths = [someBaseToOriginPath originPath]
       , additionalData = additional
       }
@@ -427,24 +427,24 @@ instance FromJSON ReferencedDependency where
                   <$> (obj `neText` "name")
                   <*> pure depType
                   <*> (unTextLike <$$> obj .:? "version")
-                  <* forbidNonRefDepFields obj
-                  <* forbidLinuxFields depType obj
-                  <* forbidEpoch depType obj
+                    <* forbidNonRefDepFields obj
+                    <* forbidLinuxFields depType obj
+                    <* forbidEpoch depType obj
               )
 
       parseApkOrDebDependency :: Object -> DepType -> Parser ReferencedDependency
       parseApkOrDebDependency obj depType =
         LinuxApkDebDep
           <$> parseLinuxDependency obj depType
-          <* forbidNonRefDepFields obj
-          <* forbidEpoch depType obj
+            <* forbidNonRefDepFields obj
+            <* forbidEpoch depType obj
 
       parseRpmDependency :: Object -> DepType -> Parser ReferencedDependency
       parseRpmDependency obj depType =
         LinuxRpmDep
           <$> parseLinuxDependency obj depType
           <*> (unTextLike <$$> obj .:? "epoch")
-          <* forbidNonRefDepFields obj
+            <* forbidNonRefDepFields obj
 
       parseLinuxDependency :: Object -> DepType -> Parser LinuxReferenceDependency
       parseLinuxDependency obj depType =
@@ -511,7 +511,7 @@ instance FromJSON CustomDependency where
       <*> (obj `neText` "license")
       <*> obj
         .:? "metadata"
-      <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
+        <* forbidMembers "custom dependencies" ["type", "path", "url"] obj
 
 instance FromJSON RemoteDependency where
   parseJSON = withObject "RemoteDependency" $ \obj -> do
@@ -521,7 +521,7 @@ instance FromJSON RemoteDependency where
       <*> (obj `neText` "url")
       <*> obj
         .:? "metadata"
-      <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
+        <* forbidMembers "remote dependencies" ["license", "path", "type"] obj
 
 validateRemoteDep :: (Has Diagnostics sig m) => RemoteDependency -> Organization -> m RemoteDependency
 validateRemoteDep r org =

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -71,6 +71,7 @@ toSourceUnit leaveUnfiltered path dependencies projectType graphBreadth originPa
             , buildDependencies = deps
             }
     , sourceUnitGraphBreadth = graphBreadth
+    , sourceUnitNoticeFiles = Nothing
     , sourceUnitOriginPaths = originPaths
     , additionalData = Nothing
     }

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -71,7 +71,7 @@ toSourceUnit leaveUnfiltered path dependencies projectType graphBreadth originPa
             , buildDependencies = deps
             }
     , sourceUnitGraphBreadth = graphBreadth
-    , sourceUnitNoticeFiles = Nothing
+    , sourceUnitNoticeFiles = []
     , sourceUnitOriginPaths = originPaths
     , additionalData = Nothing
     }

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -112,6 +112,25 @@ textToOriginPath = OriginPath . toString
 --   Manifest?: string;
 -- }
 
+data SourceUnitNoticeFile = SourceUnitNoticeFile
+  { sourceUnitNoticeFilePath :: Text
+  , sourceUnitNoticeFileContents :: Text
+  }
+  deriving (Eq, Ord, Show)
+
+instance ToJSON SourceUnitNoticeFile where
+  toJSON SourceUnitNoticeFile{..} =
+    object
+      [ "path" .= sourceUnitNoticeFilePath
+      , "contents" .= sourceUnitNoticeFileContents
+      ]
+
+instance FromJSON SourceUnitNoticeFile where
+  parseJSON = withObject "SourceUnitNoticeFile" $ \obj ->
+    SourceUnitNoticeFile
+      <$> obj .: "path"
+      <*> obj .: "contents"
+
 data FullSourceUnit = FullSourceUnit
   { fullSourceUnitName :: Text
   , fullSourceUnitType :: Text
@@ -119,6 +138,7 @@ data FullSourceUnit = FullSourceUnit
   , fullSourceUnitManifest :: Maybe Text
   , fullSourceUnitBuild :: Maybe SourceUnitBuild
   , fullSourceUnitGraphBreadth :: GraphBreadth
+  , fullSourceUnitNoticeFiles :: Maybe (NonEmpty SourceUnitNoticeFile)
   , fullSourceUnitOriginPaths :: [OriginPath]
   , fullSourceUnitAdditionalData :: Maybe AdditionalDepData
   , fullSourceUnitFiles :: Maybe (NonEmpty Text)
@@ -136,6 +156,7 @@ licenseUnitToFullSourceUnit LicenseUnit{..} =
     , fullSourceUnitManifest = Nothing
     , fullSourceUnitBuild = Nothing
     , fullSourceUnitGraphBreadth = Complete
+    , fullSourceUnitNoticeFiles = licenseUnitNoticeFiles
     , fullSourceUnitOriginPaths = []
     , fullSourceUnitAdditionalData = Nothing
     , fullSourceUnitFiles = Just licenseUnitFiles
@@ -153,6 +174,7 @@ sourceUnitToFullSourceUnit SourceUnit{..} =
     , fullSourceUnitBuild = sourceUnitBuild
     , fullSourceUnitGraphBreadth = sourceUnitGraphBreadth
     , fullSourceUnitOriginPaths = sourceUnitOriginPaths
+    , fullSourceUnitNoticeFiles = sourceUnitNoticeFiles
     , fullSourceUnitAdditionalData = additionalData
     , fullSourceUnitFiles = Nothing
     , fullSourceUnitData = Nothing
@@ -169,6 +191,7 @@ instance ToJSON FullSourceUnit where
       , "Build" .= fullSourceUnitBuild
       , "GraphBreadth" .= fullSourceUnitGraphBreadth
       , "OriginPaths" .= fullSourceUnitOriginPaths
+      , "NoticeFiles" .= fullSourceUnitNoticeFiles
       , "AdditionalDependencyData" .= fullSourceUnitAdditionalData
       , "Files" .= fullSourceUnitFiles
       , "Data" .= fullSourceUnitData
@@ -204,6 +227,7 @@ data LicenseUnit = LicenseUnit
   , licenseUnitDir :: Text
   , licenseUnitFiles :: (NonEmpty Text)
   , licenseUnitData :: (NonEmpty LicenseUnitData)
+  , licenseUnitNoticeFiles :: Maybe (NonEmpty SourceUnitNoticeFile)
   , licenseUnitInfo :: LicenseUnitInfo
   }
   deriving (Eq, Ord, Show)
@@ -217,6 +241,7 @@ emptyLicenseUnit =
     , licenseUnitDir = ""
     , licenseUnitFiles = "" :| []
     , licenseUnitData = emptyLicenseUnitData :| []
+    , licenseUnitNoticeFiles = Nothing
     , licenseUnitInfo = LicenseUnitInfo{licenseUnitInfoDescription = Nothing}
     }
 
@@ -235,6 +260,7 @@ instance ToJSON LicenseUnit where
       , "Dir" .= licenseUnitDir
       , "Files" .= licenseUnitFiles
       , "Data" .= licenseUnitData
+      , "NoticeFiles" .= licenseUnitNoticeFiles
       , "Info" .= licenseUnitInfo
       ]
 
@@ -247,6 +273,7 @@ instance FromJSON LicenseUnit where
       <*> obj .: "Dir"
       <*> obj .: "Files"
       <*> obj .: "Data"
+      <*> obj .:? "NoticeFiles"
       <*> obj .: "Info"
 
 newtype LicenseUnitInfo = LicenseUnitInfo
@@ -350,6 +377,7 @@ data SourceUnit = SourceUnit
   -- ^ path to manifest file
   , sourceUnitBuild :: Maybe SourceUnitBuild
   , sourceUnitGraphBreadth :: GraphBreadth
+  , sourceUnitNoticeFiles :: Maybe (NonEmpty SourceUnitNoticeFile)
   , sourceUnitOriginPaths :: [OriginPath]
   , additionalData :: Maybe AdditionalDepData
   }
@@ -431,6 +459,7 @@ instance ToJSON SourceUnit where
       , "Manifest" .= sourceUnitManifest
       , "Build" .= sourceUnitBuild
       , "GraphBreadth" .= sourceUnitGraphBreadth
+      , "NoticeFiles" .= sourceUnitNoticeFiles
       , "OriginPaths" .= sourceUnitOriginPaths
       , "AdditionalDependencyData" .= additionalData
       ]
@@ -443,6 +472,7 @@ instance FromJSON SourceUnit where
       <*> obj .: "Manifest"
       <*> obj .:? "Build"
       <*> obj .: "GraphBreadth"
+      <*> obj .:? "NoticeFiles"
       <*> obj .: "OriginPaths"
       <*> obj .:? "AdditionalDependencyData"
 

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -116,7 +116,7 @@ textToOriginPath = OriginPath . toString
 data SourceUnitNoticeFile = SourceUnitNoticeFile
   { sourceUnitNoticeFilePath :: Text
   , sourceUnitNoticeFileContents :: Text
-  , sourceUnitNoticeFileCopyrights :: Maybe (NonEmpty Text)
+  , sourceUnitNoticeFileCopyrights :: [Text]
   }
   deriving (Eq, Ord, Show)
 
@@ -133,7 +133,7 @@ instance FromJSON SourceUnitNoticeFile where
     SourceUnitNoticeFile
       <$> obj .: "path"
       <*> obj .: "contents"
-      <*> obj .:? "copyrights"
+      <*> obj .:? "copyrights" .!= []
 
 data FullSourceUnit = FullSourceUnit
   { fullSourceUnitName :: Text
@@ -142,7 +142,7 @@ data FullSourceUnit = FullSourceUnit
   , fullSourceUnitManifest :: Maybe Text
   , fullSourceUnitBuild :: Maybe SourceUnitBuild
   , fullSourceUnitGraphBreadth :: GraphBreadth
-  , fullSourceUnitNoticeFiles :: Maybe (NonEmpty SourceUnitNoticeFile)
+  , fullSourceUnitNoticeFiles :: [SourceUnitNoticeFile]
   , fullSourceUnitOriginPaths :: [OriginPath]
   , fullSourceUnitAdditionalData :: Maybe AdditionalDepData
   , fullSourceUnitFiles :: Maybe (NonEmpty Text)
@@ -231,7 +231,7 @@ data LicenseUnit = LicenseUnit
   , licenseUnitDir :: Text
   , licenseUnitFiles :: (NonEmpty Text)
   , licenseUnitData :: (NonEmpty LicenseUnitData)
-  , licenseUnitNoticeFiles :: Maybe (NonEmpty SourceUnitNoticeFile)
+  , licenseUnitNoticeFiles :: [SourceUnitNoticeFile]
   , licenseUnitInfo :: LicenseUnitInfo
   }
   deriving (Eq, Ord, Show)
@@ -245,7 +245,7 @@ emptyLicenseUnit =
     , licenseUnitDir = ""
     , licenseUnitFiles = "" :| []
     , licenseUnitData = emptyLicenseUnitData :| []
-    , licenseUnitNoticeFiles = Nothing
+    , licenseUnitNoticeFiles = []
     , licenseUnitInfo = LicenseUnitInfo{licenseUnitInfoDescription = Nothing}
     }
 
@@ -277,7 +277,7 @@ instance FromJSON LicenseUnit where
       <*> obj .: "Dir"
       <*> obj .: "Files"
       <*> obj .: "Data"
-      <*> obj .:? "NoticeFiles"
+      <*> obj .:? "NoticeFiles" .!= []
       <*> obj .: "Info"
 
 newtype LicenseUnitInfo = LicenseUnitInfo
@@ -381,7 +381,7 @@ data SourceUnit = SourceUnit
   -- ^ path to manifest file
   , sourceUnitBuild :: Maybe SourceUnitBuild
   , sourceUnitGraphBreadth :: GraphBreadth
-  , sourceUnitNoticeFiles :: Maybe (NonEmpty SourceUnitNoticeFile)
+  , sourceUnitNoticeFiles :: [SourceUnitNoticeFile]
   , sourceUnitOriginPaths :: [OriginPath]
   , additionalData :: Maybe AdditionalDepData
   }
@@ -476,7 +476,7 @@ instance FromJSON SourceUnit where
       <*> obj .: "Manifest"
       <*> obj .:? "Build"
       <*> obj .: "GraphBreadth"
-      <*> obj .:? "NoticeFiles"
+      <*> obj .:? "NoticeFiles" .!= []
       <*> obj .: "OriginPaths"
       <*> obj .:? "AdditionalDependencyData"
 

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -5,6 +5,7 @@ module Srclib.Types (
   SourceUnit (..),
   SourceUnitBuild (..),
   SourceUnitDependency (..),
+  SourceUnitNoticeFile (..),
   AdditionalDepData (..),
   SourceUserDefDep (..),
   SourceRemoteDep (..),
@@ -115,6 +116,7 @@ textToOriginPath = OriginPath . toString
 data SourceUnitNoticeFile = SourceUnitNoticeFile
   { sourceUnitNoticeFilePath :: Text
   , sourceUnitNoticeFileContents :: Text
+  , sourceUnitNoticeFileCopyrights :: Maybe (NonEmpty Text)
   }
   deriving (Eq, Ord, Show)
 
@@ -123,6 +125,7 @@ instance ToJSON SourceUnitNoticeFile where
     object
       [ "path" .= sourceUnitNoticeFilePath
       , "contents" .= sourceUnitNoticeFileContents
+      , "copyrights" .= sourceUnitNoticeFileCopyrights
       ]
 
 instance FromJSON SourceUnitNoticeFile where
@@ -130,6 +133,7 @@ instance FromJSON SourceUnitNoticeFile where
     SourceUnitNoticeFile
       <$> obj .: "path"
       <*> obj .: "contents"
+      <*> obj .:? "copyrights"
 
 data FullSourceUnit = FullSourceUnit
   { fullSourceUnitName :: Text

--- a/test/App/Fossa/Analyze/UploadSpec.hs
+++ b/test/App/Fossa/Analyze/UploadSpec.hs
@@ -88,7 +88,7 @@ expectedMergedFullSourceUnits = NE.fromList [fullSourceUnit, fullLicenseUnit]
         , fullSourceUnitFiles = Nothing
         , fullSourceUnitData = Nothing
         , fullSourceUnitInfo = Nothing
-        , fullSourceUnitNoticeFiles = Nothing
+        , fullSourceUnitNoticeFiles = []
         }
     fullLicenseUnit =
       FullSourceUnit
@@ -103,7 +103,7 @@ expectedMergedFullSourceUnits = NE.fromList [fullSourceUnit, fullLicenseUnit]
         , fullSourceUnitFiles = Just $ "" NE.:| []
         , fullSourceUnitData = Just $ emptyLicenseUnitData NE.:| []
         , fullSourceUnitInfo = Just LicenseUnitInfo{licenseUnitInfoDescription = Nothing}
-        , fullSourceUnitNoticeFiles = Nothing
+        , fullSourceUnitNoticeFiles = []
         }
 
 expectGetSuccessWithReachability :: Has MockApi sig m => m ()

--- a/test/App/Fossa/Analyze/UploadSpec.hs
+++ b/test/App/Fossa/Analyze/UploadSpec.hs
@@ -88,6 +88,7 @@ expectedMergedFullSourceUnits = NE.fromList [fullSourceUnit, fullLicenseUnit]
         , fullSourceUnitFiles = Nothing
         , fullSourceUnitData = Nothing
         , fullSourceUnitInfo = Nothing
+        , fullSourceUnitNoticeFiles = Nothing
         }
     fullLicenseUnit =
       FullSourceUnit
@@ -102,6 +103,7 @@ expectedMergedFullSourceUnits = NE.fromList [fullSourceUnit, fullLicenseUnit]
         , fullSourceUnitFiles = Just $ "" NE.:| []
         , fullSourceUnitData = Just $ emptyLicenseUnitData NE.:| []
         , fullSourceUnitInfo = Just LicenseUnitInfo{licenseUnitInfoDescription = Nothing}
+        , fullSourceUnitNoticeFiles = Nothing
         }
 
 expectGetSuccessWithReachability :: Has MockApi sig m => m ()

--- a/test/App/Fossa/Container/AnalyzeNativeSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeSpec.hs
@@ -236,6 +236,7 @@ jarsInContainerSpec = describe "Jars in Containers" $ do
                     }
             , sourceUnitGraphBreadth = Complete
             , sourceUnitOriginPaths = [textToOriginPath "package-lock.json"]
+            , sourceUnitNoticeFiles = Nothing
             , additionalData = Nothing
             }
 

--- a/test/App/Fossa/Container/AnalyzeNativeSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeSpec.hs
@@ -236,7 +236,7 @@ jarsInContainerSpec = describe "Jars in Containers" $ do
                     }
             , sourceUnitGraphBreadth = Complete
             , sourceUnitOriginPaths = [textToOriginPath "package-lock.json"]
-            , sourceUnitNoticeFiles = Nothing
+            , sourceUnitNoticeFiles = []
             , additionalData = Nothing
             }
 

--- a/test/App/Fossa/FirstPartyScanSpec.hs
+++ b/test/App/Fossa/FirstPartyScanSpec.hs
@@ -10,6 +10,7 @@ import Control.Effect.FossaApiClient (FossaApiClientF (..))
 import Data.List qualified as List
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, isJust)
+import Data.Text (strip)
 import Fossa.API.Types (Organization (..))
 import Path (Dir, Path, Rel, mkRelDir, (</>))
 import Path.IO (getCurrentDir)
@@ -120,7 +121,7 @@ spec = do
           length copyrights `shouldBe'` 1
           let copyright = NE.head copyrights
           copyright `shouldBe'` "2024 Frank Frankson"
-          sourceUnitNoticeFileContents noticeFile `shouldBe'` "This is a notice file that is copyright 2024 Frank Frankson\n"
+          strip (sourceUnitNoticeFileContents noticeFile) `shouldBe'` "This is a notice file that is copyright 2024 Frank Frankson\n"
           sourceUnitNoticeFilePath noticeFile `shouldBe'` "NOTICE.txt"
 
 -- The default org defaults to not running first party scans but has first-party scans enabled

--- a/test/App/Fossa/FirstPartyScanSpec.hs
+++ b/test/App/Fossa/FirstPartyScanSpec.hs
@@ -9,7 +9,7 @@ import Control.Algebra (Has)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
 import Data.List qualified as List
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (isJust)
 import Data.Text (strip)
 import Fossa.API.Types (Organization (..))
 import Path (Dir, Path, Rel, mkRelDir, (</>))
@@ -114,12 +114,12 @@ spec = do
           let noticeUnit = NE.head units
           licenseUnitName noticeUnit `shouldBe'` ""
           licenseUnitType noticeUnit `shouldBe'` "NoticeFileMatches"
-          let noticeFiles = fromMaybe (NE.fromList []) (licenseUnitNoticeFiles noticeUnit)
+          let noticeFiles = licenseUnitNoticeFiles noticeUnit
           length noticeFiles `shouldBe'` 1
-          let noticeFile = NE.head noticeFiles
-          let copyrights = fromMaybe (NE.fromList []) (sourceUnitNoticeFileCopyrights noticeFile)
+          let noticeFile = head noticeFiles
+          let copyrights = sourceUnitNoticeFileCopyrights noticeFile
           length copyrights `shouldBe'` 1
-          let copyright = NE.head copyrights
+          let copyright = head copyrights
           copyright `shouldBe'` "2024 Frank Frankson"
           strip (sourceUnitNoticeFileContents noticeFile) `shouldBe'` "This is a notice file that is copyright 2024 Frank Frankson"
           sourceUnitNoticeFilePath noticeFile `shouldBe'` "NOTICE.txt"

--- a/test/App/Fossa/FirstPartyScanSpec.hs
+++ b/test/App/Fossa/FirstPartyScanSpec.hs
@@ -121,7 +121,7 @@ spec = do
           length copyrights `shouldBe'` 1
           let copyright = NE.head copyrights
           copyright `shouldBe'` "2024 Frank Frankson"
-          strip (sourceUnitNoticeFileContents noticeFile) `shouldBe'` "This is a notice file that is copyright 2024 Frank Frankson\n"
+          strip (sourceUnitNoticeFileContents noticeFile) `shouldBe'` "This is a notice file that is copyright 2024 Frank Frankson"
           sourceUnitNoticeFilePath noticeFile `shouldBe'` "NOTICE.txt"
 
 -- The default org defaults to not running first party scans but has first-party scans enabled

--- a/test/App/Fossa/FirstPartyScanSpec.hs
+++ b/test/App/Fossa/FirstPartyScanSpec.hs
@@ -9,11 +9,11 @@ import Control.Algebra (Has)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
 import Data.List qualified as List
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (isJust)
+import Data.Maybe (fromMaybe, isJust)
 import Fossa.API.Types (Organization (..))
 import Path (Dir, Path, Rel, mkRelDir, (</>))
 import Path.IO (getCurrentDir)
-import Srclib.Types (LicenseSourceUnit (..), LicenseUnit (licenseUnitData, licenseUnitName), LicenseUnitData (licenseUnitDataContents), licenseUnitType)
+import Srclib.Types (LicenseSourceUnit (..), LicenseUnit (..), LicenseUnitData (licenseUnitDataContents), SourceUnitNoticeFile (..))
 import Test.Effect (expectFatal', expectationFailure', it', shouldBe')
 import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec, describe, runIO)
@@ -113,6 +113,15 @@ spec = do
           let noticeUnit = NE.head units
           licenseUnitName noticeUnit `shouldBe'` ""
           licenseUnitType noticeUnit `shouldBe'` "NoticeFileMatches"
+          let noticeFiles = fromMaybe (NE.fromList []) (licenseUnitNoticeFiles noticeUnit)
+          length noticeFiles `shouldBe'` 1
+          let noticeFile = NE.head noticeFiles
+          let copyrights = fromMaybe (NE.fromList []) (sourceUnitNoticeFileCopyrights noticeFile)
+          length copyrights `shouldBe'` 1
+          let copyright = NE.head copyrights
+          copyright `shouldBe'` "2024 Frank Frankson"
+          sourceUnitNoticeFileContents noticeFile `shouldBe'` "This is a notice file that is copyright 2024 Frank Frankson\n"
+          sourceUnitNoticeFilePath noticeFile `shouldBe'` "NOTICE.txt"
 
 -- The default org defaults to not running first party scans but has first-party scans enabled
 expectGetOrganizationThatDefaultsToNoFirstPartyScans :: Has MockApi sig m => m ()

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -172,7 +172,7 @@ expectedLicenseUnit =
     , licenseUnitFiles = NE.singleton $ toText . toFilePath $ absDir </> $(mkRelDir "two.txt")
     , licenseUnitData = NE.singleton expectedUnitData
     , licenseUnitInfo = LicenseUnitInfo{licenseUnitInfoDescription = Just "custom license search Proprietary License"}
-    , licenseUnitNoticeFiles = Nothing
+    , licenseUnitNoticeFiles = []
     }
 
 expectedDoubleSourceUnit :: LicenseSourceUnit

--- a/test/App/Fossa/LernieSpec.hs
+++ b/test/App/Fossa/LernieSpec.hs
@@ -172,6 +172,7 @@ expectedLicenseUnit =
     , licenseUnitFiles = NE.singleton $ toText . toFilePath $ absDir </> $(mkRelDir "two.txt")
     , licenseUnitData = NE.singleton expectedUnitData
     , licenseUnitInfo = LicenseUnitInfo{licenseUnitInfoDescription = Just "custom license search Proprietary License"}
+    , licenseUnitNoticeFiles = Nothing
     }
 
 expectedDoubleSourceUnit :: LicenseSourceUnit

--- a/test/App/Fossa/LicenseScannerSpec.hs
+++ b/test/App/Fossa/LicenseScannerSpec.hs
@@ -43,7 +43,7 @@ unitOne =
     , licenseUnitFiles =
         NE.fromList ["foo/bar/LICENSE", "foo/bar/one.txt"]
     , licenseUnitInfo = info
-    , licenseUnitNoticeFiles = Nothing
+    , licenseUnitNoticeFiles = []
     }
 
 unitTwo :: LicenseUnit
@@ -56,7 +56,7 @@ unitTwo =
     , licenseUnitData = NE.fromList [emptyLicenseUnitData{licenseUnitDataPath = "foo/bar/baz/ANOTHER_LICENSE"}, emptyLicenseUnitData{licenseUnitDataPath = "foo/bar/baz/two.txt"}]
     , licenseUnitFiles = NE.fromList ["foo/bar/baz/ANOTHER_LICENSE", "foo/bar/baz/two.txt"]
     , licenseUnitInfo = info
-    , licenseUnitNoticeFiles = Nothing
+    , licenseUnitNoticeFiles = []
     }
 expectedCombinedUnit :: LicenseUnit
 expectedCombinedUnit =
@@ -80,7 +80,7 @@ expectedCombinedUnit =
           , "foo/bar/one.txt"
           ]
     , licenseUnitInfo = info
-    , licenseUnitNoticeFiles = Nothing
+    , licenseUnitNoticeFiles = []
     }
 
 fixtureDir :: Path Rel Dir

--- a/test/App/Fossa/LicenseScannerSpec.hs
+++ b/test/App/Fossa/LicenseScannerSpec.hs
@@ -43,6 +43,7 @@ unitOne =
     , licenseUnitFiles =
         NE.fromList ["foo/bar/LICENSE", "foo/bar/one.txt"]
     , licenseUnitInfo = info
+    , licenseUnitNoticeFiles = Nothing
     }
 
 unitTwo :: LicenseUnit
@@ -55,6 +56,7 @@ unitTwo =
     , licenseUnitData = NE.fromList [emptyLicenseUnitData{licenseUnitDataPath = "foo/bar/baz/ANOTHER_LICENSE"}, emptyLicenseUnitData{licenseUnitDataPath = "foo/bar/baz/two.txt"}]
     , licenseUnitFiles = NE.fromList ["foo/bar/baz/ANOTHER_LICENSE", "foo/bar/baz/two.txt"]
     , licenseUnitInfo = info
+    , licenseUnitNoticeFiles = Nothing
     }
 expectedCombinedUnit :: LicenseUnit
 expectedCombinedUnit =
@@ -78,6 +80,7 @@ expectedCombinedUnit =
           , "foo/bar/one.txt"
           ]
     , licenseUnitInfo = info
+    , licenseUnitNoticeFiles = Nothing
     }
 
 fixtureDir :: Path Rel Dir

--- a/test/App/Fossa/VendoredDependency/testdata/firstparty-with-notice/APACHE_LICENSE
+++ b/test/App/Fossa/VendoredDependency/testdata/firstparty-with-notice/APACHE_LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test/App/Fossa/VendoredDependency/testdata/firstparty-with-notice/NOTICE.txt
+++ b/test/App/Fossa/VendoredDependency/testdata/firstparty-with-notice/NOTICE.txt
@@ -1,1 +1,1 @@
-This is a notice file
+This is a notice file that is copyright 2024 Frank Frankson

--- a/test/App/Fossa/VendoredDependency/testdata/firstparty-with-notice/NOTICE.txt
+++ b/test/App/Fossa/VendoredDependency/testdata/firstparty-with-notice/NOTICE.txt
@@ -1,0 +1,1 @@
+This is a notice file

--- a/test/App/Fossa/VendoredDependency/testdata/firstparty-with-notice/fossa-deps.yml
+++ b/test/App/Fossa/VendoredDependency/testdata/firstparty-with-notice/fossa-deps.yml
@@ -1,0 +1,5 @@
+vendored-dependencies:
+  - name: bar
+    path: vendored/bar.zip
+  - name: foo
+    path: vendored/foo

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -244,6 +244,7 @@ sourceUnits = [unit]
         , sourceUnitBuild = Nothing
         , sourceUnitGraphBreadth = Complete
         , sourceUnitOriginPaths = []
+        , sourceUnitNoticeFiles = Nothing
         , additionalData = Nothing
         }
 
@@ -310,6 +311,7 @@ vsiSourceUnit =
             }
     , sourceUnitGraphBreadth = Complete
     , sourceUnitOriginPaths = ["/tmp/one/two"]
+    , sourceUnitNoticeFiles = Nothing
     , additionalData = Nothing
     }
 

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -244,7 +244,7 @@ sourceUnits = [unit]
         , sourceUnitBuild = Nothing
         , sourceUnitGraphBreadth = Complete
         , sourceUnitOriginPaths = []
-        , sourceUnitNoticeFiles = Nothing
+        , sourceUnitNoticeFiles = []
         , additionalData = Nothing
         }
 
@@ -311,7 +311,7 @@ vsiSourceUnit =
             }
     , sourceUnitGraphBreadth = Complete
     , sourceUnitOriginPaths = ["/tmp/one/two"]
-    , sourceUnitNoticeFiles = Nothing
+    , sourceUnitNoticeFiles = []
     , additionalData = Nothing
     }
 

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -77,12 +77,13 @@ esac
 
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-echo "Downloading themis binary from latest release"
+# TODO: Do not merge with this tag forced on
+echo "Downloading themis binary from v1.0.17-beta release"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json
 curl -sSL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
-    https://api.github.com/repos/fossas/themis/releases/latest > $THEMIS_RELEASE_JSON
+    https://api.github.com/repos/fossas/themis/releases/174193232 > $THEMIS_RELEASE_JSON
 
 THEMIS_TAG=$(jq -cr ".name" $THEMIS_RELEASE_JSON)
 echo "Using themis release: $THEMIS_TAG"

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -83,7 +83,7 @@ THEMIS_RELEASE_JSON=vendor-bins/themis-release.json
 curl -sSL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
-    https://api.github.com/repos/fossas/themis/releases/174193232 > $THEMIS_RELEASE_JSON
+    https://api.github.com/repos/fossas/themis/releases/174441989 > $THEMIS_RELEASE_JSON
 
 THEMIS_TAG=$(jq -cr ".name" $THEMIS_RELEASE_JSON)
 echo "Using themis release: $THEMIS_TAG"

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -83,7 +83,7 @@ THEMIS_RELEASE_JSON=vendor-bins/themis-release.json
 curl -sSL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
-    https://api.github.com/repos/fossas/themis/releases/174441989 > $THEMIS_RELEASE_JSON
+    https://api.github.com/repos/fossas/themis/releases/174635703 > $THEMIS_RELEASE_JSON
 
 THEMIS_TAG=$(jq -cr ".name" $THEMIS_RELEASE_JSON)
 echo "Using themis release: $THEMIS_TAG"

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -77,8 +77,7 @@ esac
 
 echo "Downloading asset information from latest tag for architecture '$ASSET_POSTFIX'"
 
-# TODO: Do not merge with this tag forced on
-echo "Downloading themis binary from v1.0.17-beta release"
+echo "Downloading themis binary from latest release"
 THEMIS_RELEASE_JSON=vendor-bins/themis-release.json
 curl -sSL \
     -H "Authorization: token $GITHUB_TOKEN" \

--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -83,7 +83,7 @@ THEMIS_RELEASE_JSON=vendor-bins/themis-release.json
 curl -sSL \
     -H "Authorization: token $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3.raw" \
-    https://api.github.com/repos/fossas/themis/releases/174635703 > $THEMIS_RELEASE_JSON
+    https://api.github.com/repos/fossas/themis/releases/latest > $THEMIS_RELEASE_JSON
 
 THEMIS_TAG=$(jq -cr ".name" $THEMIS_RELEASE_JSON)
 echo "Using themis release: $THEMIS_TAG"


### PR DESCRIPTION
# Overview

In https://github.com/fossas/themis/pull/68, Themis added NoticeFiles to its srclib output.

This PR updates the CLI to parse the NoticeFiles fields.

## Acceptance criteria

- The CLI can parse SourceUnits with and without NoticeFile entries

## Testing plan

First, you'll need to update the version of Themis that is embedded into the CLI. Run `vendor_download.sh` with the temporary edits in this PR, and then `cabal clean; cabal build`.

Run `fossa analyze --experimental-force-first-party-scans` on a directory structure with and without notice files in it. 

For a directory structure with notice files in it, you can use this:
[notice-file-tester.zip](https://github.com/user-attachments/files/16937912/notice-file-tester.zip)

For a directory without notice files, just copy a license into an empty directory.

Run `cabal run fossa -- analyze --experimental-force-first-party-scans --output` on both directories.

For the run against the directory structure with just licenses and no notice files, you should see one SourceUnit per license in the directory structure, and all SourceUnits should have a type of "LicenseUnit".

For the run against the notice-file-tester directory structure, the output will look something like this.  There are two sourceUnits with a type of "LicenseUnit" and a third with a type of "NoticeFileMatches" that contains the notice file data.

```
{
  "projects": [],
  "sourceUnits": [
    {
      "AdditionalDependencyData": null,
      "Build": null,
      "Data": [
        {
          "Contents": null,
          "Copyright": null,
          "Copyrights": null,
          "ThemisVersion": "1.0.17-beta",
          "match_data": null,
          "path": "NOTICE.txt"
        },
        {
          "Contents": null,
          "Copyright": null,
          "Copyrights": null,
          "ThemisVersion": "1.0.17-beta",
          "match_data": null,
          "path": "foo_NOTICE.txt"
        },
        {
          "Contents": null,
          "Copyright": null,
          "Copyrights": null,
          "ThemisVersion": "1.0.17-beta",
          "match_data": null,
          "path": "mit_NOTICE.txt"
        },
        {
          "Contents": null,
          "Copyright": null,
          "Copyrights": null,
          "ThemisVersion": "1.0.17-beta",
          "match_data": null,
          "path": "one/two/three/third-party-notices.txt"
        }
      ],
      "Files": [
        "NOTICE.txt",
        "foo_NOTICE.txt",
        "mit_NOTICE.txt",
        "one/two/three/third-party-notices.txt"
      ],
      "GraphBreadth": "complete",
      "Info": {
        "Description": ""
      },
      "Manifest": null,
      "Name": "",
      "NoticeFiles": [
        {
          "contents": "Apache Commons Lang\nCopyright 2001-2017 The Apache Software Foundation\n\nThis product includes software developed at\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())\n",
          "path": "NOTICE.txt"
        },
        {
          "contents": "Apache Commons Lang\nCopyright 2001-2017 The Apache Software Foundation\n\nThis product includes software developed at\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())\n",
          "path": "foo_NOTICE.txt"
        },
        {
          "contents": "Permission is hereby granted, free of charge, to any person obtaining\na copy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to\npermit persons to whom the Software is furnished to do so, subject to\nthe following conditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\nIN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,\nTORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\nSOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.",
          "path": "mit_NOTICE.txt"
        },
        {
          "contents": "This is a third-party notice\n",
          "path": "one/two/three/third-party-notices.txt"
        }
      ],
      "OriginPaths": [],
      "Title": null,
      "Type": "NoticeFileMatches"
    },
    {
      "AdditionalDependencyData": null,
      "Build": null,
      "Data": [
        {
          "Contents": null,
          "Copyright": "2001-2017 The Apache Software Foundation",
          "Copyrights": [
            "2001-2017 The Apache Software Foundation"
          ],
          "ThemisVersion": "1.0.17-beta",
          "match_data": null,
          "path": "NOTICE.txt"
        },
        {
          "Contents": null,
          "Copyright": null,
          "Copyrights": null,
          "ThemisVersion": "1.0.17-beta",
          "match_data": null,
          "path": "foo.rb"
        },
        {
          "Contents": null,
          "Copyright": "2001-2017 The Apache Software Foundation",
          "Copyrights": [
            "2001-2017 The Apache Software Foundation"
          ],
          "ThemisVersion": "1.0.17-beta",
          "match_data": null,
          "path": "foo_NOTICE.txt"
        },
        {
          "Contents": null,
          "Copyright": null,
          "Copyrights": null,
          "ThemisVersion": "1.0.17-beta",
          "match_data": null,
          "path": "one/two/three/third-party-notices.txt"
        }
      ],
      "Files": [
        "NOTICE.txt",
        "foo.rb",
        "foo_NOTICE.txt",
        "one/two/three/third-party-notices.txt"
      ],
      "GraphBreadth": "complete",
      "Info": {
        "Description": "2001-2017 The Apache Software Foundation"
      },
      "Manifest": null,
      "Name": "No_license_found",
      "NoticeFiles": null,
      "OriginPaths": [],
      "Title": null,
      "Type": "LicenseUnit"
    },
    {
      "AdditionalDependencyData": null,
      "Build": null,
      "Data": [
        {
          "Contents": null,
          "Copyright": null,
          "Copyrights": null,
          "ThemisVersion": "1.0.17-beta",
          "match_data": [
            {
              "end_line": 18,
              "index": 0,
              "length": 1021,
              "location": 0,
              "match_string": "Permission is hereby granted, free of charge, to any person obtaining\na copy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to\npermit persons to whom the Software is furnished to do so, subject to\nthe following conditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\nIN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,\nTORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\nSOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.",
              "start_line": 1
            }
          ],
          "path": "mit_NOTICE.txt"
        }
      ],
      "Files": [
        "mit_NOTICE.txt"
      ],
      "GraphBreadth": "complete",
      "Info": {
        "Description": ""
      },
      "Manifest": null,
      "Name": "mit",
      "NoticeFiles": null,
      "OriginPaths": [],
      "Title": null,
      "Type": "LicenseUnit"
    }
  ]
}
```


## Risks

This is safe to merge with and without the change to Themis, but the tests won't pass unless we use the version of Themis in https://github.com/fossas/themis/pull/68

## Metrics


## References


## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
~- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.~
~- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.~
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
~- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).~
~- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.~
