### PR TITLE
[ane-2575] scan all layers for os info

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - gradle: Do not report version constraints, version contraints are contained within an`DependencyResult`, filter out any constraints by checking [`isConstraint()`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/result/DependencyResult.html#isConstraint()). ([#1563](https://github.com/fossas/fossa-cli/pull/1563))
+- container scanning: search all layers for os information. ([#1566](https://github.com/fossas/fossa-cli/pull/1566))
 
 ## 3.10.13
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## 3.10.14
 
 - gradle: Do not report version constraints, version contraints are contained within an`DependencyResult`, filter out any constraints by checking [`isConstraint()`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/result/DependencyResult.html#isConstraint()). ([#1563](https://github.com/fossas/fossa-cli/pull/1563))
 - container scanning: search all layers for os information. ([#1566](https://github.com/fossas/fossa-cli/pull/1566))

--- a/src/App/Fossa/Container/Sources/DockerArchive.hs
+++ b/src/App/Fossa/Container/Sources/DockerArchive.hs
@@ -123,7 +123,7 @@ analyzeFromDockerArchive systemDepsOnly filters withoutDefaultFilters tarball = 
   let imageBaseLayer = baseLayer image
       baseDigest = layerDigest imageBaseLayer
   baseFs <- context "Building Base Layer FS" $ mkFsFromChangeset $ baseLayer image
-  layersFs <- 
+  layersFs <-
     if hasOtherLayers image
       then pure <$> context "Building Other Layers FS" (mkFsFromChangeset (otherLayersSquashed image))
       else pure Nothing

--- a/src/App/Fossa/Container/Sources/DockerArchive.hs
+++ b/src/App/Fossa/Container/Sources/DockerArchive.hs
@@ -123,9 +123,10 @@ analyzeFromDockerArchive systemDepsOnly filters withoutDefaultFilters tarball = 
   let imageBaseLayer = baseLayer image
       baseDigest = layerDigest imageBaseLayer
   baseFs <- context "Building Base Layer FS" $ mkFsFromChangeset $ baseLayer image
-  layersFs <- if hasOtherLayers image
-    then pure <$> context "Building Other Layers FS" (mkFsFromChangeset (otherLayersSquashed image))
-    else pure Nothing
+  layersFs <- 
+    if hasOtherLayers image
+      then pure <$> context "Building Other Layers FS" (mkFsFromChangeset (otherLayersSquashed image))
+      else pure Nothing
   osInfo <- getOsInfoFromLayers layersFs baseFs tarball
 
   when (isNothing osInfo) $
@@ -340,14 +341,15 @@ listTargetsFromDockerArchive tarball = do
   logInfo "Analyzing Base Layer"
 
   baseFs <- mkFsFromChangeset $ baseLayer image
-  layersFs <- if hasOtherLayers image
-    then pure <$> context "Building squashed FS from other layers" (mkFsFromChangeset $ otherLayersSquashed image)
-    else pure Nothing
+  layersFs <-
+    if hasOtherLayers image
+      then pure <$> context "Building squashed FS from other layers" (mkFsFromChangeset $ otherLayersSquashed image)
+      else pure Nothing
   osInfo <- getOsInfoFromLayers layersFs baseFs tarball
 
   context "Analyzing From Base Layer" $ listTargetLayer capabilities osInfo baseFs tarball "Base Layer"
 
-  case layersFs  of
+  case layersFs of
     Nothing -> logInfo "No other layers found in the image."
     Just fs -> do
       void . context "Analyzing from Other Layers" $ listTargetLayer capabilities osInfo fs tarball "Other Layers"
@@ -400,7 +402,7 @@ getOsInfoFromLayers ::
   Path Abs File ->
   m (Maybe OsInfo)
 getOsInfoFromLayers layersFs baseFs tarball =
-   context "Retrieving OS Information" $ do
+  context "Retrieving OS Information" $ do
     layersFSOsInfo <- case layersFs of
       Just fs -> warnThenRecover @Text "Could not retrieve OS info from other layers, falling back to base layer." $ runTarballReadFSIO fs tarball getOsInfo
       Nothing -> pure Nothing

--- a/src/App/Fossa/Container/Sources/DockerArchive.hs
+++ b/src/App/Fossa/Container/Sources/DockerArchive.hs
@@ -350,7 +350,7 @@ listTargetsFromDockerArchive tarball = do
   context "Analyzing From Base Layer" $ listTargetLayer capabilities osInfo baseFs tarball "Base Layer"
 
   case layersFs of
-    Nothing -> logInfo "No other layers found in the image."
+    Nothing -> pure ()
     Just fs -> do
       void . context "Analyzing from Other Layers" $ listTargetLayer capabilities osInfo fs tarball "Other Layers"
 

--- a/test/App/Fossa/Container/AnalyzeNativeSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeSpec.hs
@@ -51,10 +51,10 @@ import Types (DiscoveredProjectType (SetuptoolsProjectType), GraphBreadth (..), 
 
 spec :: Spec
 spec = do
-  -- dockerEngineSpec
+  dockerEngineSpec
   analyzeSpec
-  -- jarsInContainerSpec
-  -- nestedJarsInContainerSpec
+  jarsInContainerSpec
+  nestedJarsInContainerSpec
 
 dockerEngineSpec :: Spec
 dockerEngineSpec = describe "parseDockerEngineSource" $ do

--- a/test/App/Fossa/Container/AnalyzeNativeSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeSpec.hs
@@ -115,7 +115,7 @@ analyzeSpec = describe "analyze" $ do
   it' "should get os-info from any layer" $ do
     containerScan <- analyzeFromDockerArchive False mempty (toFlag' False) osInfoArchive
     let osInfo = imageData containerScan
-    (imageOs osInfo) `shouldBe'` Just "Fake OS"
+    (imageOs osInfo) `shouldBe'` Just "fakeos"
 
 buildImportsOf :: ContainerScan -> [Locator]
 buildImportsOf scan =

--- a/test/App/Fossa/Container/AnalyzeNativeSpec.hs
+++ b/test/App/Fossa/Container/AnalyzeNativeSpec.hs
@@ -7,7 +7,7 @@ import App.Fossa.Container.Scan (
   parseDockerEngineSource,
  )
 import App.Fossa.Container.Sources.DockerArchive (analyzeFromDockerArchive)
-import Container.Types (ContainerScan (ContainerScan, imageData), ContainerScanImage (ContainerScanImage, imageLayers), layerId, observations, srcUnits)
+import Container.Types (ContainerScan (ContainerScan, imageData), ContainerScanImage (ContainerScanImage, imageLayers, imageOs), layerId, observations, srcUnits)
 import Control.Carrier.Debug (IgnoreDebugC, ignoreDebug)
 import Control.Carrier.Diagnostics (DiagnosticsC, Has)
 import Control.Carrier.Stack (StackC, runStack)
@@ -51,10 +51,10 @@ import Types (DiscoveredProjectType (SetuptoolsProjectType), GraphBreadth (..), 
 
 spec :: Spec
 spec = do
-  dockerEngineSpec
+  -- dockerEngineSpec
   analyzeSpec
-  jarsInContainerSpec
-  nestedJarsInContainerSpec
+  -- jarsInContainerSpec
+  -- nestedJarsInContainerSpec
 
 dockerEngineSpec :: Spec
 dockerEngineSpec = describe "parseDockerEngineSource" $ do
@@ -81,6 +81,7 @@ analyzeSpec :: Spec
 analyzeSpec = describe "analyze" $ do
   currDir <- runIO getCurrentDir
   let imageArchive = currDir </> appDepsImage
+  let osInfoArchive = currDir </> osInfoImage
 
   it' "should not analyze application dependencies when only-system-dependencies are requested" $ do
     containerScan <- analyzeFromDockerArchive True mempty (toFlag' False) imageArchive
@@ -110,6 +111,11 @@ analyzeSpec = describe "analyze" $ do
     containerScan <- analyzeFromDockerArchive False (excludePath appAPath) (toFlag' False) imageArchive
     buildImportsOf containerScan `shouldNotContain'` [black]
     buildImportsOf containerScan `shouldBeSupersetOf'` [numpy, scipy]
+
+  it' "should get os-info from any layer" $ do
+    containerScan <- analyzeFromDockerArchive False mempty (toFlag' False) osInfoArchive
+    let osInfo = imageData containerScan
+    (imageOs osInfo) `shouldBe'` Just "Fake OS"
 
 buildImportsOf :: ContainerScan -> [Locator]
 buildImportsOf scan =
@@ -155,6 +161,9 @@ runWithMockDockerEngineEff =
 
 appDepsImage :: Path Rel File
 appDepsImage = $(mkRelFile "test/Container/testdata/app_deps_example.tar")
+
+osInfoImage :: Path Rel File
+osInfoImage = $(mkRelFile "test/Container/testdata/osinfo_example.tar")
 
 -- | From "app/services/a/" project.
 numpy :: Locator

--- a/test/Container/testdata/Dockerfile.osinfo.sample
+++ b/test/Container/testdata/Dockerfile.osinfo.sample
@@ -1,0 +1,18 @@
+# Testcase: osinfo_example.tar
+#
+# To Build:
+#   docker build -f Dockerfile.osinfo.sample . -t osinfo_example:latest
+#
+# To Export:
+#   docker save osinfo_example:latest > osinfo_example.tar
+#
+# To Run:
+#   docker run -it osinfo_example:latest /bin/sh
+FROM busybox
+
+# Generate fake os-release file
+RUN echo "NAME=\"Fake OS\"" > /etc/os-release && \
+    echo "VERSION=\"1.0\"" >> /etc/os-release && \
+    echo "ID=fakeos" >> /etc/os-release && \
+    echo "VERSION_ID=\"1.0\"" >> /etc/os-release && \
+    echo "PRETTY_NAME=\"Fake OS 1.0\"" >> /etc/os-release


### PR DESCRIPTION
# Overview

- change to scan all layers (the "squashed" layers first, then base layer) for os information. This change could technically cause os information to be different between previous scans, we previously only checked the base layer. A layer further down the chain could update the os information. If someone feel strongly we should only check for os info after none is found in the base layer - I'm happy to make the change, this feels more accurate though.

## Acceptance criteria

- os info is retrieved even if it exists in another layer

## Testing plan

- download the tarballs from the ANE on call ticket, specifically `1.52.0`, then an analysis on it and dependencies are reported.
- try it on `cgr.dev/chainguard/glibc-dynamic:latest-dev` and dependencies are also reported

## Risks

- I highlighted it in my overview but this change could cause os-information to change between the previous container scans.

## Metrics

n/a

## References

https://fossa.atlassian.net/browse/ANE-2575

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
