### PR TITLE
document how we accept PRs from forks

### DIFF
--- a/docs/contributing/HACKING.md
+++ b/docs/contributing/HACKING.md
@@ -61,6 +61,8 @@ If you build without these binaries, a compiler warning will be emitted.  If ghc
 
 There is no supported way for Non-FOSSA users to obtain these binaries, though we are working on a solution to allow this in the future.  As a result, **we cannot accept pull requests from any forked repository**, since those builds will fail in CI.  This means that outside contributions are possible, but a FOSSA employee needs to cherry pick the commits and create a new PR with them.
 
+Here's a document that explains [how we do this](./forks.md) while making sure that you get credit for your PR.
+
 ### Running tests
 
 > You will need to run `git lfs pull` to retrieve testdata stored in git lfs. If you do not have git-lfs installed on your system,

--- a/docs/contributing/forks.md
+++ b/docs/contributing/forks.md
@@ -1,5 +1,7 @@
 # Accepting PRs from a fork
 
+This document is mainly for FOSSA employees. It explains the process that we use to accept PRs from forks, and why we need this process.
+
 Unfortunately, our CI does not work with PRs from forks. This is because we pull in some proprietary executables and CI will only have the right secrets to download those executables if it is run from the main repo.
 
 To accept a PR from a fork, you create a new branch and cherry pick the commits from the forked PR onto the new branch. Then you push that branch to the main repo and create a new PR.

--- a/docs/contributing/forks.md
+++ b/docs/contributing/forks.md
@@ -1,0 +1,27 @@
+# Accepting PRs from a fork
+
+Unfortunately, our CI does not work with PRs from forks. This is because we pull in some proprietary executables and CI will only have the right secrets to download those executables if it is run from the main repo.
+
+To accept a PR from a fork, you create a new branch and cherry pick the commits from the forked PR onto the new branch. Then you push that branch to the main repo and create a new PR.
+
+In order to cherry pick the commits, you will have to [add the fork as a remote to your local repo](https://simonhartcher.com/how-to-cherry-pick-a-git-commit-from-a-fork/), fetch the remote and then cherry-pick.
+
+```
+git checkout -b my-branch
+git remote add fork git@github.com:<username>/fossa-cli.git
+git fetch fork
+git cherry-pick <commit id>
+<repeat for all commits in the PR>
+git remote rm fork
+git push -u origin my-branch
+```
+
+Then, on the original PR, add a message like this:
+
+> Hi, thank you for this contribution. Unfortunately due to the way our CI works (we pull in a few proprietary executables) I have to make a new PR with it. You will still be credited for the work of course.
+>
+> The new PR is here: #1511
+
+You can then close the original PR.
+
+Here's an example PR where we did this: https://github.com/fossas/fossa-cli/pull/1510


### PR DESCRIPTION
# Overview

We had a PR from a contributor come in today and I had to remember yet again how we accept PRs from forks.

So this PR documents how and why we do this.

## Acceptance criteria

The documents make sense

## Testing plan

This is a doc-only change.

## Risks

## Metrics

## References

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
