### PR TITLE
Support labels in `fossa-deps` files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.10.0
+- Support for user-provided dependency labels in `fossa-deps` ([#1505](https://github.com/fossas/fossa-cli/pull/1505)).
+  For details, see the [`fossa-deps` documentation](https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-deps.md).
+
 ## 3.9.47
 - Licensing: Adds support for Zeebe Community License v1.1 and Camunda License v1.0
 

--- a/docs/contributing/HACKING.md
+++ b/docs/contributing/HACKING.md
@@ -198,9 +198,11 @@ Yes.  Missing language extensions are usually compile-time errors, and will be c
 If, for any reason, GHC tells you add an extension, and hlint tells you to remove the extension you just added, keep it there and ignore hlint.  You should also file
 an issue in this repository for that scenario, since we may be able to fix that.
 
+<!-- markdown-link-check-disable -->
 [fourmolu]: https://github.com/fourmolu/fourmolu
 [ghcup]: https://www.haskell.org/ghcup
 [hackage]: https://hackage.haskell.org/
 [hlint]: https://github.com/ndmitchell/hlint
 [hls]: https://github.com/haskell/haskell-language-server
 [hoogle]: https://hoogle.haskell.org/
+<!-- markdown-link-check-enable-->

--- a/docs/references/files/fossa-deps.md
+++ b/docs/references/files/fossa-deps.md
@@ -95,8 +95,6 @@ For more details, please refer to the [feature](../../features/vendored-dependen
 
 Each kind of dependency referenced above can have a `labels` field, which is a list of labels to be added to the dependency.
 These labels are **user-defined**; you may choose any labels. What they mean is up to you and/or your organization.
-For more information on labels, refer to the main [FOSSA documentation](https://docs.fossa.com).
-<!-- Note: We should really link to a more specific page here, but these docs don't yet exist. -->
 
 Labels have a `scope` field, which is the scope of the label. The possible scopes are:
 - `org`: The label is scoped to the organization.

--- a/docs/references/files/fossa-deps.md
+++ b/docs/references/files/fossa-deps.md
@@ -15,7 +15,7 @@ Denotes listing of dependencies, which are to be analyzed in conjunction with th
 - `type`: Type of dependency. (Required)
 - `name`: Name of the dependency. It should be the same name as listed in dependencies registry. (Required)
 - `version`: Revision of the dependency. If left unspecified, the latest version discovered from the registry will be used.
-
+- `labels`: An optional list of labels to be added to the dependency.
 ```yaml
 referenced-dependencies:
 - type: gem
@@ -90,6 +90,59 @@ vendored-dependencies:
 > Note: License scanning currently operates by uploading the files at the specified path to a secure S3 bucket. All files that do not contain licenses are then removed after 2 weeks.
 
 For more details, please refer to the [feature](../../features/vendored-dependencies.md) walk through.
+
+## Labels
+
+Each kind of dependency referenced above can have a `labels` field, which is a list of labels to be added to the dependency.
+These labels are **user-defined**; you may choose any labels. What they mean is up to you and/or your organization.
+For more information on labels, refer to the main [FOSSA documentation](https://docs.fossa.com).
+<!-- Note: We should really link to a more specific page here, but these docs don't yet exist. -->
+
+Labels have a `scope` field, which is the scope of the label. The possible scopes are:
+- `org`: The label is scoped to the organization.
+- `revision`: The label is scoped to the revision.
+- `project`: The label is scoped to the project.
+
+You may attach multiple labels to a single dependency.
+For example:
+
+```yaml
+referenced-dependencies:
+- type: pypi
+  name: numpy
+  version: 2.2.0
+  labels:
+  - label: numbers-go-brr
+    scope: org
+  - label: oss-approved
+    scope: revision
+
+custom-dependencies:
+- name: somecorp-api-client
+  version: 1.2.3
+  license: Proprietary
+  metadata:
+    homepage: https://www.partner.somecorp.com/interface/client/wrapper/lib
+    description: Gives access to the SomeCorp API.
+  labels:
+  - label: proprietary
+    scope: version
+  - label: license-paid-2024
+    scope: revision
+
+vendored-dependencies:
+- name: Django
+  path: vendor/Django-3.4.16.zip
+  version: 3.4.16
+  metadata:
+    homepage: https://djangoproject.com
+    description: Django
+  labels:
+  - label: hr-docs
+    scope: project
+  - label: internal-dependency
+    scope: revision
+```
 
 ## Errors in the `fossa-deps` file
 

--- a/docs/references/files/fossa-deps.schema.json
+++ b/docs/references/files/fossa-deps.schema.json
@@ -1,310 +1,370 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "fossa-deps",
-    "description": "fossa-deps for dependency specification for FOSSA CLI",
-    "$defs": {
-        "os": {
-            "enum": [
-                "alpine",
-                "centos",
-                "debian",
-                "redhat",
-                "ubuntu",
-                "oraclelinux",
-                "busybox",
-                "sles",
-                "fedora",
-                "rocky"
-            ],
-            "description": "Name of the distribution OS."
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "fossa-deps",
+  "description": "fossa-deps for dependency specification for FOSSA CLI",
+  "$defs": {
+    "label": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The label to be added to the dependency.",
+          "minLength": 1,
+          "maxLength": 255
         },
-        "referenced-app-dependency": {
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Name of the dependency. This name will be used to search for dependency in relevant registries."
-                },
-                "type": {
-                    "enum": [
-                        "bower",
-                        "cargo",
-                        "carthage",
-                        "composer",
-                        "cpan",
-                        "renv",
-                        "gem",
-                        "git",
-                        "go",
-                        "hackage",
-                        "hex",
-                        "maven",
-                        "npm",
-                        "nuget",
-                        "paket",
-                        "pub",
-                        "pypi",
-                        "cocoapods",
-                        "swift",
-                        "url"
-                    ],
-                    "description": "Type of the dependency. It informs FOSSA which relevant registries to search for dependency's distribution."
-                },
-                "version": {
-                    "type": "string",
-                    "description": "Version of the dependency. It informs FOSSA which version of the dependency to scan. If not provided, latest version will be used."
-                }
-            },
-            "required": [
-                "name",
-                "type"
-            ],
-            "additionalProperties": false
-        },
-        "referenced-apk-deb-dependency": {
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Name of the dependency. This name will be used to search for dependency in relevant registries."
-                },
-                "type": {
-                    "enum": [
-                        "apk",
-                        "deb"
-                    ],
-                    "description": "Type of the dependency. It informs FOSSA which relevant registries to search for dependency's distribution."
-                },
-                "version": {
-                    "type": "string",
-                    "description": "Version of the dependency. It informs FOSSA which version of the dependency to scan. If not provided, latest version will be used."
-                },
-                "arch": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Architecture associated with this package"
-                },
-                "os": {
-                    "$ref": "#/$defs/os"
-                },
-                "osVersion": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Version of the distribution OS."
-                }
-            },
-            "required": [
-                "name",
-                "type",
-                "arch",
-                "os",
-                "osVersion"
-            ],
-            "additionalProperties": false
-        },
-        "referenced-rpm-dependency": {
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Name of the dependency. This name will be used to search for dependency in relevant registries."
-                  },
-                "type": {
-                    "enum": [
-                        "rpm-generic"
-                    ],
-                    "description": "Type of the dependency. It informs FOSSA which relevant registries to search for dependency's distribution."
-                },
-                "version": {
-                    "type": "string",
-                    "description": "Version of the dependency. It informs FOSSA which version of the dependency to scan. If not provided, latest version will be used."
-                },
-                "arch": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Architecture associated with this package"
-                },
-                "epoch": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Epoch associated with version (if any)."
-                },
-                "os": {
-                    "$ref": "#/$defs/os"
-                },
-                "osVersion": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Version of the distribution OS."
-                }
-            },
-            "required": [
-                "name",
-                "type",
-                "arch",
-                "os",
-                "osVersion"
-            ],
-            "additionalProperties": false
-        },
-        "referenced-dependency": {
-            "oneOf": [
-                {
-                    "$ref": "#/$defs/referenced-app-dependency"
-                },
-                {
-                    "$ref": "#/$defs/referenced-apk-deb-dependency"
-                },
-                {
-                    "$ref": "#/$defs/referenced-rpm-dependency"
-                }
-            ]
-        },
-        "custom-dependency": {
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "Name of the dependency. This will be the name used in FOSSA's dashboard.",
-                    "minLength": 1
-                },
-                "version": {
-                    "type": "string",
-                    "description": "Version of the dependency. This will be the version used in FOSSA's dashboard.",
-                    "minLength": 1
-                },
-                "license": {
-                    "type": "string",
-                    "description": "License of the dependency. This string will be used to infer license type.",
-                    "minLength": 1
-                },
-                "metadata": {
-                    "type": "object",
-                    "properties": {
-                        "description": {
-                            "type": "string",
-                            "description": "Description of the dependency (if any)"
-                        },
-                        "homepage": {
-                            "type": "string",
-                            "description": "Homepage of the dependency. This should be web address."
-                        }
-                    }
-                }
-            },
-            "required": [
-                "name",
-                "version",
-                "license"
-            ],
-            "additionalProperties": false
-        },
-        "vendored-dependency": {
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "Name of the dependency. This will be the name associated with this vendored dependency in FOSSA's dashboard",
-                    "minLength": 1
-                },
-                "path": {
-                    "type": "string",
-                    "description": "Path to directory, which will be archived and upload to provided endpoint for license scanning.",
-                    "minLength": 1
-                },
-                "version": {
-                    "type": "string",
-                    "description": "Version of the dependency. This will be the version associated with this vendored dependency in FOSSA's dashboard"
-                },
-                "metadata": {
-                    "type": "object",
-                    "properties": {
-                        "description": {
-                            "type": "string",
-                            "description": "Description of the dependency (if any)"
-                        },
-                        "homepage": {
-                            "type": "string",
-                            "description": "Homepage of the dependency. This should be web address."
-                        }
-                    }
-                }
-            },
-            "required": [
-                "name",
-                "path"
-            ],
-            "additionalProperties": false
-        },
-        "remote-dependency": {
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "Name of the dependency. This will be the version used in FOSSA's dashboard.",
-                    "minLength": 1
-                },
-                "url": {
-                    "type": "string",
-                    "description": "Url of the dependency's source code. This will be the downloaded by FOSSA for scanning with the analysis.",
-                    "minLength": 1
-                },
-                "version": {
-                    "type": "string",
-                    "description": "Version of the dependency."
-                },
-                "metadata": {
-                    "type": "object",
-                    "properties": {
-                        "description": {
-                            "type": "string",
-                            "description": "Description of the dependency (if any)"
-                        },
-                        "homepage": {
-                            "type": "string",
-                            "description": "Homepage of the dependency. This should be web address."
-                        }
-                    }
-                }
-            },
-            "required": [
-                "name",
-                "url",
-                "version"
-            ],
-            "additionalProperties": false
+        "scope": {
+          "type": "string",
+          "description": "The scope of the label.",
+          "enum": [
+            "org",
+            "revision",
+            "project"
+          ]
         }
+      },
+      "required": [
+        "label",
+        "scope"
+      ]
     },
-    "type": "object",
-    "properties": {
+    "os": {
+      "enum": [
+        "alpine",
+        "centos",
+        "debian",
+        "redhat",
+        "ubuntu",
+        "oraclelinux",
+        "busybox",
+        "sles",
+        "fedora",
+        "rocky"
+      ],
+      "description": "Name of the distribution OS."
+    },
+    "referenced-app-dependency": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the dependency. This name will be used to search for dependency in relevant registries."
+        },
+        "type": {
+          "enum": [
+            "bower",
+            "cargo",
+            "carthage",
+            "composer",
+            "cpan",
+            "renv",
+            "gem",
+            "git",
+            "go",
+            "hackage",
+            "hex",
+            "maven",
+            "npm",
+            "nuget",
+            "paket",
+            "pub",
+            "pypi",
+            "cocoapods",
+            "swift",
+            "url"
+          ],
+          "description": "Type of the dependency. It informs FOSSA which relevant registries to search for dependency's distribution."
+        },
         "version": {
-            "type": "integer"
+          "type": "string",
+          "description": "Version of the dependency. It informs FOSSA which version of the dependency to scan. If not provided, latest version will be used."
         },
-        "referenced-dependencies": {
-            "type": "array",
-            "description": "Reference dependency to locate from registry and include it project's dependency and license scanning.",
-            "items": {
-                "$ref": "#/$defs/referenced-dependency"
-            }
-        },
-        "custom-dependencies": {
-            "type": "array",
-            "description": "Custom dependency and their license for project",
-            "items": {
-                "$ref": "#/$defs/custom-dependency"
-            }
-        },
-        "vendored-dependencies": {
-            "type": "array",
-            "description": "Local dependencies upload to server for license scanning",
-            "items": {
-                "$ref": "#/$defs/vendored-dependency"
-            }
-        },
-        "remote-dependencies": {
-            "type": "array",
-            "description": "Remote dependencies to license scanning",
-            "items": {
-                "$ref": "#/$defs/remote-dependency"
-            }
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/label"
+          }
         }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "additionalProperties": false
     },
-    "required": []
+    "referenced-apk-deb-dependency": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the dependency. This name will be used to search for dependency in relevant registries."
+        },
+        "type": {
+          "enum": [
+            "apk",
+            "deb"
+          ],
+          "description": "Type of the dependency. It informs FOSSA which relevant registries to search for dependency's distribution."
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the dependency. It informs FOSSA which version of the dependency to scan. If not provided, latest version will be used."
+        },
+        "arch": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Architecture associated with this package"
+        },
+        "os": {
+          "$ref": "#/$defs/os"
+        },
+        "osVersion": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Version of the distribution OS."
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/label"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "arch",
+        "os",
+        "osVersion"
+      ],
+      "additionalProperties": false
+    },
+    "referenced-rpm-dependency": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the dependency. This name will be used to search for dependency in relevant registries."
+        },
+        "type": {
+          "enum": [
+            "rpm-generic"
+          ],
+          "description": "Type of the dependency. It informs FOSSA which relevant registries to search for dependency's distribution."
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the dependency. It informs FOSSA which version of the dependency to scan. If not provided, latest version will be used."
+        },
+        "arch": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Architecture associated with this package"
+        },
+        "epoch": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Epoch associated with version (if any)."
+        },
+        "os": {
+          "$ref": "#/$defs/os"
+        },
+        "osVersion": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Version of the distribution OS."
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/label"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "arch",
+        "os",
+        "osVersion"
+      ],
+      "additionalProperties": false
+    },
+    "referenced-dependency": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/referenced-app-dependency"
+        },
+        {
+          "$ref": "#/$defs/referenced-apk-deb-dependency"
+        },
+        {
+          "$ref": "#/$defs/referenced-rpm-dependency"
+        }
+      ]
+    },
+    "custom-dependency": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the dependency. This will be the name used in FOSSA's dashboard.",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the dependency. This will be the version used in FOSSA's dashboard.",
+          "minLength": 1
+        },
+        "license": {
+          "type": "string",
+          "description": "License of the dependency. This string will be used to infer license type.",
+          "minLength": 1
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Description of the dependency (if any)"
+            },
+            "homepage": {
+              "type": "string",
+              "description": "Homepage of the dependency. This should be web address."
+            }
+          }
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/label"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "version",
+        "license"
+      ],
+      "additionalProperties": false
+    },
+    "vendored-dependency": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the dependency. This will be the name associated with this vendored dependency in FOSSA's dashboard",
+          "minLength": 1
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to directory, which will be archived and upload to provided endpoint for license scanning.",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the dependency. This will be the version associated with this vendored dependency in FOSSA's dashboard"
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Description of the dependency (if any)"
+            },
+            "homepage": {
+              "type": "string",
+              "description": "Homepage of the dependency. This should be web address."
+            }
+          }
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/label"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "path"
+      ],
+      "additionalProperties": false
+    },
+    "remote-dependency": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the dependency. This will be the version used in FOSSA's dashboard.",
+          "minLength": 1
+        },
+        "url": {
+          "type": "string",
+          "description": "Url of the dependency's source code. This will be the downloaded by FOSSA for scanning with the analysis.",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the dependency."
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Description of the dependency (if any)"
+            },
+            "homepage": {
+              "type": "string",
+              "description": "Homepage of the dependency. This should be web address."
+            }
+          }
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/label"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "url",
+        "version"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "integer"
+    },
+    "referenced-dependencies": {
+      "type": "array",
+      "description": "Reference dependency to locate from registry and include it project's dependency and license scanning.",
+      "items": {
+        "$ref": "#/$defs/referenced-dependency"
+      }
+    },
+    "custom-dependencies": {
+      "type": "array",
+      "description": "Custom dependency and their license for project",
+      "items": {
+        "$ref": "#/$defs/custom-dependency"
+      }
+    },
+    "vendored-dependencies": {
+      "type": "array",
+      "description": "Local dependencies upload to server for license scanning",
+      "items": {
+        "$ref": "#/$defs/vendored-dependency"
+      }
+    },
+    "remote-dependencies": {
+      "type": "array",
+      "description": "Remote dependencies to license scanning",
+      "items": {
+        "$ref": "#/$defs/remote-dependency"
+      }
+    }
+  },
+  "required": []
 }

--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -47,7 +47,7 @@ vendoredDep =
     "vendor/foo.tar.gz"
     (Just "0.0.1")
     Nothing
-    Nothing
+    []
 
 -- the contents of the archive look like this. The `FOO_LICENSE` files contain an MIT license.
 -- `bar_apache.rb` and `something.rb` contain an Apache-2.0 license.

--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -47,6 +47,7 @@ vendoredDep =
     "vendor/foo.tar.gz"
     (Just "0.0.1")
     Nothing
+    Nothing
 
 -- the contents of the archive look like this. The `FOO_LICENSE` files contain an MIT license.
 -- `bar_apache.rb` and `something.rb` contain an Apache-2.0 license.

--- a/src/App/Fossa/FirstPartyScan.hs
+++ b/src/App/Fossa/FirstPartyScan.hs
@@ -99,7 +99,7 @@ firstPartyScanMain ::
 firstPartyScanMain base cfg org = do
   runFirstPartyScans <- shouldRunFirstPartyScans cfg org
   manualDeps <- findAndReadFossaDepsFile base
-  let vdep = VendoredDependency "first-party" "." Nothing Nothing Nothing
+  let vdep = VendoredDependency "first-party" "." Nothing Nothing []
       uploadKind = orgFileUpload org
   pathFilters <- mergePathFilters base manualDeps (licenseScanPathFilters $ vendoredDeps cfg)
   case runFirstPartyScans of

--- a/src/App/Fossa/FirstPartyScan.hs
+++ b/src/App/Fossa/FirstPartyScan.hs
@@ -99,7 +99,7 @@ firstPartyScanMain ::
 firstPartyScanMain base cfg org = do
   runFirstPartyScans <- shouldRunFirstPartyScans cfg org
   manualDeps <- findAndReadFossaDepsFile base
-  let vdep = VendoredDependency "first-party" "." Nothing Nothing
+  let vdep = VendoredDependency "first-party" "." Nothing Nothing Nothing
       uploadKind = orgFileUpload org
   pathFilters <- mergePathFilters base manualDeps (licenseScanPathFilters $ vendoredDeps cfg)
   case runFirstPartyScans of

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -185,9 +185,7 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendor
 
   -- Some manual deps, such as remote dependencies in source unit cannot be
   -- validated without the org data.
-  org <- case maybeApiOpts of
-    Just apiOpts -> Just <$> runFossaApiClient apiOpts getOrganization
-    Nothing -> pure Nothing
+  org <- traverse (`runFossaApiClient` getOrganization) maybeApiOpts
 
   -- Labels are provided by users attached to actual dependencies,
   -- but are collected into the root of the source unit for reporting to FOSSA.

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -356,7 +356,7 @@ refToLocator (LinuxRpmDep LinuxReferenceDependency{..} rpmEpoch) =
     version = Just $ locLinuxDepArch <> "#" <> epoch <> (fromMaybe "" locLinuxDepVersion)
 
     epoch :: Text
-    epoch = maybe "" ((<> ":") . toText . show) rpmEpoch
+    epoch = maybe "" ((<> ":") . toText) rpmEpoch
 
 mkLinuxPackage :: Text -> Text -> Text -> Text
 mkLinuxPackage depName os osVersion = depName <> "#" <> os <> "#" <> osVersion
@@ -461,9 +461,7 @@ data RemoteDependency = RemoteDependency
   deriving (Eq, Ord, Show)
 
 instance FromJSON LocatorDependency where
-  parseJSON val = do
-    when (val == Null) $ fail "locator must not be null"
-    parsePlain val <|> parseLabeled val
+  parseJSON val = parseLabeled val <|> parsePlain val
     where
       parsePlain :: Value -> Parser LocatorDependency
       parsePlain = withText "locator" $ pure . LocatorDependencyPlain . parseLocator

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -462,10 +462,10 @@ instance FromJSON LocatorDependency where
   parseJSON val = parseLabeled val <|> parsePlain val
     where
       parsePlain :: Value -> Parser LocatorDependency
-      parsePlain = withText "locator" $ pure . LocatorDependencyPlain . parseLocator
+      parsePlain = withText "Locator" $ pure . LocatorDependencyPlain . parseLocator
 
       parseLabeled :: Value -> Parser LocatorDependency
-      parseLabeled = withObject "locator" $ \obj ->
+      parseLabeled = withObject "Locator" $ \obj ->
         LocatorDependencyStructured <$> obj .: "locator" <*> obj .:? "labels"
 
 instance FromJSON ManualDependencies where

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -461,7 +461,9 @@ data RemoteDependency = RemoteDependency
   deriving (Eq, Ord, Show)
 
 instance FromJSON LocatorDependency where
-  parseJSON val = parsePlain val <|> parseLabeled val
+  parseJSON val = do
+    when (val == Null) $ fail "locator must not be null"
+    parsePlain val <|> parseLabeled val
     where
       parsePlain :: Value -> Parser LocatorDependency
       parsePlain = withText "locator" $ pure . LocatorDependencyPlain . parseLocator

--- a/src/App/Fossa/ManualDeps.hs
+++ b/src/App/Fossa/ManualDeps.hs
@@ -201,11 +201,9 @@ toSourceUnit root depsFile manualDeps@ManualDependencies{..} maybeApiOpts vendor
 
   -- Some manual deps, such as remote dependencies in source unit cannot be
   -- validated without endpoint interactions.
-  rdeps <- case maybeApiOpts of
-    Just apiOpts -> runFossaApiClient apiOpts $ do
-      org' <- maybe getOrganization pure org
-      traverse (`validateRemoteDep` org') remoteDependencies
-    Nothing -> pure remoteDependencies
+  rdeps <- case (maybeApiOpts, org) of
+    (Just apiOpts, Just org') -> runFossaApiClient apiOpts $ traverse (`validateRemoteDep` org') remoteDependencies
+    (_, _) -> pure remoteDependencies
 
   let renderedPath = toText root
       referenceLocators = (extractLocator <$> locatorDependencies) ++ (refToLocator <$> referencedDependencies)

--- a/src/App/Fossa/VendoredDependency.hs
+++ b/src/App/Fossa/VendoredDependency.hs
@@ -25,7 +25,7 @@ import Codec.Compression.GZip qualified as GZip
 import Control.Algebra (Has)
 import Control.Carrier.Diagnostics (Diagnostics, fatalText)
 import Crypto.Hash (Digest, MD5, hashlazy)
-import Data.Aeson (FromJSON (parseJSON), withObject, (.:?))
+import Data.Aeson (FromJSON (parseJSON), withObject, (.!=), (.:?))
 import Data.Aeson.Extra (TextLike (unTextLike), forbidMembers, neText)
 import Data.ByteString.Lazy qualified as BS
 import Data.Functor.Extra ((<$$>))
@@ -57,7 +57,7 @@ data VendoredDependency = VendoredDependency
   , vendoredPath :: Text
   , vendoredVersion :: Maybe Text
   , vendoredMetadata :: Maybe DependencyMetadata
-  , vendoredLabels :: Maybe [ProvidedPackageLabel]
+  , vendoredLabels :: [ProvidedPackageLabel]
   }
   deriving (Eq, Ord, Show)
 
@@ -69,7 +69,7 @@ instance FromJSON VendoredDependency where
         <*> (obj `neText` "path")
         <*> (unTextLike <$$> obj .:? "version")
         <*> (obj .:? "metadata")
-        <*> (obj .:? "labels")
+        <*> (obj .:? "labels" .!= [])
         <* forbidMembers "vendored dependencies" ["type", "license", "url", "description"] obj
 
     case vendoredVersion vendorDep of

--- a/src/App/Fossa/VendoredDependency.hs
+++ b/src/App/Fossa/VendoredDependency.hs
@@ -49,7 +49,7 @@ import Fossa.API.Types (
  )
 import Path (Abs, Dir, Path)
 import Prettyprinter (Pretty (pretty), vsep)
-import Srclib.Types (Locator (..))
+import Srclib.Types (Locator (..), ProvidedPackageLabel)
 import System.FilePath.Posix (splitDirectories, (</>))
 
 data VendoredDependency = VendoredDependency
@@ -57,6 +57,7 @@ data VendoredDependency = VendoredDependency
   , vendoredPath :: Text
   , vendoredVersion :: Maybe Text
   , vendoredMetadata :: Maybe DependencyMetadata
+  , vendoredLabels :: Maybe [ProvidedPackageLabel]
   }
   deriving (Eq, Ord, Show)
 
@@ -68,6 +69,7 @@ instance FromJSON VendoredDependency where
         <*> (obj `neText` "path")
         <*> (unTextLike <$$> obj .:? "version")
         <*> (obj .:? "metadata")
+        <*> (obj .:? "labels")
         <* forbidMembers "vendored dependencies" ["type", "license", "url", "description"] obj
 
     case vendoredVersion vendorDep of

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -478,6 +478,9 @@ instance Pretty Issues where
 newtype OrgId = OrgId Int
   deriving (Eq, Ord, FromJSON, ToJSON)
 
+instance ToText OrgId where
+  toText (OrgId orgId) = toText orgId
+
 instance Show OrgId where
   show (OrgId orgId) = show orgId
 

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -477,9 +478,7 @@ instance Pretty Issues where
 
 newtype OrgId = OrgId Int
   deriving (Eq, Ord, FromJSON, ToJSON)
-
-instance ToText OrgId where
-  toText (OrgId orgId) = toText orgId
+  deriving (ToText) via Int
 
 instance Show OrgId where
   show (OrgId orgId) = show orgId

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -477,7 +477,10 @@ instance Pretty Issues where
 
 newtype OrgId = OrgId Int
   deriving (Eq, Ord, FromJSON, ToJSON)
-deriving ToText via Int
+
+instance ToText OrgId where
+  toText (OrgId orgId) = toText orgId
+
 instance Show OrgId where
   show (OrgId orgId) = show orgId
 

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -477,10 +477,7 @@ instance Pretty Issues where
 
 newtype OrgId = OrgId Int
   deriving (Eq, Ord, FromJSON, ToJSON)
-
-instance ToText OrgId where
-  toText (OrgId orgId) = toText orgId
-
+deriving ToText via Int
 instance Show OrgId where
   show (OrgId orgId) = show orgId
 

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -74,6 +74,7 @@ toSourceUnit leaveUnfiltered path dependencies projectType graphBreadth originPa
     , sourceUnitNoticeFiles = []
     , sourceUnitOriginPaths = originPaths
     , additionalData = Nothing
+    , sourceUnitLabels = Nothing
     }
   where
     filteredGraph :: Graphing Dependency

--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -620,6 +620,9 @@ instance FromJSON ProvidedPackageLabels where
   parseJSON = withObject "ProvidedPackageLabels" $ \obj ->
     ProvidedPackageLabels <$> parseJSON (Object obj)
 
+-- | Note: The ToJSON and FromJSON implementations for this type differ
+-- because ToJSON is used to upload to Core and FromJSON is used to parse
+-- from a fossa-deps file.
 instance ToJSON ProvidedPackageLabel where
   toJSON ProvidedPackageLabel{..} =
     object
@@ -628,10 +631,13 @@ instance ToJSON ProvidedPackageLabel where
       , "scope" .= providedPackageLabelScope
       ]
 
+-- | Note: The ToJSON and FromJSON implementations for this type differ
+-- because ToJSON is used to upload to Core and FromJSON is used to parse
+-- from a fossa-deps file.
 instance FromJSON ProvidedPackageLabel where
   parseJSON = withObject "ProvidedPackageLabel" $ \obj ->
     ProvidedPackageLabel
-      <$> obj .: "content"
+      <$> obj .: "label"
       <*> obj .: "scope"
 
 instance ToJSON ProvidedPackageLabelScope where

--- a/src/Strategy/Conan/Enrich.hs
+++ b/src/Strategy/Conan/Enrich.hs
@@ -132,7 +132,7 @@ conanDepToVendorDep :: Dependency -> Either Dependency (Dependency, VendoredDepe
 conanDepToVendorDep d =
   case listToMaybe $ dependencyLocations d of
     Nothing -> Left d
-    Just pathOfDep -> Right (d, VendoredDependency depName pathOfDep depVersion Nothing Nothing)
+    Just pathOfDep -> Right (d, VendoredDependency depName pathOfDep depVersion Nothing [])
   where
     depName :: Text
     depName = dependencyName d

--- a/src/Strategy/Conan/Enrich.hs
+++ b/src/Strategy/Conan/Enrich.hs
@@ -132,7 +132,7 @@ conanDepToVendorDep :: Dependency -> Either Dependency (Dependency, VendoredDepe
 conanDepToVendorDep d =
   case listToMaybe $ dependencyLocations d of
     Nothing -> Left d
-    Just pathOfDep -> Right (d, VendoredDependency depName pathOfDep depVersion Nothing)
+    Just pathOfDep -> Right (d, VendoredDependency depName pathOfDep depVersion Nothing Nothing)
   where
     depName :: Text
     depName = dependencyName d

--- a/test/App/Fossa/Container/AnalyzeNativeSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeSpec.hs
@@ -239,6 +239,7 @@ jarsInContainerSpec = describe "Jars in Containers" $ do
             , sourceUnitOriginPaths = [textToOriginPath "package-lock.json"]
             , sourceUnitNoticeFiles = []
             , additionalData = Nothing
+            , sourceUnitLabels = Nothing
             }
 
     Map.lookup otherLayerId srcUnitsMap `shouldBe'` Just [expectedSrcUnit]

--- a/test/App/Fossa/ManualDepsSpec.hs
+++ b/test/App/Fossa/ManualDepsSpec.hs
@@ -72,8 +72,8 @@ theWorksLabeled = ManualDependencies references customs vendors remotes locators
     references =
       [ Managed (ManagedReferenceDependency "one" GemType Nothing (Just [ProvidedPackageLabel "gem-label" ProvidedPackageLabelScopeRevision]))
       , Managed (ManagedReferenceDependency "two" PipType (Just "1.0.0") (Just [ProvidedPackageLabel "pypi-label" ProvidedPackageLabelScopeOrg, ProvidedPackageLabel "pypi-label-2" ProvidedPackageLabelScopeProject]))
-      , LinuxApkDebDep (LinuxReferenceDependency "libssl" LinuxAPK (Just "3.2.1") "x86_64" "alpine" "3.18" Nothing)
-      , LinuxRpmDep (LinuxReferenceDependency "libcurl" LinuxRPM (Just "7.89.1") "aarch64" "fedora" "38" (Just [ProvidedPackageLabel "fedora-container" ProvidedPackageLabelScopeRevision])) Nothing
+      , LinuxApkDebDep (LinuxReferenceDependency "libssl" LinuxAPK (Just "3.2.1") "x86_64" "alpine" "3.18" (Just [ProvidedPackageLabel "alpine-container" ProvidedPackageLabelScopeOrg]))
+      , LinuxRpmDep (LinuxReferenceDependency "libcurl" LinuxRPM (Just "7.89.1") "aarch64" "fedora" "38" (Just [ProvidedPackageLabel "fedora-container" ProvidedPackageLabelScopeRevision])) (Just "1")
       ]
     customs =
       [ CustomDependency "hello" "1.2.3" "MIT" Nothing (Just [ProvidedPackageLabel "custom-label-hello" ProvidedPackageLabelScopeOrg])
@@ -104,9 +104,9 @@ theWorksLabels org =
   where
     referencedLabels :: [(Text, [ProvidedPackageLabel])]
     referencedLabels =
-      [ ("gem+one", [ProvidedPackageLabel "gem-label" ProvidedPackageLabelScopeRevision])
-      , ("pypi+two$1.0.0", [ProvidedPackageLabel "pypi-label" ProvidedPackageLabelScopeOrg, ProvidedPackageLabel "pypi-label-2" ProvidedPackageLabelScopeProject])
-      , ("apk+libssl#alpine#3.18$x86_64#1.2.3", [ProvidedPackageLabel "alpine-container" ProvidedPackageLabelScopeOrg])
+      [ ("gem+one$", [ProvidedPackageLabel "gem-label" ProvidedPackageLabelScopeRevision])
+      , ("pip+two$1.0.0", [ProvidedPackageLabel "pypi-label" ProvidedPackageLabelScopeOrg, ProvidedPackageLabel "pypi-label-2" ProvidedPackageLabelScopeProject])
+      , ("apk+libssl#alpine#3.18$x86_64#3.2.1", [ProvidedPackageLabel "alpine-container" ProvidedPackageLabelScopeOrg])
       , ("rpm-generic+libcurl#fedora#38$aarch64#1:7.89.1", [ProvidedPackageLabel "fedora-container" ProvidedPackageLabelScopeRevision])
       ]
 
@@ -131,12 +131,12 @@ theWorksLabels org =
 
     urlPrivateLabels :: Maybe OrgId -> [(Text, [ProvidedPackageLabel])]
     urlPrivateLabels Nothing =
-      [ ("url-private+url-dep-one$1.2.3", [ProvidedPackageLabel "url-dep-one-label" ProvidedPackageLabelScopeOrg])
-      , ("url-private+url-dep-two$1.2.4", [ProvidedPackageLabel "url-dep-two-label" ProvidedPackageLabelScopeRevision])
+      [ ("url-private+www.url1.tar.gz$1.2.3", [ProvidedPackageLabel "url-dep-one-label" ProvidedPackageLabelScopeOrg])
+      , ("url-private+www.url2.tar.gz$1.2.4", [ProvidedPackageLabel "url-dep-two-label" ProvidedPackageLabelScopeRevision])
       ]
     urlPrivateLabels (Just orgId) =
-      [ ("url-private+" <> toText orgId <> "/url-dep-one$1.2.3", [ProvidedPackageLabel "url-dep-one-label" ProvidedPackageLabelScopeOrg])
-      , ("url-private+" <> toText orgId <> "/url-dep-two$1.2.4", [ProvidedPackageLabel "url-dep-two-label" ProvidedPackageLabelScopeRevision])
+      [ ("url-private+" <> toText orgId <> "/www.url1.tar.gz$1.2.3", [ProvidedPackageLabel "url-dep-one-label" ProvidedPackageLabelScopeOrg])
+      , ("url-private+" <> toText orgId <> "/www.url2.tar.gz$1.2.4", [ProvidedPackageLabel "url-dep-two-label" ProvidedPackageLabelScopeRevision])
       ]
 
 exceptionContains :: BS.ByteString -> String -> Expectation

--- a/test/App/Fossa/ManualDepsSpec.hs
+++ b/test/App/Fossa/ManualDepsSpec.hs
@@ -112,7 +112,7 @@ theWorksLabels org =
 
     archiveLabels :: [(Text, [ProvidedPackageLabel])]
     archiveLabels =
-      [ ("archive+vendored", [ProvidedPackageLabel "vendored-dependency-label" ProvidedPackageLabelScopeOrg])
+      [ ("archive+vendored$", [ProvidedPackageLabel "vendored-dependency-label" ProvidedPackageLabelScopeOrg])
       , ("archive+versioned$2.1.0", [ProvidedPackageLabel "versioned-dependency-label" ProvidedPackageLabelScopeProject])
       , ("archive+metadata$1.1.0", [ProvidedPackageLabel "metadata-dependency-label" ProvidedPackageLabelScopeRevision])
       ]
@@ -125,7 +125,7 @@ theWorksLabels org =
 
     locatorLabels :: [(Text, [ProvidedPackageLabel])]
     locatorLabels =
-      [ ("fetcher-1+one", [ProvidedPackageLabel "locator-dependency-label" ProvidedPackageLabelScopeOrg])
+      [ ("fetcher-1+one$", [ProvidedPackageLabel "locator-dependency-label" ProvidedPackageLabelScopeOrg])
       , ("fetcher-2+two$1.0.0", [ProvidedPackageLabel "locator-dependency-label" ProvidedPackageLabelScopeOrg])
       ]
 

--- a/test/App/Fossa/ManualDepsSpec.hs
+++ b/test/App/Fossa/ManualDepsSpec.hs
@@ -45,21 +45,21 @@ theWorks :: ManualDependencies
 theWorks = ManualDependencies references customs vendors remotes locators
   where
     references =
-      [ Managed (ManagedReferenceDependency "one" GemType Nothing Nothing)
-      , Managed (ManagedReferenceDependency "two" PipType (Just "1.0.0") Nothing)
+      [ Managed (ManagedReferenceDependency "one" GemType Nothing [])
+      , Managed (ManagedReferenceDependency "two" PipType (Just "1.0.0") [])
       ]
     customs =
-      [ CustomDependency "hello" "1.2.3" "MIT" Nothing Nothing
-      , CustomDependency "full" "3.2.1" "GPL-3.0" (Just (DependencyMetadata (Just "description for full custom") (Just "we don't validate homepages - custom"))) Nothing
+      [ CustomDependency "hello" "1.2.3" "MIT" Nothing []
+      , CustomDependency "full" "3.2.1" "GPL-3.0" (Just (DependencyMetadata (Just "description for full custom") (Just "we don't validate homepages - custom"))) []
       ]
     remotes =
-      [ RemoteDependency "url-dep-one" "1.2.3" "www.url1.tar.gz" (Just (DependencyMetadata (Just "description for url") (Just "we don't validate homepages - url"))) Nothing
-      , RemoteDependency "url-dep-two" "1.2.4" "www.url2.tar.gz" Nothing Nothing
+      [ RemoteDependency "url-dep-one" "1.2.3" "www.url1.tar.gz" (Just (DependencyMetadata (Just "description for url") (Just "we don't validate homepages - url"))) []
+      , RemoteDependency "url-dep-two" "1.2.4" "www.url2.tar.gz" Nothing []
       ]
     vendors =
-      [ VendoredDependency "vendored" "path" Nothing Nothing Nothing
-      , VendoredDependency "versioned" "path/to/dep" (Just "2.1.0") Nothing Nothing
-      , VendoredDependency "metadata" "path" (Just "1.1.0") (Just (DependencyMetadata (Just "description for vendored") (Just "we don't validate homepages - vendored"))) Nothing
+      [ VendoredDependency "vendored" "path" Nothing Nothing []
+      , VendoredDependency "versioned" "path/to/dep" (Just "2.1.0") Nothing []
+      , VendoredDependency "metadata" "path" (Just "1.1.0") (Just (DependencyMetadata (Just "description for vendored") (Just "we don't validate homepages - vendored"))) []
       ]
     locators =
       [ LocatorDependencyPlain (Locator "fetcher-1" "one" Nothing)
@@ -70,27 +70,27 @@ theWorksLabeled :: ManualDependencies
 theWorksLabeled = ManualDependencies references customs vendors remotes locators
   where
     references =
-      [ Managed (ManagedReferenceDependency "one" GemType Nothing (Just [ProvidedPackageLabel "gem-label" ProvidedPackageLabelScopeRevision]))
-      , Managed (ManagedReferenceDependency "two" PipType (Just "1.0.0") (Just [ProvidedPackageLabel "pypi-label" ProvidedPackageLabelScopeOrg, ProvidedPackageLabel "pypi-label-2" ProvidedPackageLabelScopeProject]))
-      , LinuxApkDebDep (LinuxReferenceDependency "libssl" LinuxAPK (Just "3.2.1") "x86_64" "alpine" "3.18" (Just [ProvidedPackageLabel "alpine-container" ProvidedPackageLabelScopeOrg]))
-      , LinuxRpmDep (LinuxReferenceDependency "libcurl" LinuxRPM (Just "7.89.1") "aarch64" "fedora" "38" (Just [ProvidedPackageLabel "fedora-container" ProvidedPackageLabelScopeRevision])) (Just "1")
+      [ Managed (ManagedReferenceDependency "one" GemType Nothing [ProvidedPackageLabel "gem-label" ProvidedPackageLabelScopeRevision])
+      , Managed (ManagedReferenceDependency "two" PipType (Just "1.0.0") [ProvidedPackageLabel "pypi-label" ProvidedPackageLabelScopeOrg, ProvidedPackageLabel "pypi-label-2" ProvidedPackageLabelScopeProject])
+      , LinuxApkDebDep (LinuxReferenceDependency "libssl" LinuxAPK (Just "3.2.1") "x86_64" "alpine" "3.18" [ProvidedPackageLabel "alpine-container" ProvidedPackageLabelScopeOrg])
+      , LinuxRpmDep (LinuxReferenceDependency "libcurl" LinuxRPM (Just "7.89.1") "aarch64" "fedora" "38" [ProvidedPackageLabel "fedora-container" ProvidedPackageLabelScopeRevision]) (Just "1")
       ]
     customs =
-      [ CustomDependency "hello" "1.2.3" "MIT" Nothing (Just [ProvidedPackageLabel "custom-label-hello" ProvidedPackageLabelScopeOrg])
-      , CustomDependency "full" "3.2.1" "GPL-3.0" (Just (DependencyMetadata (Just "description for full custom") (Just "we don't validate homepages - custom"))) (Just [ProvidedPackageLabel "custom-label-full" ProvidedPackageLabelScopeProject])
+      [ CustomDependency "hello" "1.2.3" "MIT" Nothing [ProvidedPackageLabel "custom-label-hello" ProvidedPackageLabelScopeOrg]
+      , CustomDependency "full" "3.2.1" "GPL-3.0" (Just (DependencyMetadata (Just "description for full custom") (Just "we don't validate homepages - custom"))) [ProvidedPackageLabel "custom-label-full" ProvidedPackageLabelScopeProject]
       ]
     remotes =
-      [ RemoteDependency "url-dep-one" "1.2.3" "www.url1.tar.gz" (Just (DependencyMetadata (Just "description for url") (Just "we don't validate homepages - url"))) (Just [ProvidedPackageLabel "url-dep-one-label" ProvidedPackageLabelScopeOrg])
-      , RemoteDependency "url-dep-two" "1.2.4" "www.url2.tar.gz" Nothing (Just [ProvidedPackageLabel "url-dep-two-label" ProvidedPackageLabelScopeRevision])
+      [ RemoteDependency "url-dep-one" "1.2.3" "www.url1.tar.gz" (Just (DependencyMetadata (Just "description for url") (Just "we don't validate homepages - url"))) [ProvidedPackageLabel "url-dep-one-label" ProvidedPackageLabelScopeOrg]
+      , RemoteDependency "url-dep-two" "1.2.4" "www.url2.tar.gz" Nothing [ProvidedPackageLabel "url-dep-two-label" ProvidedPackageLabelScopeRevision]
       ]
     vendors =
-      [ VendoredDependency "vendored" "path" Nothing Nothing (Just [ProvidedPackageLabel "vendored-dependency-label" ProvidedPackageLabelScopeOrg])
-      , VendoredDependency "versioned" "path/to/dep" (Just "2.1.0") Nothing (Just [ProvidedPackageLabel "versioned-dependency-label" ProvidedPackageLabelScopeProject])
-      , VendoredDependency "metadata" "path" (Just "1.1.0") (Just (DependencyMetadata (Just "description for vendored") (Just "we don't validate homepages - vendored"))) (Just [ProvidedPackageLabel "metadata-dependency-label" ProvidedPackageLabelScopeRevision])
+      [ VendoredDependency "vendored" "path" Nothing Nothing [ProvidedPackageLabel "vendored-dependency-label" ProvidedPackageLabelScopeOrg]
+      , VendoredDependency "versioned" "path/to/dep" (Just "2.1.0") Nothing [ProvidedPackageLabel "versioned-dependency-label" ProvidedPackageLabelScopeProject]
+      , VendoredDependency "metadata" "path" (Just "1.1.0") (Just (DependencyMetadata (Just "description for vendored") (Just "we don't validate homepages - vendored"))) [ProvidedPackageLabel "metadata-dependency-label" ProvidedPackageLabelScopeRevision]
       ]
     locators =
-      [ LocatorDependencyStructured (Locator "fetcher-1" "one" Nothing) (Just [ProvidedPackageLabel "locator-dependency-label" ProvidedPackageLabelScopeOrg])
-      , LocatorDependencyStructured (Locator "fetcher-2" "two" (Just "1.0.0")) (Just [ProvidedPackageLabel "locator-dependency-label" ProvidedPackageLabelScopeOrg])
+      [ LocatorDependencyStructured (Locator "fetcher-1" "one" Nothing) [ProvidedPackageLabel "locator-dependency-label" ProvidedPackageLabelScopeOrg]
+      , LocatorDependencyStructured (Locator "fetcher-2" "two" (Just "1.0.0")) [ProvidedPackageLabel "locator-dependency-label" ProvidedPackageLabelScopeOrg]
       ]
 
 theWorksLabels :: Maybe OrgId -> Map Text [ProvidedPackageLabel]
@@ -428,7 +428,7 @@ referenced-dependencies:
 linuxRefManualDep :: Text -> Maybe Text -> ManualDependencies
 linuxRefManualDep os epoch =
   ManualDependencies
-    [LinuxRpmDep (LinuxReferenceDependency "pkgName" LinuxRPM (Just "1.1") "x86" os "2.2" Nothing) epoch]
+    [LinuxRpmDep (LinuxReferenceDependency "pkgName" LinuxRPM (Just "1.1") "x86" os "2.2" []) epoch]
     mempty
     mempty
     mempty

--- a/test/App/Fossa/testdata/the-works-labeled.yml
+++ b/test/App/Fossa/testdata/the-works-labeled.yml
@@ -1,0 +1,99 @@
+referenced-dependencies:
+- name: one
+  type: gem
+  labels:
+  - label: gem-label
+    scope: revision
+- type: pypi
+  name: two
+  version: 1.0.0
+  labels:
+  - label: pypi-label
+    scope: org
+  - label: pypi-label-2
+    scope: project
+- type: apk
+  name: libssl
+  version: 3.2.1
+  arch: x86_64
+  os: alpine
+  osVersion: 3.18
+  labels:
+  - label: alpine-container
+    scope: org
+- type: rpm-generic
+  name: libcurl
+  version: 7.89.1
+  arch: aarch64
+  os: fedora
+  osVersion: 38
+  epoch: 1
+  labels:
+  - label: fedora-container
+    scope: revision
+
+vendored-dependencies:
+- name: vendored
+  path: path
+  labels:
+  - label: vendored-dependency-label
+    scope: org
+- name: versioned
+  path: path/to/dep
+  version: 2.1.0
+  labels:
+  - label: versioned-dependency-label
+    scope: project
+- name: metadata
+  path: path
+  version: 1.1.0
+  metadata:
+    description: description for vendored
+    homepage: we don't validate homepages - vendored
+  labels:
+  - label: metadata-dependency-label
+    scope: revision
+
+custom-dependencies:
+- name: hello
+  version: 1.2.3
+  license: MIT
+  labels:
+  - label: custom-label-hello
+    scope: org
+- name: full
+  version: 3.2.1
+  license: GPL-3.0
+  metadata:
+    description: description for full custom
+    homepage: we don't validate homepages - custom
+  labels:
+  - label: custom-label-full
+    scope: project
+
+remote-dependencies:
+- name: url-dep-one
+  version: 1.2.3
+  url: www.url1.tar.gz
+  metadata:
+    description: description for url
+    homepage: we don't validate homepages - url
+  labels:
+  - label: url-dep-one-label
+    scope: org
+- name: url-dep-two
+  version: 1.2.4
+  url: www.url2.tar.gz
+  labels:
+  - label: url-dep-two-label
+    scope: revision
+
+locator-dependencies:
+- locator: "fetcher-1+one"
+  labels:
+  - label: locator-dependency-label
+    scope: org
+- locator: "fetcher-2+two$1.0.0"
+  labels:
+  - label: locator-dependency-label
+    scope: org

--- a/test/Conan/EnrichSpec.hs
+++ b/test/Conan/EnrichSpec.hs
@@ -183,7 +183,7 @@ conanToVendoredDepSpec =
   describe "conanToVendoredDep" $ do
     it "should transforms conan to vendor dep, when dep has location" $ do
       let res = conanDepToVendorDep conanDepFoo
-      res `shouldBe` Right (conanDepFoo, VendoredDependency "foo" "vendored/foo" (Just "0.0.1") Nothing)
+      res `shouldBe` Right (conanDepFoo, VendoredDependency "foo" "vendored/foo" (Just "0.0.1") Nothing Nothing)
 
     it "should not transforms conan to vendor dep, when dep does not have location" $ do
       let dep = conanDepFoo{dependencyLocations = []}

--- a/test/Conan/EnrichSpec.hs
+++ b/test/Conan/EnrichSpec.hs
@@ -183,7 +183,7 @@ conanToVendoredDepSpec =
   describe "conanToVendoredDep" $ do
     it "should transforms conan to vendor dep, when dep has location" $ do
       let res = conanDepToVendorDep conanDepFoo
-      res `shouldBe` Right (conanDepFoo, VendoredDependency "foo" "vendored/foo" (Just "0.0.1") Nothing Nothing)
+      res `shouldBe` Right (conanDepFoo, VendoredDependency "foo" "vendored/foo" (Just "0.0.1") Nothing [])
 
     it "should not transforms conan to vendor dep, when dep does not have location" $ do
       let dep = conanDepFoo{dependencyLocations = []}

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -251,6 +251,7 @@ sourceUnits = [unit]
         , sourceUnitOriginPaths = []
         , sourceUnitNoticeFiles = []
         , additionalData = Nothing
+        , sourceUnitLabels = Nothing
         }
 
 sourceUnitBuildMaven :: SourceUnitBuild
@@ -318,6 +319,7 @@ vsiSourceUnit =
     , sourceUnitOriginPaths = ["/tmp/one/two"]
     , sourceUnitNoticeFiles = []
     , additionalData = Nothing
+    , sourceUnitLabels = Nothing
     }
 
 -- | A base dir for testing.  This directory is not guaranteed to exist.  If you
@@ -450,7 +452,7 @@ firstVendoredDep =
     "vendored/foo"
     (Just "0.0.1")
     Nothing
-
+    Nothing
 secondVendoredDep :: VendoredDependency
 secondVendoredDep =
   VendoredDependency
@@ -458,7 +460,7 @@ secondVendoredDep =
     "vendored/bar"
     (Just "0.0.1")
     Nothing
-
+    Nothing
 vendoredDeps :: NonEmpty VendoredDependency
 vendoredDeps = NE.fromList [firstVendoredDep, secondVendoredDep]
 

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -452,7 +452,7 @@ firstVendoredDep =
     "vendored/foo"
     (Just "0.0.1")
     Nothing
-    Nothing
+    []
 secondVendoredDep :: VendoredDependency
 secondVendoredDep =
   VendoredDependency
@@ -460,7 +460,7 @@ secondVendoredDep =
     "vendored/bar"
     (Just "0.0.1")
     Nothing
-    Nothing
+    []
 vendoredDeps :: NonEmpty VendoredDependency
 vendoredDeps = NE.fromList [firstVendoredDep, secondVendoredDep]
 


### PR DESCRIPTION
# Overview

Support user-provided labels for dependencies in `fossa-deps` files.

## Acceptance criteria

- Users are able to provide labels to dependencies inside `fossa-deps`.
- Labels are collected at the root of the uploaded build under a new `Labels` key, which is a map of locator strings to an array of labels for that locator.

## Testing plan

Automated tests, mainly- but also manually tested with the below:
```yaml
referenced-dependencies:
- name: lodash
  type: npm
  labels:
  - label: npm-rev
    scope: revision
  - label: npm-proj
    scope: project
  - label: npm-org
    scope: org

```

```shell
cabal run fossa -- analyze ~/scratch/labels -e https://staging.int.fossa.io
```

<img width="1708" alt="image" src="https://github.com/user-attachments/assets/3d01f3fc-ed0c-49c8-a422-230e5e5cfdb1" />

## Risks

No real risk

## Metrics

None

## References

[RFC](https://go/user-dep-labels-fossa-cli)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
