### PR TITLE
Prep for release 3.9.35

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.9.35
+
+- Licensing: Add to the list of ignored copyright phrases (No PR)
+
 ## 3.9.34
 
 - `--strict`: Users can now enable strict mode for analysis. ([#1463](https://github.com/fossas/fossa-cli/pull/1463))


### PR DESCRIPTION
# Overview

This release pulls in a change to our license scanner that adds to the list of ignored copyright phrases.

So we will no longer find (invalid) copyrights for phrases like 

> See the copyright.txt in the distribution for a full listing of individual contributors.

and

> The author hereby disclaims copyright to this source code.

There are also some formatting changes included in this release, but I did not think that was worth noting in the changelog.

## Acceptance criteria

- the tests pass

## Testing plan

No need to test. This is just an update to the changelog.

## Risks

None

## Metrics


## References


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
