### PR TITLE
Updating documentation for SBOM commands to be clearer

### DIFF
--- a/docs/references/subcommands/sbom.md
+++ b/docs/references/subcommands/sbom.md
@@ -37,8 +37,18 @@ When using `fossa sbom analyze`, the command respects team-scoped permissions:
 
 The `sbom test` command checks whether the most-recent scan of your FOSSA project raised license-policy or vulnerability issues. This command is usually run immediately after `fossa sbom analyze`.
 
+While `fossa sbom analyze` uploads and processes an SBOM file, `fossa sbom test` verifies the analysis results against your organization's license and security policies. The key differences:
+
+- `sbom analyze` - Uploads and scans an SBOM file, creating a build in FOSSA
+- `sbom test` - Checks if that scan found any policy violations or security issues
+
+The test command has the following behavior:
 - If there are issues, it prints them to stderr and fails with an exit code of 1
 - If there are no issues, it prints nothing and succeeds with an exit code of 0
+
+These commands are typically used together in a workflow:
+1. Run `fossa sbom analyze` to upload and analyze your SBOM
+2. Run `fossa sbom test` to verify the analysis against your organization's policies
 
 `fossa sbom test` supports the [Common FOSSA Project Flags](./analyze.md#common-fossa-project-flags).
 

--- a/src/App/Fossa/Config/SBOM/Analyze.hs
+++ b/src/App/Fossa/Config/SBOM/Analyze.hs
@@ -82,7 +82,7 @@ subcommand f =
   command
     "analyze"
     ( info (f <$> cliParser) $
-        progDescDoc (formatStringToDoc "Scan an SBOM file")
+        progDescDoc (formatStringToDoc "Upload and analyze an SBOM file in FOSSA")
     )
 
 data ForceRescan = ForceRescan deriving (Generic)

--- a/src/App/Fossa/Config/SBOM/Test.hs
+++ b/src/App/Fossa/Config/SBOM/Test.hs
@@ -113,7 +113,7 @@ subcommand f =
   command
     "test"
     ( info (f <$> parser) $
-        progDescDoc (formatStringToDoc "Scan an SBOM file")
+        progDescDoc (formatStringToDoc "Check for policy violations in a previously analyzed SBOM")
     )
 
 instance GetCommonOpts SBOMTestOptions where


### PR DESCRIPTION
### Overview
This PR clarifies the command descriptions for the fossa sbom analyze and fossa sbom test commands. Previously, both commands displayed the same description ("Scan an SBOM file") in the CLI help, which was confusing since they serve different purposes. 

This PR updates the descriptions to accurately reflect each command's functionality.

### Acceptance criteria
When users run `fossa sbom -h`, they will see clear and distinct descriptions for each subcommand:
- `analyze` will be described as "Upload and analyze an SBOM file in FOSSA"
- `test` will be described as "Check for policy violations in a previously analyzed SBOM"

### Testing plan
1. Build the CLI with the updated changes
2. Run `fossa sbom -h` and verify the updated descriptions appear in the help text
3. Ensure the commands still function as expected by:
- Running fossa sbom analyze <sbom-file> and confirming it uploads to FOSSA
- Running fossa sbom test <sbom-file> and confirming it checks for policy violations

### Risks
Low risk change as this only affects help text display and not command functionality.

### Metrics
Not applicable for a documentation-only change.

### References
User feedback indicating confusion about the purpose of these commands

### Checklist
[ ] I added tests for this PR's change (not needed for documentation-only change).
[x] If this PR introduced a user-visible change, I added documentation into docs/.
[ ] If this PR added docs, I added links as appropriate to the user manual's ToC in docs/README.ms and gave consideration to how discoverable or not my documentation is.
[ ] If this change is externally visible, I updated Changelog.md. If this PR did not mark a release, I added my changes into an ## Unreleased section at the top.
[ ] If I made changes to .fossa.yml or fossa-deps.{json.yml}, I updated docs/references/files/*.schema.json AND I have updated example files used by fossa init command.
[x] If I made changes to a subcommand's options, I updated docs/references/subcommands/<subcommand>.md.