### PR TITLE
Fix "Default Filters" link

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## 3.10.13
 
 - Updates the `fossa test` output to include severity data on supported FOSSA instances ([#1562](https://github.com/fossas/fossa-cli/pull/1562))
 

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -39,7 +39,7 @@ The paths and targets filtering options allow you to specify the exact targets w
 | `--exclude-path`                 | Exclude these paths from scannig. See [paths.exclude](../files/fossa-yml.md#paths.exclude) in the fossa.yml spec.        |
 | `--include-unused-deps`          | Include all deps found, instead of filtering non-production deps.  Ignored by VSI.                                       |
 | `--debug-no-discovery-exclusion` | Ignore these filters during discovery phase.  This flag is for debugging only and may be removed without warning.        |
-| `--without-default-filters`      | Ignore default path filters. See [default path filters](./analyze.md#what-are-the-default-path-filters)                  |
+| `--without-default-filters`      | Ignore default path filters. See [default path filters](./analyze.md#what-are-the-default-filters)                       |
 
 
 ### Printing results without uploading to FOSSA
@@ -178,7 +178,7 @@ Note that the `MY_RG` release group must already exist, as well as `MY_RELEASE_V
 `fossa-cli` skips analysis, if and only if
 
 - (a) Target is excluded via [fossa configuration file](https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md#analysis-target-configuration) (this filtering is referred to as "exclusion filters").
-- (b) Target is excluded via [default path filters](./analyze.md#what-are-the-default-path-filters) (this filtering was previously referred to as "production path filtering").
+- (b) Target is excluded via [default path filters](./analyze.md#what-are-the-default-filters) (this filtering was previously referred to as "production path filtering").
 
 #### What are the default filters?
 


### PR DESCRIPTION
# Overview

Fixes a broken link, Docs-only change.

## Acceptance criteria

The user is directed to the appropriate section

## Testing plan

I clicked the link to verify it was correct.
- https://github.com/fossas/fossa-cli/blob/fix-broken-default-filter-link/docs/references/subcommands/analyze.md#filtering-paths-and-targets
- https://github.com/fossas/fossa-cli/blob/fix-broken-default-filter-link/docs/references/subcommands/analyze.md#why-is-the-fossa-cli-skipping-my-project

## Risks

Low risk, link was broken. Docs-only change.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
