### PR TITLE
Do not error on rocky linux referenced deps

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,6 +44,6 @@ _Example:_
 - [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
 - [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
 - [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
-- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
+- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
 - [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
 - [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
-# Unreleased
-
-- fossa-deps: Fixed an issue where Rocky linux deps could skip the fossa-deps file during analysis
-
 # FOSSA CLI Changelog
+
+## Unreleased
+
+- fossa-deps: Fixed an issue where Rocky Linux deps were not supported in the fossa-deps file ([#1473](https://github.com/fossas/fossa-cli/pull/1473))  
 
 ## 3.9.35
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- fossa-deps: Fixed an issue where Rocky linux deps could skip the fossa-deps file during analysis
+
 # FOSSA CLI Changelog
 
 ## 3.9.35

--- a/docs/features/manual-dependencies.md
+++ b/docs/features/manual-dependencies.md
@@ -73,6 +73,7 @@ At this moment the following `os` are supported:
 - `busybox`
 - `sles`
 - `fedora`
+- `rocky`
 
 For example:
 

--- a/docs/references/files/fossa-deps.schema.json
+++ b/docs/references/files/fossa-deps.schema.json
@@ -13,7 +13,8 @@
                 "oraclelinux",
                 "busybox",
                 "sles",
-                "fedora"
+                "fedora",
+                "rocky"
             ],
             "description": "Name of the distribution OS."
         },

--- a/src/App/Fossa/Init/fossa-deps.yml
+++ b/src/App/Fossa/Init/fossa-deps.yml
@@ -60,7 +60,7 @@
 #   name: bash              # Name of the dependency. (Required)
 #   version: 5.1-6ubuntu1   # Revision of the dependency. (Optional)
 #   arch: amd64             # Arch associated with package. (Required)
-#   os: ubuntu              # OS (Required). Supported OS include: alpine, centos, debian, rehat, ubuntu, oraclelinux, busybox, seles, fedora.
+#   os: ubuntu              # OS (Required). Supported OS include: alpine, centos, debian, rehat, ubuntu, oraclelinux, busybox, sles, fedora, rocky.
 #   osVersion: 22.04        # Version of the OS. (Required)
 #
 #

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -635,4 +635,5 @@ supportedOSs =
   , "busybox"
   , "sles"
   , "fedora"
+  , "rocky"
   ]


### PR DESCRIPTION
# Overview

If using `rocky` as an os in the fossa-deps.yml, fossa will fail to read the fossa-deps file with the following error:
```
[ERROR] An issue occurred

  *** Relevant Errors ***

      Error: parsing file: path/to/fossa-deps.yml
        Aeson exception:
        Error in $['referenced-dependencies'][1]: Provided os: rocky is not supported! Please provide oneOf: alpine, centos, debian, redhat, ubuntu, oraclelinux, busybox, sles, fedora
      Support: If you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com, with a copy of: /path/to/fossa-deps.yml
```

This aims to fix that, and allow the use of rocky for rpm-generic deps. It also updates the fossa-deps schema.

## Acceptance criteria

FOSSA CLI analysis does not fail when using `rocky` as an os value.

## Testing plan

I created a fossa-deps.yml with the follwing:
```yml
referenced-dependencies:
- name: binutils
  type: rpm-generic
  arch: x86_64
  os: rocky
  osVersion: '8.6'
  version: 0:2.30-113.el8
```
This will fail on fossa-cli versions outside of this branch.

I tested by downloading the built MacOS arm build from this run:
- https://github.com/fossas/fossa-cli/actions/runs/10962995805

My scan was successful, and the dependency was included in my FOSSA project.

## Risks

I looked at this very quickly; I may have missed a spot where I need to update the OS, or provide additional info.

## References

N/A

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `# Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
