### PR TITLE
[No Ticket] Tee output

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.10.9
+
+- CLI Args: Add a `--tee-output` argument to allow uploading results and also printing them to stdout.([#1546](https://github.com/fossas/fossa-cli/pull/1546))
+
 ## 3.10.8
 
 - Custom license scans: Apply `licenseScanPathFilters` to custom license scans ([#1535](https://github.com/fossas/fossa-cli/pull/1535)).

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -42,12 +42,18 @@ The paths and targets filtering options allow you to specify the exact targets w
 | `--without-default-filters`      | Ignore default path filters. See [default path filters](./analyze.md#what-are-the-default-path-filters)                  |
 
 
-### Printing results without uploading to FOSSA
+### Printing FOSSA results
 
 The `--output` flag can be used to print projects and dependency graph information to stdout, rather than uploading to FOSSA
 
 ```sh
 fossa analyze --output
+```
+
+To print projects and dependency graph information to stdout *in addition* to uploading to FOSSA as normal, use the `--tee-output` flag.
+
+```sh
+fossa analyze --tee-output
 ```
 
 ### Printing project metadata

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -137,6 +137,8 @@ import Prettyprinter.Render.Terminal (
 import Srclib.Converter qualified as Srclib
 import Srclib.Types (LicenseSourceUnit (..), Locator, SourceUnit, sourceUnitToFullSourceUnit)
 import Types (DiscoveredProject (..), FoundTargets)
+import App.Fossa.Config.Common (destinationMetadata, DestinationMeta (..), destinationApiOpts)
+import Data.Traversable (for)
 
 debugBundlePath :: FilePath
 debugBundlePath = "fossa.debug.json.gz"
@@ -278,9 +280,8 @@ analyze ::
 analyze cfg = Diag.context "fossa-analyze" $ do
   capabilities <- sendIO getNumCapabilities
 
-  let maybeApiOpts = case destination of
-        OutputStdout -> Nothing
-        UploadScan opts _ -> Just opts
+  let maybeDestMeta = destinationMetadata destination
+      maybeApiOpts = destinationApiOpts <$> maybeDestMeta
       BaseDir basedir = Config.baseDir cfg
       destination = Config.scanDestination cfg
       filters = Config.filterSet cfg
@@ -305,10 +306,12 @@ analyze cfg = Diag.context "fossa-analyze" $ do
           pure Nothing
         else Diag.context "fossa-deps" . runStickyLogger SevInfo $ analyzeFossaDepsFile basedir customFossaDepsFile maybeApiOpts vendoredDepsOptions
 
-  orgInfo <- case destination of
-    OutputStdout -> pure Nothing
-    UploadScan apiOpts metadata ->
-      fmap Just . runFossaApiClient apiOpts . preflightChecks $ AnalyzeChecks revision metadata
+  orgInfo <- for maybeDestMeta (\(DestinationMeta (apiOpts, metadata)) -> runFossaApiClient apiOpts . preflightChecks $ AnalyzeChecks revision metadata)
+
+    -- case destination of
+    -- OutputStdout -> pure Nothing
+    -- UploadScan apiOpts metadata ->
+    --   fmap Just . runFossaApiClient apiOpts . preflightChecks $ AnalyzeChecks revision metadata
 
   -- additional source units are built outside the standard strategy flow, because they either
   -- require additional information (eg API credentials), or they return additional information (eg user deps).
@@ -387,21 +390,20 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   let filteredProjects = mapMaybe toProjectResult projectScans
   logDebug $ "Filtered project scans: " <> pretty (show filteredProjects)
 
-  maybeEndpointAppVersion <- case destination of
-    UploadScan apiOpts _ -> runFossaApiClient apiOpts $ do
-      -- Using 'recovery' as API corresponding to 'getEndpointVersion',
-      -- seems to be not stable and we sometimes see TimeoutError in telemetry
-      version <- recover getEndpointVersion
-      debugMetadata "FossaEndpointCoreVersion" version
-      pure version
-    _ -> pure Nothing
+  maybeEndpointAppVersion <- fmap join . for maybeApiOpts $
+     \apiOpts -> runFossaApiClient apiOpts $ do
+          -- Using 'recovery' as API corresponding to 'getEndpointVersion',
+          -- seems to be not stable and we sometimes see TimeoutError in telemetry
+          version <- recover getEndpointVersion
+          debugMetadata "FossaEndpointCoreVersion" version
+          pure version
 
   -- In our graph, we may have unresolved path dependencies
   -- If we are in output mode, do nothing. If we are in upload mode
   -- license scan all path dependencies, and upload findings to Endpoint,
   -- and queue a build for all path+ dependencies
-  filteredProjects' <- case (shouldAnalyzePathDependencies, destination) of
-    (True, UploadScan apiOpts _) ->
+  filteredProjects' <- case (shouldAnalyzePathDependencies, destinationMetadata destination) of
+    (True, Just (DestinationMeta (apiOpts, _))) ->
       Diag.context "path-dependencies"
         . runFossaApiClient apiOpts
         $ runStickyLogger SevInfo
@@ -440,19 +442,23 @@ analyze cfg = Diag.context "fossa-analyze" $ do
       (False, FilteredAll) -> Diag.warn ErrFilteredAllProjects $> emptyScanUnits
       (True, FilteredAll) -> Diag.warn ErrOnlyKeywordSearchResultsFound $> emptyScanUnits
       (_, CountedScanUnits scanUnits) -> pure scanUnits
-  doUpload outputResult iatAssertion destination basedir jsonOutput revision scanUnits reachabilityUnits
+  sendToDestination outputResult iatAssertion destination basedir jsonOutput revision scanUnits reachabilityUnits
 
   pure outputResult
   where
-    doUpload result iatAssertion destination basedir jsonOutput revision scanUnits reachabilityUnits =
-      case destination of
-        OutputStdout -> logStdout . decodeUtf8 $ Aeson.encode result
-        UploadScan apiOpts metadata ->
-          Diag.context "upload-results"
+    sendToDestination result iatAssertion destination basedir jsonOutput revision scanUnits reachabilityUnits =
+      let doUpload (DestinationMeta (apiOpts, metadata))=
+            Diag.context "upload-results"
             . runFossaApiClient apiOpts
             $ do
-              locator <- uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnits reachabilityUnits
-              doAssertRevisionBinaries iatAssertion locator
+            locator <- uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnits reachabilityUnits
+            doAssertRevisionBinaries iatAssertion locator
+      in
+        case destination of
+          OutputStdout -> logStdout . decodeUtf8 $ Aeson.encode result
+          UploadScan meta -> doUpload meta
+          OutputAndUpload meta -> do logStdout . decodeUtf8 $ Aeson.encode result
+                                     doUpload meta
 
     emptyScanUnits :: ScanUnits
     emptyScanUnits = SourceUnitOnly []

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -50,7 +50,7 @@ import App.Fossa.Config.Common (
   targetOpt,
   validateDir,
   validateExists,
-  validateFile, DestinationMeta (..),
+  validateFile, DestinationMeta (..), OutputStyle (..), outputStyleArgs,
  )
 import App.Fossa.Config.ConfigFile (
   ConfigFile (..),
@@ -121,7 +121,7 @@ import Options.Applicative (
   short,
   strOption,
   switch,
-  (<|>), flag', flag,
+  (<|>),
  )
 import Path (Abs, Dir, File, Path, Rel)
 import Path.Extra (SomePath)
@@ -198,16 +198,6 @@ data VendoredDependencyOptions = VendoredDependencyOptions
 
 instance ToJSON VendoredDependencyOptions where
   toEncoding = genericToEncoding defaultOptions
-
--- | What to do with analysis results.
-data OutputStyle =
-  -- | Upload results
-  Default
-  -- | Output results to stdout, but do not upload
-  | Output
-  -- | Upload results as with `Upload`, but also output them to stdout as with `Output`
-  | TeeOutput
-  deriving (Ord, Eq, Show)
 
 data AnalyzeCliOpts = AnalyzeCliOpts
   { commons :: CommonOpts
@@ -319,7 +309,7 @@ cliParser :: Parser AnalyzeCliOpts
 cliParser =
   AnalyzeCliOpts
     <$> commonOpts
-    <*> outputKind
+    <*> outputStyleArgs
     <*> flagOpt UnpackArchives (applyFossaStyle <> long "unpack-archives" <> stringToHelpDoc "Recursively unpack and analyze discovered archives")
     <*> flagOpt JsonOutput (applyFossaStyle <> long "json" <> stringToHelpDoc "Output project metadata as JSON to the console. This is useful for communicating with the FOSSA API.")
     <*> flagOpt IncludeAll (applyFossaStyle <> long "include-unused-deps" <> stringToHelpDoc "Include all deps found, instead of filtering non-production deps. Ignored by VSI.")
@@ -357,10 +347,6 @@ cliParser =
           [ "Path to fossa-deps file including filename"
           , boldItalicized "Default:" <> " fossa-deps.{yaml|yml|json}"
           ]
-
-    outputKind :: Parser OutputStyle
-    outputKind = flag' Output (applyFossaStyle <> long "output" <> short 'o' <> stringToHelpDoc "Output results to stdout instead of uploading to FOSSA")
-                 <|> flag Default TeeOutput (applyFossaStyle <> long "tee-output" <> stringToHelpDoc "Like --output, but upload in addition to outputting to stdout.")
 
 branchHelp :: Maybe (Doc AnsiStyle)
 branchHelp =

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -36,6 +36,8 @@ import App.Docs (fossaAnalyzeDefaultFilterDocUrl)
 import App.Fossa.Config.Common (
   CacheAction (WriteOnly),
   CommonOpts (..),
+  DestinationMeta (..),
+  OutputStyle (..),
   ScanDestination (..),
   applyReleaseGroupDeprecationWarning,
   baseDirArg,
@@ -46,11 +48,12 @@ import App.Fossa.Config.Common (
   collectRevisionData',
   commonOpts,
   metadataOpts,
+  outputStyleArgs,
   pathOpt,
   targetOpt,
   validateDir,
   validateExists,
-  validateFile, DestinationMeta (..), OutputStyle (..), outputStyleArgs,
+  validateFile,
  )
 import App.Fossa.Config.ConfigFile (
   ConfigFile (..),
@@ -647,12 +650,13 @@ collectScanDestination maybeCfgFile envvars AnalyzeCliOpts{..} =
     Output -> pure OutputStdout
     TeeOutput -> getScanUploadDest OutputAndUpload
     Default -> getScanUploadDest UploadScan
-  where getScanUploadDest constructor = do
-          apiOpts <- collectApiOpts maybeCfgFile envvars commons
-          metaMerged <- maybe (pure analyzeMetadata) (mergeFileCmdMetadata analyzeMetadata) (maybeCfgFile)
-          void $ applyReleaseGroupDeprecationWarning metaMerged
-          when (length (projectLabel metaMerged) > 5) $ fatalText "Projects are only allowed to have 5 associated project labels"
-          pure $ constructor (DestinationMeta (apiOpts, metaMerged))
+  where
+    getScanUploadDest constructor = do
+      apiOpts <- collectApiOpts maybeCfgFile envvars commons
+      metaMerged <- maybe (pure analyzeMetadata) (mergeFileCmdMetadata analyzeMetadata) (maybeCfgFile)
+      void $ applyReleaseGroupDeprecationWarning metaMerged
+      when (length (projectLabel metaMerged) > 5) $ fatalText "Projects are only allowed to have 5 associated project labels"
+      pure $ constructor (DestinationMeta (apiOpts, metaMerged))
 
 collectVsiModeOptions ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -35,9 +35,11 @@ module App.Fossa.Config.Common (
 
   -- * Configuration Types
   ScanDestination (..),
+  OutputStyle(..),
   DestinationMeta (..),
   destinationMetadata,
   destinationApiOpts,
+  outputStyleArgs,
 
   -- * Global Defaults
   defaultTimeoutDuration,
@@ -140,7 +142,7 @@ import Options.Applicative (
   strOption,
   switch,
   value,
-  (<|>),
+  (<|>), flag', flag,
  )
 import Options.Applicative.Builder (helpDoc)
 import Options.Applicative.Help (AnsiStyle)
@@ -162,6 +164,23 @@ destinationApiOpts (DestinationMeta m) = fst m
 
 instance ToJSON DestinationMeta where
   toEncoding = genericToEncoding defaultOptions
+
+-- | CLI options describing what to do with analysis results.
+data OutputStyle =
+  -- | Upload results
+  Default
+  -- | Output results to stdout, but do not upload
+  | Output
+  -- | Upload results as with `Upload`, but also output them to stdout as with `Output`
+  | TeeOutput
+  deriving (Ord, Eq, Show)
+
+outputStyleArgs :: Parser OutputStyle
+outputStyleArgs =
+  flag' Output (applyFossaStyle <> long "output" <> short 'o' <> stringToHelpDoc "Output results to stdout instead of uploading to FOSSA")
+  <|> flag Default TeeOutput (applyFossaStyle <> long "tee-output" <> stringToHelpDoc "Like --output, but upload in addition to outputting to stdout.")
+
+
 
 data ScanDestination
   = -- | upload to fossa with provided api key and base url

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -35,6 +35,9 @@ module App.Fossa.Config.Common (
 
   -- * Configuration Types
   ScanDestination (..),
+  DestinationMeta (..),
+  destinationMetadata,
+  destinationApiOpts,
 
   -- * Global Defaults
   defaultTimeoutDuration,
@@ -151,11 +154,26 @@ import Text.Megaparsec (errorBundlePretty, runParser)
 import Text.URI (URI, mkURI)
 import Types (TargetFilter)
 
+newtype DestinationMeta = DestinationMeta (ApiOpts, ProjectMetadata)
+  deriving (Eq, Ord, Show, Generic)
+
+destinationApiOpts :: DestinationMeta -> ApiOpts
+destinationApiOpts (DestinationMeta m) = fst m
+
+instance ToJSON DestinationMeta where
+  toEncoding = genericToEncoding defaultOptions
+
 data ScanDestination
   = -- | upload to fossa with provided api key and base url
-    UploadScan ApiOpts ProjectMetadata
+    UploadScan DestinationMeta
+  | OutputAndUpload DestinationMeta
   | OutputStdout
   deriving (Eq, Ord, Show, Generic)
+
+destinationMetadata :: ScanDestination -> Maybe DestinationMeta
+destinationMetadata (UploadScan meta) = Just meta
+destinationMetadata (OutputAndUpload meta) = Just meta
+destinationMetadata _ = Nothing
 
 instance ToJSON ScanDestination where
   toEncoding = genericToEncoding defaultOptions

--- a/src/App/Fossa/Config/Common.hs
+++ b/src/App/Fossa/Config/Common.hs
@@ -35,7 +35,7 @@ module App.Fossa.Config.Common (
 
   -- * Configuration Types
   ScanDestination (..),
-  OutputStyle(..),
+  OutputStyle (..),
   DestinationMeta (..),
   destinationMetadata,
   destinationApiOpts,
@@ -132,6 +132,8 @@ import Options.Applicative (
   argument,
   auto,
   eitherReader,
+  flag,
+  flag',
   long,
   metavar,
   option,
@@ -142,7 +144,7 @@ import Options.Applicative (
   strOption,
   switch,
   value,
-  (<|>), flag', flag,
+  (<|>),
  )
 import Options.Applicative.Builder (helpDoc)
 import Options.Applicative.Help (AnsiStyle)
@@ -166,21 +168,19 @@ instance ToJSON DestinationMeta where
   toEncoding = genericToEncoding defaultOptions
 
 -- | CLI options describing what to do with analysis results.
-data OutputStyle =
-  -- | Upload results
-  Default
-  -- | Output results to stdout, but do not upload
-  | Output
-  -- | Upload results as with `Upload`, but also output them to stdout as with `Output`
-  | TeeOutput
+data OutputStyle
+  = -- | Upload results
+    Default
+  | -- | Output results to stdout, but do not upload
+    Output
+  | -- | Upload results as with `Upload`, but also output them to stdout as with `Output`
+    TeeOutput
   deriving (Ord, Eq, Show)
 
 outputStyleArgs :: Parser OutputStyle
 outputStyleArgs =
   flag' Output (applyFossaStyle <> long "output" <> short 'o' <> stringToHelpDoc "Output results to stdout instead of uploading to FOSSA")
-  <|> flag Default TeeOutput (applyFossaStyle <> long "tee-output" <> stringToHelpDoc "Like --output, but upload in addition to outputting to stdout.")
-
-
+    <|> flag Default TeeOutput (applyFossaStyle <> long "tee-output" <> stringToHelpDoc "Like --output, but upload in addition to outputting to stdout.")
 
 data ScanDestination
   = -- | upload to fossa with provided api key and base url

--- a/src/App/Fossa/Config/Container/Analyze.hs
+++ b/src/App/Fossa/Config/Container/Analyze.hs
@@ -14,13 +14,16 @@ import App.Docs (fossaContainerAnalyzeDefaultFilterDocUrl)
 import App.Fossa.Config.Analyze (WithoutDefaultFilters, branchHelp, withoutDefaultFilterParser)
 import App.Fossa.Config.Common (
   CommonOpts (CommonOpts, optDebug, optProjectName, optProjectRevision),
+  DestinationMeta (..),
+  OutputStyle (..),
   ScanDestination (..),
   collectAPIMetadata,
   collectApiOpts,
   collectConfigFileFilters,
   collectRevisionOverride,
   commonOpts,
-  metadataOpts, DestinationMeta (..), outputStyleArgs, OutputStyle (..),
+  metadataOpts,
+  outputStyleArgs,
  )
 import App.Fossa.Config.ConfigFile
 import App.Fossa.Config.Container.Common (
@@ -170,11 +173,12 @@ collectScanDestination maybeCfgFile envvars ContainerAnalyzeOptions{..} =
   case containerOutputStyle of
     Output -> pure OutputStdout
     TeeOutput -> getScanUploadDest OutputAndUpload
-    Default ->  getScanUploadDest UploadScan
-  where getScanUploadDest constructor = do
-          apiOpts <- collectApiOpts maybeCfgFile envvars analyzeCommons
-          metaMerged <- collectAPIMetadata maybeCfgFile containerMetadata
-          pure $ constructor (DestinationMeta (apiOpts, metaMerged))
+    Default -> getScanUploadDest UploadScan
+  where
+    getScanUploadDest constructor = do
+      apiOpts <- collectApiOpts maybeCfgFile envvars analyzeCommons
+      metaMerged <- collectAPIMetadata maybeCfgFile containerMetadata
+      pure $ constructor (DestinationMeta (apiOpts, metaMerged))
 
 collectFilters :: Maybe ConfigFile -> AllFilters
 collectFilters maybeConfig = do

--- a/src/App/Fossa/Config/Container/Analyze.hs
+++ b/src/App/Fossa/Config/Container/Analyze.hs
@@ -20,7 +20,7 @@ import App.Fossa.Config.Common (
   collectConfigFileFilters,
   collectRevisionOverride,
   commonOpts,
-  metadataOpts,
+  metadataOpts, DestinationMeta (..),
  )
 import App.Fossa.Config.ConfigFile
 import App.Fossa.Config.Container.Common (
@@ -178,7 +178,7 @@ collectScanDestination maybeCfgFile envvars ContainerAnalyzeOptions{..} =
     else do
       apiOpts <- collectApiOpts maybeCfgFile envvars analyzeCommons
       metaMerged <- collectAPIMetadata maybeCfgFile containerMetadata
-      pure $ UploadScan apiOpts metaMerged
+      pure $ UploadScan (DestinationMeta (apiOpts, metaMerged))
 
 collectFilters :: Maybe ConfigFile -> AllFilters
 collectFilters maybeConfig = do

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -10,8 +10,9 @@ import App.Fossa.API.BuildLink (getFossaBuildUrl)
 import App.Fossa.Analyze.Debug (collectDebugBundle)
 import App.Fossa.Analyze.Upload (emitBuildWarnings)
 import App.Fossa.Config.Common (
+  DestinationMeta (..),
   ScanDestination (..),
-  applyReleaseGroupDeprecationWarning, DestinationMeta (..),
+  applyReleaseGroupDeprecationWarning,
  )
 import App.Fossa.Config.Container.Analyze (
   ContainerAnalyzeConfig (..),

--- a/src/App/Fossa/Container/AnalyzeNative.hs
+++ b/src/App/Fossa/Container/AnalyzeNative.hs
@@ -10,8 +10,8 @@ import App.Fossa.API.BuildLink (getFossaBuildUrl)
 import App.Fossa.Analyze.Debug (collectDebugBundle)
 import App.Fossa.Analyze.Upload (emitBuildWarnings)
 import App.Fossa.Config.Common (
-  ScanDestination (OutputStdout, UploadScan),
-  applyReleaseGroupDeprecationWarning,
+  ScanDestination (..),
+  applyReleaseGroupDeprecationWarning, DestinationMeta (..),
  )
 import App.Fossa.Config.Container.Analyze (
   ContainerAnalyzeConfig (..),
@@ -114,14 +114,19 @@ analyze cfg = do
         let branchText = fromMaybe "No branch (detached HEAD)" $ projectBranch revision
         logInfo ("Using branch: `" <> pretty branchText <> "`")
 
+  let doUpload apiOpts projectMetadata = runFossaApiClient apiOpts $ do
+        orgInfo <- preflightChecks $ AnalyzeChecks revision projectMetadata
+        logProjectInfo
+        void $ uploadScan orgInfo revision projectMetadata (jsonOutput cfg) scannedImage
+
+  let scannedImageToStdout = do
+        logProjectInfo
+        logStdout . decodeUtf8 $ Aeson.encode scannedImage
+
   case scanDestination cfg of
-    OutputStdout -> do
-      logProjectInfo
-      logStdout . decodeUtf8 $ Aeson.encode scannedImage
-    UploadScan apiOpts projectMetadata -> runFossaApiClient apiOpts $ do
-      orgInfo <- preflightChecks $ AnalyzeChecks revision projectMetadata
-      logProjectInfo
-      void $ uploadScan orgInfo revision projectMetadata (jsonOutput cfg) scannedImage
+    OutputStdout -> scannedImageToStdout
+    UploadScan (DestinationMeta (apiOpts, projectMetadata)) -> doUpload apiOpts projectMetadata
+    OutputAndUpload (DestinationMeta (apiOpts, projectMetadata)) -> scannedImageToStdout >> doUpload apiOpts projectMetadata
 
   pure scannedImage
 


### PR DESCRIPTION
# Overview

In some contexts it may be good for a customer to be able to see the actual output of fossa during a CI run, but also upload it as normal. The current ways we have to handle this that I can think of are inelegant:

1. Run `fossa analyze` twice, once with the `-o` flag and once without. 
2. Run `fossa analyze -o` once, and then script the upload to FOSSA as a second step.
2. Run `fossa analyze --debug` and extract the output from the debug bundle.

This PR adds a `--tee-output` flag to `fossa analyze` and `fossa container analyze` which uploads results while also printing them to stdout like `--output`.

## Acceptance criteria

* The `-o` flag (or its absence) works like it did before for `fossa analyze` and `fossa container analyze`.
* The `--tee-output` outputs the same thing as `-o` but otherwise does everything _not_ having the `-o` option would do.
* It shows up nice in the help.

## Testing plan

I am relying on manual tests. I ran:

```
fossa analyze -o
```

```
fossa analyze --tee-output
```

```
fossa analyze
```

and verified that each one either uploaded results or did not as appropriate and also output the text as appropriate.

I repeated the process for `fossa container analyze`.

`--help` text:

![Screenshot 2025-05-16 at 1 01 17 AM](https://github.com/user-attachments/assets/268e4780-5977-43b4-bd99-dbf98644ced4)

![Screenshot 2025-05-16 at 1 01 05 AM](https://github.com/user-attachments/assets/94a6b8c0-a43e-448e-a566-e87fbaf7753f)

![Screenshot 2025-05-16 at 1 10 54 AM](https://github.com/user-attachments/assets/9c7dca96-cb5a-46e0-915e-d9723b618331)


## Risks

None. Perhaps this makes customers more likely to script about this output, but we already crossed that bridge with `--output` imo. 

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
