### PR TITLE
Rebar config parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -254,22 +254,20 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
 dependencies = [
  "bzip2-sys",
- "libc",
 ]
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -394,7 +392,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -546,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -568,15 +566,15 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ace6c86376be0b6cdcf3fb41882e81d94b31587573d1cfa9d01cd06bba210d"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -594,13 +592,13 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -613,7 +611,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -658,7 +656,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -725,7 +723,7 @@ dependencies = [
  "sha2",
  "strum 0.26.2",
  "tap",
- "thiserror",
+ "thiserror 1.0.61",
  "tracing",
  "zip",
 ]
@@ -773,7 +771,21 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -967,7 +979,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1075,10 +1087,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1102,7 +1115,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1161,6 +1174,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,7 +1215,7 @@ checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1221,7 +1245,7 @@ dependencies = [
  "strum 0.25.0",
  "tap",
  "tar",
- "thiserror",
+ "thiserror 1.0.61",
  "tikv-jemallocator",
  "traceconf",
  "tracing",
@@ -1417,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -1432,6 +1456,12 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -1460,7 +1490,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1538,7 +1568,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -1712,7 +1742,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1811,7 +1841,7 @@ dependencies = [
  "sha2",
  "strum 0.25.0",
  "tap",
- "thiserror",
+ "thiserror 1.0.61",
  "tracing",
  "tree-sitter",
  "tree-sitter-c",
@@ -1836,7 +1866,7 @@ dependencies = [
  "regex",
  "serde",
  "strum 0.24.1",
- "thiserror",
+ "thiserror 1.0.61",
  "typed-builder 0.10.0",
 ]
 
@@ -1919,7 +1949,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1932,7 +1962,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1954,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1971,7 +2001,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2012,7 +2042,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.61",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2023,7 +2062,18 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2058,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2071,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tinystr"
@@ -2127,7 +2177,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2254,7 +2304,7 @@ checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2265,7 +2315,7 @@ checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2348,7 +2398,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -2380,35 +2430,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2416,22 +2476,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
@@ -2623,6 +2686,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2715,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]
@@ -2671,7 +2752,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -2692,7 +2773,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2712,7 +2793,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -2733,7 +2814,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2755,14 +2836,14 @@ checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zip"
-version = "2.1.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
+checksum = "938cc23ac49778ac8340e366ddc422b2227ea176edb447e23fc0627608dddadd"
 dependencies = [
  "aes",
  "arbitrary",
@@ -2773,15 +2854,16 @@ dependencies = [
  "deflate64",
  "displaydoc",
  "flate2",
+ "getrandom 0.3.2",
  "hmac",
  "indexmap 2.2.6",
  "lzma-rs",
  "memchr",
  "pbkdf2",
- "rand",
  "sha1",
- "thiserror",
+ "thiserror 2.0.12",
  "time",
+ "xz2",
  "zeroize",
  "zopfli",
  "zstd",

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,13 @@
 # FOSSA CLI Changelog
-## 3.10.3
 
-License Scanning: Added the archive name to the path for licenses found inside of archives during vendored dependency and first-party license scanning ([#1520](https://github.com/fossas/fossa-cli/pull/1520))
+## 3.10.4
+- Erlang: Rebar config parsing bug fixes ([#1522](https://github.com/fossas/fossa-cli/pull/1522))
+
+## 3.10.3
+- PDM Parser: Proper parsing for PDM platform_machine line ([#1521](https://github.com/fossas/fossa-cli/pull/1521))
+- License Scanning: Added the archive name to the path for licenses found inside of archives during vendored dependency and first-party license scanning ([#1520](https://github.com/fossas/fossa-cli/pull/1520))
 
 ## 3.10.2
-
 - Cargo: Do not create Cargo.lock if it already exists ([#1516](https://github.com/fossas/fossa-cli/pull/1516))
 
 ## 3.10.1

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -38,7 +38,7 @@ tracing-subscriber = { version = "0.3.17", features = ["json"] }
 lazy-regex = { version = "3.0.2", features = ["std", "regex"] }
 fingerprint = { git = "https://github.com/fossas/lib-fingerprint.git", tag = "v3.0.0", default-features = false, features = ["fp-content-serialize-base64"] }
 tar = "0.4.41"
-zip = "2.1.3"
+zip = "2.3.0"
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/src/Strategy/Erlang/ConfigParser.hs
+++ b/src/Strategy/Erlang/ConfigParser.hs
@@ -66,7 +66,7 @@ parseConfig :: Parser ConfigValues
 parseConfig = ConfigValues <$ scn <*> parseTuple `endBy1` symbol "."
 
 parseErlValue :: Parser ErlValue
-parseErlValue = parseErlArray <|> parseTuple <|> parseNumber <|> parseErlString <|> parseAtom
+parseErlValue = parseErlArray <|> parseTuple <|> parseMap <|> parseBinary <|> parseNumber <|> parseErlString <|> parseAtom
 
 parseNumber :: Parser ErlValue
 parseNumber = try parseRadixLiteral <|> parseCharNum <|> try parseFloatLiteral <|> parseIntLiteral
@@ -172,3 +172,34 @@ scn = L.space space1 (L.skipLineComment "%") empty
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme scn
+
+parseMap :: Parser ErlValue
+parseMap = do
+    _ <- symbol "#"
+    -- Parse map contents between curly braces
+    _ <- symbol "{"
+    -- Parse key-value pairs separated by commas
+    _ <- parseMapPairs `sepBy` symbol ","
+    _ <- symbol "}"
+    -- Return an empty tuple as a placeholder since we don't need the map contents
+    pure $ ErlTuple []
+  where
+    parseMapPairs :: Parser ()
+    parseMapPairs = do
+      -- Parse key (any ErlValue)
+      _ <- parseErlValue
+      -- Parse the arrow operator '=>'
+      _ <- symbol "=>"
+      -- Parse value (any ErlValue)
+      _ <- parseErlValue
+      pure ()
+
+-- Parse Erlang binary syntax << ... >>
+parseBinary :: Parser ErlValue
+parseBinary = do
+    _ <- symbol "<<"
+    -- Parse binary contents separated by commas
+    _ <- parseErlValue `sepBy` symbol ","
+    _ <- symbol ">>"
+    -- Return an empty tuple as placeholder since we don't need the binary contents
+    pure $ ErlTuple []

--- a/src/Strategy/Erlang/ConfigParser.hs
+++ b/src/Strategy/Erlang/ConfigParser.hs
@@ -32,6 +32,7 @@ import GHC.Generics (Generic)
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import Text.Megaparsec.Char.Lexer qualified as L
+import Control.Monad (void)
 
 type Parser = Parsec Void Text
 
@@ -175,12 +176,12 @@ lexeme = L.lexeme scn
 
 parseMap :: Parser ErlValue
 parseMap = do
-  _ <- symbol "#"
+  void $ symbol "#"
   -- Parse map contents between curly braces
-  _ <- symbol "{"
+  void $ symbol "{"
   -- Parse key-value pairs separated by commas
-  _ <- parseMapPairs `sepBy` symbol ","
-  _ <- symbol "}"
+  void $ parseMapPairs `sepBy` symbol ","
+  void $ symbol "}"
   -- Return an empty tuple as a placeholder since we don't need the map contents
   pure $ ErlTuple []
   where
@@ -195,6 +196,7 @@ parseMap = do
       pure ()
 
 -- Parse Erlang binary syntax << ... >>
+-- https://www.erlang.org/doc/system/bit_syntax.html
 parseBinary :: Parser ErlValue
 parseBinary = do
   _ <- symbol "<<"

--- a/src/Strategy/Erlang/ConfigParser.hs
+++ b/src/Strategy/Erlang/ConfigParser.hs
@@ -175,14 +175,14 @@ lexeme = L.lexeme scn
 
 parseMap :: Parser ErlValue
 parseMap = do
-    _ <- symbol "#"
-    -- Parse map contents between curly braces
-    _ <- symbol "{"
-    -- Parse key-value pairs separated by commas
-    _ <- parseMapPairs `sepBy` symbol ","
-    _ <- symbol "}"
-    -- Return an empty tuple as a placeholder since we don't need the map contents
-    pure $ ErlTuple []
+  _ <- symbol "#"
+  -- Parse map contents between curly braces
+  _ <- symbol "{"
+  -- Parse key-value pairs separated by commas
+  _ <- parseMapPairs `sepBy` symbol ","
+  _ <- symbol "}"
+  -- Return an empty tuple as a placeholder since we don't need the map contents
+  pure $ ErlTuple []
   where
     parseMapPairs :: Parser ()
     parseMapPairs = do
@@ -197,9 +197,9 @@ parseMap = do
 -- Parse Erlang binary syntax << ... >>
 parseBinary :: Parser ErlValue
 parseBinary = do
-    _ <- symbol "<<"
-    -- Parse binary contents separated by commas
-    _ <- parseErlValue `sepBy` symbol ","
-    _ <- symbol ">>"
-    -- Return an empty tuple as placeholder since we don't need the binary contents
-    pure $ ErlTuple []
+  _ <- symbol "<<"
+  -- Parse binary contents separated by commas
+  _ <- parseErlValue `sepBy` symbol ","
+  _ <- symbol ">>"
+  -- Return an empty tuple as placeholder since we don't need the binary contents
+  pure $ ErlTuple []

--- a/src/Strategy/Erlang/ConfigParser.hs
+++ b/src/Strategy/Erlang/ConfigParser.hs
@@ -20,6 +20,7 @@ module Strategy.Erlang.ConfigParser (
   alphaNumToInt,
 ) where
 
+import Control.Monad (void)
 import Data.Aeson.Types (ToJSON (toJSON))
 import Data.Char qualified as C
 import Data.Functor (($>))
@@ -32,7 +33,6 @@ import GHC.Generics (Generic)
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import Text.Megaparsec.Char.Lexer qualified as L
-import Control.Monad (void)
 
 type Parser = Parsec Void Text
 

--- a/test/Erlang/testdata/rebar.config
+++ b/test/Erlang/testdata/rebar.config
@@ -15,8 +15,8 @@
 
 {ex_doc, [
     {source_url,<<"https://github.com/beam-telemetry/telemetry">>},
-    {extras, [<<"README.md">>,<<"CHANGELOG.md">>,<<"LICENSE">>,<<"NOTICE">>]},
-    {main, <<"readme">>}
+    {extras, [<<"README.md">>,<<"CHANGELOG.md">>,<<"LICENSE">>,<<"NOTICE"     >>]},
+    {main, <<" readme">>}
 ]}.
 
 %% == Erlang Compiler ==

--- a/test/Erlang/testdata/rebar.config
+++ b/test/Erlang/testdata/rebar.config
@@ -19,8 +19,6 @@
     {main, <<"readme">>}
 ]}.
 
-
-
 %% == Erlang Compiler ==
 
 %% Erlang files to compile before the rest. Rebar automatically compiles

--- a/test/Erlang/testdata/rebar.config
+++ b/test/Erlang/testdata/rebar.config
@@ -15,7 +15,7 @@
 
 {ex_doc, [
     {source_url,<<"https://github.com/beam-telemetry/telemetry">>},
-    {extras, [<<"README.md">>,    <<"CHANGELOG.md">>,        <<"LICENSE">>,            <<"NOTICE">>]},
+    {extras, [<<"README.md">>,<<"CHANGELOG.md">>,<<"LICENSE">>,<<"NOTICE">>]},
     {main, <<"readme">>}
 ]}.
 
@@ -125,15 +125,15 @@
 
 %% directory for artifacts produced by rebar3
 {base_dir, "_build"}.
-%% directory in '<base_dir>/<profile>/' where deps go
+%% directory in '<base_dir>/                <profile>/' where deps go
 {deps_dir, "lib"}.
 %% where rebar3 operates from; defaults to the current working directory
 {root_dir, "."}.
 %% where checkout dependencies are to be located
 {checkouts_dir, "_checkouts"}.
-%% where, under <base_dir>/<profile> checkout dependencies are to be built
+%% where, under <base_dir>/                    <profile> checkout dependencies are to be built
 {checkouts_out_dir, "checkouts"}.
-%% directory in '<base_dir>/<profile>/' where plugins go
+%% directory in '<base_dir>/                        <profile>/' where plugins go
 {plugins_dir, "plugins"}.
 %% directories where OTP applications for the project can be located
 {project_app_dirs, ["apps/*", "lib/*", "."]}.

--- a/test/Erlang/testdata/rebar.config
+++ b/test/Erlang/testdata/rebar.config
@@ -9,6 +9,17 @@
 %% presence is necessary for a build to be considered successful
 {artifacts, ["priv/mycode.so"]}.
 
+{hex, [
+    {doc, #{provider => ex_doc}}
+]}.
+
+{ex_doc, [
+    {source_url,<<"https://github.com/beam-telemetry/telemetry">>},
+    {extras, [<<"README.md">>,    <<"CHANGELOG.md">>,        <<"LICENSE">>,            <<"NOTICE">>]},
+    {main, <<"readme">>}
+]}.
+
+
 
 %% == Erlang Compiler ==
 
@@ -116,15 +127,15 @@
 
 %% directory for artifacts produced by rebar3
 {base_dir, "_build"}.
-%% directory in '<base_dir>/<profile>/' where deps go
+%% directory in '<base_dir>/                <profile>/' where deps go
 {deps_dir, "lib"}.
 %% where rebar3 operates from; defaults to the current working directory
 {root_dir, "."}.
 %% where checkout dependencies are to be located
 {checkouts_dir, "_checkouts"}.
-%% where, under <base_dir>/<profile> checkout dependencies are to be built
+%% where, under <base_dir>/                    <profile> checkout dependencies are to be built
 {checkouts_out_dir, "checkouts"}.
-%% directory in '<base_dir>/<profile>/' where plugins go
+%% directory in '<base_dir>/                        <profile>/' where plugins go
 {plugins_dir, "plugins"}.
 %% directories where OTP applications for the project can be located
 {project_app_dirs, ["apps/*", "lib/*", "."]}.

--- a/test/Erlang/testdata/rebar.config
+++ b/test/Erlang/testdata/rebar.config
@@ -125,15 +125,15 @@
 
 %% directory for artifacts produced by rebar3
 {base_dir, "_build"}.
-%% directory in '<base_dir>/                <profile>/' where deps go
+%% directory in '<base_dir>/<profile>/' where deps go
 {deps_dir, "lib"}.
 %% where rebar3 operates from; defaults to the current working directory
 {root_dir, "."}.
 %% where checkout dependencies are to be located
 {checkouts_dir, "_checkouts"}.
-%% where, under <base_dir>/                    <profile> checkout dependencies are to be built
+%% where, under <base_dir>/<profile> checkout dependencies are to be built
 {checkouts_out_dir, "checkouts"}.
-%% directory in '<base_dir>/                        <profile>/' where plugins go
+%% directory in '<base_dir>/<profile>/' where plugins go
 {plugins_dir, "plugins"}.
 %% directories where OTP applications for the project can be located
 {project_app_dirs, ["apps/*", "lib/*", "."]}.


### PR DESCRIPTION
# Overview

We currently have issues parsing binary and map formats inside of rebar.config files. This PR addresses those issues.

Example code below
`#` - Map syntax
`<<` and `>>` - Binary syntax
```
{hex, [
    {doc, #{provider => ex_doc}}
]}.

{ex_doc, [
    {source_url, <<"https://github.com/beam-telemetry/telemetry">>},
    {extras, [<<"README.md">>, <<"CHANGELOG.md">>, <<"LICENSE">>, <<"NOTICE">>]},
    {main, <<"readme">>}
]}.

```

## Acceptance criteria

Rebar analysis works for the users impacted project.

## Testing plan

Not done yet.

1. Test with the problem file in the ticket (lines affected posted above)
2. Test with more than 4 open source repos to make sure I didn't break anything
3. Add tests

## Risks

I'm tempted to make rebar.config parsing optional because I think it may be doing more harm than good. These two features have been around for I think 7 major versions and we don't support them. They also don't apply to anything that we need out of the file, which is alias data that is not prevalent in any major rebar.config files that I found on GitHub.

## References

[ANE-2036](https://fossa.atlassian.net/browse/ANE-2036): Implement rebar config fix

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2036]: https://fossa.atlassian.net/browse/ANE-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ