### PR TITLE
Improve Link Checking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check Markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@v1.1.0
         with:
           use-quiet-mode: "yes"
           config-file: ".markdown-link-check.json"

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 ![FOSSA](https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/assets/header.png)
 
 # FOSSA CLI
-<!-- markdown-link-check-disable -->
 <!-- NOTE: If you change the format of the "FOSSA Downloads" badge, make sure to also update the CI action at `./github/workflows/badges.yml` that updates the download count. -->
+<!-- markdown-link-check-disable-next-line -->
 [![FOSSA Downloads](https://img.shields.io/badge/downloads-5.8M-brightgreen)](https://github.com/fossas/fossa-cli/releases)
+<!-- markdown-link-check-disable-next-line -->
 [![Build](https://img.shields.io/github/actions/workflow/status/fossas/fossa-cli/build.yml)](https://github.com/fossas/fossa-cli/actions/workflows/build.yml)
+<!-- markdown-link-check-disable-next-line -->
 [![Dependency scan](https://img.shields.io/github/actions/workflow/status/fossas/fossa-cli/dependency-scan.yml?label=dependency%20scan)](https://github.com/fossas/fossa-cli/actions/workflows/dependency-scan.yml)
+<!-- markdown-link-check-disable-next-line -->
 [![FOSSA Security Status](https://app.fossa.com/api/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli.svg?type=shield&issueType=security)](https://app.fossa.com/projects/custom%2B1%2Fgit%40github.com%3Afossas%2Ffossa-cli?ref=badge_shield)
-
+<!-- markdown-link-check-disable-next-line -->
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli.svg?type=large&issueType=license)](https://app.fossa.com/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli?ref=badge_large&issueType=license)
-<!-- markdown-link-check-enable-->
 
 `fossa-cli` is a zero-configuration polyglot dependency analysis tool. You can point fossa CLI at any codebase or build, and it will automatically detect dependencies being used by your project.
 

--- a/docs/contributing/HACKING.md
+++ b/docs/contributing/HACKING.md
@@ -200,11 +200,9 @@ Yes.  Missing language extensions are usually compile-time errors, and will be c
 If, for any reason, GHC tells you add an extension, and hlint tells you to remove the extension you just added, keep it there and ignore hlint.  You should also file
 an issue in this repository for that scenario, since we may be able to fix that.
 
-<!-- markdown-link-check-disable -->
 [fourmolu]: https://github.com/fourmolu/fourmolu
 [ghcup]: https://www.haskell.org/ghcup
 [hackage]: https://hackage.haskell.org/
 [hlint]: https://github.com/ndmitchell/hlint
 [hls]: https://github.com/haskell/haskell-language-server
 [hoogle]: https://hoogle.haskell.org/
-<!-- markdown-link-check-enable-->

--- a/docs/differences-from-v1.md
+++ b/docs/differences-from-v1.md
@@ -133,7 +133,7 @@ Following CLI commands are not supported with 3.x:
    - `$FOSSA_GRADLE_COMMAND` environment variable cannot be configured. 3.x uses Gradle executable in `$PATH`.
 - Refer to [FOSSA 3.x gradle docs](references/strategies/languages/gradle/gradle.md) for more information for gradle.
 
-#### Clojure 
+#### Clojure
 - 3.x performs the `lein deps :tree` strategy by default. 
 - 3.x does not support any options - `strategy`, and `lien` for Clojure analysis.
 - Refer to [FOSSA 3.x clojure docs](references/strategies/languages/clojure/clojure.md) for more information on how 3.x performs analysis for clojure.
@@ -143,7 +143,7 @@ Following CLI commands are not supported with 3.x:
 - 3.x does not support following options: `tags`, `all-tags,` `strategy`, `lockfile`, `manifest`, `modules-vendor`, `allow-unresolved`, `allow-unresolved-prefix`, `allow-nested-vendor`, `allow-deep-vendor`, `allow-external-vendor`, `allow-external-vendor-prefix`.
 - Refer to [FOSSA 3.x Go docs](references/strategies/languages/golang/golang.md) for more information on how 3.x performs analysis for Go.
 
-#### Haskell 
+#### Haskell
 - 3.x will apply stack strategy when a project is discovered having stack.yaml file
 - 3.x will apply cabal-install strategy for projects using cabal.project or file with .cabal extension
 - 3.x does not support `strategy` option for Haskell analysis
@@ -242,7 +242,7 @@ If you run into poor dependency results with 3.x, you can get support by opening
 
 If you are integrating a private project and want to share more details, or if you're a FOSSA customer with priority support, you can file a ticket at [support.fossa.com](https://support.fossa.com) for assistance.
 
-#### How do I run only a specific analyzer for my project? 
+#### How do I run only a specific analyzer for my project?
 
 You can configure to run specific analyzer or only analyze specific paths in `.fossa.yml` file. Please refer to documentation [here](references/files/fossa-yml.md)
 

--- a/docs/references/subcommands/report.md
+++ b/docs/references/subcommands/report.md
@@ -45,16 +45,16 @@ After using [`fossa sbom analyze`](./sbom.md), you can specify an SBOM that you 
 fossa report attribution --format json ~/my-project-sbom.txt
 ```
 
-#### Project Arguments
+#### Common FOSSA Project Flags
 
 All `fossa` commands support the following FOSSA-project-related flags:
 
-| Name                               | Short | Description                                                                                                                                            |
-| ---------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--project 'some project'`         | `-p`  | Override the detected project name                                                                                                                     |
-| `--revision 'some revision'`       | `-r`  | -Override the detected project revision                                                                                                                |
-| `--fossa-api-key 'my-api-key'`     |       | An alternative to using the `FOSSA_API_KEY` environment variable to specify a FOSSA API key                                                            |
-| `--endpoint 'https://example.com'` | `-e`  | Override the FOSSA API server base URL                                                                                                                 |
+| Name                               | Short | Description                                                                                                                              |
+|------------------------------------|-------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `--project 'some project'`         | `-p`  | Override the detected project name                                                                                                       |
+| `--revision 'some revision'`       | `-r`  | -Override the detected project revision                                                                                                  |
+| `--fossa-api-key 'my-api-key'`     |       | An alternative to using the `FOSSA_API_KEY` environment variable to specify a FOSSA API key                                              |
+| `--endpoint 'https://example.com'` | `-e`  | Override the FOSSA API server base URL                                                                                                   |
 | `--config /path/to/file`           | `-c`  | Path to a [configuration file](../files/fossa-yml.md) including filename. By default we look for `.fossa.yml` in base working directory. |
 
 In this case, FOSSA will attempt to fetch any report it can find matching the `project` and `revision` criteria.

--- a/docs/walkthroughs/aosp.md
+++ b/docs/walkthroughs/aosp.md
@@ -1,8 +1,7 @@
 # Analyzing the Android Open Source Project
 
-<!-- markdown-link-check-disable -->
+<!-- markdown-link-check-disable-next-line -->
 [Android Open Source Project (AOSP)](https://source.android.com/) is used to make custom Android operating system distributions.
-<!-- markdown-link-check-enable -->
 This document describes how to analyze AOSP distributions for licenses using FOSSA.
 It does not describe how to analyze AOSP distributions for dependencies and security vulnerabilities.
 
@@ -10,10 +9,9 @@ It does not describe how to analyze AOSP distributions for dependencies and secu
 
 ## Requirements
 
-<!-- markdown-link-check-disable -->
 In our testing, we have been able to analyze unmodified AOSP sources for licenses in about 2 hours and 30 minutes with 32 CPU cores and 64 GB of memory (`m5a.8xlarge` EC2 instance), with a peak system memory usage of 54 GB.
+<!-- markdown-link-check-disable-next-line -->
 This is in line with the [hardware requirements to build AOSP suggested by Google](https://source.android.com/docs/setup/build/requirements).
-<!-- markdown-link-check-enable -->
 
 ## Analyzing AOSP
 


### PR DESCRIPTION
# Overview

Jess pointed out that the tests should've caught the broken link in https://github.com/fossas/fossa-cli/pull/1556

In testing, the global enable/disable wasn't playing well with the previously broken link. Using the targeted disables fixed this for me locally.

The dead link has since been removed, but I went ahead and removed the other global disables just in case, and updated the action as the previous action is now deprecated.

## Acceptance criteria

Better link checking! Nothing should fail here, but if the links go down in the future, we should be alerted.

## Testing plan

I just tested the links manually 

## Risks

Ideally little risk, maybe I break our tests.

## References

- Continues the work in https://github.com/fossas/fossa-cli/pull/1556

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
