### PR TITLE
Convert MSB errors to warnings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # FOSSA CLI Changelog
 
+
+## 3.9.33
+
+- MSB: Failure to resolve a linked project no longer causes the scan to fail ([[#1469](https://github.com/fossas/fossa-cli/pull/1469)]).
+
 ## 3.9.32
 
 - Platform Support: Add a binary for ARM64 Linux environments. ([#1465](https://github.com/fossas/fossa-cli/pull/1465))

--- a/test/App/Fossa/VSI/IAT/ResolveSpec.hs
+++ b/test/App/Fossa/VSI/IAT/ResolveSpec.hs
@@ -54,7 +54,7 @@ spec = do
           dep2 = testLocator 12
           skips = SkipResolution (Set.empty)
           expectedGraph =
-            Graphing.directs [package1, package2]
+            Graphing.directs [package1]
               <> Graphing.edges [(package1, dep1), (package1, dep2)]
       -- Package1 is fine
       ResolveProjectDependencies package1 `returnsOnce` [dep1, dep2]


### PR DESCRIPTION
# Overview

When a user has configured a project to be linked to a binary via MSB, and then they lose access to the project (either because a different user is running the scan, or the project has been deleted, or some other reason) the scan currently fails:

```shell
Failed to resolve dependencies for the following FOSSA projects:
	custom+19518/some-project$some-revision

You may not have access to the projects, or they may not exist (see the warnings below for details).
If desired you can use --experimental-skip-vsi-graph to skip resolving the dependencies of these projects.
```

The user then has to use `--experimental-skip-vsi-graph` to resolve this issue.
This PR alters the error to be a warning instead of a fatal error.

The `--experimental-skip-vsi-graph` flag is still there so that users using it don't encounter problems, but it is now largely irrelevant (it would only suppress this warning).

## Acceptance criteria

This error is now a warning.

## Testing plan

This is proven in the type system, I don't believe it requires testing.
No tests currently exist for this functionality, so I didn't alter any existing tests.

## Risks

No risk.

## Metrics

None

## References

https://fossa.atlassian.net/browse/ANE-2005

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
