### PR TITLE
docs: Document the usage of MAVEN_ARGS.

### DIFF
--- a/docs/references/strategies/languages/maven/maven.md
+++ b/docs/references/strategies/languages/maven/maven.md
@@ -39,7 +39,7 @@ Not directly, but `mvn` itself has an [environment variable](https://maven.apach
 For example, to set a custom `settings.xml` file you can use an invocation like this:
 
 ```sh
-export MAVEN_ARGS="/foo/bar/settings.xml" fossa analyze
+export MAVEN_ARGS="--settings /foo/bar/settings.xml" fossa analyze
 ```
 
 ## Filtering by Maven Dependency Scope 


### PR DESCRIPTION
This is meant to document findings from this [slack thread](https://teamfossa.slack.com/archives/C043EM3L96Z/p1741210104640349) about how to pass command-line arguments to the `mvn` command the CLI uses. 
