### PR TITLE
[ANE-2506] use finalize build endpoints on sparkle

### DIFF
--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -326,13 +326,13 @@ uploadUrl :: AnalysisService -> Url scheme -> Url scheme
 uploadUrl service baseurl =
   case service of
     Core -> baseurl /: "api" /: "builds" /: "custom"
-    Sparkle -> baseurl /: "api" /: "proxy" /: "analysis" /: "api" /: "v1" /: "provided_build" /: "finalize"
+    Sparkle -> baseurl /: "api" /: "proxy" /: "analysis" /: "api" /: "builds" /: "custom"
 
 uploadWithFirstPartyUrl :: AnalysisService -> Url scheme -> Url scheme
 uploadWithFirstPartyUrl service baseurl =
   case service of
     Core -> baseurl /: "api" /: "builds" /: "custom_with_first_party"
-    Sparkle -> baseurl /: "api" /: "proxy" /: "analysis" /: "api" /: "v1" /: "provided_build" /: "finalize_with_first_party_licenses"
+    Sparkle -> baseurl /: "api" /: "proxy" /: "analysis" /: "api" /: "builds" /: "custom_with_first_party"
 
 -- | This renders an organization + locator into a path piece for the fossa API
 renderLocatorUrl :: OrgId -> Locator -> Text


### PR DESCRIPTION
# Overview

This is a WIP that implements the CLI side of what we need to move finalizing builds from Core to Sparkle.

For more detail on why we aren't delivering this now and what needs to be done before we deliver it, see https://github.com/fossas/sparkle/pull/612