### PR TITLE
Fix small typo in error response

### DIFF
--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -531,7 +531,7 @@ instance ToDiagnostic FossaError where
           body = createBody (Just content) Nothing (Just $ renderIt requestReportIfPersistsWithDebugBundle) Nothing (Just ctx)
       Errata (Just header) [] (Just body)
     NoResponseDataError ereq -> do
-      let header = "he connection to the FOSSA endpoint was closed without a response"
+      let header = "The connection to the FOSSA endpoint was closed without a response"
           content = renderIt $ reportFossaBugErrorMsg $ fossaEnvironment ereq
           ctx = "Request: " <> renderIt (renderRequest ereq)
           body = createBody (Just content) Nothing (Just $ renderIt requestReportIfPersistsWithDebugBundle) Nothing (Just ctx)


### PR DESCRIPTION
# Overview

Noticed a typo when investigating a ticket, figured I'd fix it.

## Acceptance criteria

Corrects a typo, nothing breaks.

## Testing plan

Text-only change, no testing was done.

## Risks

Little risk, text-only. Unsure if this needs to be declared in the changelog.

## Metrics

None

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
