### PR TITLE
Make "invalid project permission" error message clearer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+- Adds clarity to "Invalid project permission" error message, instructing user to specify a team using `fossa analyze --team` or in the `.fossa.yml` file.
+
 ## 3.9.37
 
 - License Scanning: Update Themis to include NOTICE files, and parse the additional NOTICE file fields in Themis's output. ([#1466](https://github.com/fossas/fossa-cli/pull/1466))

--- a/src/App/Fossa/PreflightChecks.hs
+++ b/src/App/Fossa/PreflightChecks.hs
@@ -160,7 +160,7 @@ instance ToDiagnostic ProjectPermissionErr where
   renderDiagnostic CreateTeamProjectPermissionErr =
     Errata (Just projectPermissionErrHeader) [] $ Just "You do not have permission to create projects for the specified team"
   renderDiagnostic CreateProjectOnlyToTeamPermissionErr =
-    Errata (Just projectPermissionErrHeader) [] $ Just "You only have permission to create projects for your team"
+    Errata (Just projectPermissionErrHeader) [] $ Just "You only have permission to create projects for your team. Please specify a team in .fossa.yml or using the --team flag"
 
 releaseGroupPermissionErrHeader :: Text
 releaseGroupPermissionErrHeader = "Invalid release group permission"

--- a/src/App/Fossa/PreflightChecks.hs
+++ b/src/App/Fossa/PreflightChecks.hs
@@ -112,7 +112,7 @@ uploadBuildPermissionsCheck CustomBuildUploadPermissions{..} =
             $ fatal CreateTeamProjectPermissionErr
         InvalidCreateProjectOnlyToTeamPermission ->
           errDoc fossaConfigDocsUrl
-            . errHelp ("Ensure that you have specified a team to add this project to" :: Text)
+            . errHelp ("Please specify your team name, either in .fossa.yml or using the --team option with fossa analyze." :: Text)
             $ fatal CreateProjectOnlyToTeamPermissionErr
   where
     permissionHelpMsg :: Text

--- a/src/App/Fossa/PreflightChecks.hs
+++ b/src/App/Fossa/PreflightChecks.hs
@@ -154,13 +154,13 @@ data ProjectPermissionErr
 instance ToDiagnostic ProjectPermissionErr where
   renderDiagnostic :: ProjectPermissionErr -> Errata
   renderDiagnostic CreateProjectPermissionErr =
-    Errata (Just projectPermissionErrHeader) [] $ Just "You do not have permission to create projects for your Organization"
+    Errata (Just projectPermissionErrHeader) [] $ Just "You do not have permission to create projects for your Organization."
   renderDiagnostic EditProjectPermissionErr =
-    Errata (Just projectPermissionErrHeader) [] $ Just "You do not have permission to edit projects for your Organization"
+    Errata (Just projectPermissionErrHeader) [] $ Just "You do not have permission to edit projects for your Organization."
   renderDiagnostic CreateTeamProjectPermissionErr =
-    Errata (Just projectPermissionErrHeader) [] $ Just "You do not have permission to create projects for the specified team"
+    Errata (Just projectPermissionErrHeader) [] $ Just "You do not have permission to create projects for the specified team."
   renderDiagnostic CreateProjectOnlyToTeamPermissionErr =
-    Errata (Just projectPermissionErrHeader) [] $ Just "You only have permission to create projects for your team. Please specify a team in .fossa.yml or using the --team flag"
+    Errata (Just projectPermissionErrHeader) [] $ Just "You only have permission to create projects for your team(s)."
 
 releaseGroupPermissionErrHeader :: Text
 releaseGroupPermissionErrHeader = "Invalid release group permission"


### PR DESCRIPTION
This adds detail on how to fix "invalid project permission" error.

# Overview

We get a lot of support tickets from team admins/editors getting "invalid project permission" who don't understand that they need to specify a team with `fossa analyze`. This makes resolving the error clearer to the end user to reduce support ticket volume.

## Acceptance criteria

This adds explanation to the error message, instructing the user to add `--team 'team-name'` to the command or specify a team in the `.fossa.yml`.

## Testing plan

I have not tested this as I haven't yet built fossa-cli locally. A reviewer could build this locally and test that the error message looks OK when trying to analyze a project as a team admin without specifying a team name. Otherwise, it's a straightforward text change.

## Risks

I haven't tested that the longer error message looks OK in the command output. 

## Metrics


## References


## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
