### PR TITLE
Expose a static only Go modules tactic.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
 # FOSSA CLI Changelog
+
+## 3.9.41
+- GoModules: Fix a bug where a static analysis method was not exposed. ([#1468](https://github.com/fossas/fossa-cli/pull/1486))
+
 ## 3.9.40
 - Licensing: Fix a bug where license scanner output sometimes included log lines, which breaks JSON parsing
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## 3.9.41
-- GoModules: Fix a bug where a static analysis method was not exposed. ([#1468](https://github.com/fossas/fossa-cli/pull/1486))
+- GoModules: Expose a static only analysis method for Go. ([#1468](https://github.com/fossas/fossa-cli/pull/1486))
 
 ## 3.9.40
 - Licensing: Fix a bug where license scanner output sometimes included log lines, which breaks JSON parsing

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -106,7 +106,7 @@ where:
 
 
 This strategy will attempt to fill in transitive dependencies by calling out to Go tools.
-If it fails for `fossa analyze` is invoked with `--static-analysis-only`, it will report what it found in `go.mod` without any transitive dependencies.
+If it fails or `fossa analyze` is invoked with `--static-analysis-only`, the strategy will report what it found in `go.mod` without any transitive dependencies.
 
 ## FAQ
 

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -104,6 +104,10 @@ where:
 - `replace` rewrites `require`s. In this example, our requires resolve to
   `[github.com/example/one v1.2.3, github.com/example/other v2.0.0]`
 
+
+This strategy will attempt to fill in transitive dependencies by calling out to Go tools.
+If it fails for `fossa analyze` is invoked with `--static-analysis-only`, it will report what it found in `go.mod` without any transitive dependencies.
+
 ## FAQ
 
 ### Why do I see a dependency in `go.mod`, but it is not reflected in FOSSA?

--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -14,6 +14,7 @@ module Strategy.Go.Gomod (
   PackageVersion (..),
   parsePackageVersion,
   gomodParser,
+  analyzeStatic,
 ) where
 
 import Control.Algebra (Has)
@@ -394,6 +395,14 @@ analyze' file = do
       . warnOnErr MissingEdges
       $ fillInTransitive (parent file)
     pure ()
+  pure (graph, Partial)
+
+-- | This variant of analyze will not attempt to fill in transitive dependencies.
+analyzeStatic :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency, GraphBreadth)
+analyzeStatic file = do
+  graph <- graphingGolang $ do
+    gomod <- readContentsParser gomodParser file
+    context "Building dependency graph (static)" $ buildGraph gomod
   pure (graph, Partial)
 
 buildGraph :: Has GolangGrapher sig m => Gomod -> m ()

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -11,7 +11,7 @@ import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProjectStaticOnly), analy
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig (useV3GoResolver), GoDynamicTactic (..))
 import App.Util (guardStrictMode)
 import Control.Carrier.Diagnostics (warn)
-import Control.Effect.Diagnostics (Diagnostics, context, fatalText, recover, (<||>))
+import Control.Effect.Diagnostics (Diagnostics, context, recover, (<||>))
 import Control.Effect.Reader (Reader, ask, asks)
 import Control.Monad (when)
 import Data.Aeson (ToJSON)
@@ -58,7 +58,7 @@ instance ToJSON GomodulesProject
 
 instance AnalyzeProject GomodulesProject where
   analyzeProject _ proj = asks useV3GoResolver >>= getDeps proj
-  analyzeProjectStaticOnly _ proj = staticAnalysisResults proj <$> staticAnalysis proj
+  analyzeProjectStaticOnly _ = staticAnalysis
 
 mkProject :: GomodulesProject -> DiscoveredProject GomodulesProject
 mkProject project =
@@ -72,7 +72,9 @@ mkProject project =
 getDeps :: (GetDepsEffs sig m) => GomodulesProject -> GoDynamicTactic -> m DependencyResults
 getDeps project goDynamicTactic = do
   mode <- ask
-  (graph, graphBreadth) <- context "Gomodules" $ dynamicAnalysis <||> guardStrictMode mode (staticAnalysis project)
+  (graph, graphBreadth) <-
+    context "Gomodules" $
+      dynamicAnalysis <||> guardStrictMode mode fallbacks
   stdlib <- recover . context "Collect go standard library information" . listGoStdlibPackages $ gomodulesDir project
   pure $
     DependencyResults
@@ -81,11 +83,16 @@ getDeps project goDynamicTactic = do
       , dependencyManifestFiles = [gomodulesGomod project]
       }
   where
+    fallbacks :: (Has Diagnostics sig m, Has Exec sig m, Has ReadFS sig m) => m (Graphing Dependency, GraphBreadth)
+    fallbacks = goDotModAnalysis <||> Gomod.analyzeStatic (gomodulesGomod project)
     -- `go list -json -deps all` marks std lib deps with a boolean, so Strategy.Go.GoListPackages does this filtering itself.
     -- I think this can be removed when `go list -json -deps all` becomes the default.
     filterGraph :: Maybe [GoStdlibDep] -> Graphing Dependency -> Graphing Dependency
     filterGraph Nothing deps = deps
     filterGraph (Just stdlib) deps = filterGoStdlibPackages stdlib deps
+
+    goDotModAnalysis :: (Has ReadFS sig m, Has Exec sig m, Has Diagnostics sig m) => m (Graphing Dependency, GraphBreadth)
+    goDotModAnalysis = context "Go.mod analysis" (Gomod.analyze' (gomodulesGomod project))
 
     dynamicAnalysis :: (Has Exec sig m, Has Diagnostics sig m) => m (Graphing Dependency, GraphBreadth)
     dynamicAnalysis =
@@ -97,13 +104,13 @@ getDeps project goDynamicTactic = do
 
         context "analysis using go list (V3 Resolver)" (GoListPackages.analyze (gomodulesDir project))
 
-staticAnalysis :: (Has Exec sig m, Has ReadFS sig m, Has Diagnostics sig m) => GomodulesProject -> m (Graphing Dependency, GraphBreadth)
-staticAnalysis project = context "Static analysis" (Gomod.analyze' (gomodulesGomod project))
-
-staticAnalysisResults :: GomodulesProject -> (Graphing Dependency, GraphBreadth) -> DependencyResults
-staticAnalysisResults proj (graph, graphBreadth) =
-  DependencyResults
-    { dependencyGraph = graph
-    , dependencyGraphBreadth = graphBreadth
-    , dependencyManifestFiles = [gomodulesGomod proj]
-    }
+staticAnalysis :: (Has Diagnostics sig m, Has ReadFS sig m) => GomodulesProject -> m DependencyResults
+staticAnalysis proj = do
+  let projectPath = gomodulesGomod proj
+  (graph, breadth) <- context "Go.mod analysis (static)" $ Gomod.analyzeStatic projectPath
+  pure $
+    DependencyResults
+      { dependencyGraph = graph
+      , dependencyGraphBreadth = breadth
+      , dependencyManifestFiles = [projectPath]
+      }

--- a/src/Strategy/Gomodules.hs
+++ b/src/Strategy/Gomodules.hs
@@ -74,7 +74,7 @@ getDeps project goDynamicTactic = do
   mode <- ask
   (graph, graphBreadth) <-
     context "Gomodules" $
-      dynamicAnalysis <||> guardStrictMode mode fallbacks
+      dynamicAnalysis <||> guardStrictMode mode goDotModAnalysis
   stdlib <- recover . context "Collect go standard library information" . listGoStdlibPackages $ gomodulesDir project
   pure $
     DependencyResults
@@ -83,8 +83,6 @@ getDeps project goDynamicTactic = do
       , dependencyManifestFiles = [gomodulesGomod project]
       }
   where
-    fallbacks :: (Has Diagnostics sig m, Has Exec sig m, Has ReadFS sig m) => m (Graphing Dependency, GraphBreadth)
-    fallbacks = goDotModAnalysis <||> Gomod.analyzeStatic (gomodulesGomod project)
     -- `go list -json -deps all` marks std lib deps with a boolean, so Strategy.Go.GoListPackages does this filtering itself.
     -- I think this can be removed when `go list -json -deps all` becomes the default.
     filterGraph :: Maybe [GoStdlibDep] -> Graphing Dependency -> Graphing Dependency


### PR DESCRIPTION
# Overview

We initially didn't expose a static only analysis method in the CLI for Go modules despite there being a pretty low-effort path to providing one. This PR makes a truly static Go analysis method and exposes it for use with the `--static-only-analysis` flag. 

## Acceptance criteria

It is possible to analyze go projects statically.

## Testing plan

Compare running `fossa analyze --static-only-analysis` on this branch and in a release version. Static Go analysis fails using the current release version:


![Screenshot 2024-12-02 at 6 16 30 PM](https://github.com/user-attachments/assets/583c0db4-a7b5-43eb-8ea9-fd75116e6bb0)
But succeeds in the one on this branch:

![Screenshot 2024-12-02 at 6 34 52 PM](https://github.com/user-attachments/assets/7d08d5d8-4ea9-48b1-85cf-b011058c72ea)


## Risks

The main risk is that projects which didn't produce a result in the past may start to. This is the correct thing to do, but may result in more questions.

## Metrics


## References

[slack thread](https://teamfossa.slack.com/archives/C0155DTGWB1/p1732903477682909)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
