### PR TITLE
gradle: exclude constraints when retrieving dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- gradle: Do not report version constraints, version contraints are contained within an`DependencyResult`, filter out any constraints by checking [`isConstraint()`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/result/DependencyResult.html#isConstraint()). ([#1563](https://github.com/fossas/fossa-cli/pull/1563))
+
 ## 3.10.13
 
 - Updates the `fossa test` output to include severity data on supported FOSSA instances ([#1562](https://github.com/fossas/fossa-cli/pull/1562))

--- a/scripts/jsondeps.gradle
+++ b/scripts/jsondeps.gradle
@@ -114,8 +114,11 @@ allprojects {
                             printDebugToFossa("Could not resolve dependency: ${resolvedDep.getAttempted()}", "resolvedConfigToJSON")
                             return
                         }
-
                         def resolvedDependencyId = resolvedDep.getSelected().getId()
+                        if (resolvedDep.isConstraint()) {
+                            printDebugToFossa("Skipping constraint dependency: ${resolvedDependencyId}", "resolvedConfigToJSON")
+                            return
+                        }
                         if (resolvedDependencyId != resolvedComponent.getId()) {
                             adjacencyMap.get(resolvedComponent, []) << resolvedDependencyId
                         }


### PR DESCRIPTION
# Overview

This PR excludes constraints when retrieving dependencies.  

One of the API calls we use for retrieving Gradle dependencies also includes "constraints", which get treated as a direct dependency. After reviewing the gradle GitHub issues it seems this used to affect `gradle dependencies` but they filtered out the constraint dependencies. Any dependencies (direct or transitive) are still reported without issues. 

Constraints guide: https://docs.gradle.org/current/userguide/dependency_constraints.html

I did not include tests since the change is specifically to the jsondeps.gradle file and we don't have any testing setup for it. I manually tested the changes, see below

## Acceptance criteria

- dependency constraints are not reported as direct dependencies
- direct & transitive dependencies which are constrained are still reported 

## Testing plan

Use this Gradle.build file:
```
plugins {
    id('java-platform')
}

group = 'com.example.platform'

// allow the definition of dependencies to other platforms like the Spring Boot BOM
javaPlatform.allowDependencies()

repositories {
    mavenCentral()
}

dependencies {
    api('org.springframework.boot:spring-boot-cli:3.4.7')

    constraints {
        api('org.apache.httpcomponents.client5:httpclient5:5.5')
    }
}

```
check out the master branch:
run `gradle -I/path/to/fossa-cli/scripts/jsondeps.gradle jsonDeps`
look for `RESOLUTIONAPI_JSONDEPS_:_` - then I either copy & paste or use jq on the json snippet
in particular - you'll see `org.apache.httpcomponents.client5:httpclient5:5.5` as a direct dependency (`resolvedConfigurationDirectComponents`)
<img width="573" height="303" alt="image" src="https://github.com/user-attachments/assets/1d17928f-0ba6-440e-b760-7be75ebd58d7" />

^ this is no bueno

switch to this branch, run the gradle command again, and now you get:
<img width="489" height="220" alt="image" src="https://github.com/user-attachments/assets/26688adb-3157-40ad-9790-dba3a44b982e" />
mucho better!
and the httpclient dependency still exists:
<img width="600" height="193" alt="image" src="https://github.com/user-attachments/assets/91150a9b-1a9b-407b-882a-3b283a8e3e30" />


## Risks

n/a

## Metrics

n/a

## References

Ticket: https://fossa.atlassian.net/browse/ANE-2564

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
