### PR TITLE
Update set FOSSA_API_KEY powershell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ fossa analyze
 Set-ExecutionPolicy Bypass -Scope Process -Force; iex  ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.ps1'))
 
 # Set your API key. Get this from the FOSSA web application.
-$env:FOSSA_API_KEY=XXXX
+$env:FOSSA_API_KEY="XXXX"
 
 # Run an analysis in your project's directory.
 cd $MY_PROJECT_DIR


### PR DESCRIPTION
# Overview
It's a minor thing, but might save some time for people getting started. Without quotes, powershell will throw the following error

```
The term 'XXXX' is not recognized as the name of a
cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify
that the path is correct and try again.
At line:1 char:20
```
