### PR TITLE
[ANE-2245] Add the NREL disclaimer to the changelog for v3.10.6

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 3.10.6
 - Licensing: Fix a bug where the scikit-learn had an incorrect license detected ([#1527](https://github.com/fossas/fossa-cli/pull/1527))
+- Licensing: Adds support for the NREL disclaimer
 
 ## 3.10.5
 


### PR DESCRIPTION
# Overview

Adds a line to the changelog for v3.10.6 to note the addition of the [NREL-disclaimer](https://www.nrel.gov/disclaimer.html)

## Acceptance criteria

This just captures the external factor of the added NREL-discliamer.

## Testing plan

N/A: just picking up the themis change.

## Risks

None to speak of.

## Metrics

N/A

## References

- [ANE-2245](https://fossa.atlassian.net/browse/ANE-2245)
- [NREL-disclaimer](https://www.nrel.gov/disclaimer.html)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2245]: https://fossa.atlassian.net/browse/ANE-2245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ