### PR TITLE
[ANE-2105] Update Themis to fix ANE-2105

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 # FOSSA CLI Changelog
+## 3.9.40
+- Licensing: Fix a bug where license scanner output sometimes included log lines, which breaks JSON parsing
 
 ## 3.9.39
 - Licensing: Add the PSF-3.12.7 license. Make a correction to the MulanPSL license. Add a new public-domain rule ([#1480](https://github.com/fossas/fossa-cli/pull/1480))


### PR DESCRIPTION
# Overview

Pull in the changes to Themis that fix [ANE-2105](https://fossa.atlassian.net/browse/ANE-2105)

## Acceptance criteria

We use the new version of Themis

## Testing plan

Run a license scan on a directory with a `.map` file that does not contain JSON, and show that it still returns results from other licenses in that directory.

```
mkdir bad-map-files
echo "this is not JSON" > bad-map-files/something.map
```

Also, copy something with a license into the `bad-map-files` directory. I copied the MIT license from Themis: https://github.com/fossas/themis/blob/main/license-data/licenses/mit.LICENSE

Then, scan that directory. With Themis versions >=1.0.21 and <1.0.25, this will fail to find any licenses. With the current Themis (1.0.25) it will find the MIT license.

With Themis 1.0.24:

```
cabal run fossa -- analyze --experimental-force-first-party-scans --output $scandirs/bad-map-files
{"projects":[],"sourceUnits":[]}%                                                                                                                                                 
```

With Themis 1.0.25:

```
cabal run fossa -- analyze --experimental-force-first-party-scans --output $scandirs/bad-map-files | jq
{
  "projects": [],
  "sourceUnits": [
    {
      "AdditionalDependencyData": null,
      "Build": null,
      "Data": [
        {
          "Contents": null,
          "Copyright": null,
          "Copyrights": null,
          "ThemisVersion": "1.0.25",
          "match_data": null,
          "path": "bad.map"
        }
      ],
      "Files": [
        "bad.map"
      ],
      "GraphBreadth": "complete",
      "Info": {
        "Description": ""
      },
      "Manifest": null,
      "Name": "No_license_found",
      "NoticeFiles": [],
      "OriginPaths": [],
      "Title": null,
      "Type": "LicenseUnit"
    },
    {
      "AdditionalDependencyData": null,
      "Build": null,
      "Data": [
        {
          "Contents": null,
          "Copyright": null,
          "Copyrights": null,
          "ThemisVersion": "1.0.25",
          "match_data": [
            {
              "end_line": 18,
              "index": 0,
              "length": 1021,
              "location": 0,
              "match_string": "Permission is hereby granted, free of charge, to any person obtaining\na copy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to\npermit persons to whom the Software is furnished to do so, subject to\nthe following conditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\nIN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,\nTORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\nSOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.",
              "start_line": 1
            }
          ],
          "path": "mit.LICENSE"
        }
      ],
      "Files": [
        "mit.LICENSE"
      ],
      "GraphBreadth": "complete",
      "Info": {
        "Description": ""
      },
      "Manifest": null,
      "Name": "mit",
      "NoticeFiles": [],
      "OriginPaths": [],
      "Title": null,
      "Type": "LicenseUnit"
    }
  ]
}
```

## Risks



## Metrics



## References


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
