### PR TITLE
Update grafana image hash.

### DIFF
--- a/src/Control/Carrier/ContainerRegistryApi.hs
+++ b/src/Control/Carrier/ContainerRegistryApi.hs
@@ -105,6 +105,7 @@ import Network.HTTP.Conduit qualified as HTTPConduit
 import Network.HTTP.Types.Header (ResponseHeaders)
 import Path (Abs, Dir, File, Path, filename, mkRelFile, toFilePath, (</>))
 import Path.Internal (Path (..))
+import Debug.Trace (traceShowM)
 
 -- | A carrier to run Registry API functions in the IO monad
 type ContainerRegistryApiC m = SimpleC ContainerRegistryApiF (ReaderC RegistryCtx m)
@@ -166,14 +167,16 @@ getImageManifest ::
   m OciManifestV2
 getImageManifest src = context "Getting Image Manifest" $ do
   manager <- reqManager
+  endpoint <- manifestEndpoint src
+  traceShowM endpoint
   resp <-
     fromResponse
-      =<< mkRequest manager (registryCred src) (Just supportedManifestKinds)
-      =<< manifestEndpoint src
+      =<< mkRequest manager (registryCred src) (Just supportedManifestKinds) endpoint
 
   let respBody :: ByteStringLazy.ByteString
       respBody = responseBody resp
 
+  traceShowM respBody
   if isManifestIndex (responseHeaders resp)
     then do
       manifestIndex <- fromEither $ eitherDecode respBody
@@ -182,6 +185,7 @@ getImageManifest src = context "Getting Image Manifest" $ do
       let platformArch :: Text
           platformArch = platformArchitecture src
 
+      traceShowM manifestIndex
       logDebug . pretty $ "Looking for platform architecture: " <> platformArch
       manifestDigest <-
         fromMaybeText
@@ -193,7 +197,10 @@ getImageManifest src = context "Getting Image Manifest" $ do
         =<< (manifestEndpoint $ src{registryContainerRepositoryReference = manifestDigest})
     else do
       logDebug "Retrieved single-platform image manifest."
-      parseOciManifest resp
+
+      res <- parseOciManifest resp
+      traceShowM res
+      pure res
   where
     isSupportedManifestKind :: ResponseHeaders -> Bool
     isSupportedManifestKind headers =

--- a/test/Container/RegistryApiSpec.hs
+++ b/test/Container/RegistryApiSpec.hs
@@ -118,9 +118,6 @@ amd64 = "amd64"
 arm64 :: Text
 arm64 = "arm64"
 
-arm :: Text
-arm = "arm"
-
 githubImage :: Text
 githubImage = "ghcr.io/fossas/haskell-dev-tools:8.10.4"
 

--- a/test/Container/RegistryApiSpec.hs
+++ b/test/Container/RegistryApiSpec.hs
@@ -11,7 +11,7 @@ import Control.Effect.Lift (Lift)
 import Data.Text (Text)
 import Data.Void (Void)
 import Test.Effect (it', shouldBe')
-import Test.Hspec (Expectation, Spec, describe, it, focus)
+import Test.Hspec (Expectation, Spec, describe, it)
 import Test.Hspec.Megaparsec (shouldParse)
 import Text.Megaparsec (Parsec, parse)
 import Text.Megaparsec.Error (ParseErrorBundle)
@@ -42,7 +42,7 @@ getImageConfig arch img =
     <$> (getImageManifest =<< fromEitherShow (decodeStrict arch img))
 
 spec :: Spec
-spec = focus $ do
+spec = do
   registryApiSpec
   parseAuthChallengeSpec
 

--- a/test/Container/RegistryApiSpec.hs
+++ b/test/Container/RegistryApiSpec.hs
@@ -104,7 +104,7 @@ registryApiSpec =
           confDigest <- getImageConfig amd64 dhImageWithDigest
           confDigest `shouldBe'` dhImageDigest
 
-        focus $ it' "should get manifest for multi-platform image (chooses target platform - grafana arm)" $ do
+        it' "should get manifest for multi-platform image (chooses target platform - grafana arm)" $ do
           confDigest <- getImageConfig arm64 grafanaMultiArchImage
           confDigest `shouldBe'` grafanaMultiArchImageDigest
 
@@ -174,7 +174,7 @@ redisImage :: Text
 redisImage = "redis:6.0.14-buster"
 
 redisImageDigest :: RepoDigest
-redisImageDigest = RepoDigest "sha256:86813a7dd3971d9b8088bb34fd894d2cf18a48679d3d8d958a1a0bd4955e6cef"
+redisImageDigest = RepoDigest "sha256:dd347200af9dbdb9a5f55851d1a0b8b5fb89462b94e84ac0bba89dfec30504fb"
 
 haskellDevImage :: Text
 haskellDevImage = "ghcr.io/fossas/haskell-dev-tools:9.0.2"

--- a/test/Container/RegistryApiSpec.hs
+++ b/test/Container/RegistryApiSpec.hs
@@ -11,7 +11,7 @@ import Control.Effect.Lift (Lift)
 import Data.Text (Text)
 import Data.Void (Void)
 import Test.Effect (it', shouldBe')
-import Test.Hspec (Expectation, Spec, describe, it)
+import Test.Hspec (Expectation, Spec, describe, it, focus)
 import Test.Hspec.Megaparsec (shouldParse)
 import Text.Megaparsec (Parsec, parse)
 import Text.Megaparsec.Error (ParseErrorBundle)
@@ -42,7 +42,7 @@ getImageConfig arch img =
     <$> (getImageManifest =<< fromEitherShow (decodeStrict arch img))
 
 spec :: Spec
-spec = do
+spec = focus $ do
   registryApiSpec
   parseAuthChallengeSpec
 
@@ -104,8 +104,8 @@ registryApiSpec =
           confDigest <- getImageConfig amd64 dhImageWithDigest
           confDigest `shouldBe'` dhImageDigest
 
-        it' "should get manifest for multi-platform image (chooses target platform - grafana arm)" $ do
-          confDigest <- getImageConfig arm grafanaMultiArgeImage
+        focus $ it' "should get manifest for multi-platform image (chooses target platform - grafana arm)" $ do
+          confDigest <- getImageConfig arm64 grafanaMultiArchImage
           confDigest `shouldBe'` grafanaMultiArchImageDigest
 
         it' "should get manifest for multi-platform images (chooses target platform -  redis arm64)" $ do
@@ -151,12 +151,12 @@ dhImageWithDigest :: Text
 dhImageWithDigest =
   "amazon/aws-cli@sha256:7a27c26c2937a3d0b84171675709df1dc09aa331e86cad90f74ada6df7b59c89"
 
-grafanaMultiArgeImage :: Text
-grafanaMultiArgeImage = "grafana/grafana:8.1.7-ubuntu"
+grafanaMultiArchImage :: Text
+grafanaMultiArchImage = "grafana/grafana:8.1.7-ubuntu"
 
 grafanaMultiArchImageDigest :: RepoDigest
 grafanaMultiArchImageDigest =
-  RepoDigest "sha256:fff202f54b5922c3e42c55c45a58edd1e103bffd1f62992fce49dd55500013dd"
+  RepoDigest "sha256:86618e1e78e4962b5abec6cc7fabe89010ebfbbf0885cbba1aada7287457c263"
 
 mcrRegistryImage :: Text
 mcrRegistryImage = "mcr.microsoft.com/azure-cli:0.10.13"

--- a/test/Container/RegistryApiSpec.hs
+++ b/test/Container/RegistryApiSpec.hs
@@ -174,7 +174,7 @@ redisImage :: Text
 redisImage = "redis:6.0.14-buster"
 
 redisImageDigest :: RepoDigest
-redisImageDigest = RepoDigest "sha256:dd347200af9dbdb9a5f55851d1a0b8b5fb89462b94e84ac0bba89dfec30504fb"
+redisImageDigest = RepoDigest "sha256:86813a7dd3971d9b8088bb34fd894d2cf18a48679d3d8d958a1a0bd4955e6cef"
 
 haskellDevImage :: Text
 haskellDevImage = "ghcr.io/fossas/haskell-dev-tools:9.0.2"

--- a/test/Container/RegistryApiSpec.hs
+++ b/test/Container/RegistryApiSpec.hs
@@ -87,7 +87,7 @@ registryApiSpec =
           confDigest <- getImageConfig amd64 githubImageWithDigest
           confDigest `shouldBe'` githubImageConfigDigest
 
-        it' "should get manifest for multi-platform image (chooses target platform)" $ do
+        it' "should get manifest for multi-platform image (chooses target platform - graalvm-ce)" $ do
           confDigest <- getImageConfig amd64 githubMultiArchImage
           confDigest `shouldBe'` githubMultiArchImageConfigDigest
 
@@ -104,11 +104,11 @@ registryApiSpec =
           confDigest <- getImageConfig amd64 dhImageWithDigest
           confDigest `shouldBe'` dhImageDigest
 
-        it' "should get manifest for multi-platform image (chooses target platform)" $ do
-          confDigest <- getImageConfig arm dhMultiArchImage
-          confDigest `shouldBe'` dhMultiArchImageDigest
+        it' "should get manifest for multi-platform image (chooses target platform - grafana arm)" $ do
+          confDigest <- getImageConfig arm grafanaMultiArgeImage
+          confDigest `shouldBe'` grafanaMultiArchImageDigest
 
-        it' "should get manifest for multi-platform images (chooses target platform)" $ do
+        it' "should get manifest for multi-platform images (chooses target platform -  redis arm64)" $ do
           redisDigest <- getImageConfig arm64 redisImage
           redisDigest `shouldBe'` redisImageDigest
 
@@ -151,12 +151,12 @@ dhImageWithDigest :: Text
 dhImageWithDigest =
   "amazon/aws-cli@sha256:7a27c26c2937a3d0b84171675709df1dc09aa331e86cad90f74ada6df7b59c89"
 
-dhMultiArchImage :: Text
-dhMultiArchImage = "grafana/grafana:8.1.7-ubuntu"
+grafanaMultiArgeImage :: Text
+grafanaMultiArgeImage = "grafana/grafana:8.1.7-ubuntu"
 
-dhMultiArchImageDigest :: RepoDigest
-dhMultiArchImageDigest =
-  RepoDigest "sha256:86618e1e78e4962b5abec6cc7fabe89010ebfbbf0885cbba1aada7287457c263"
+grafanaMultiArchImageDigest :: RepoDigest
+grafanaMultiArchImageDigest =
+  RepoDigest "sha256:fff202f54b5922c3e42c55c45a58edd1e103bffd1f62992fce49dd55500013dd"
 
 mcrRegistryImage :: Text
 mcrRegistryImage = "mcr.microsoft.com/azure-cli:0.10.13"


### PR DESCRIPTION
# Overview

One of our unit tests broke because we were expecting the wrong digest hash. I'm really not sure what happened here since no changes we made seem to have touched this. I first noticed this with #1468 to master - it succeeded in the PR but failed when merged to master.

When I `docker pull grafana/grafana:8.1.7-ubuntu` I get an `amd64` image which has the same hash as we were originally expecting. This is despite the fact that the test requests "arm". When I explicitly request arm with `docker pull --platform=arm grafana/grafana:8.1.7-ubuntu` I get an image downloaded with the correct manifest.

Testing with the `redis` image shows the same thing.

This implies to me that in the past we requested the arm image in our unit test but the remote server was sending the amd64 image instead and now for some reason the remote is sending the actual arm image. The difference in digest hashes are what broke our tests.

In any case, this should allow tests to pass on master when it merges.

## Acceptance criteria

* Tests and build succeed.

## Testing plan

I looked at the results of CI.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
