### PR TITLE
Fix PDM Parser when it encounters multiple OR lines

### DIFF
--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -259,7 +259,7 @@ requirementParser = specification
     marker_var :: Parser Text
     marker_var = label "marker_var" $ whitespace *> (env_var <|> fmap toText python_str)
     marker_expr :: Parser Marker
-    marker_expr = 
+    marker_expr =
       label "marker_expr" $
         MarkerExpr <$> marker_var <*> marker_op <*> marker_var
           <|> whitespace *> char '(' *> marker_or <* char ')'

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -271,7 +271,7 @@ requirementParser = specification
     marker_or =
       label "marker_or" $ do
         first <- marker_and
-        rest <- many (whitespace *> string "or" *> whitespace *> marker_and)
+        rest <- many (whitespace *> string "or" *> whitespace *> marker_or)
         pure $ case rest of
           [] -> first
           xs -> foldr MarkerOr first xs

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -15,6 +15,7 @@ import Control.Monad (join)
 import Control.Monad.Identity (Identity)
 import Data.Char qualified as C
 import Data.Foldable (asum, find, for_)
+import Data.List (foldl')
 import Data.Map.Strict qualified as Map
 import Data.String.Conversion (toText)
 import Data.Text (Text)
@@ -266,13 +267,13 @@ requirementParser = specification
     marker_and = label "marker_and" $ do
       first <- marker_expr
       rest <- many (try $ whitespace *> string "and" *> whitespace *> marker_expr)
-      pure $ foldl MarkerAnd first rest
+      pure $ foldl' MarkerAnd first rest
 
     marker_or :: Parser Marker
     marker_or = label "marker_or" $ do
       first <- marker_and
       rest <- many (try $ whitespace *> string "or" *> whitespace *> marker_and)
-      pure $ foldl MarkerOr first rest
+      pure $ foldl' MarkerOr first rest
 
     marker = label "marker" marker_or
     quoted_marker = label "quoted_marker" $ char ';' *> whitespace *> marker

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -269,9 +269,12 @@ requirementParser = specification
 
     marker_or :: Parser Marker
     marker_or =
-      label "marker_or" $
-        try (MarkerOr <$> marker_and <* whitespace <* string "or" <*> marker_and)
-          <|> marker_and
+      label "marker_or" $ do
+        first <- marker_and
+        rest <- many (whitespace *> string "or" *> whitespace *> marker_and)
+        pure $ case rest of
+          [] -> first
+          xs -> foldr MarkerOr first xs
 
     marker = label "marker" marker_or
     quoted_marker = label "quoted_marker" $ char ';' *> whitespace *> marker

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -259,9 +259,10 @@ requirementParser = specification
     marker_var :: Parser Text
     marker_var = label "marker_var" $ whitespace *> (env_var <|> fmap toText python_str)
     marker_expr :: Parser Marker
-    marker_expr = label "marker_expr" $
-      MarkerExpr <$> marker_var <*> marker_op <*> marker_var
-        <|> whitespace *> char '(' *> marker_or <* char ')'
+    marker_expr = 
+      label "marker_expr" $
+        MarkerExpr <$> marker_var <*> marker_op <*> marker_var
+          <|> whitespace *> char '(' *> marker_or <* char ')'
 
     marker_and :: Parser Marker
     marker_and = label "marker_and" $ do

--- a/test/Pdm/PdmSpec.hs
+++ b/test/Pdm/PdmSpec.hs
@@ -71,6 +71,7 @@ spec = do
       -- > └── pluggy 1.0.0 [ required: <2.0,>=0.12 ]
       -- > requests 2.25.1 [ required: ==2.25.1 ]
       -- > ├── certifi 2023.5.7 [ required: >=2017.4.17 ]
+      -- > ├── greenlet 3.1.1 [ required: !=0.4.17 ]
       -- > ├── chardet 4.0.0 [ required: <5,>=3.0.2 ]
       -- > ├── idna 2.10 [ required: <3,>=2.5 ]
       -- > └── urllib3 1.26.16 [ required: <1.27,>=1.21.1 ]
@@ -92,6 +93,7 @@ spec = do
         , iniconfig
         , packaging
         , pluggy
+        , greenlet
         , requests
         , certifi
         , chardet
@@ -104,8 +106,9 @@ spec = do
         , (pytest, iniconfig)
         , (pytest, packaging)
         , (pytest, pluggy)
-        , (requests, certifi)
         , (requests, chardet)
+        , (requests, greenlet)
+        , (requests, certifi)
         , (requests, idna)
         , (requests, urllib3)
         ]
@@ -176,3 +179,6 @@ urllib3 = mkPipProdDep "urllib3@1.26.16"
 
 colorama :: Dependency
 colorama = mkPipDevDep "colorama@0.4.6"
+
+greenlet :: Dependency
+greenlet = mkPipDevDep "greenlet@3.1.1"

--- a/test/Pdm/PdmSpec.hs
+++ b/test/Pdm/PdmSpec.hs
@@ -181,4 +181,4 @@ colorama :: Dependency
 colorama = mkPipDevDep "colorama@0.4.6"
 
 greenlet :: Dependency
-greenlet = mkPipDevDep "greenlet@3.1.1"
+greenlet = mkPipProdDep "greenlet@3.1.1"

--- a/test/Pdm/testdata/basic/pdm.lock
+++ b/test/Pdm/testdata/basic/pdm.lock
@@ -71,7 +71,7 @@ requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 summary = "Python HTTP for Humans."
 dependencies = [
     "certifi>=2017.4.17",
-    "greenlet!=0.4.17; (platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine = \"ppc64le\" or platform_machine == \"aarch64\") and python_version < \"3.14\"",
+    "greenlet!=0.4.17; (platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\") and python_version < \"3.14\"",
     "chardet<5,>=3.0.2",
     "idna<3,>=2.5",
     "urllib3<1.27,>=1.21.1",
@@ -82,26 +82,6 @@ name = "urllib3"
 version = "1.26.16"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
-
-[[package]]
-name = "greenlet"
-version = "3.1.1"
-requires_python = ">=3.7"
-summary = "Lightweight in-process concurrent programming"
-groups = ["test"]
-marker = "(platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\") and python_version < \"3.14\""
-files = [
-    {file = "greenlet-3.1.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:4afe7ea89de619adc868e087b4d2359282058479d7cfb94970adf4b55284574d"},
-    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79"},
-    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3a701fe5a9695b238503ce5bbe8218e03c3bcccf7e204e455e7462d770268aa"},
-    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2846930c65b47d70b9d178e89c7e1a69c95c1f68ea5aa0a58646b7a96df12441"},
-    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36"},
-    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1443279c19fca463fc33e65ef2a935a5b09bb90f978beab37729e1c3c6c25fe9"},
-    {file = "greenlet-3.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b7cede291382a78f7bb5f04a529cb18e068dd29e0fb27376074b6d0317bf4dd0"},
-    {file = "greenlet-3.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:23f20bb60ae298d7d8656c6ec6db134bca379ecefadb0b19ce6f19d1f232a942"},
-    {file = "greenlet-3.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:7124e16b4c55d417577c2077be379514321916d5790fa287c9ed6f23bd2ffd01"},
-    {file = "greenlet-3.1.1.tar.gz", hash = "sha256:4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467"},
-]
 
 [metadata]
 lock_version = "4.2"

--- a/test/Pdm/testdata/basic/pdm.lock
+++ b/test/Pdm/testdata/basic/pdm.lock
@@ -71,6 +71,7 @@ requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 summary = "Python HTTP for Humans."
 dependencies = [
     "certifi>=2017.4.17",
+    "greenlet!=0.4.17; (platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine =     = \"ppc64le\" or platform_machine == \"aarch64\") and python_version < \"3.14\"",
     "chardet<5,>=3.0.2",
     "idna<3,>=2.5",
     "urllib3<1.27,>=1.21.1",
@@ -81,6 +82,26 @@ name = "urllib3"
 version = "1.26.16"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
+
+[[package]]
+name = "greenlet"
+version = "3.1.1"
+requires_python = ">=3.7"
+summary = "Lightweight in-process concurrent programming"
+groups = ["test"]
+marker = "(platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\") and python_version < \"3.14\""
+files = [
+    {file = "greenlet-3.1.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:4afe7ea89de619adc868e087b4d2359282058479d7cfb94970adf4b55284574d"},
+    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79"},
+    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3a701fe5a9695b238503ce5bbe8218e03c3bcccf7e204e455e7462d770268aa"},
+    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2846930c65b47d70b9d178e89c7e1a69c95c1f68ea5aa0a58646b7a96df12441"},
+    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36"},
+    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1443279c19fca463fc33e65ef2a935a5b09bb90f978beab37729e1c3c6c25fe9"},
+    {file = "greenlet-3.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b7cede291382a78f7bb5f04a529cb18e068dd29e0fb27376074b6d0317bf4dd0"},
+    {file = "greenlet-3.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:23f20bb60ae298d7d8656c6ec6db134bca379ecefadb0b19ce6f19d1f232a942"},
+    {file = "greenlet-3.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:7124e16b4c55d417577c2077be379514321916d5790fa287c9ed6f23bd2ffd01"},
+    {file = "greenlet-3.1.1.tar.gz", hash = "sha256:4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467"},
+]
 
 [metadata]
 lock_version = "4.2"

--- a/test/Pdm/testdata/basic/pdm.lock
+++ b/test/Pdm/testdata/basic/pdm.lock
@@ -71,7 +71,7 @@ requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 summary = "Python HTTP for Humans."
 dependencies = [
     "certifi>=2017.4.17",
-    "greenlet!=0.4.17; (platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine =     = \"ppc64le\" or platform_machine == \"aarch64\") and python_version < \"3.14\"",
+    "greenlet!=0.4.17; (platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine = \"ppc64le\" or platform_machine == \"aarch64\") and python_version < \"3.14\"",
     "chardet<5,>=3.0.2",
     "idna<3,>=2.5",
     "urllib3<1.27,>=1.21.1",

--- a/test/Pdm/testdata/basic/pdm.lock
+++ b/test/Pdm/testdata/basic/pdm.lock
@@ -71,7 +71,7 @@ requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 summary = "Python HTTP for Humans."
 dependencies = [
     "certifi>=2017.4.17",
-    "greenlet!=0.4.17; (platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\") and python_version < \"3.14\"",
+    "greenlet!=0.4.17",
     "chardet<5,>=3.0.2",
     "idna<3,>=2.5",
     "urllib3<1.27,>=1.21.1",
@@ -82,6 +82,26 @@ name = "urllib3"
 version = "1.26.16"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
+
+[[package]]
+name = "greenlet"
+version = "3.1.1"
+requires_python = ">=3.7"
+summary = "Lightweight in-process concurrent programming"
+groups = ["test"]
+marker = "(platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\") and python_version < \"3.14\""
+files = [
+    {file = "greenlet-3.1.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:4afe7ea89de619adc868e087b4d2359282058479d7cfb94970adf4b55284574d"},
+    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79"},
+    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3a701fe5a9695b238503ce5bbe8218e03c3bcccf7e204e455e7462d770268aa"},
+    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2846930c65b47d70b9d178e89c7e1a69c95c1f68ea5aa0a58646b7a96df12441"},
+    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36"},
+    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1443279c19fca463fc33e65ef2a935a5b09bb90f978beab37729e1c3c6c25fe9"},
+    {file = "greenlet-3.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b7cede291382a78f7bb5f04a529cb18e068dd29e0fb27376074b6d0317bf4dd0"},
+    {file = "greenlet-3.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:23f20bb60ae298d7d8656c6ec6db134bca379ecefadb0b19ce6f19d1f232a942"},
+    {file = "greenlet-3.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:7124e16b4c55d417577c2077be379514321916d5790fa287c9ed6f23bd2ffd01"},
+    {file = "greenlet-3.1.1.tar.gz", hash = "sha256:4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467"},
+]
 
 [metadata]
 lock_version = "4.2"

--- a/test/Python/RequirementsSpec.hs
+++ b/test/Python/RequirementsSpec.hs
@@ -30,6 +30,8 @@ examples =
   , "name; os_name=='a' or os_name=='b'"
   , "name; os_name=='a' and os_name=='b' or os_name=='c'"
   , "name; os_name=='a' and (os_name=='b' or os_name=='c')"
+  , "name; os_name=='a' and (os_name=='b' or os_name=='c' and os_name=='d')"
+  , "name; (os_name=='b' or os_name=='c' and os_name=='d') and os_name=='a'"
   , "name; os_name=='a' or os_name=='b' and os_name=='c'"
   , "name; (os_name=='a' or os_name=='b') and os_name=='c'"
   ]


### PR DESCRIPTION
# Overview

The PDM Parser gets tripped up when handling multiple OR markers, such as
```
"greenlet!=0.4.17; (platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine = \"ppc64le\" or platform_machine == \"aarch64\") and python_version < \"3.14\"",
```

## Acceptance criteria

pdm.lock files containing complex combinations of "or" and "and" marker's can now be scanned.

## Testing plan

1. I started by testing on the supplied pdm.lock file that was failing. I addressed this issue.
2. I then added tests for this exact issue
3. I then iterated on the combination of "and" and "or"s trying to find another failing case.

## Risks

I missed a certain combination of "and" and "or"s that still fails.

## References

[ANE-2303](https://fossa.atlassian.net/browse/ANE-2303):  Solve PDM parsing bug

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2303]: https://fossa.atlassian.net/browse/ANE-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ