### PR TITLE
[ANE-2269] Cut release including themis bug fix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## 3.9.46
+- Licensing: Fix a bug where the tzdata debian package copyright was not detected as a public domain license
 - Container scanning: Fix a bug where Docker URLs were being constructed incorrectly, resulting in a 403 error
 
 ## 3.9.45

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 # FOSSA CLI Changelog
 
 ## 3.9.46
-- Licensing: Fix a bug where the tzdata debian package copyright was not detected as a public domain license
-- Container scanning: Fix a bug where Docker URLs were being constructed incorrectly, resulting in a 403 error
+- Licensing: Fix a bug where the tzdata debian package copyright was not detected as a public domain license ([#1504](https://github.com/fossas/fossa-cli/pull/1504))
+- Container scanning: Fix a bug where Docker URLs were being constructed incorrectly, resulting in a 403 error ([#1500](https://github.com/fossas/fossa-cli/pull/1500))
 
 ## 3.9.45
 - Preflight: Fix a bug where the preflight checks fail for SBOM team analysis ([#1499](https://github.com/fossas/fossa-cli/pull/1499))


### PR DESCRIPTION
# Overview

Pull in changes to Themis that fix [ANE-2269](https://fossa.atlassian.net/browse/ANE-2269).

## Acceptance criteria

We use the new version of Themis

## Testing plan

Do a license scan on a project with the `deb+tzdata#debian#12.9$all#0:2024b-0+deb12u1` dep and observe that the public domain license is found.

## Risks

## Metrics

## References

- [ANE-2269](https://fossa.atlassian.net/browse/ANE-2269): Debian copyright file with clear public-domain license not detected

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2269]: https://fossa.atlassian.net/browse/ANE-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANE-2269]: https://fossa.atlassian.net/browse/ANE-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ