### PR TITLE
SBOM report ane 2277

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.10.7
+
+- Report: Allow generating SBOMs attribution reports using fossa-cli. ([#1534](https://github.com/fossas/fossa-cli/pull/1534))
+
 ## 3.10.6
 - Licensing: Fix a bug where the scikit-learn had an incorrect license detected ([#1527](https://github.com/fossas/fossa-cli/pull/1527))
 - Licensing: Adds support for the NREL disclaimer

--- a/docs/references/subcommands/report.md
+++ b/docs/references/subcommands/report.md
@@ -39,7 +39,7 @@ With no final path, FOSSA will try to fetch a report for the current directory's
 
 #### SBOM Files
 
-You can specify an SBOM that you would like to generate a report for by listing its filename:
+After using [`fossa sbom analyze`](./sbom.md), you can specify an SBOM that you would like to generate a report for using its file:
 
 ```
 fossa report attribution --format json ~/my-project-sbom.txt

--- a/docs/references/subcommands/report.md
+++ b/docs/references/subcommands/report.md
@@ -24,6 +24,41 @@ fossa report attribution --timeout 60
 
 Where `60` is the maximum number of seconds to wait for the report to be downloaded.
 
+### Valid Report Targets
+
+#### Project Directory
+
+You can specify a project directly like you would with `fossa analyze` to generate a report.
+For example:
+
+```
+fossa report attribution --format json ~/my-project
+```
+
+With no final path, FOSSA will try to fetch a report for the current directory's project.
+
+#### SBOM Files
+
+You can specify an SBOM that you would like to generate a report for by listing its filename:
+
+```
+fossa report attribution --format json ~/my-project-sbom.txt
+```
+
+#### Project Arguments
+
+All `fossa` commands support the following FOSSA-project-related flags:
+
+| Name                               | Short | Description                                                                                                                                            |
+| ---------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--project 'some project'`         | `-p`  | Override the detected project name                                                                                                                     |
+| `--revision 'some revision'`       | `-r`  | -Override the detected project revision                                                                                                                |
+| `--fossa-api-key 'my-api-key'`     |       | An alternative to using the `FOSSA_API_KEY` environment variable to specify a FOSSA API key                                                            |
+| `--endpoint 'https://example.com'` | `-e`  | Override the FOSSA API server base URL                                                                                                                 |
+| `--config /path/to/file`           | `-c`  | Path to a [configuration file](../files/fossa-yml.md) including filename. By default we look for `.fossa.yml` in base working directory. |
+
+In this case, FOSSA will attempt to fetch any report it can find matching the `project` and `revision` criteria.
+
 ### Specifying a report format
 
 `fossa report` supports customizing the format used to render a report via the `--format` flag.
@@ -59,15 +94,3 @@ To use this compatibility script:
 2. Run `fossa report attribution --format json`, piping its output to `compat-attribution`.
    For example, `fossa report attribution --format json | compat-attribution`
 3. Parse the resulting output as you would have from FOSSAv1.
-
-## Common FOSSA Project Flags
-
-All `fossa` commands support the following FOSSA-project-related flags:
-
-| Name                               | Short | Description                                                                                                                                            |
-| ---------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--project 'some project'`         | `-p`  | Override the detected project name                                                                                                                     |
-| `--revision 'some revision'`       | `-r`  | -Override the detected project revision                                                                                                                |
-| `--fossa-api-key 'my-api-key'`     |       | An alternative to using the `FOSSA_API_KEY` environment variable to specify a FOSSA API key                                                            |
-| `--endpoint 'https://example.com'` | `-e`  | Override the FOSSA API server base URL                                                                                                                 |
-| `--config /path/to/file`           | `-c`  | Path to a [configuration file](../files/fossa-yml.md) including filename. By default we look for `.fossa.yml` in base working directory. |

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -127,7 +127,6 @@ import Options.Applicative (
   argument,
   auto,
   eitherReader,
-  help,
   long,
   metavar,
   option,

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -48,6 +48,7 @@ module App.Fossa.Config.Common (
   titleHelp,
   -- Deprecation
   applyReleaseGroupDeprecationWarning,
+  disambiguateSBOMFlag,
 ) where
 
 import App.Fossa.Config.ConfigFile (
@@ -126,6 +127,7 @@ import Options.Applicative (
   argument,
   auto,
   eitherReader,
+  help,
   long,
   metavar,
   option,
@@ -268,6 +270,13 @@ baseDirArg = argument str (applyFossaStyle <> metavar "DIR" <> helpDoc baseDirDo
           [ "Set the base directory for scanning"
           , boldItalicized "Default: " <> "Current directory"
           ]
+
+disambiguateSBOMFlag :: Parser Bool
+disambiguateSBOMFlag =
+  switch $
+    applyFossaStyle
+      <> long "sbom"
+      <> help "Disambiguate that the report should be for an SBOM project."
 
 collectBaseDir ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -48,7 +48,6 @@ module App.Fossa.Config.Common (
   titleHelp,
   -- Deprecation
   applyReleaseGroupDeprecationWarning,
-  disambiguateSBOMFlag,
   collectBaseFile,
 ) where
 
@@ -273,13 +272,6 @@ baseDirArg = argument str (applyFossaStyle <> metavar "DIR" <> helpDoc baseDirDo
           [ "Set the base directory for scanning"
           , boldItalicized "Default: " <> "Current directory"
           ]
-
-disambiguateSBOMFlag :: Parser Bool
-disambiguateSBOMFlag =
-  switch $
-    applyFossaStyle
-      <> long "sbom"
-      <> help "Disambiguate that the report should be for an SBOM project."
 
 collectBaseDir ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -49,6 +49,7 @@ module App.Fossa.Config.Common (
   -- Deprecation
   applyReleaseGroupDeprecationWarning,
   disambiguateSBOMFlag,
+  collectBaseFile,
 ) where
 
 import App.Fossa.Config.ConfigFile (
@@ -261,6 +262,8 @@ pathOpt = first show . parseRelDir
 targetOpt :: String -> Either String TargetFilter
 targetOpt = first errorBundlePretty . runParser targetFilterParser "(Command-line arguments)" . toText
 
+-- | Argument for the base dir for FOSSA to operate out of.
+-- Defaults to the current directory, ".".
 baseDirArg :: Parser String
 baseDirArg = argument str (applyFossaStyle <> metavar "DIR" <> helpDoc baseDirDoc <> value ".")
   where
@@ -286,6 +289,14 @@ collectBaseDir ::
   FilePath ->
   m BaseDir
 collectBaseDir = fmap BaseDir . validateDir
+
+collectBaseFile ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has ReadFS sig m
+  ) =>
+  FilePath -> m (Path Abs File)
+collectBaseFile = validateFile
 
 validateDir ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Config/Report.hs
+++ b/src/App/Fossa/Config/Report.hs
@@ -227,6 +227,7 @@ mergeOpts cfgfile envvars ReportCliOptions{..} = do
     <*> pure timeoutduration
     <*> pure cliReportType
     <*> revision
+    <*> pure cliForceSBOM
 
 newtype NoFormatProvided = NoFormatProvided SourceLocation
 instance ToDiagnostic NoFormatProvided where
@@ -260,6 +261,7 @@ data ReportConfig = ReportConfig
   , timeoutDuration :: Duration
   , reportType :: ReportType
   , revision :: ProjectRevision
+  , fetchSBOMReport :: Bool
   }
   deriving (Eq, Ord, Show, Generic)
 

--- a/src/App/Fossa/Config/Report.hs
+++ b/src/App/Fossa/Config/Report.hs
@@ -19,6 +19,7 @@ import App.Fossa.Config.Common (
   collectRevisionData',
   commonOpts,
   defaultTimeoutDuration,
+  disambiguateSBOMFlag,
  )
 import App.Fossa.Config.ConfigFile (ConfigFile, resolveLocalConfigFile)
 import App.Fossa.Config.EnvironmentVars (EnvVars)
@@ -147,6 +148,7 @@ parser =
     <*> optional (option auto (applyFossaStyle <> long "timeout" <> stringToHelpDoc "Duration to wait for build completion (in seconds)"))
     <*> reportTypeArg
     <*> baseDirArg
+    <*> disambiguateSBOMFlag
   where
     jsonHelp :: Maybe (Doc AnsiStyle)
     jsonHelp =
@@ -179,6 +181,7 @@ data ReportCliOptions = ReportCliOptions
   , cliReportTimeout :: Maybe Int
   , cliReportType :: ReportType
   , cliReportBaseDir :: FilePath
+  , cliForceSBOM :: Bool
   }
   deriving (Eq, Ord, Show)
 

--- a/src/App/Fossa/Config/SBOM/Common.hs
+++ b/src/App/Fossa/Config/SBOM/Common.hs
@@ -66,4 +66,4 @@ getProjectRevision sbomPath override cacheStrategy = do
   let version = fromMaybe inferredVersion $ overrideRevision override
   let revision = ProjectRevision name version Nothing
   when (cacheStrategy == WriteOnly) $ saveRevision revision
-  pure $ ProjectRevision name version Nothing
+  pure revision

--- a/src/App/Fossa/Container/Scan.hs
+++ b/src/App/Fossa/Container/Scan.hs
@@ -16,7 +16,7 @@ import App.Fossa.Container.Sources.DockerArchive (analyzeFromDockerArchive, revi
 import App.Fossa.Container.Sources.DockerEngine (analyzeFromDockerEngine, revisionFromDockerEngine)
 import App.Fossa.Container.Sources.Podman (analyzeFromPodman, podmanInspectImage, revisionFromPodman)
 import App.Fossa.Container.Sources.Registry (analyzeFromRegistry, revisionFromRegistry, runWithCirceReexport)
-import App.Types (OverrideProject (..), ProjectRevision (ProjectRevision))
+import App.Types (LocatorType (LocatorTypeCustom), OverrideProject (..), ProjectRevision (ProjectRevision))
 import Container.Docker.SourceParser (RegistryImageSource (..), parseImageUrl)
 import Container.Types (ContainerScan (..))
 import Control.Carrier.DockerEngineApi (runDockerEngineApi)

--- a/src/App/Fossa/Container/Scan.hs
+++ b/src/App/Fossa/Container/Scan.hs
@@ -16,7 +16,7 @@ import App.Fossa.Container.Sources.DockerArchive (analyzeFromDockerArchive, revi
 import App.Fossa.Container.Sources.DockerEngine (analyzeFromDockerEngine, revisionFromDockerEngine)
 import App.Fossa.Container.Sources.Podman (analyzeFromPodman, podmanInspectImage, revisionFromPodman)
 import App.Fossa.Container.Sources.Registry (analyzeFromRegistry, revisionFromRegistry, runWithCirceReexport)
-import App.Types (LocatorType (LocatorTypeCustom), OverrideProject (..), ProjectRevision (ProjectRevision))
+import App.Types (OverrideProject (..), ProjectRevision (..))
 import Container.Docker.SourceParser (RegistryImageSource (..), parseImageUrl)
 import Container.Types (ContainerScan (..))
 import Control.Carrier.DockerEngineApi (runDockerEngineApi)

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -89,10 +89,7 @@ fetchReport ReportConfig{..} =
       locatorType <-
         case reportBase of
           SBOMBase _ -> waitForSbomCompletion
-          CustomBase _ -> waitForCustomCompletion
-          CurrentDir _ ->
-            waitForCustomCompletion
-              <||> (Diag.errCtx ("Tried custom+ locator as well." :: Text) waitForSbomCompletion)
+          DirectoryBase _ -> waitForCustomCompletion <||> waitForSbomCompletion
 
       logSticky "[ Waiting for scan completion... ]"
 

--- a/src/App/Fossa/Report.hs
+++ b/src/App/Fossa/Report.hs
@@ -18,14 +18,12 @@ import Control.Carrier.Debug (ignoreDebug)
 import Control.Carrier.FossaApiClient (runFossaApiClient)
 import Control.Carrier.StickyLogger (StickyLogger, logSticky, runStickyLogger)
 import Control.Effect.Diagnostics (Diagnostics, (<||>))
-import Control.Effect.Diagnostics qualified as Diag
 import Control.Effect.FossaApiClient (FossaApiClient, getAttribution)
 import Control.Effect.Lift (Has, Lift)
 import Control.Monad (void, when)
 import Control.Timeout (timeout')
 import Data.Functor (($>))
 import Data.String.Conversion (toText)
-import Data.Text (Text)
 import Data.Text.Extra (showT)
 import Effect.Logger (
   Logger,

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -24,6 +24,7 @@ module App.Types (
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toEncoding), defaultOptions, genericToEncoding, object, withObject, (.:), (.=))
 import Data.Aeson.Types (toJSON)
 import Data.Map (Map)
+import Data.String (IsString)
 import Data.String.Conversion (ToText (..), showText)
 import Data.Text (Text)
 import DepTypes (DepType)
@@ -92,13 +93,16 @@ data ProjectRevision = ProjectRevision
 data LocatorType = LocatorTypeCustom | LocatorTypeSBOM
   deriving (Eq, Ord, Show, Generic)
 
+-- | How to output a 'LocatorType' when interacting with FOSSA APIs.
+locatorAPIText :: IsString a => LocatorType -> a
+locatorAPIText LocatorTypeCustom = "custom"
+locatorAPIText LocatorTypeSBOM = "sbom"
+
 instance ToText LocatorType where
-  toText LocatorTypeCustom = "custom"
-  toText LocatorTypeSBOM = "sbom"
+  toText = locatorAPIText
 
 instance ToJSON LocatorType where
-  toEncoding LocatorTypeCustom = "custom"
-  toEncoding LocatorTypeSBOM = "sbom"
+  toEncoding = locatorAPIText
 
 instance ToJSON ProjectRevision where
   toEncoding = genericToEncoding defaultOptions

--- a/src/App/Types.hs
+++ b/src/App/Types.hs
@@ -19,6 +19,7 @@ module App.Types (
   ComponentUploadFileType (..),
   Mode (..),
   uploadFileTypeToFetcherName,
+  locatorAPIText,
 ) where
 
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toEncoding), defaultOptions, genericToEncoding, object, withObject, (.:), (.=))

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -66,11 +66,11 @@ runFossaApiClient apiOpts action = do
             FinalizeLicenseScan components -> LicenseScanning.finalizeLicenseScan components
             FinalizeLicenseScanForPathDependency locators forceRebuild -> LicenseScanning.finalizePathDependencyScan locators forceRebuild
             GetApiOpts -> pure apiOpts
-            GetAttribution rev format -> Core.getAttribution rev format
+            GetAttribution rev format locType -> Core.getAttribution rev format locType
             GetIssues rev diffRev locatorType -> Core.getIssues rev diffRev locatorType
             GetEndpointVersion -> Core.getEndpointVersion
             GetLatestBuild rev locatorType -> Core.getLatestBuild rev locatorType
-            GetRevisionDependencyCacheStatus rev -> Core.getRevisionDependencyCacheStatus rev
+            GetRevisionDependencyCacheStatus rev locatorType -> Core.getRevisionDependencyCacheStatus rev locatorType
             GetOrganization -> Core.getOrganization
             GetPolicies -> Core.getPolicies
             GetProject rev locatorType -> Core.getProject rev locatorType

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -199,20 +199,22 @@ getAttribution ::
   ) =>
   ProjectRevision ->
   ReportOutputFormat ->
+  LocatorType ->
   m Text
-getAttribution revision format = do
+getAttribution revision format locatorType = do
   apiOpts <- ask
-  API.getAttribution apiOpts revision format
+  API.getAttribution apiOpts revision format locatorType
 
 getRevisionDependencyCacheStatus ::
   ( API.APIClientEffs sig m
   , Has (Reader ApiOpts) sig m
   ) =>
   ProjectRevision ->
+  LocatorType ->
   m RevisionDependencyCache
-getRevisionDependencyCacheStatus rev = do
+getRevisionDependencyCacheStatus rev locatorType = do
   apiOpts <- ask
-  API.getRevisionDependencyCacheStatus apiOpts rev
+  API.getRevisionDependencyCacheStatus apiOpts rev locatorType
 
 getSignedUploadUrl ::
   ( API.APIClientEffs sig m

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -1219,8 +1219,6 @@ getIssues apiOpts ProjectRevision{..} diffRevision locatorType = fossaReq $ do
       jsonResponse
       opts
 
-  -- this function works!
-
   pure (responseBody response)
 
 newtype EndpointDoesNotSupportIssueDiffing = EndpointDoesNotSupportIssueDiffing SourceLocation

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -109,6 +109,7 @@ import App.Types (
   ProjectRevision (..),
   ReleaseGroupMetadata (releaseGroupName, releaseGroupRelease),
   ReleaseGroupReleaseRevision,
+  locatorAPIText,
   uploadFileTypeToFetcherName,
  )
 import App.Version (versionNumber)
@@ -1269,7 +1270,7 @@ getAttributionJson apiOpts ProjectRevision{..} locatorType = fossaReq $ do
           -- Large reports can take over a minute to generate, so increase the timeout to 10 minutes
           <> responseTimeoutSeconds 600
   orgId <- organizationId <$> getOrganization apiOpts
-  response <- req GET (attributionEndpoint baseUrl orgId (Locator (toText locatorType) projectName (Just projectRevision)) ReportJson) NoReqBody jsonResponse opts
+  response <- req GET (attributionEndpoint baseUrl orgId (Locator (locatorAPIText locatorType) projectName (Just projectRevision)) ReportJson) NoReqBody jsonResponse opts
   pure (responseBody response)
 
 getAttribution ::
@@ -1288,7 +1289,7 @@ getAttribution apiOpts ProjectRevision{..} format locatorType = fossaReq $ do
   let opts = baseOpts <> responseTimeoutSeconds 600
 
   orgId <- organizationId <$> getOrganization apiOpts
-  response <- req GET (attributionEndpoint baseUrl orgId (Locator (toText locatorType) projectName (Just projectRevision)) format) NoReqBody bsResponse opts
+  response <- req GET (attributionEndpoint baseUrl orgId (Locator (locatorAPIText locatorType) projectName (Just projectRevision)) format) NoReqBody bsResponse opts
   pure (decodeUtf8 $ responseBody response)
 
 ----------

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -117,14 +117,14 @@ data FossaApiClientF a where
   FinalizeLicenseScan :: ArchiveComponents -> FossaApiClientF ()
   FinalizeLicenseScanForPathDependency :: [Locator] -> Bool -> FossaApiClientF ()
   GetApiOpts :: FossaApiClientF ApiOpts
-  GetAttribution :: ProjectRevision -> ReportOutputFormat -> FossaApiClientF Text
+  GetAttribution :: ProjectRevision -> ReportOutputFormat -> LocatorType -> FossaApiClientF Text
   GetCustomBuildPermissons ::
     ProjectRevision ->
     ProjectMetadata ->
     FossaApiClientF CustomBuildUploadPermissions
   GetIssues :: ProjectRevision -> Maybe DiffRevision -> LocatorType -> FossaApiClientF Issues
   GetEndpointVersion :: FossaApiClientF Text
-  GetRevisionDependencyCacheStatus :: ProjectRevision -> FossaApiClientF RevisionDependencyCache
+  GetRevisionDependencyCacheStatus :: ProjectRevision -> LocatorType -> FossaApiClientF RevisionDependencyCache
   GetLatestBuild :: ProjectRevision -> LocatorType -> FossaApiClientF Build
   GetOrganization :: FossaApiClientF Organization
   GetPolicies :: FossaApiClientF [CoreTypes.Policy]
@@ -217,14 +217,14 @@ uploadContributors locator contributors = sendSimple $ UploadContributors locato
 getLatestBuild :: (Has FossaApiClient sig m) => ProjectRevision -> LocatorType -> m Build
 getLatestBuild rev locatorType = sendSimple $ GetLatestBuild rev locatorType
 
-getRevisionDependencyCacheStatus :: (Has FossaApiClient sig m) => ProjectRevision -> m RevisionDependencyCache
-getRevisionDependencyCacheStatus = sendSimple . GetRevisionDependencyCacheStatus
+getRevisionDependencyCacheStatus :: (Has FossaApiClient sig m) => ProjectRevision -> LocatorType -> m RevisionDependencyCache
+getRevisionDependencyCacheStatus locType = sendSimple . GetRevisionDependencyCacheStatus locType
 
 getIssues :: (Has FossaApiClient sig m) => ProjectRevision -> Maybe DiffRevision -> LocatorType -> m Issues
 getIssues projectRevision diffRevision locatorType = sendSimple $ GetIssues projectRevision diffRevision locatorType
 
-getAttribution :: Has FossaApiClient sig m => ProjectRevision -> ReportOutputFormat -> m Text
-getAttribution revision format = sendSimple $ GetAttribution revision format
+getAttribution :: Has FossaApiClient sig m => ProjectRevision -> ReportOutputFormat -> LocatorType -> m Text
+getAttribution revision format locatorType = sendSimple $ GetAttribution revision format locatorType
 
 getSignedUploadUrl :: Has FossaApiClient sig m => ComponentUploadFileType -> PackageRevision -> m SignedURL
 getSignedUploadUrl fileType packageSpec = sendSimple $ GetSignedUploadUrl fileType packageSpec

--- a/src/Diag/Result.hs
+++ b/src/Diag/Result.hs
@@ -34,7 +34,6 @@ module Diag.Result (
   renderFailure,
   renderSuccess,
   renderFailureWithoutWarnings,
-  isFailure,
 ) where
 
 import Data.Error (DiagnosticStyle (..), applyDiagnosticStyle, combineErrataHeaders, renderErrataStack)
@@ -68,10 +67,6 @@ import Prettyprinter.Render.Terminal
 -- on the first Failure.
 data Result a = Failure [EmittedWarn] ErrGroup | Success [EmittedWarn] a
   deriving (Show)
-
-isFailure :: Result a -> Bool
-isFailure (Failure _ _) = True
-isFailure _ = False
 
 -- | A warning emitted during a computation
 --

--- a/src/Diag/Result.hs
+++ b/src/Diag/Result.hs
@@ -34,6 +34,7 @@ module Diag.Result (
   renderFailure,
   renderSuccess,
   renderFailureWithoutWarnings,
+  isFailure,
 ) where
 
 import Data.Error (DiagnosticStyle (..), applyDiagnosticStyle, combineErrataHeaders, renderErrataStack)
@@ -67,6 +68,10 @@ import Prettyprinter.Render.Terminal
 -- on the first Failure.
 data Result a = Failure [EmittedWarn] ErrGroup | Success [EmittedWarn] a
   deriving (Show)
+
+isFailure :: Result a -> Bool
+isFailure (Failure _ _) = True
+isFailure _ = False
 
 -- | A warning emitted during a computation
 --

--- a/test/App/Fossa/API/BuildWaitSpec.hs
+++ b/test/App/Fossa/API/BuildWaitSpec.hs
@@ -112,7 +112,7 @@ spec =
         expectIssuesAvailable
         expectGetRevisionCache Ready
         runWithTimeout $
-          waitForReportReadiness Fixtures.projectRevision
+          \c -> waitForReportReadiness Fixtures.projectRevision c LocatorTypeCustom
 
       it' "should retry periodically if the revision's dependency cache is in waiting state" $ do
         expectGetApiOpts
@@ -123,7 +123,7 @@ spec =
         expectGetRevisionCache Waiting
         expectGetRevisionCache Ready
         runWithTimeout $
-          waitForReportReadiness Fixtures.projectRevision
+          \c -> waitForReportReadiness Fixtures.projectRevision c LocatorTypeCustom
 
       it' "should cancel when the timeout expires" $ do
         expectGetApiOpts
@@ -131,7 +131,7 @@ spec =
         expectIssuesAvailable
         expectRevisionDependencyCacheAlwaysWaiting
         expectFatal' . runWithTimeout $
-          waitForReportReadiness Fixtures.projectRevision
+          \c -> waitForReportReadiness Fixtures.projectRevision c LocatorTypeCustom
 
 expectGetApiOpts :: Has MockApi sig m => m ()
 expectGetApiOpts =
@@ -150,7 +150,7 @@ expectGetLatestBuild status =
 
 expectGetRevisionCache :: Has MockApi sig m => RevisionDependencyCacheStatus -> m ()
 expectGetRevisionCache status =
-  (GetRevisionDependencyCacheStatus Fixtures.projectRevision)
+  (GetRevisionDependencyCacheStatus Fixtures.projectRevision LocatorTypeCustom)
     `returnsOnce` (RevisionDependencyCache status)
 
 expectIssuesAvailable :: Has MockApi sig m => m ()
@@ -175,7 +175,7 @@ expectBuildAlwaysRunning =
 
 expectRevisionDependencyCacheAlwaysWaiting :: Has MockApi sig m => m ()
 expectRevisionDependencyCacheAlwaysWaiting =
-  (GetRevisionDependencyCacheStatus Fixtures.projectRevision)
+  (GetRevisionDependencyCacheStatus Fixtures.projectRevision LocatorTypeCustom)
     `alwaysReturns` RevisionDependencyCache Waiting
 
 expectIssuesAlwaysWaiting :: Has MockApi sig m => m ()

--- a/test/App/Fossa/ReportSpec.hs
+++ b/test/App/Fossa/ReportSpec.hs
@@ -11,6 +11,7 @@ import Fossa.API.Types (RevisionDependencyCache (RevisionDependencyCache), Revis
 import Test.Effect (expectFatal', it')
 import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec, describe, it, runIO, shouldBe)
+import Test.Hspec.Core.Spec (fdescribe)
 import Test.MockApi (MockApi, alwaysReturns, fails, returnsOnce)
 
 reportConfig :: IO ReportConfig
@@ -30,41 +31,89 @@ reportConfig = do
 spec :: Spec
 spec =
   describe "Report" $ do
-    config <- runIO reportConfig
-    it' "should timeout if build-completion doesn't complete" $ do
-      expectGetOrganization
-      expectBuildPending
-      expectFatal' $ fetchReport config
-    it' "should timeout if issue-generation doesn't complete" $ do
-      expectGetOrganization
-      expectBuildSuccess
-      expectFetchIssuesPending
-      expectFatal' $ fetchReport config
-    it' "should fetch a report when the build and issues are ready" $ do
-      expectGetOrganization
-      expectBuildSuccess
-      expectFetchIssuesSuccess
-      expectFetchRevisionDependencyCacheSuccess
-      expectFetchReportSuccess
-      fetchReport config
-    it' "should die if fetching the build fails" $ do
-      expectGetOrganization
-      expectBuildError
-      expectFatal' $ fetchReport config
-    it' "should die if fetching issues fails" $ do
-      expectGetOrganization
-      expectBuildSuccess
-      expectFetchIssuesError
-      expectFatal' $ fetchReport config
-    it' "should die if fetching the report fails" $ do
-      expectGetOrganization
-      expectBuildSuccess
-      expectFetchIssuesSuccess
-      expectFetchRevisionDependencyCacheSuccess
-      expectFetchReportError
-      expectFatal' $ fetchReport config
+    baseConfig <- runIO reportConfig
+    customBuildSpec baseConfig
+    sbomBuildSpec baseConfig
 
-    parseReportOutputSpec
+customBuildSpec :: ReportConfig -> Spec
+customBuildSpec config = describe "Custom build" $ do
+  let buildType = LocatorTypeCustom
+  it' "should timeout if build-completion doesn't complete" $ do
+    expectGetOrganization
+    expectBuildPending buildType
+    expectBuildPending LocatorTypeSBOM
+    expectFatal' $ fetchReport config
+  it' "should timeout if issue-generation doesn't complete" $ do
+    expectGetOrganization
+    expectBuildSuccess buildType
+    expectFetchIssuesPending buildType
+    expectFatal' $ fetchReport config
+  it' "should fetch a report when the build and issues are ready" $ do
+    expectGetOrganization
+    expectBuildSuccess buildType
+    expectFetchIssuesSuccess buildType
+    expectFetchRevisionDependencyCacheSuccess buildType
+    expectFetchReportSuccess buildType
+    fetchReport config
+  it' "should die if fetching the build fails" $ do
+    expectGetOrganization
+    expectBuildError buildType
+    -- It will try to see if there's an SBOM with that name, so this failure happens too.
+    expectBuildError LocatorTypeSBOM
+    expectFatal' $ fetchReport config
+  it' "should die if fetching issues fails" $ do
+    expectGetOrganization
+    expectBuildSuccess buildType
+    expectFetchIssuesError buildType
+    expectFatal' $ fetchReport config
+  it' "should die if fetching the report fails" $ do
+    expectGetOrganization
+    expectBuildSuccess buildType
+    expectFetchIssuesSuccess buildType
+    expectFetchRevisionDependencyCacheSuccess buildType
+    expectFetchReportError buildType
+    expectFatal' $ fetchReport config
+
+  parseReportOutputSpec
+
+sbomBuildSpec :: ReportConfig -> Spec
+sbomBuildSpec config = describe "Custom build" $ do
+  let config' = config{fetchSBOMReport = True}
+      buildType = LocatorTypeSBOM
+  it' "should timeout if build-completion doesn't complete" $ do
+    expectGetOrganization
+    expectBuildPending buildType
+    expectFatal' $ fetchReport config'
+  it' "should timeout if issue-generation doesn't complete" $ do
+    expectGetOrganization
+    expectBuildSuccess buildType
+    expectFetchIssuesPending buildType
+    expectFatal' $ fetchReport config'
+  it' "should fetch a report when the build and issues are ready" $ do
+    expectGetOrganization
+    expectBuildSuccess buildType
+    expectFetchIssuesSuccess buildType
+    expectFetchRevisionDependencyCacheSuccess buildType
+    expectFetchReportSuccess buildType
+    fetchReport config'
+  it' "should die if fetching the build fails" $ do
+    expectGetOrganization
+    expectBuildError buildType
+    expectFatal' $ fetchReport config'
+  it' "should die if fetching issues fails" $ do
+    expectGetOrganization
+    expectBuildSuccess buildType
+    expectFetchIssuesError buildType
+    expectFatal' $ fetchReport config'
+  it' "should die if fetching the report fails" $ do
+    expectGetOrganization
+    expectBuildSuccess buildType
+    expectFetchIssuesSuccess buildType
+    expectFetchRevisionDependencyCacheSuccess buildType
+    expectFetchReportError buildType
+    expectFatal' $ fetchReport config'
+
+  parseReportOutputSpec
 
 parseReportOutputSpec :: Spec
 parseReportOutputSpec =
@@ -74,48 +123,48 @@ parseReportOutputSpec =
         let fmt = show reportFmt
          in it ("Parses \"" <> fmt <> "\"") $ (parseReportOutputFormat fmt) `shouldBe` Just reportFmt
 
-expectBuildSuccess :: (Has MockApi sig m) => m ()
-expectBuildSuccess = do
-  (GetProject Fixtures.projectRevision LocatorTypeCustom) `returnsOnce` Fixtures.project
-  (GetLatestBuild Fixtures.projectRevision LocatorTypeCustom) `returnsOnce` Fixtures.successfulBuild
+expectBuildSuccess :: (Has MockApi sig m) => LocatorType -> m ()
+expectBuildSuccess locType = do
+  (GetProject Fixtures.projectRevision locType) `returnsOnce` Fixtures.project
+  (GetLatestBuild Fixtures.projectRevision locType) `returnsOnce` Fixtures.successfulBuild
 
-expectBuildPending :: (Has MockApi sig m) => m ()
-expectBuildPending = do
+expectBuildPending :: (Has MockApi sig m) => LocatorType -> m ()
+expectBuildPending locType = do
   GetApiOpts `alwaysReturns` Fixtures.apiOpts -- It needs to fetch the poll delay
-  (GetProject Fixtures.projectRevision LocatorTypeCustom) `returnsOnce` Fixtures.project
-  (GetLatestBuild Fixtures.projectRevision LocatorTypeCustom) `alwaysReturns` Fixtures.pendingBuild
+  (GetProject Fixtures.projectRevision locType) `returnsOnce` Fixtures.project
+  (GetLatestBuild Fixtures.projectRevision locType) `alwaysReturns` Fixtures.pendingBuild
 
-expectBuildError :: (Has MockApi sig m) => m ()
-expectBuildError = do
-  (GetProject Fixtures.projectRevision LocatorTypeCustom) `returnsOnce` Fixtures.project
-  (GetLatestBuild Fixtures.projectRevision LocatorTypeCustom) `fails` "Mock failure: GetLatestBuild"
+expectBuildError :: (Has MockApi sig m) => LocatorType -> m ()
+expectBuildError locType = do
+  (GetProject Fixtures.projectRevision locType) `returnsOnce` Fixtures.project
+  (GetLatestBuild Fixtures.projectRevision locType) `fails` "Mock failure: GetLatestBuild"
 
-expectFetchIssuesSuccess :: (Has MockApi sig m) => m ()
-expectFetchIssuesSuccess =
-  (GetIssues Fixtures.projectRevision Nothing LocatorTypeCustom) `returnsOnce` Fixtures.issuesAvailable
+expectFetchIssuesSuccess :: (Has MockApi sig m) => LocatorType -> m ()
+expectFetchIssuesSuccess locType =
+  (GetIssues Fixtures.projectRevision Nothing locType) `returnsOnce` Fixtures.issuesAvailable
 
-expectFetchIssuesPending :: (Has MockApi sig m) => m ()
-expectFetchIssuesPending = do
+expectFetchIssuesPending :: (Has MockApi sig m) => LocatorType -> m ()
+expectFetchIssuesPending locType = do
   GetApiOpts `alwaysReturns` Fixtures.apiOpts -- It needs to fetch the poll delay
-  (GetIssues Fixtures.projectRevision Nothing LocatorTypeCustom) `alwaysReturns` Fixtures.issuesPending
+  (GetIssues Fixtures.projectRevision Nothing locType) `alwaysReturns` Fixtures.issuesPending
 
-expectFetchIssuesError :: (Has MockApi sig m) => m ()
-expectFetchIssuesError =
-  (GetIssues Fixtures.projectRevision Nothing LocatorTypeCustom) `fails` "Mock failure: GetIssues"
+expectFetchIssuesError :: (Has MockApi sig m) => LocatorType -> m ()
+expectFetchIssuesError locType =
+  (GetIssues Fixtures.projectRevision Nothing locType) `fails` "Mock failure: GetIssues"
 
-expectFetchReportSuccess :: (Has MockApi sig m) => m ()
-expectFetchReportSuccess =
-  (GetAttribution Fixtures.projectRevision ReportJson LocatorTypeCustom)
+expectFetchReportSuccess :: (Has MockApi sig m) => LocatorType -> m ()
+expectFetchReportSuccess locType =
+  (GetAttribution Fixtures.projectRevision ReportJson locType)
     `returnsOnce` Fixtures.attributionReportAsSerializedJson
 
-expectFetchReportError :: (Has MockApi sig m) => m ()
-expectFetchReportError =
-  (GetAttribution Fixtures.projectRevision ReportJson LocatorTypeCustom)
+expectFetchReportError :: (Has MockApi sig m) => LocatorType -> m ()
+expectFetchReportError locType =
+  (GetAttribution Fixtures.projectRevision ReportJson locType)
     `fails` "Mock failure: GetAttribution"
 
-expectFetchRevisionDependencyCacheSuccess :: (Has MockApi sig m) => m ()
-expectFetchRevisionDependencyCacheSuccess =
-  (GetRevisionDependencyCacheStatus Fixtures.projectRevision LocatorTypeCustom)
+expectFetchRevisionDependencyCacheSuccess :: (Has MockApi sig m) => LocatorType -> m ()
+expectFetchRevisionDependencyCacheSuccess locType =
+  (GetRevisionDependencyCacheStatus Fixtures.projectRevision locType)
     `returnsOnce` RevisionDependencyCache Ready
 
 expectGetOrganization :: Has MockApi sig m => m ()

--- a/test/App/Fossa/ReportSpec.hs
+++ b/test/App/Fossa/ReportSpec.hs
@@ -24,6 +24,7 @@ reportConfig = do
       , timeoutDuration = MilliSeconds 100
       , reportType = Attribution
       , revision = Fixtures.projectRevision
+      , fetchSBOMReport = False
       }
 
 spec :: Spec
@@ -104,17 +105,17 @@ expectFetchIssuesError =
 
 expectFetchReportSuccess :: (Has MockApi sig m) => m ()
 expectFetchReportSuccess =
-  (GetAttribution Fixtures.projectRevision ReportJson)
+  (GetAttribution Fixtures.projectRevision ReportJson LocatorTypeCustom)
     `returnsOnce` Fixtures.attributionReportAsSerializedJson
 
 expectFetchReportError :: (Has MockApi sig m) => m ()
 expectFetchReportError =
-  (GetAttribution Fixtures.projectRevision ReportJson)
+  (GetAttribution Fixtures.projectRevision ReportJson LocatorTypeCustom)
     `fails` "Mock failure: GetAttribution"
 
 expectFetchRevisionDependencyCacheSuccess :: (Has MockApi sig m) => m ()
 expectFetchRevisionDependencyCacheSuccess =
-  (GetRevisionDependencyCacheStatus Fixtures.projectRevision)
+  (GetRevisionDependencyCacheStatus Fixtures.projectRevision LocatorTypeCustom)
     `returnsOnce` RevisionDependencyCache Ready
 
 expectGetOrganization :: Has MockApi sig m => m ()

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -58,6 +58,8 @@ module Test.Fixtures (
   policy,
   team,
   excludePath,
+  absFile,
+  absDir,
 )
 where
 
@@ -96,7 +98,18 @@ import Fossa.API.Types (
   Subscription (..),
  )
 import Fossa.API.Types qualified as API
-import Path (Abs, Dir, Path, Rel, mkAbsDir, mkRelDir, parseAbsDir, (</>))
+import Path (
+  Abs,
+  Dir,
+  File,
+  Path,
+  Rel,
+  mkAbsDir,
+  mkAbsFile,
+  mkRelDir,
+  parseAbsDir,
+  (</>),
+ )
 import Srclib.Types (LicenseScanType (..), LicenseSourceUnit (..), Locator (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (..), emptyLicenseUnit)
 import System.Directory (getTemporaryDirectory)
 import Text.RawString.QQ (r)
@@ -622,8 +635,13 @@ customFossaDepsFile = Nothing
 mavenScopeFilterSet :: MavenScopeFilters
 mavenScopeFilterSet = MavenScopeIncludeFilters mempty
 
+-- | Arbitrary absolute directory path for tests that require one.
 absDir :: Path Abs Dir
 absDir = $(mkAbsDir "/")
+
+-- | Arbitrary absolute file path for tests that require one.
+absFile :: Path Abs File
+absFile = $(mkAbsFile "/file.txt")
 
 standardAnalyzeConfig :: AnalyzeConfig
 standardAnalyzeConfig =

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -637,7 +637,7 @@ mavenScopeFilterSet = MavenScopeIncludeFilters mempty
 
 #ifdef mingw32_HOST_OS
 -- | Arbitrary absolute directory path for tests that require one.
- absDir :: Path Abs Dir
+absDir :: Path Abs Dir
 absDir = $(mkAbsDir "C:/")
 #else
 absDir :: Path Abs Dir

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -58,7 +58,8 @@ module Test.Fixtures (
   policy,
   team,
   excludePath,
-) where
+)
+where
 
 import App.Fossa.Config.Analyze (AnalysisTacticTypes (Any), AnalyzeConfig (AnalyzeConfig), ExperimentalAnalyzeConfig (..), GoDynamicTactic (..), IncludeAll (..), JsonOutput (JsonOutput), NoDiscoveryExclusion (..), ScanDestination (..), UnpackArchives (..), VSIModeOptions (..), VendoredDependencyOptions (..), WithoutDefaultFilters (..))
 import App.Fossa.Config.Analyze qualified as ANZ
@@ -88,7 +89,12 @@ import Discovery.Filters (
  )
 import Effect.Logger (Severity (..))
 import Fossa.API.CoreTypes qualified as CoreAPI
-import Fossa.API.Types (Archive (..))
+import Fossa.API.Types (
+  Archive (..),
+  OrgId (OrgId),
+  Organization (..),
+  Subscription (..),
+ )
 import Fossa.API.Types qualified as API
 import Path (Abs, Dir, Path, Rel, mkAbsDir, mkRelDir, parseAbsDir, (</>))
 import Srclib.Types (LicenseScanType (..), LicenseSourceUnit (..), Locator (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (..), emptyLicenseUnit)
@@ -106,13 +112,67 @@ apiOpts =
     }
 
 organization :: API.Organization
-organization = API.Organization (API.OrgId 42) True True True CLILicenseScan True True True False False False True [] False False API.Free
+organization =
+  Organization
+    { organizationId = (OrgId 42)
+    , orgUsesSAML = True
+    , orgCoreSupportsLocalLicenseScan = True
+    , orgSupportsAnalyzedRevisionsQuery = True
+    , orgDefaultVendoredDependencyScanType = CLILicenseScan
+    , orgSupportsIssueDiffs = True
+    , orgSupportsNativeContainerScan = True
+    , orgSupportsDependenciesCachePolling = True
+    , orgRequiresFullFileUploads = False
+    , orgDefaultsToFirstPartyScans = False
+    , orgSupportsPathDependencyScans = False
+    , orgSupportsFirstPartyScans = True
+    , orgCustomLicenseScanConfigs = []
+    , orgSupportsReachability = False
+    , orgSupportsPreflightChecks = False
+    , orgSubscription = Free
+    }
 
 organizationWithPreflightChecks :: API.Organization
-organizationWithPreflightChecks = API.Organization (API.OrgId 42) True True True CLILicenseScan True True True False False False True [] False True API.Free
+organizationWithPreflightChecks =
+  Organization
+    { organizationId = (OrgId 42)
+    , orgUsesSAML = True
+    , orgCoreSupportsLocalLicenseScan = True
+    , orgSupportsAnalyzedRevisionsQuery = True
+    , orgDefaultVendoredDependencyScanType = CLILicenseScan
+    , orgSupportsIssueDiffs = True
+    , orgSupportsNativeContainerScan = True
+    , orgSupportsDependenciesCachePolling = True
+    , orgRequiresFullFileUploads = False
+    , orgDefaultsToFirstPartyScans = False
+    , orgSupportsPathDependencyScans = False
+    , orgSupportsFirstPartyScans = True
+    , orgCustomLicenseScanConfigs = []
+    , orgSupportsReachability = False
+    , orgSupportsPreflightChecks = True
+    , orgSubscription = Free
+    }
 
 organizationWithPremiumSubscription :: API.Organization
-organizationWithPremiumSubscription = API.Organization (API.OrgId 42) True True True CLILicenseScan True True True False False False True [] False True API.Premium
+organizationWithPremiumSubscription =
+  Organization
+    { organizationId = (OrgId 42)
+    , orgUsesSAML = True
+    , orgCoreSupportsLocalLicenseScan = True
+    , orgSupportsAnalyzedRevisionsQuery = True
+    , orgDefaultVendoredDependencyScanType = CLILicenseScan
+    , orgSupportsIssueDiffs = True
+    , orgSupportsNativeContainerScan = True
+    , orgSupportsDependenciesCachePolling = True
+    , orgRequiresFullFileUploads = False
+    , orgDefaultsToFirstPartyScans = False
+    , orgSupportsPathDependencyScans = False
+    , orgSupportsFirstPartyScans = True
+    , orgCustomLicenseScanConfigs = []
+    , orgSupportsReachability = False
+    , orgSupportsPreflightChecks = True
+    , orgSubscription = Premium
+    }
 
 pushToken :: API.TokenTypeResponse
 pushToken = API.TokenTypeResponse API.Push
@@ -453,6 +513,7 @@ firstVendoredDep =
     (Just "0.0.1")
     Nothing
     []
+
 secondVendoredDep :: VendoredDependency
 secondVendoredDep =
   VendoredDependency
@@ -461,6 +522,7 @@ secondVendoredDep =
     (Just "0.0.1")
     Nothing
     []
+
 vendoredDeps :: NonEmpty VendoredDependency
 vendoredDeps = NE.fromList [firstVendoredDep, secondVendoredDep]
 
@@ -560,13 +622,8 @@ customFossaDepsFile = Nothing
 mavenScopeFilterSet :: MavenScopeFilters
 mavenScopeFilterSet = MavenScopeIncludeFilters mempty
 
-#ifdef mingw32_HOST_OS
-absDir :: Path Abs Dir
-absDir = $(mkAbsDir "C:/")
-#else
 absDir :: Path Abs Dir
 absDir = $(mkAbsDir "/")
-#endif
 
 standardAnalyzeConfig :: AnalyzeConfig
 standardAnalyzeConfig =

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -108,13 +108,14 @@ import Path (
   mkAbsFile,
   mkRelDir,
   parseAbsDir,
-  (</>),
+  (</>), parseAbsFile,
  )
 import Srclib.Types (LicenseScanType (..), LicenseSourceUnit (..), Locator (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (..), emptyLicenseUnit)
 import System.Directory (getTemporaryDirectory)
 import Text.RawString.QQ (r)
 import Text.URI.QQ (uri)
 import Types (ArchiveUploadType (..), GraphBreadth (..))
+import Data.Maybe (fromMaybe)
 
 apiOpts :: API.ApiOpts
 apiOpts =
@@ -637,11 +638,11 @@ mavenScopeFilterSet = MavenScopeIncludeFilters mempty
 
 -- | Arbitrary absolute directory path for tests that require one.
 absDir :: Path Abs Dir
-absDir = $(mkAbsDir "/")
+absDir = fromMaybe $(mkAbsDir "/") (Path.parseAbsDir "C:\\")
 
 -- | Arbitrary absolute file path for tests that require one.
 absFile :: Path Abs File
-absFile = $(mkAbsFile "/file.txt")
+absFile = fromMaybe $(mkAbsFile "/file.txt") (Path.parseAbsFile "C:\\file.txt")
 
 standardAnalyzeConfig :: AnalyzeConfig
 standardAnalyzeConfig =

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -105,17 +105,16 @@ import Path (
   Path,
   Rel,
   mkAbsDir,
-  mkAbsFile,
   mkRelDir,
+  mkRelFile,
   parseAbsDir,
-  (</>), parseAbsFile,
+  (</>),
  )
 import Srclib.Types (LicenseScanType (..), LicenseSourceUnit (..), Locator (..), SourceUnit (..), SourceUnitBuild (..), SourceUnitDependency (..), emptyLicenseUnit)
 import System.Directory (getTemporaryDirectory)
 import Text.RawString.QQ (r)
 import Text.URI.QQ (uri)
 import Types (ArchiveUploadType (..), GraphBreadth (..))
-import Data.Maybe (fromMaybe)
 
 apiOpts :: API.ApiOpts
 apiOpts =
@@ -636,13 +635,18 @@ customFossaDepsFile = Nothing
 mavenScopeFilterSet :: MavenScopeFilters
 mavenScopeFilterSet = MavenScopeIncludeFilters mempty
 
+#ifdef mingw32_HOST_OS
 -- | Arbitrary absolute directory path for tests that require one.
+ absDir :: Path Abs Dir
+absDir = $(mkAbsDir "C:/")
+#else
 absDir :: Path Abs Dir
-absDir = fromMaybe $(mkAbsDir "/") (Path.parseAbsDir "C:\\")
+absDir = $(mkAbsDir "/")
+#endif
 
 -- | Arbitrary absolute file path for tests that require one.
 absFile :: Path Abs File
-absFile = fromMaybe $(mkAbsFile "/file.txt") (Path.parseAbsFile "C:\\file.txt")
+absFile = absDir </> $(Path.mkRelFile "file.txt")
 
 standardAnalyzeConfig :: AnalyzeConfig
 standardAnalyzeConfig =


### PR DESCRIPTION
# Overview

This PR makes it possible to download attribution reports for SBOM-based projects from FOSSA.

## Acceptance criteria

* If a file is given to `fossa report attribution` the CLI downloads an SBOM attribution report.
* If a project and version are given using `--project` and `--version` the CLI will try to fetch both `custom+` attribution reports and fall back to `sbom+` attribution reports.
* If a project directory is given, the CLI tries to download a report for a `custom+` project.

## Testing plan

I copied the existing tests and tried made them work with both types of target. For the actual user interactions, I tested by analyzing using `fossa sbom analyze <sbom>` and then `fossa report attribution --format json <sbom>`. 

```
fossa sbom analyze --revision 1 sbomfile.txt
fossa report attribution --format json sbomfile.txt
fossa sbom analyze --project sbomfile.txt --revision 1
```

I also tested the same sequence, but with `fossa analyze <dir>`, and tested downloading an SBOM using `--project...`

If you try to fetch a non-existent project you get an error that indicates the CLI tried to download both forms and failed:

![Screenshot 2025-04-18 at 3 28 20 PM](https://github.com/user-attachments/assets/e3c3a29b-ea97-4ea1-a53f-dad7fe01c6cd)

## Risks

None.


## References

- [ANE-2277](https://fossa.atlassian.net/browse/ANE-2277)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2277]: https://fossa.atlassian.net/browse/ANE-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ