### PR TITLE
[ANE-2235] Add support for PNPM v9 lockfile format

### DIFF
--- a/src/Strategy/Node/Pnpm/PnpmLock.hs
+++ b/src/Strategy/Node/Pnpm/PnpmLock.hs
@@ -8,6 +8,7 @@ module Strategy.Node.Pnpm.PnpmLock (
 import Control.Applicative ((<|>))
 import Control.Effect.Diagnostics (Diagnostics, Has, context)
 import Data.Aeson.Extra (TextLike (..))
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Foldable (for_)
 import Data.Map (Map, toList)
 import Data.Map qualified as Map
@@ -256,7 +257,7 @@ newtype CatalogMap = CatalogMap
 
 instance FromJSON CatalogMap where
   parseJSON = Yaml.withObject "CatalogMap" $ \obj ->
-    CatalogMap <$> traverse Yaml.parseJSON obj
+    CatalogMap <$> traverse Yaml.parseJSON (KeyMap.toMap obj)
 
 data CatalogEntry = CatalogEntry
   { specifier :: Text

--- a/src/Strategy/Node/Pnpm/PnpmLock.hs
+++ b/src/Strategy/Node/Pnpm/PnpmLock.hs
@@ -256,7 +256,7 @@ newtype CatalogMap = CatalogMap
 
 instance FromJSON CatalogMap where
   parseJSON = Yaml.withObject "CatalogMap" $ \obj ->
-    CatalogMap <$> traverse parseJSON obj
+    CatalogMap <$> traverse Yaml.parseJSON obj
 
 data CatalogEntry = CatalogEntry
   { specifier :: Text

--- a/src/Strategy/Node/Pnpm/PnpmLock.hs
+++ b/src/Strategy/Node/Pnpm/PnpmLock.hs
@@ -184,7 +184,7 @@ instance FromJSON ProjectMap where
       <*> obj .:? "devDependencies" .!= mempty
 
 newtype ProjectMapDepMetadata = ProjectMapDepMetadata
-  { version :: Text
+  { depVersion :: Text  -- renamed from version to avoid name collision
   }
   deriving (Show, Eq, Ord)
 
@@ -256,7 +256,7 @@ newtype CatalogMap = CatalogMap
 
 instance FromJSON CatalogMap where
   parseJSON = Yaml.withObject "CatalogMap" $ \obj ->
-    CatalogMap <$> traverse parseCatalogEntry obj
+    CatalogMap <$> traverse parseJSON obj
 
 data CatalogEntry = CatalogEntry
   { specifier :: Text
@@ -268,7 +268,7 @@ instance FromJSON CatalogEntry where
   parseJSON = Yaml.withObject "CatalogEntry" $ \obj ->
     CatalogEntry
       <$> obj .: "specifier"
-      <*> obj .: "version"
+      <*> obj .: "version"  -- maps the JSON field "version" to our catalogVersion field
 
 analyze :: (Has ReadFS sig m, Has Logger sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
 analyze file = context "Analyzing Npm Lockfile (v3)" $ do

--- a/src/Strategy/Node/Pnpm/PnpmLock.hs
+++ b/src/Strategy/Node/Pnpm/PnpmLock.hs
@@ -260,7 +260,7 @@ instance FromJSON CatalogMap where
 
 data CatalogEntry = CatalogEntry
   { specifier :: Text
-  , version :: Text
+  , catalogVersion :: Text  -- renamed from version to avoid name collision
   }
   deriving (Show, Eq, Ord)
 
@@ -435,7 +435,7 @@ buildGraph lockFile = withoutLocalPackages $
         then do
           defaultCatalog <- Map.lookup "default" (catalogs lockFile)
           entry <- Map.lookup name (catalogEntries defaultCatalog)
-          Just $ version entry
+          Just $ catalogVersion entry
         else Just version
 
     toDependency :: Text -> Maybe Text -> PackageData -> Bool -> Dependency


### PR DESCRIPTION
# Overview

## Changes
This PR improves the PNPM v9 lockfile parsing to correctly handle:

1. Package keys without leading slashes in v9 format
2. Catalog versions (e.g., `workspace:*` or `workspace:^1.0.0`)
3. Proper version normalization for workspace dependencies

### Implementation Details
- Added `catalogs` field to `PnpmLockfile` type to parse the new catalog section
- Created `CatalogMap` and `CatalogEntry` types to properly handle catalog entries
- Added `getPackageVersion` helper to resolve catalog version references
- Updated version parsing to properly handle v7-v9 lockfiles
- Simplified lockfile version handling by consolidating v7+ into `PnpmLockGt6`

### Fixes
This addresses several issues where:
- Package names and versions were incorrectly concatenated in the UI
- Dependencies with catalog versions weren't properly resolved
- Dev dependencies under the importers field weren't correctly identified

## Motivation
PNPM v9 introduced a new lockfile format that uses a catalog system for version management. This change ensures we can correctly parse these lockfiles and extract accurate dependency information.

## Acceptance criteria

Using pnpm 9 with a v9 lockfile, all npm dependencies are correctly resolved with proper locators in the FOSSA UI.

## Testing plan

Tested against PNPM's own repository (which uses v9 lockfile) to verify correct handling of:
- Catalog version references
- Package keys without leading slashes
- Workspace dependencies

## Risks

_Highlight any areas that you're unsure of, want feedback on, or want reviewers to pay particular attention to._

_Example: I'm not sure I did X correctly, can reviewers please double-check that for me?_

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

https://fossa.atlassian.net/browse/ANE-2235
https://fossa.atlassian.net/browse/ANE-2177
https://teamfossa.slack.com/archives/C022BQWCR45/p1733495478363879

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
