### PR TITLE
Handle lack of access while traversing directories

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 # FOSSA CLI Changelog
 
 
+## 3.9.48
+- General: Fix a bug where directory traversal could fail if the user does not have permission to read a directory.
+
 ## 3.9.47
 - Licensing: Adds support for Zeebe Community License v1.1 and Camunda License v1.0
 - NuGet: Consolidate `project.assets.json` and `PackageReference` strategies ([#1461](https://github.com/fossas/fossa-cli/pull/1461))


### PR DESCRIPTION
# Overview

Updates FOSSA CLI to be resilient to directories it does not have permission to access while walking directories.

Happily, we use the same walking function basically everywhere, so this should transparently enhance _all_ path traversal operations in FOSSA CLI.

When a directory is walked into, FOSSA CLI attempts to list the contents. Before, if this failed, it'd stop the walk operation with an error. Now it skips that subtree and emits a warning.

Before a directory is walked into, FOSSA CLI attempts to get its unique identifier in order to determine if it has already been walked. Before, if this operation failed, it'd stop the walk operation with an error. Now it acts as though the directory has already been walked (which has the effect of skipping it).

## Acceptance criteria

Walk operations are successful even in the face of directories to which we don't have access.

## Testing plan

Created a test case in a project:

```shell
; mkdir -p scratch/noaccess
; touch scratch/noaccess/some-file
; chmod 000 scratch/noaccess
; eza -l --git -b scratch/
d--------- - jess 19 Feb 13:51 -- noaccess
; eza -l --git -b scratch/noaccess/
"scratch/noaccess/": Permission denied (os error 13)
```

I made sure a subdirectory existed that should still be scanned and contained license info:
```shell
; mkdir scratch/other
; cp ../../LICENSE scratch/other
; zip -r scratch/other.zip scratch/other
; rm -rf scratch/other
```

I then ran a first-party license scan on the results, which failed (note the warning at the end):
```shell
; fossa analyze -p licenses-only -r with-noaccess --debug --exclude-target npm --only-target npm --experimental-force-first-party-scans .
[DEBUG] Running a first-party license scan on the code in this repository. Licenses found in this repository will show up as 'Directly in code' in the FOSSA UI
[DEBUG] License Scanning 'first-party' at '.'
[DEBUG] Unfiltered project scans: []
[DEBUG] Filtered project scans: []
[DEBUG] Filtered projects with path dependencies: []

Using project name: `licenses-only`
Using revision: `with-noaccess`
Using branch: `fix/warn-when-walk-fails`
============================================================

    View FOSSA Report:
    (snip)

============================================================
[DEBUG] A task succeeded with warnings

    Warn: No analysis targets found in directory
    Documentation: https://github.com/fossas/fossa-cli/blob/v3.9.41/docs/README.md
    Help: Refer to the provided documentation to ensure your project is supported
```

You can also see that there were no licenses reported in the UI:
<img width="1708" alt="image" src="https://github.com/user-attachments/assets/c90594a3-b85c-4c57-9460-a783e29b6f72" />

I applied the fixes in this PR and tried again, this worked (note the upload step):
```shell
; cabal run fossa -- analyze -p licenses-only -r with-noaccess-fixed --debug --exclude-target npm --only-target npm --experimental-force-first-party-scans ~/projects/(snip)
[DEBUG] Running a first-party license scan on the code in this repository. Licenses found in this repository will show up as 'Directly in code' in the FOSSA UI
[DEBUG] License Scanning 'first-party' at '.'
[DEBUG] Unfiltered project scans: []
[DEBUG] Filtered project scans: []
[DEBUG] Filtered projects with path dependencies: []

Using project name: `licenses-only`
Using revision: `with-noaccess-fixed`
Using branch: `fix/warn-when-walk-fails`
[DEBUG] Uploading 'licenses-only' to secure S3 bucket
============================================================

    View FOSSA Report:
    (snip)

============================================================
```

You can see that the debug bundle shows fossa cli continuing despite errors:
<img width="1116" alt="Screenshot 2025-02-19 at 2 33 45 PM" src="https://github.com/user-attachments/assets/442d2190-fb15-4459-aee4-d7d2130ecaf6" />

And you can see licenses in the UI again, even in the other subdirectory:
<img width="1314" alt="image" src="https://github.com/user-attachments/assets/59cb3606-e1a0-4f2b-ae65-03f97ed47a97" />

I don't think we have automated tests for walking directories, so I didn't add them.

## Risks

I don't think this is risky.

## Metrics

None

## References

Slack thread: https://teamfossa.slack.com/archives/C05NQ2BJLTH/p1740002098120309?thread_ts=1739992602.467979&cid=C05NQ2BJLTH

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
