### PR TITLE
Update Changelog.md to have the correct PR #

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## 3.10.4
-- Erlang: Rebar config parsing bug fixes ([#1522](https://github.com/fossas/fossa-cli/pull/1522))
+- Erlang: Rebar config parsing bug fixes ([#1524](https://github.com/fossas/fossa-cli/pull/1522))
 
 ## 3.10.3
 - PDM Parser: Proper parsing for PDM platform_machine line ([#1521](https://github.com/fossas/fossa-cli/pull/1521))


### PR DESCRIPTION
# Overview

I accidentally put the wrong PR link in the changelog for 1524

## Acceptance criteria

The Changelog PR # is correct

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
