### PR TITLE
Remove subscription check on fossa report preflight check

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,9 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## 3.9.36
 
 - fossa-deps: Fixed an issue where Rocky Linux deps were not supported in the fossa-deps file ([#1473](https://github.com/fossas/fossa-cli/pull/1473))  
+- `fossa report`: Remove subscription type check in preflight checks ([#1474](https://github.com/fossas/fossa-cli/pull/1474))  
 
 ## 3.9.35
 

--- a/src/App/Fossa/PreflightChecks.hs
+++ b/src/App/Fossa/PreflightChecks.hs
@@ -24,7 +24,7 @@ import Data.Text.IO qualified as TIO
 import Diag.Diagnostic (ToDiagnostic (..))
 import Effect.Logger (renderIt)
 import Errata (Errata (..))
-import Fossa.API.Types (ApiOpts, CustomBuildUploadPermissions (..), Organization (..), ProjectPermissionStatus (..), ReleaseGroupPermissionStatus (..), Subscription (..), TokenType (..), TokenTypeResponse (..))
+import Fossa.API.Types (ApiOpts, CustomBuildUploadPermissions (..), Organization (..), ProjectPermissionStatus (..), ReleaseGroupPermissionStatus (..), TokenType (..), TokenTypeResponse (..))
 import Path (
   File,
   Path,

--- a/src/App/Fossa/PreflightChecks.hs
+++ b/src/App/Fossa/PreflightChecks.hs
@@ -78,7 +78,6 @@ preflightChecks cmd = context "preflight-checks" $ do
           ReportChecks -> do
             tokenType <- getTokenType
             fullAccessTokenCheck tokenType
-            premiumSubscriptionCheck org
           _ -> pure ()
   pure org
 
@@ -128,14 +127,6 @@ fullAccessTokenCheck TokenTypeResponse{..} = case tokenType of
       $ fatal TokenTypeErr
   _ -> pure ()
 
-premiumSubscriptionCheck :: Has Diagnostics sig m => Organization -> m ()
-premiumSubscriptionCheck Organization{..} = case orgSubscription of
-  Free ->
-    errHelp ("To proceed, please upgrade your subscription" :: Text)
-      . errCtx ("You currently have a free subscription" :: Text)
-      $ fatal SubscriptionTypeErr
-  _ -> pure ()
-
 preflightCheckFileName :: Path Rel File
 preflightCheckFileName = $(mkRelFile "preflight-check.txt")
 
@@ -150,12 +141,6 @@ instance ToDiagnostic TokenTypeErr where
   renderDiagnostic :: TokenTypeErr -> Errata
   renderDiagnostic TokenTypeErr =
     Errata (Just "Invalid API token type") [] $ Just "The action you are trying to perform requires a `Full Access` API token"
-
-data SubscriptionTypeErr = SubscriptionTypeErr
-instance ToDiagnostic SubscriptionTypeErr where
-  renderDiagnostic :: SubscriptionTypeErr -> Errata
-  renderDiagnostic SubscriptionTypeErr =
-    Errata (Just "Invalid subscription type") [] $ Just "The action you are trying to perform requires a premium subscription"
 
 projectPermissionErrHeader :: Text
 projectPermissionErrHeader = "Invalid project permission"

--- a/test/App/Fossa/PreflightChecksSpec.hs
+++ b/test/App/Fossa/PreflightChecksSpec.hs
@@ -53,10 +53,6 @@ spec = do
       expectOrganizationWithPremiumSubscription
       expectPushToken
       expectFatal' $ ignoreDebug $ preflightChecks ReportChecks
-    it' "should fail premium subscription check for report command" $ do
-      expectOrganizationWithPreflightChecks
-      expectFullAccessToken
-      expectFatal' $ ignoreDebug $ preflightChecks ReportChecks
     it' "should pass all custom upload permission checks for analyze command" $ do
       expectOrganizationWithPreflightChecks
       (GetCustomBuildPermissons Fixtures.projectRevision Fixtures.projectMetadata) `returnsOnce` Fixtures.validCustomUploadPermissions


### PR DESCRIPTION
# Overview

`fossa report` fails for free tier users. This shouldn't be the case with the changes to our free plan: https://fossa.com/blog/secure-open-source-fossa-upgraded-free-plan/ . We are currently failing because our preflight checks for `fossa report` are still configured to check if users have a premium subscription type. Remove this preflight check to account for FOSSA's free plan changes.

Slack threads:
- https://teamfossa.slack.com/archives/CCPE2LSRL/p1726587987001969
- https://teamfossa.slack.com/archives/CCPE2LSRL/p1726592473411099?thread_ts=1726587987.001969&cid=CCPE2LSRL

## Acceptance criteria

- `fossa report` works for free tier users

## Testing plan

With a free tier account, do the following:

- `fossa analyze`
-  `fossa report attribution --format html`

![Screenshot 2024-09-23 at 4 44 16 PM](https://github.com/user-attachments/assets/b52cfedc-9261-4327-ae77-de51f615eba3)


## Risks

## Metrics


## References

- [ANE-2048](https://fossa.atlassian.net/browse/ANE-2048)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2048]: https://fossa.atlassian.net/browse/ANE-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ