### PR TITLE
git remote-url auto enrichment

### DIFF
--- a/src/Effect/Git.hs
+++ b/src/Effect/Git.hs
@@ -1,0 +1,8 @@
+-- | Get the Git remote URL for the repository
+getRemoteUrl :: Has Git sig m => m (Maybe Text)
+getRemoteUrl = do
+  -- Try to get the origin remote URL
+  result <- git ["config", "--get", "remote.origin.url"]
+  pure $ case result of
+    Right url -> Just (Text.strip url)
+    Left _ -> Nothing 

--- a/test/App/Fossa/Analyze/GitUrlSpec.hs
+++ b/test/App/Fossa/Analyze/GitUrlSpec.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module App.Fossa.Analyze.GitUrlSpec (spec) where
+
+import App.Fossa.Analyze
+import App.Fossa.Config.Analyze
+import Control.Carrier.Diagnostics
+import Control.Carrier.Git.Test
+import Control.Effect.Git
+import Data.Flag
+import Data.Text (Text)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "Git URL detection in analyze" $ do
+    it "should use Git remote URL when auto-detection is enabled and no manual URL is provided" $ do
+      let expectedUrl = "https://github.com/fossas/fossa-cli.git"
+      let config = defaultAnalyzeConfig
+            { autoDetectProjectUrl = Flag $ AutoDetectProjectUrl True
+            , projectUrl = Nothing
+            }
+      
+      result <- runGitTest [("config --get remote.origin.url", Right expectedUrl)] $ do
+        url <- getProjectUrl config
+        pure url
+
+      result `shouldBe` Just expectedUrl
+
+    it "should prefer manual URL over Git remote URL" $ do
+      let manualUrl = "https://example.com/manual"
+      let gitUrl = "https://github.com/fossas/fossa-cli.git"
+      let config = defaultAnalyzeConfig
+            { autoDetectProjectUrl = Flag $ AutoDetectProjectUrl True
+            , projectUrl = Just manualUrl
+            }
+      
+      result <- runGitTest [("config --get remote.origin.url", Right gitUrl)] $ do
+        url <- getProjectUrl config
+        pure url
+
+      result `shouldBe` Just manualUrl
+
+    it "should return Nothing when auto-detection is disabled and no manual URL is provided" $ do
+      let gitUrl = "https://github.com/fossas/fossa-cli.git"
+      let config = defaultAnalyzeConfig
+            { autoDetectProjectUrl = Flag $ AutoDetectProjectUrl False
+            , projectUrl = Nothing
+            }
+      
+      result <- runGitTest [("config --get remote.origin.url", Right gitUrl)] $ do
+        url <- getProjectUrl config
+        pure url
+
+      result `shouldBe` Nothing
+
+    it "should handle Git command failures gracefully" $ do
+      let config = defaultAnalyzeConfig
+            { autoDetectProjectUrl = Flag $ AutoDetectProjectUrl True
+            , projectUrl = Nothing
+            }
+      
+      result <- runGitTest [("config --get remote.origin.url", Left "fatal: not a git repository")] $ do
+        url <- getProjectUrl config
+        pure url
+
+      result `shouldBe` Nothing
+
+    it "should continue analysis when no Git URL is detected" $ do
+      let config = defaultAnalyzeConfig
+            { autoDetectProjectUrl = Flag $ AutoDetectProjectUrl True
+            , projectUrl = Nothing
+            }
+      
+      result <- runGitTest [("config --get remote.origin.url", Left "fatal: not a git repository")] $ do
+        -- Simulate analyze command execution
+        url <- getProjectUrl config
+        -- Verify that even with no URL, we get a valid result
+        pure $ case url of
+          Nothing -> True  -- Analysis should continue
+          Just _ -> False -- We shouldn't get a URL in this case
+
+      result `shouldBe` True
+
+    it "should log debug message when no Git URL is detected" $ do
+      let config = defaultAnalyzeConfig
+            { autoDetectProjectUrl = Flag $ AutoDetectProjectUrl True
+            , projectUrl = Nothing
+            }
+      
+      (result, logs) <- runGitTest [("config --get remote.origin.url", Left "fatal: not a git repository")] $ do
+        -- Capture logs during execution
+        url <- getProjectUrl config
+        logs <- getLogs
+        pure (url, logs)
+
+      logs `shouldContain` "No Git remote URL detected, continuing without project URL"
+      result `shouldBe` Nothing
+
+-- Helper function to simulate the URL detection logic from analyze
+getProjectUrl :: 
+  ( Has Git sig m
+  , Has Diagnostics sig m
+  ) => 
+  AnalyzeConfig -> 
+  m (Maybe Text)
+getProjectUrl cfg = case (projectUrl cfg, fromFlag AutoDetectProjectUrl $ autoDetectProjectUrl cfg) of
+  (Just url, _) -> pure (Just url)
+  (Nothing, True) -> getRemoteUrl
+  (Nothing, False) -> pure Nothing
+
+-- Default config for testing
+defaultAnalyzeConfig :: AnalyzeConfig
+defaultAnalyzeConfig = AnalyzeConfig
+  { autoDetectProjectUrl = Flag $ AutoDetectProjectUrl True
+  , projectUrl = Nothing
+  -- ... other fields with default values ...
+  } 

--- a/test/Control/Carrier/Git/Test.hs
+++ b/test/Control/Carrier/Git/Test.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Control.Carrier.Git.Test
+  ( GitTest,
+    runGitTest,
+    GitCommand,
+  )
+where
+
+import Control.Algebra
+import Control.Carrier.Reader
+import Control.Effect.Git
+import Control.Monad.IO.Class
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Text (Text)
+
+type GitCommand = (String, Either String Text)
+
+newtype GitTest m a = GitTest
+  { runGitTest' :: ReaderC (Map String (Either String Text)) m a
+  }
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+instance (Algebra sig m) => Algebra (Git :+: sig) (GitTest m) where
+  alg hdl sig ctx = GitTest $ case sig of
+    L (Git args k) -> do
+      responses <- ask
+      let cmdStr = unwords args
+      let response = Map.findWithDefault (Left $ "No mock response for: " ++ cmdStr) cmdStr responses
+      pure (k response ctx)
+    R other -> ReaderC $ \env -> alg (runGitTest' . hdl) (R other) ctx
+
+runGitTest :: [GitCommand] -> GitTest m a -> m a
+runGitTest responses = (`runReader` Map.fromList responses) . runGitTest' 


### PR DESCRIPTION
# Overview

This PR enhances the fossa analyze command by automatically detecting and using the Git remote URL of the repository being analyzed. This eliminates the need for users to manually specify the --project-url parameter, streamlining the analysis process and ensuring more consistent project metadata in FOSSA.

The implementation detects the Git remote URL using standard Git commands and uses it as the project URL when no explicit URL is provided by the user.

## Acceptance criteria

When users run fossa analyze in a Git repository without specifying a --project-url, the CLI should:
- Automatically detect the Git remote URL from the repository
- Use the detected URL as the project URL in the analysis
- Log a debug message indicating the URL was automatically detected

Users should also be able to:
- Override the automatic detection by explicitly providing a --project-url
- Disable the automatic detection using a new --AutoDetectProjectUrl=false flag

## Testing plan

#!!!!Did not fully test -- would appreciate som help // feedback!!!


## Risks

Not sure if any of this is correct, experimenting :)
hopefully this would not fail if there's no git url

## References

This is in relations to mapping FOSSA project to a github repo if the FOSSA project name/locator is not the remote git url

## Checklist

- will need to update the docs if this works