### PR TITLE
disable link-checks for creativecommons.org

### DIFF
--- a/attribution.md
+++ b/attribution.md
@@ -1,10 +1,13 @@
 ## Licensing Data
 
-Some of the data used for CLI-side license scanning is provided by nexB under a [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/legalcode) license. This data can be found here: https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data.
+<!-- markdown-link-check-disable-next-line -->
+Some of the data used for CLI-side license scanning is provided by nexB under a [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/legalcode) license.
+This data can be found here: https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data.
 
 The licensing data is Copyright (c) nexB Inc. and others. All rights reserved.
     ScanCode is a trademark of nexB Inc.
     SPDX-License-Identifier: CC-BY-4.0
+    <!-- markdown-link-check-disable-next-line -->
     See https://creativecommons.org/licenses/by/4.0/legalcode for the license text.
     See https://github.com/nexB/scancode-toolkit for support or download.
     See https://aboutcode.org for more information about nexB OSS projects.


### PR DESCRIPTION
# Overview

creativecommons.org is using Cloudflare, so our link checks are always returning 403. You can see this with curl:

```
curl -I https://creativecommons.org/licenses/by/4.0/legalcode
HTTP/2 403 
date: Mon, 07 Jul 2025 22:51:42 GMT
content-type: text/html; charset=UTF-8
...
server: cloudflare
cf-ray: 95bae875aca80948-SEA
```

I turned off the link-checks for the two creativecommons.org links in our markdown docs, which should fix this.

## Acceptance criteria

The markdown link checks pass

## Testing plan


## Risks

Maybe it would be better to do this by adding creativecommons.org to the ignore patterns `.markdown-link-check.json`, but I think I prefer that we ignore these wherever they are used

## Metric

## References


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
