### PR TITLE
[ANE-2237] make the preflight check filename unique

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,10 @@
 # FOSSA CLI Changelog
 
+## 3.9.44
+- Preflight: Fix a bug where the preflight check could fail if you ran fossa multiple times simultaneously ([#1498](https://github.com/fossas/fossa-cli/pull/1498))
+
 ## 3.9.43
-- Discovery: Fix a bug where directories in paths.exclude may still be accessed during discovery which causes an error when users don't have permission to read those directories.
+- Discovery: Fix a bug where directories in paths.exclude may still be accessed during discovery which causes an error when users don't have permission to read those directories ([#1493](https://github.com/fossas/fossa-cli/pull/1493))
 
 ## 3.9.42
 - Licensing: Adds support for the Text-Tabs+Wrap License

--- a/src/App/Fossa/PreflightChecks.hs
+++ b/src/App/Fossa/PreflightChecks.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module App.Fossa.PreflightChecks (
   PreflightCommandChecks (..),


### PR DESCRIPTION
# Overview

In [ANE-2237](https://fossa.atlassian.net/browse/ANE-2237), Lukas from SEW Eurodrive reported that the preflight check was failing around 10% of the time on their CI instance.

This was happening because they were running multiple runs of `fossa` in parallel, so the processes were sometimes deleting the preflight check file created by another instance of `fossa`, and it was raising an error when it tried to delete the nonexistent file.

Two obvious ways to fix this are to just not fail if you can't delete or to make the filename unique. I opted for the unique filename approach, but I have no strong opinion here.

## Acceptance criteria



## Testing plan

I was able to repro the initial problem by running this in one terminal:

```
while true; do rm -f $TMPDIR/preflight-check.txt; done
```

and then running `fossa report` a bunch of times in another:

```
repeat 20 { fossa report --format spdx-json --project zd-5344 --revision 2022-12-21T01:21:22Z attribution > /dev/null }
```

That's no longer going to reproduce the problem. So I just put in some logging and validated that the filename being returned by preflightCheckFilename was different between runs.

## Risks

This is low risk

## Metrics



## References

[ANE-2237](https://fossa.atlassian.net/browse/ANE-2237)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2237]: https://fossa.atlassian.net/browse/ANE-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANE-2237]: https://fossa.atlassian.net/browse/ANE-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ