### PR TITLE
[ANE-2484] Download ficus in vendor_download.sh

### DIFF
--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -32,6 +32,7 @@ mkdir -p vendor-bins
 
 ASSET_POSTFIX=""
 THEMIS_ASSET_POSTFIX=""
+FICUS_ASSET_POSTFIX=""
 LERNIE_ASSET_POSTFIX=""
 CIRCE_ASSET_POSTFIX=""
 case "$(uname -s)" in
@@ -39,6 +40,7 @@ case "$(uname -s)" in
     case "$(uname -m)" in
       arm64)
         ASSET_POSTFIX="darwin-arm64"
+        FICUS_ASSET_POSTFIX="aarch64-apple-darwin.tar.gz"
         LERNIE_ASSET_POSTFIX="aarch64-macos"
         THEMIS_ASSET_POSTFIX="darwin-arm64"
         CIRCE_ASSET_POSTFIX="aarch64-apple-darwin"
@@ -46,6 +48,7 @@ case "$(uname -s)" in
 
       *)
         ASSET_POSTFIX="darwin-amd64"
+        FICUS_ASSET_POSTFIX="x86_64-apple-darwin.tar.gz"
         LERNIE_ASSET_POSTFIX="x86_64-macos"
         THEMIS_ASSET_POSTFIX="darwin-amd64"
         CIRCE_ASSET_POSTFIX="x86_64-apple-darwin"
@@ -58,6 +61,7 @@ case "$(uname -s)" in
       aarch64)
         ASSET_POSTFIX="linux"
         THEMIS_ASSET_POSTFIX="linux-arm64"
+        FICUS_ASSET_POSTFIX="aarch64-linux.tar.gz"
         LERNIE_ASSET_POSTFIX="aarch64-linux"
         CIRCE_ASSET_POSTFIX="aarch64-unknown-linux-musl"
       ;;
@@ -65,6 +69,7 @@ case "$(uname -s)" in
       *)
         ASSET_POSTFIX="linux"
         THEMIS_ASSET_POSTFIX="linux-amd64"
+        FICUS_ASSET_POSTFIX="x86_64-linux.tar.gz"
         LERNIE_ASSET_POSTFIX="x86_64-linux"
         CIRCE_ASSET_POSTFIX="x86_64-unknown-linux-musl"
         ;;
@@ -74,6 +79,7 @@ case "$(uname -s)" in
     echo "Warn: Assuming $(uname -s) is Windows"
     ASSET_POSTFIX="windows.exe"
     THEMIS_ASSET_POSTFIX="windows-amd64"
+    FICUS_ASSET_POSTFIX="x86_64-windows.exe.zip"
     LERNIE_ASSET_POSTFIX="x86_64-windows.exe"
     CIRCE_ASSET_POSTFIX="x86_64-pc-windows-msvc"
     ;;
@@ -141,6 +147,47 @@ done
 echo "Lernie download successful"
 
 rm $LERNIE_RELEASE_JSON
+
+# Download latest release of Ficus
+
+echo "Downloading ficus binary from latest release"
+FICUS_RELEASE_JSON=vendor-bins/ficus-release.json
+curl -sSL \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3.raw" \
+    https://api.github.com/repos/fossas/ficus/releases/latest > $FICUS_RELEASE_JSON
+
+FICUS_TAG=$(jq -cr ".name" $FICUS_RELEASE_JSON)
+# Strip the leading 'v' off of the tag
+FICUS_VERSION="${FICUS_TAG/#v/}"
+FILTER=".name == \"ficus-$FICUS_ASSET_POSTFIX\""
+jq -c ".assets | map({url: .url, name: .name}) | map(select($FILTER)) | .[]" $FICUS_RELEASE_JSON | while read -r ASSET; do
+  URL="$(echo "$ASSET" | jq -c -r '.url')"
+  NAME="$(echo "$ASSET" | jq -c -r '.name')"
+  OUTPUT="$(echo vendor-bins/"$NAME" | sed 's/-'"$FICUS_VERSION"'-'$FICUS_ASSET_POSTFIX'$//')"
+
+  echo "Downloading '$NAME' to '$OUTPUT'"
+  curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/octet-stream" -s "$URL" > "$OUTPUT"
+
+  case "$(uname -s)" in
+    Darwin)
+      tar -zxf $OUTPUT --strip-components 1 --exclude LICENSE --exclude README.md --directory vendor-bins
+      ;;
+    Linux)
+      tar -zxf $OUTPUT --strip-components 1 --exclude LICENSE --exclude README.md --directory vendor-bins
+      ;;
+    *)
+      echo "Warn: Assuming $(uname -s) is Windows"
+      unzip $OUTPUT ficus.exe -d vendor-bins
+      ;;
+  esac
+  rm $OUTPUT
+
+
+done
+echo "Ficus download successful"
+
+rm $FICUS_RELEASE_JSON
 
 # Download latest release of Circe
 


### PR DESCRIPTION
# Overview

Pull ficus' latest release in as part of `vendor_download.sh`.

## Acceptance criteria

- If this PR is successful, we will download `ficus` as part of `vendor_download.sh` on any supported platform.
- It will not be called in the CLI (yet.)
- There is no CHANGELOG change here because the internal binary is not called anywhere and so is invisible to the user.

## Testing plan

- Locally comment-out `case` statements on `uname -s` to force e.g. MacOS vs Windows, and witness this continue to work on both.
- If it *doesn't* work, we will fail CI
- No new tests, as CI should serve as a test

## Risks

Low-to-no-risk: the resulting `ficus` is not called yet.

## Metrics

N/A

## References

- [ANE-2484](https://fossa.atlassian.net/browse/ANE-2484).

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
