### PR TITLE
Add caveat about pnpm v9 lockfile incompatibility

### DIFF
--- a/docs/references/strategies/languages/nodejs/pnpm.md
+++ b/docs/references/strategies/languages/nodejs/pnpm.md
@@ -161,10 +161,17 @@ CLI will infer the package name and version using `/${dependencyName}/${dependen
 You can explicitly specify an analysis target in `.fossa.yml` file. The example below will exclude all analysis targets except for pnpm.
 
 ```yaml
-# .fossa.yml 
+# .fossa.yml
 
 version: 3
 targets:
   only:
     - type: pnpm
 ```
+### Are all versions of `pnpm` supported?
+
+At this time, the latest version of pnpm (v9) and its associated v9 lockfiles are not correctly parsed by FOSSA. Please revert to v8 (v6 lockfile) if your dependencies are not resolved in the FOSSA UI: "FOSSA was unable to analyze this dependency. If it is behind a private registry or auth you may need to configure FOSSA's access, then rebuild this dependency." This is due to the version number being appended to the package name:
+
+<img width="796" alt="image" src="https://github.com/user-attachments/assets/d1461506-d3e7-42da-b9be-2b53a87f79f1" />
+
+We have [requested](https://github.com/pnpm/spec/issues/6#issuecomment-2588100182) more details on the pnpm v9 lockfile spec and hope to be able to prioritize this improvement soon.


### PR DESCRIPTION
# Overview

Updating docs to disclaim pnpm v9 incompatibility.

## Acceptance criteria

Docs updated

## Testing plan

n/a

## Risks

n/a

## Metrics

n/a

## References

https://fossa.atlassian.net/browse/ANE-2177


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
