### PR TITLE
Cut release for themis

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 
 ## 3.10.6
-- Licensing: Fix a bug where the scikit-learn had an incorrect license detected
+- Licensing: Fix a bug where the scikit-learn had an incorrect license detected ([#1527](https://github.com/fossas/fossa-cli/pull/1527))
 
 ## 3.10.5
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## 3.10.6
+- Licensing: Fix a bug where the scikit-learn had an incorrect license detected
+
 ## 3.10.5
 
 Container scanning: Resolved a large number of issues with scanning containers ([#1514](https://github.com/fossas/fossa-cli/pull/1514), [#1521](https://github.com/fossas/fossa-cli/pull/1521))


### PR DESCRIPTION
# Overview

Pull in changes to Themis that fix [ANE-2331](https://fossa.atlassian.net/browse/ANE-2331).

## Acceptance criteria

We use the new version of Themis

## Testing plan

1. Copy the `license` text from https://pypi.org/pypi/scikit-learn/json
2. Run themis on it
3. Observe that the GPT license _is not_ found

## Risks

## Metrics

## References

- [ANE-2331](https://fossa.atlassian.net/browse/ANE-2331): Unexpected GPL-2.0 Declared License with No File Matches (scikit-learn@0.22.1)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.

[ANE-2331]: https://fossa.atlassian.net/browse/ANE-2331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANE-2331]: https://fossa.atlassian.net/browse/ANE-2331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ