### PR TITLE
add support for Swift path deps with names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,6 @@
 # FOSSA CLI Changelog
 
 ## 3.10.1
-
 - Swift: Add support for parsing path dependencies with names ([#1515](https://github.com/fossas/fossa-cli/pull/1515))
 
 ## 3.10.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.10.1
+
+- Swift: Add support for parsing path dependencies with names ([#1515](https://github.com/fossas/fossa-cli/pull/1515))
+
 ## 3.10.0
 - Support for user-provided dependency labels in `fossa-deps` ([#1505](https://github.com/fossas/fossa-cli/pull/1505)).
   For details, see the [`fossa-deps` documentation](https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-deps.md).

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -144,7 +144,7 @@ parsePackageDep = try parsePathDep <|> parseGitDep
     parsePathDep :: Parser SwiftPackageDep
     parsePathDep = do
       _ <- symbol ".package" <* symbol "("
-      -- As of Swift 5.2+ you can optionally specify a name for a path dependency
+      -- As of SwiftPM 5.2+ you can optionally specify a name for a path dependency
       -- https://developer.apple.com/documentation/packagedescription/package/dependency/package(name:path:)
       _ <- optionallyTry (parseKeyValue "name" parseQuotedText)
       path <- parseKeyValue "path" parseQuotedText

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -143,12 +143,12 @@ parsePackageDep = try parsePathDep <|> parseGitDep
     -- A path dependency must have a path and may have a name
     parsePathDep :: Parser SwiftPackageDep
     parsePathDep = do
-      _ <- symbol ".package" <* symbol "("
+      void $ symbol ".package" <* symbol "("
       -- As of SwiftPM 5.2+ you can optionally specify a name for a path dependency
       -- https://developer.apple.com/documentation/packagedescription/package/dependency/package(name:path:)
-      _ <- optionallyTry (parseKeyValue "name" parseQuotedText)
+      void $ optionallyTry (parseKeyValue "name" parseQuotedText)
       path <- parseKeyValue "path" parseQuotedText
-      _ <- symbol ")"
+      void $ symbol ")"
       pure $ PathSource path
 
     parseRequirement :: Text -> Parser Text

--- a/test/Swift/PackageSwiftSpec.hs
+++ b/test/Swift/PackageSwiftSpec.hs
@@ -72,6 +72,7 @@ expectedSwiftPackage =
         gitDepWithRhsHalfOpenInterval "https://github.com/LeoNatan/LNPopupController.git" "2.5.0" "2.5.6"
       , gitDepWithClosedRange "https://github.com/Polidea/RxBluetoothKit.git" "3.0.5" "3.0.7"
       ]
+    ++ [PathSource "../..", PathSource "../.."]
 
 spec :: Spec
 spec = do

--- a/test/Swift/PackageSwiftSpec.hs
+++ b/test/Swift/PackageSwiftSpec.hs
@@ -72,7 +72,7 @@ expectedSwiftPackage =
         gitDepWithRhsHalfOpenInterval "https://github.com/LeoNatan/LNPopupController.git" "2.5.0" "2.5.6"
       , gitDepWithClosedRange "https://github.com/Polidea/RxBluetoothKit.git" "3.0.5" "3.0.7"
       ]
-    ++ [PathSource "../..", PathSource "../.."]
+      ++ [PathSource "../..", PathSource "../.."]
 
 spec :: Spec
 spec = do

--- a/test/Swift/testdata/Package.swift
+++ b/test/Swift/testdata/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
 
         // pkg version
         .package(
-            name: "PlayingCard", 
-            url: "https://github.com/apple/example-package-playingcard.git", 
+            name: "PlayingCard",
+            url: "https://github.com/apple/example-package-playingcard.git",
             from: "3.0.0"
         ),
         .package(url: "https://github.com/kaishin/Gifu.git", .from("3.2.2")),
@@ -33,7 +33,7 @@ let package = Package(
 
         // upToNextMajor
         .package(url: "https://github.com/dankogai/swift-sion", .upToNextMajor(from: "0.0.1")),
-        
+
         // upToNextMinor
         .package(url: "git@github.com:behrang/YamlSwift.git", .upToNextMinor(from: "3.4.0")),
 
@@ -48,6 +48,10 @@ let package = Package(
         // range
         .package(url: "https://github.com/LeoNatan/LNPopupController.git", "2.5.0"..<"2.5.6"),
         .package(url: "https://github.com/Polidea/RxBluetoothKit.git", "3.0.5"..."3.0.7"),
+
+        // path
+        .package(path: "../.."),
+        .package(name: "package-with-name", path: "../.."),
     ],
     targets: [
         .target(


### PR DESCRIPTION
# Overview

Delivers [ANE-2299](https://fossa.atlassian.net/browse/ANE-2299)

The problem is happening when we scan a `Package.swift` file with a path dependency that has a name specified:

```
// swift-tools-version:5.5

import PackageDescription

let package = Package(
        name: "QueryCpuData",
        platforms: [
            .macOS(.v10_15)
        ],
        products: [
            .executable(name: "query-cpu-data", targets: ["QueryCpuData"])
        ],
        dependencies: [
            .package(name: "influxdb-client-swift", path: "../.."),
            .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.2")
        ],
        targets: [
            .executableTarget(name: "QueryCpuData", dependencies: [
                .product(name: "InfluxDBSwiftApis", package: "influxdb-client-swift"),
                .product(name: "ArgumentParser", package: "swift-argument-parser"),
            ])
        ]
)
```

The `name` option was introduced in SwiftPM 5.2: https://developer.apple.com/documentation/packagedescription/package/dependency/package(name:path:)

This PR adds the ability to parse path dependencies with names.

## Acceptance criteria

- We can parse path dependencies with names

## Testing plan

```
git clone https://github.com/influxdata/influxdb-client-swift.git 
cd influxdb-client-swift/Examples/QueryCpuData/ 
fossa analyze --output
```

That analysis will fail on master but should pass using this branch. It won't find the path dependencies, but it won't fail to analyze.

Edit `Package.swift` and remove the `name` field from the path dependency. Analyze again. It should still work.

## Risks

This seems low risk.

## Metrics


## References

[ANE-2299](https://fossa.atlassian.net/browse/ANE-2299)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2299]: https://fossa.atlassian.net/browse/ANE-2299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANE-2299]: https://fossa.atlassian.net/browse/ANE-2299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ