### PR TITLE
[TKT-13372] Fix syntax error in Maven documentation

### DIFF
--- a/docs/references/strategies/languages/maven/maven.md
+++ b/docs/references/strategies/languages/maven/maven.md
@@ -39,7 +39,8 @@ Not directly, but `mvn` itself has an [environment variable](https://maven.apach
 For example, to set a custom `settings.xml` file you can use an invocation like this:
 
 ```sh
-export MAVEN_ARGS="--settings /foo/bar/settings.xml" fossa analyze
+export MAVEN_ARGS="--settings /foo/bar/settings.xml"
+fossa analyze
 ```
 
 ## Filtering by Maven Dependency Scope 


### PR DESCRIPTION
# Overview

Fixes a bash syntax error in the Maven documentation where `fossa analyze` was incorrectly on the same line as the `export` statement.

## Acceptance criteria

Users can now copy and execute the Maven MAVEN_ARGS example without syntax errors.

## Testing plan

1. Found the syntax error on line 42 of `docs/references/strategies/languages/maven/maven.md`
2. Split the export and command onto separate lines
3. Verified correct bash syntax

## Risks

None - minor documentation fix only.

## References

- TKT-13372: Customer reported syntax error in Maven documentation