### PR TITLE
Added documentation to ignore list

### DIFF
--- a/src/Discovery/Filters.hs
+++ b/src/Discovery/Filters.hs
@@ -210,6 +210,8 @@ ignoredPaths =
   [ "dist-newstyle"
   , "doc/"
   , "docs/"
+  , "Documentation/"
+  , "documentation/"
   , "test/"
   , "tests/"
   , "example/"


### PR DESCRIPTION
# Overview

_A prospect foudn out oython deps named 0,1,2 . Turns out these were *req.txt files being scanned from their Documentation/ directory. Added Documentation/ to the default ignoredPaths_

## Acceptance criteria

_Directories with names Documentation/ documentation/ should be default ignored from scans._

## Testing plan

_Haven't tested this manually. Only added Documentation/ & documentation/ to the list of ignoredPaths_

_Example:_

1. _Add a file name something_req.txt in a directory named Documentation/ OR documentation/._
2. _Run fossa analyze to ensure these files are not picked up as python manifest files._

_This section should list concrete steps that a reviewer can sanity check and repeat on their own machine (and provide any needed test cases)._

## Risks

_I havent seen cases of valid source code, manifest files present in Documentation/ , documentation directories. if there are source, valid manifest files in these dirs , we risk missing them. _

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

_Highlighted by prospect  (Actia) over an email_

_Example:_

- None_

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
