### PR TITLE
Rubrik snippet subcommand for generating the snippet fingerprint file

### DIFF
--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -277,6 +277,7 @@ library
     App.Fossa.Snippets
     App.Fossa.Snippets.Analyze
     App.Fossa.Snippets.Commit
+    App.Fossa.Snippets.GenerateFingerprints
     App.Fossa.Subcommand
     App.Fossa.Test
     App.Fossa.VendoredDependency

--- a/src/App/Fossa/Snippets.hs
+++ b/src/App/Fossa/Snippets.hs
@@ -21,6 +21,7 @@ module App.Fossa.Snippets (
 import App.Fossa.Config.Snippets (SnippetsCommand, SnippetsConfig (..), mkSubCommand)
 import App.Fossa.Snippets.Analyze (analyzeWithMillhone)
 import App.Fossa.Snippets.Commit (commitWithMillhone)
+import App.Fossa.Snippets.GenerateFingerprints (generateFingerprints)
 import App.Fossa.Subcommand (SubCommand)
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics)
@@ -44,3 +45,4 @@ snippetsMain subcommand = do
   case subcommand of
     Analyze cfg -> analyzeWithMillhone cfg
     Commit cfg -> commitWithMillhone cfg
+    GenerateFingerprints cfg -> generateFingerprints cfg

--- a/src/App/Fossa/Snippets/GenerateFingerprints.hs
+++ b/src/App/Fossa/Snippets/GenerateFingerprints.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.Snippets.GenerateFingerprints (
+  generateFingerprints,
+) where
+
+import App.Fossa.Config.Snippets (GenerateFingerprintsConfig (..))
+import App.Fossa.EmbeddedBinary (BinaryPaths, toPath, withScanossPyBinary)
+import App.Types (unBaseDir)
+import Control.Algebra (Has)
+import Control.Effect.Diagnostics (Diagnostics)
+import Control.Effect.Lift (Lift)
+import Data.String.Conversion (toText)
+import Effect.Exec (AllowErr (Never), Command (..), Exec, argFromPath, execEffectful)
+import Effect.Logger (Logger, logInfo)
+import Path (Abs, Dir, Path)
+
+generateFingerprints ::
+  ( Has (Lift IO) sig m
+  , Has Exec sig m
+  , Has Diagnostics sig m
+  , Has Logger sig m
+  ) =>
+  GenerateFingerprintsConfig ->
+  m ()
+generateFingerprints conf = do
+  logInfo "Generating WFP fingerprints for snippet scanning"
+  withScanossPyBinary $ \bin -> execEffectful root $ mkCmd bin root conf
+  where
+    root = unBaseDir $ fingerprintsScanDir conf
+
+mkCmd :: BinaryPaths -> Path Abs Dir -> GenerateFingerprintsConfig -> Command
+mkCmd bin root GenerateFingerprintsConfig{..} =
+  Command
+    { cmdName = toText $ toPath bin
+    , cmdArgs = concat [wfpCmd, debug, output, overwriteFlag, dir]
+    , cmdAllowErr = Never
+    }
+  where
+    wfpCmd = ["wfp"]
+    dir = [argFromPath root]
+    debug = if fingerprintsDebug then ["--debug"] else []
+    output = ["-o", toText fingerprintsOutput]
+    overwriteFlag = if fingerprintsOverwrite then ["--overwrite"] else [] 


### PR DESCRIPTION
Adding a temporary subcommand in the fossa CLI for using the `scanoss-py` binary to generate a snippet fingerprint file. 

Why?
Rubrik's says they need to go through another procurement process if they are directly evaluating ScanOSS. We are trying to get them to just generate the fingerprint file locally and send it over to us. This wraps the ScanOSS functionality and outputs the wfp file locally (so they can send it to us).