### PR TITLE
Add `rendergraph` to releases

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -196,6 +196,7 @@ jobs:
         ./release/fossa.exe --version
         cp target/release/diagnose.exe release
         cp target/release/millhone.exe release
+        cp target/release/rendergraph.exe release
 
     - name: Find and move binaries (non-Windows)
       if: ${{ !contains(matrix.os, 'windows') }}
@@ -205,6 +206,7 @@ jobs:
         ./release/fossa --version
         cp target/release/diagnose release
         cp target/release/millhone release
+        cp target/release/rendergraph release
 
     - name: Strip binaries
       run: |
@@ -251,6 +253,7 @@ jobs:
         fi
         codesign --options runtime -s 'FOSSA, Inc.' release/diagnose
         codesign --options runtime -s 'FOSSA, Inc.' release/millhone
+        codesign --options runtime -s 'FOSSA, Inc.' release/rendergraph
 
         # Perform notarization
         zip -rj notarization-archive.zip release
@@ -325,10 +328,12 @@ jobs:
           cosign sign-blob --yes --bundle "$linux_kind-binaries/fossa.bundle" "$linux_kind-binaries/fossa"
           cosign sign-blob --yes --bundle "$linux_kind-binaries/diagnose.bundle" "$linux_kind-binaries/diagnose"
           cosign sign-blob --yes --bundle "$linux_kind-binaries/millhone.bundle" "$linux_kind-binaries/millhone"
+          cosign sign-blob --yes --bundle "$linux_kind-binaries/rendergraph.bundle" "$linux_kind-binaries/rendergraph"
 
           cosign verify-blob --bundle "$linux_kind-binaries/fossa.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "$linux_kind-binaries/fossa"
           cosign verify-blob --bundle "$linux_kind-binaries/diagnose.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "$linux_kind-binaries/diagnose"
           cosign verify-blob --bundle "$linux_kind-binaries/millhone.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "$linux_kind-binaries/millhone"
+          cosign verify-blob --bundle "$linux_kind-binaries/rendergraph.bundle" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" "$linux_kind-binaries/rendergraph"
 
         done
 
@@ -347,12 +352,16 @@ jobs:
         LINUX_DIAGNOSE_ZIP_PATH: "release/diagnose_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
         LINUX_MILLHONE_TAR_PATH: "release/millhone_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
         LINUX_MILLHONE_ZIP_PATH: "release/millhone_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
+        LINUX_RENDERGRAPH_TAR_PATH: "release/rendergraph_${{ steps.get-version.outputs.VERSION }}_linux_amd64.tar"
+        LINUX_RENDERGRAPH_ZIP_PATH: "release/rendergraph_${{ steps.get-version.outputs.VERSION }}_linux_amd64.zip"
         LINUX_ARM_FOSSA_TAR_PATH: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_arm64.tar"
         LINUX_ARM_FOSSA_ZIP_PATH: "release/fossa_${{ steps.get-version.outputs.VERSION }}_linux_arm64.zip"
         LINUX_ARM_DIAGNOSE_TAR_PATH: "release/diagnose_${{ steps.get-version.outputs.VERSION }}_linux_arm64.tar"
         LINUX_ARM_DIAGNOSE_ZIP_PATH: "release/diagnose_${{ steps.get-version.outputs.VERSION }}_linux_arm64.zip"
         LINUX_ARM_MILLHONE_TAR_PATH: "release/millhone_${{ steps.get-version.outputs.VERSION }}_linux_arm64.tar"
         LINUX_ARM_MILLHONE_ZIP_PATH: "release/millhone_${{ steps.get-version.outputs.VERSION }}_linux_arm64.zip"
+        LINUX_ARM_RENDERGRAPH_TAR_PATH: "release/rendergraph_${{ steps.get-version.outputs.VERSION }}_linux_arm64.tar"
+        LINUX_ARM_RENDERGRAPH_ZIP_PATH: "release/rendergraph_${{ steps.get-version.outputs.VERSION }}_linux_arm64.zip"
 
       run: |
         mkdir release
@@ -364,55 +373,67 @@ jobs:
         zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa
         zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose
         zip -j "$LINUX_MILLHONE_ZIP_PATH" Linux-binaries/millhone
+        zip -j "$LINUX_RENDERGRAPH_ZIP_PATH" Linux-binaries/rendergraph
         tar --create --verbose --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa
         tar --create --verbose --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose
         tar --create --verbose --file "$LINUX_MILLHONE_TAR_PATH" --directory Linux-binaries millhone
+        tar --create --verbose --file "$LINUX_RENDERGRAPH_TAR_PATH" --directory Linux-binaries rendergraph
 
         zip -j "$LINUX_ARM_FOSSA_ZIP_PATH" Linux-arm-binaries/fossa
         zip -j "$LINUX_ARM_DIAGNOSE_ZIP_PATH" Linux-arm-binaries/diagnose
         zip -j "$LINUX_ARM_MILLHONE_ZIP_PATH" Linux-arm-binaries/millhone
+        zip -j "$LINUX_ARM_RENDERGRAPH_ZIP_PATH" Linux-arm-binaries/rendergraph
         tar --create --verbose --file "$LINUX_ARM_FOSSA_TAR_PATH" --directory Linux-arm-binaries fossa
         tar --create --verbose --file "$LINUX_ARM_DIAGNOSE_TAR_PATH" --directory Linux-arm-binaries diagnose
         tar --create --verbose --file "$LINUX_ARM_MILLHONE_TAR_PATH" --directory Linux-arm-binaries millhone
+        tar --create --verbose --file "$LINUX_ARM_RENDERGRAPH_TAR_PATH" --directory Linux-arm-binaries rendergraph
 
         if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           tar --append --file "$LINUX_FOSSA_TAR_PATH" --directory Linux-binaries fossa.bundle
           tar --append --file "$LINUX_DIAGNOSE_TAR_PATH" --directory Linux-binaries diagnose.bundle
           tar --append --file "$LINUX_MILLHONE_TAR_PATH" --directory Linux-binaries millhone.bundle
+          tar --append --file "$LINUX_RENDERGRAPH_TAR_PATH" --directory Linux-binaries rendergraph.bundle
           zip -j "$LINUX_FOSSA_ZIP_PATH" Linux-binaries/fossa.bundle
           zip -j "$LINUX_DIAGNOSE_ZIP_PATH" Linux-binaries/diagnose.bundle
           zip -j "$LINUX_MILLHONE_ZIP_PATH" Linux-binaries/millhone.bundle
+          zip -j "$LINUX_RENDERGRAPH_ZIP_PATH" Linux-binaries/rendergraph.bundle
 
           tar --append --file "$LINUX_ARM_FOSSA_TAR_PATH" --directory Linux-arm-binaries fossa.bundle
           tar --append --file "$LINUX_ARM_DIAGNOSE_TAR_PATH" --directory Linux-arm-binaries diagnose.bundle
           tar --append --file "$LINUX_ARM_MILLHONE_TAR_PATH" --directory Linux-arm-binaries millhone.bundle
+          tar --append --file "$LINUX_ARM_RENDERGRAPH_TAR_PATH" --directory Linux-arm-binaries rendergraph.bundle
           zip -j "$LINUX_ARM_FOSSA_ZIP_PATH" Linux-arm-binaries/fossa.bundle
           zip -j "$LINUX_ARM_DIAGNOSE_ZIP_PATH" Linux-arm-binaries/diagnose.bundle
           zip -j "$LINUX_ARM_MILLHONE_ZIP_PATH" Linux-arm-binaries/millhone.bundle
+          zip -j "$LINUX_ARM_RENDERGRAPH_ZIP_PATH" Linux-arm-binaries/rendergraph.bundle
 
         fi
 
         gzip "$LINUX_FOSSA_TAR_PATH"
         gzip "$LINUX_DIAGNOSE_TAR_PATH"
         gzip "$LINUX_MILLHONE_TAR_PATH"
+        gzip "$LINUX_RENDERGRAPH_TAR_PATH"
 
         gzip "$LINUX_ARM_FOSSA_TAR_PATH"
         gzip "$LINUX_ARM_DIAGNOSE_TAR_PATH"
-        gzip "$LINUX_ARM_MILLHONE_TAR_PATH"
+        gzip "$LINUX_ARM_RENDERGRAPH_TAR_PATH"
 
         chmod +x macOS-intel-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-intel-binaries/fossa
         zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-intel-binaries/diagnose
         zip -j release/millhone_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-intel-binaries/millhone
+        zip -j release/rendergraph_${{ steps.get-version.outputs.VERSION }}_darwin_amd64.zip macOS-intel-binaries/rendergraph
         chmod +x macOS-arm64-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_darwin_arm64.zip macOS-arm64-binaries/fossa
         zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_darwin_arm64.zip macOS-arm64-binaries/diagnose
         zip -j release/millhone_${{ steps.get-version.outputs.VERSION }}_darwin_arm64.zip macOS-arm64-binaries/millhone
+        zip -j release/rendergraph_${{ steps.get-version.outputs.VERSION }}_darwin_arm64.zip macOS-arm64-binaries/rendergraph
 
         chmod +x Windows-binaries/*
         zip -j release/fossa_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/fossa.exe
         zip -j release/diagnose_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/diagnose.exe
         zip -j release/millhone_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/millhone.exe
+        zip -j release/rendergraph_${{ steps.get-version.outputs.VERSION }}_windows_amd64.zip Windows-binaries/rendergraph.exe
 
     - name: Create checksums
       # We have to run from within the release dir so that "release" isn't prepended to the relative path of the zip file.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,7 +223,7 @@ dependencies = [
  "getset",
  "lexical-sort",
  "log",
- "serde",
+ "serde 1.0.219",
  "serde_json",
  "simple_logger",
  "stable-eyre",
@@ -309,7 +324,7 @@ checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
- "serde",
+ "serde 1.0.219",
 ]
 
 [[package]]
@@ -418,6 +433,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,8 +471,24 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
- "lazy_static",
+ "lazy_static 1.5.0",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "config"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+dependencies = [
+ "lazy_static 1.5.0",
+ "nom",
+ "rust-ini",
+ "serde 1.0.219",
+ "serde-hjson",
+ "serde_json",
+ "toml",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -507,13 +565,13 @@ dependencies = [
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
- "num-traits",
+ "num-traits 0.2.19",
  "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
- "serde",
+ "serde 1.0.219",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -656,6 +714,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,7 +803,7 @@ dependencies = [
  "base64 0.22.1",
  "getset",
  "iter-read",
- "serde",
+ "serde 1.0.219",
  "sha1",
  "sha2",
  "strum 0.26.3",
@@ -734,6 +812,12 @@ dependencies = [
  "tracing",
  "zip",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flagset"
@@ -1105,9 +1189,28 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+
+[[package]]
+name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "lexical-sort"
@@ -1134,6 +1237,12 @@ dependencies = [
  "libc",
  "redox_syscall",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1226,7 +1335,7 @@ dependencies = [
  "rayon",
  "retry",
  "secrecy",
- "serde",
+ "serde 1.0.219",
  "serde_json",
  "serde_yaml",
  "snippets",
@@ -1267,6 +1376,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "5.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1401,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.19",
+]
 
 [[package]]
 name = "num-traits"
@@ -1319,6 +1448,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits 0.2.19",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1467,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "pbkdf2"
@@ -1345,6 +1489,16 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.9.0",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1364,7 +1518,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -1482,6 +1636,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptree"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de80796b316aec75344095a6d2ef68ec9b8f573b9e7adc821149ba3598e270"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "config",
+ "directories",
+ "petgraph",
+ "serde 1.0.219",
+ "serde-value",
+ "tint",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +1755,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +1795,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rendergraph"
+version = "0.1.0"
+dependencies = [
+ "atty",
+ "color-eyre",
+ "colored",
+ "eyre",
+ "petgraph",
+ "ptree",
+ "serde 1.0.219",
+ "serde_json",
+]
+
+[[package]]
 name = "retry"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1830,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rust-ini"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc-demangle"
@@ -1791,11 +1992,39 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
+
+[[package]]
+name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-hjson"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
+dependencies = [
+ "lazy_static 1.5.0",
+ "num-traits 0.1.43",
+ "regex",
+ "serde 0.8.23",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde 1.0.219",
 ]
 
 [[package]]
@@ -1818,7 +2047,7 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
- "serde",
+ "serde 1.0.219",
 ]
 
 [[package]]
@@ -1830,7 +2059,7 @@ dependencies = [
  "indexmap 2.9.0",
  "itoa",
  "ryu",
- "serde",
+ "serde 1.0.219",
  "unsafe-libyaml",
 ]
 
@@ -1862,7 +2091,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
- "lazy_static",
+ "lazy_static 1.5.0",
 ]
 
 [[package]]
@@ -1921,9 +2150,9 @@ version = "0.1.0"
 source = "git+https://github.com/fossas/foundation-libs#4bc3762e73f371717566fb075d02e1d25b21146e"
 dependencies = [
  "getset",
- "lazy_static",
+ "lazy_static 1.5.0",
  "regex",
- "serde",
+ "serde 1.0.219",
  "strum 0.24.1",
  "thiserror 1.0.69",
  "typed-builder 0.10.0",
@@ -1945,6 +2174,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2174,7 +2409,7 @@ dependencies = [
  "deranged",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde 1.0.219",
  "time-core",
 ]
 
@@ -2183,6 +2418,15 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "tint"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af24570664a3074673dbbf69a65bdae0ae0b72f2949b1adfbacb736ee4d6896"
+dependencies = [
+ "lazy_static 0.2.11",
+]
 
 [[package]]
 name = "tinystr"
@@ -2200,8 +2444,17 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde",
+ "serde 1.0.219",
  "serde_json",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde 1.0.219",
 ]
 
 [[package]]
@@ -2250,6 +2503,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,7 +2529,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
- "serde",
+ "serde 1.0.219",
  "tracing-core",
 ]
 
@@ -2277,7 +2540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "nu-ansi-term",
- "serde",
+ "serde 1.0.219",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -2415,7 +2678,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
- "serde",
+ "serde 1.0.219",
  "serde_json",
  "url",
  "webpki-roots 0.26.11",
@@ -2724,6 +2987,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,7 +3007,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
- "serde",
+ "serde 1.0.219",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "extlib/berkeleydb",
   "extlib/millhone",
   "tools/diagnose",
+  "tools/rendergraph",
 ]
 
 # This field is documented as accepting globs but apparently only prefix matches:

--- a/tools/rendergraph/Cargo.toml
+++ b/tools/rendergraph/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rendergraph"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+atty = "0.2.14"
+color-eyre = "0.6.1"
+eyre = "0.6.8"
+petgraph = "0.6.0"
+ptree = "0.4.0"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.79"
+colored = "2.0.0"

--- a/tools/rendergraph/README.md
+++ b/tools/rendergraph/README.md
@@ -1,0 +1,228 @@
+# fossa-rendergraph
+
+Utility to render the output of `fossa analyze -o` as a graph.
+
+This program isn't _guaranteed_ to not be broken by new FOSSA CLI releases,
+but we'll try to keep it from doing so especially since we try to keep output of FOSSA CLI stable.
+
+# Installation from source
+
+0. Install `rust`: https://www.rust-lang.org/tools/install
+1. Clone this repo locally
+2. Run `cargo install --path rendergraph` from the parent directory.
+3. Use as `fossa analyze -o | rendergraph` (you can also `cat output.json | rendergraph`- any stdin works)
+
+# What to expect
+
+Direct deps are roots, and tree branches leading off of them are their transitive deps.
+
+Cycles are denoted by the literal `cycle ->` followed by the name of the node that would have had a cycling edge.
+
+For example, a cycle of `a -> b -> c -> a` reads as:
+```
+a
+└─ b
+   └─ c
+      └─ cycle -> a
+```
+
+This tool outputs all dependencies found by FOSSA and doesn't currently account for FOSSA's "unused dependencies" graph pruning.
+
+# Future work
+
+A list of things I've thought of to add. Have an idea? Add it to this list via PR!
+
+- [ ] Account for graph pruning (use source units to do this)
+- [ ] Support graphviz output
+
+# Example output
+
+Note: This output was truncated for readability.
+
+```
+; fossa analyze \
+  ~/projects/fossa-cli \
+  --only-target gomod --only-target cabal \
+  -o | rendergraph
+
+[ INFO] Analyzing cabal project at /Users/kit/projects/fossa-cli/
+[ INFO] Analyzing gomod project at /Users/kit/projects/fossa-cli/
+[ INFO]
+[ INFO] Scan Summary
+[ INFO] ------------
+[ INFO] fossa-cli version 3.2.9 (revision 2e79a284caee compiled with ghc-8.10)
+[ INFO]
+[ INFO] 2 projects scanned;  0 skipped,  2 succeeded,  0 failed,  0 analysis warnings
+[ INFO]
+[ INFO] * cabal project in "/Users/kit/projects/fossa-cli/": succeeded
+[ INFO] * gomod project in "/Users/kit/projects/fossa-cli/": succeeded
+[ INFO] ------------
+
+----- Project: "/Users/kit/projects/fossa-cli/" (cabal) -----
+      186 total deps, 67 direct
+
+HUnit@1.6.2.0
+└─ call-stack@0.4.0
+aeson@1.5.6.0
+├─ vector@0.12.3.1
+│  └─ primitive@0.7.3.0
+├─ uuid-types@1.0.5
+│  ├─ random@1.2.1
+│  │  └─ splitmix@0.1.0.4
+│  └─ hashable@1.3.5.0
+├─ unordered-containers@0.2.18.0
+│  └─ hashable@1.3.5.0
+├─ time-compat@1.9.6.1
+│  ├─ hashable@1.3.5.0
+│  └─ base-orphans@0.8.6
+├─ these@1.1.1.1
+│  ├─ hashable@1.3.5.0
+│  └─ assoc@1.0.2
+│     ├─ tagged@0.8.6.1
+│     └─ bifunctors@5.5.11
+│        ├─ th-abstraction@0.4.3.0
+│        ├─ tagged@0.8.6.1
+│        ├─ comonad@5.0.8
+│        │  ├─ transformers-compat@0.7.1
+│        │  ├─ tagged@0.8.6.1
+│        │  ├─ indexed-traversable@0.1.2
+│        │  └─ distributive@0.6.2.1
+│        │     ├─ tagged@0.8.6.1
+│        │     └─ base-orphans@0.8.6
+│        └─ base-orphans@0.8.6
+├─ th-abstraction@0.4.3.0
+├─ tagged@0.8.6.1
+├─ strict@0.4.0.1
+│  ├─ these@1.1.1.1
+│  │  ├─ hashable@1.3.5.0
+│  │  └─ assoc@1.0.2
+│  │     ├─ tagged@0.8.6.1
+│  │     └─ bifunctors@5.5.11
+│  │        ├─ th-abstraction@0.4.3.0
+│  │        ├─ tagged@0.8.6.1
+│  │        ├─ comonad@5.0.8
+│  │        │  ├─ transformers-compat@0.7.1
+│  │        │  ├─ tagged@0.8.6.1
+│  │        │  ├─ indexed-traversable@0.1.2
+│  │        │  └─ distributive@0.6.2.1
+│  │        │     ├─ tagged@0.8.6.1
+│  │        │     └─ base-orphans@0.8.6
+│  │        └─ base-orphans@0.8.6
+│  ├─ hashable@1.3.5.0
+│  └─ assoc@1.0.2
+│     ├─ tagged@0.8.6.1
+│     └─ bifunctors@5.5.11
+│        ├─ th-abstraction@0.4.3.0
+│        ├─ tagged@0.8.6.1
+│        ├─ comonad@5.0.8
+│        │  ├─ transformers-compat@0.7.1
+│        │  ├─ tagged@0.8.6.1
+│        │  ├─ indexed-traversable@0.1.2
+│        │  └─ distributive@0.6.2.1
+│        │     ├─ tagged@0.8.6.1
+│        │     └─ base-orphans@0.8.6
+│        └─ base-orphans@0.8.6
+├─ scientific@0.3.7.0
+│  ├─ primitive@0.7.3.0
+│  ├─ integer-logarithms@1.0.3.1
+│  └─ hashable@1.3.5.0
+├─ primitive@0.7.3.0
+├─ hashable@1.3.5.0
+├─ dlist@1.0
+├─ data-fix@0.3.2
+│  └─ hashable@1.3.5.0
+├─ base-compat-batteries@0.12.1
+│  └─ base-compat@0.12.1
+└─ attoparsec@0.14.4
+   ├─ scientific@0.3.7.0
+   │  ├─ primitive@0.7.3.0
+   │  ├─ integer-logarithms@1.0.3.1
+   │  └─ hashable@1.3.5.0
+   └─ cycle -> attoparsec@0.14.4
+
+----- Project: "/Users/kit/projects/fossa-cli/" (gomod) -----
+      73 total deps, 1 direct
+
+github.com/fossas/fossa-cli@v1.1.10
+├─ gopkg.in/yaml.v2@v2.2.1
+├─ gopkg.in/src-d/go-git.v4@v4.7.1
+│  ├─ gopkg.in/warnings.v0@v0.1.2
+│  ├─ gopkg.in/src-d/go-git-fixtures.v3@v3.1.1
+│  ├─ gopkg.in/check.v1@788fd7840127
+│  ├─ golang.org/x/text@v0.3.0
+│  ├─ github.com/xanzy/ssh-agent@v0.2.0
+│  ├─ github.com/stretchr/testify@v1.2.2
+│  ├─ github.com/src-d/gcfg@v1.3.0
+│  ├─ github.com/sergi/go-diff@v1.0.0
+│  ├─ github.com/pmezard/go-difflib@v1.0.0
+│  ├─ github.com/pkg/errors@v0.8.0
+│  ├─ github.com/pelletier/go-buffruneio@v0.2.0
+│  ├─ github.com/mitchellh/go-homedir@v1.0.0
+│  ├─ github.com/kevinburke/ssh_config@81db2a75821e
+│  ├─ github.com/jessevdk/go-flags@v1.4.0
+│  ├─ github.com/jbenet/go-context@d14ea06fba99
+│  ├─ github.com/google/go-cmp@v0.2.0
+│  ├─ github.com/gliderlabs/ssh@v0.1.1
+│  ├─ github.com/flynn/go-shlex@3f9db97f8568
+│  ├─ github.com/davecgh/go-spew@v1.1.1
+│  ├─ github.com/anmitsu/go-shlex@648efa622239
+│  └─ github.com/alcortesm/tgz@9c5fe88206d7
+├─ gopkg.in/src-d/go-billy.v4@v4.3.0
+│  ├─ gopkg.in/check.v1@788fd7840127
+│  └─ github.com/kr/pretty@v0.1.0
+│     └─ github.com/kr/text@v0.1.0
+│        └─ github.com/kr/pty@v1.1.1
+├─ gopkg.in/ini.v1@v1.62.0
+├─ gopkg.in/go-ini/ini.v1@v1.39.1
+├─ golang.org/x/sync@112230192c58
+├─ github.com/urfave/cli@v1.20.0
+├─ github.com/stretchr/testify@v1.2.2
+├─ github.com/smartystreets/goconvey@v1.6.4
+│  ├─ golang.org/x/tools@ab21143f2384
+│  │  └─ golang.org/x/net@d8887717615a
+│  │     ├─ golang.org/x/text@v0.3.0
+│  │     └─ golang.org/x/crypto@c2843e01d9a2
+│  │        └─ golang.org/x/sys@d0b11bdaac8a
+│  ├─ github.com/smartystreets/assertions@b2de0cb4f26d
+│  ├─ github.com/jtolds/gls@v4.20.0
+│  └─ github.com/gopherjs/gopherjs@0766667cb4d1
+├─ github.com/rveen/ogdl@9c9b3105ea3e
+├─ github.com/rhysd/go-github-selfupdate@v1.0.0
+│  ├─ google.golang.org/appengine@v1.2.0
+│  │  ├─ golang.org/x/text@v0.3.0
+│  │  └─ github.com/golang/protobuf@v1.2.0
+│  ├─ golang.org/x/oauth2@d2e6202438be
+│  ├─ github.com/ulikunitz/xz@v0.5.4
+│  ├─ github.com/tcnksm/go-gitconfig@v0.1.2
+│  ├─ github.com/onsi/gomega@v1.4.2
+│  │  ├─ gopkg.in/yaml.v2@v2.2.1
+│  │  ├─ gopkg.in/tomb.v1@dd632973f1e7
+│  │  ├─ gopkg.in/fsnotify.v1@v1.4.7
+│  │  ├─ golang.org/x/text@v0.3.0
+│  │  ├─ github.com/onsi/ginkgo@v1.6.0
+│  │  ├─ github.com/hpcloud/tail@v1.0.0
+│  │  ├─ github.com/golang/protobuf@v1.2.0
+│  │  └─ github.com/fsnotify/fsnotify@v1.4.7
+│  ├─ github.com/inconshreveable/go-update@8152e7eb6ccf
+│  ├─ github.com/google/go-querystring@v1.0.0
+│  ├─ github.com/google/go-github@v17.0.0
+│  └─ github.com/blang/semver@v3.5.1
+├─ github.com/remeh/sizedwaitgroup@v1.0.0
+├─ github.com/pkg/errors@v0.8.0
+├─ github.com/olekukonko/tablewriter@v0.0.2
+├─ github.com/mitchellh/mapstructure@v1.0.0
+├─ github.com/mitchellh/go-wordwrap@v1.0.0
+├─ github.com/mattn/go-runewidth@v0.0.6
+├─ github.com/mattn/go-isatty@v0.0.4
+├─ github.com/mattn/go-colorable@v0.0.9
+├─ github.com/gnewton/jargo@41f5f186a805
+├─ github.com/fatih/color@v1.7.0
+├─ github.com/emirpasic/gods@v1.12.0
+├─ github.com/cheekybits/genny@v1.0.0
+├─ github.com/briandowns/spinner@9f016caa1359
+├─ github.com/bmatcuk/doublestar@v1.1.1
+├─ github.com/blang/semver@v3.5.1
+├─ github.com/apex/log@v1.0.0
+├─ github.com/Masterminds/semver@v1.5.0
+└─ github.com/BurntSushi/toml@v0.3.1
+```

--- a/tools/rendergraph/README.md
+++ b/tools/rendergraph/README.md
@@ -1,16 +1,12 @@
-# fossa-rendergraph
+# rendergraph
 
 Utility to render the output of `fossa analyze -o` as a graph.
 
 This program isn't _guaranteed_ to not be broken by new FOSSA CLI releases,
 but we'll try to keep it from doing so especially since we try to keep output of FOSSA CLI stable.
 
-# Installation from source
-
-0. Install `rust`: https://www.rust-lang.org/tools/install
-1. Clone this repo locally
-2. Run `cargo install --path rendergraph` from the parent directory.
-3. Use as `fossa analyze -o | rendergraph` (you can also `cat output.json | rendergraph`- any stdin works)
+`rendergraph` is unlikely to get additional features; we'll almost definitely roll this into other tooling
+such as FOSSA CLI or `ficus` itself if we choose to make changes to how this works.
 
 # What to expect
 
@@ -27,13 +23,6 @@ a
 ```
 
 This tool outputs all dependencies found by FOSSA and doesn't currently account for FOSSA's "unused dependencies" graph pruning.
-
-# Future work
-
-A list of things I've thought of to add. Have an idea? Add it to this list via PR!
-
-- [ ] Account for graph pruning (use source units to do this)
-- [ ] Support graphviz output
 
 # Example output
 
@@ -226,3 +215,13 @@ github.com/fossas/fossa-cli@v1.1.10
 ├─ github.com/Masterminds/semver@v1.5.0
 └─ github.com/BurntSushi/toml@v0.3.1
 ```
+
+# Installation from source
+
+You should be able to manually download `rendergraph` from the FOSSA CLI github releases.
+However if you have to or want to build manually:
+
+0. Install `rust`: https://www.rust-lang.org/tools/install
+1. Clone this repo locally
+2. Run `cargo install --path rendergraph` from the parent directory.
+3. Use as `fossa analyze -o | rendergraph` (you can also `cat output.json | rendergraph`- any stdin works)

--- a/tools/rendergraph/src/main.rs
+++ b/tools/rendergraph/src/main.rs
@@ -1,0 +1,191 @@
+use std::{
+    fmt::Display,
+    io::{self, Read},
+    path::PathBuf,
+};
+
+use atty::Stream;
+use color_eyre::Result;
+use colored::Colorize;
+use eyre::eyre;
+use petgraph::{algo::is_cyclic_directed, prelude::*};
+use ptree::print_tree;
+use serde::Deserialize;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    if atty::is(Stream::Stdin) {
+        return Err(eyre!(
+            "Stream the output of `fossa analyze -o` to this program"
+        ));
+    }
+
+    let stdin = io::stdin();
+    let mut handle = stdin.lock();
+
+    let mut buffer = String::new();
+    handle.read_to_string(&mut buffer)?;
+
+    let parsed = serde_json::from_str::<Output>(&buffer)?;
+    for Project { path, kind, graph } in parsed.projects.into_iter() {
+        let FossaGraph {
+            deps,
+            direct,
+            assocs,
+        } = graph;
+
+        println!();
+        println!("----- Project: {path:?} ({kind}) -----");
+        println!("      {} total deps, {} direct", deps.len(), direct.len());
+
+        let mut graph = Graph::<String, usize>::default();
+        let nodes = deps
+            .iter()
+            .map(|dep| graph.add_node(dep.to_string()))
+            .collect::<Vec<_>>();
+
+        for (origin, destinations) in assocs {
+            for destination in destinations {
+                let edge = (origin, destination);
+                let origin = nodes[origin];
+                let destination = nodes[destination];
+
+                // Graph doesn't have a method for "will adding this node make it cyclic".
+                // Therefore add the edge, then test if cyclic.
+                // If it is, remove the edge just added and add a non-cycling node and edge instead.
+                //
+                // We have to handle cyclic deps this way because actual dependency managers may allow cyclic deps,
+                // but our tree renderer will loop forever in the face of cycling deps, so we need to break the cycle.
+                let added_edge = graph.add_edge(origin, destination, 1usize);
+                if is_cyclic_directed(&graph) {
+                    graph.remove_edge(added_edge);
+
+                    let cycle = format!("cycle -> {}", deps[edge.1]);
+                    let cycling_node = graph.add_node(cycle);
+                    graph.add_edge(origin, cycling_node, 1usize);
+                }
+            }
+        }
+
+        for direct in direct {
+            println!();
+            let root = nodes[direct];
+            print_tree(&(&graph, root))?;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Deserialize, Debug)]
+struct Output {
+    projects: Vec<Project>,
+}
+
+#[derive(Deserialize, Debug)]
+struct Project {
+    #[serde(rename(deserialize = "type"))]
+    kind: String,
+    graph: FossaGraph,
+    path: PathBuf,
+}
+
+#[derive(Deserialize, Debug)]
+struct FossaGraph {
+    assocs: Vec<(usize, Vec<usize>)>,
+    direct: Vec<usize>,
+    deps: Vec<Dep>,
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+struct Dep {
+    #[serde(rename(deserialize = "type"))]
+    kind: String,
+    name: String,
+    version: Option<Version>,
+}
+
+impl Display for Dep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Dep {
+            name,
+            version,
+            kind,
+        } = self;
+
+        // https://github.com/fossas/fossa-cli/blob/440f7228b871ce8ad84f23011f3fbd5f86cec476/src/Srclib/Converter.hs#L129-L156
+        //
+        // Colors chosen roughly with the following criteria:
+        //
+        // Don't use black or white as colors
+        //
+        // FOSSA-specific kinds (archive, custom, url, user) are magenta
+        //
+        // Similar colors to each kind's logo colors (e.g. Python is yellow, Ruby is red)
+        //
+        // If a kind doesn't have a useful representative color (e.g. Perl's
+        // logo is black), choose colors that are unlikely to be found in the
+        // same analysis output. For example, Java and Haskell dependencies are
+        // unlikely to be found together and can share the same color.
+        let kind = match kind.as_str() {
+            "ArchiveType" => "archive".magenta(),
+            "BowerType" => "bower".green(),
+            "CarthageType" => "cart".blue(),
+            "CargoType" => "cargo".red(),
+            "ComposerType" => "comp".yellow(),
+            "CondaType" => "conda".yellow(),
+            "CpanType" => "cpan".cyan(),
+            "CustomType" => "custom".magenta(),
+            "GemType" => "gem".red(),
+            "GitType" => "git".cyan(),
+            "GooglesourceType" => "git".cyan(),
+            "GoType" => "go".blue(),
+            "HackageType" => "hackage".purple(),
+            "HexType" => "hex".red(),
+            "LinuxAPK" => "apk".blue(),
+            "LinuxDEB" => "deb".red(),
+            "LinuxRPM" => "rpm-generic".red(),
+            "MavenType" => "mvn".purple(),
+            "NodeJSType" => "npm".red(),
+            "NuGetType" => "nuget".blue(),
+            "PipType" => "pip".yellow(),
+            "PodType" => "pod".blue(),
+            "RPMType" => "rpm".yellow(),
+            "SubprojectType" => "mvn".purple(),
+            "URLType" => "url".magenta(),
+            "UserType" => "user".magenta(),
+            "PubType" => "pub".cyan(),
+            "SwiftType" => "swift".red(),
+            unknown => panic!("Found dependency \"{name}\" with unknown kind: {unknown}",),
+        };
+
+        let version = version
+            .as_ref()
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "@LATEST".into());
+        write!(f, "{name}{version} | {kind}")
+    }
+}
+
+#[derive(Deserialize, Debug, Default, Clone)]
+struct Version {
+    #[serde(rename(deserialize = "type"))]
+    kind: String,
+    value: String,
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Version { kind, value } = self;
+        let compat = match kind.as_str() {
+            "EQUAL" => "@",
+            "COMPATIBLE" => "~",
+            "LESSTHAN" => "<",
+            "LESSOREQUAL" => "≤",
+            "GREATERTHAN" => ">",
+            "GREATEROREQUAL" => "≥",
+            _ => panic!("Unknown version compatibility: {kind}"),
+        };
+        write!(f, "{compat}{value}")
+    }
+}


### PR DESCRIPTION
# Overview

Cortez and I are working with a customer that would benefit from having our internal `rendergraph` tool being public; this PR adds it to the FOSSA CLI repository and releases.

`rendergraph` itself is sort of a "best effort" tool so it doesn't have tests; I don't think it's worth adding to docs as we would expect users to basically use this when we suggest it for troubleshooting.

## Acceptance criteria

`rendergraph` is available in FOSSA CLI releases.

## Testing plan

Sadly, just manual testing

## Risks

Yet more random stuff plugged into FOSSA CLI releases 🙃 

## Metrics

None

## References

None

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
