### PR TITLE
Correctly identify transitive dev deps in V3 package-lock files

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@
     gmp_static =
       gmp.overrideAttrs (old: { dontDisableStatic = true; });
     lzma_static =
-      lzma.overrideAttrs (old: { dontDisableStatic = true; });
+      xz.overrideAttrs (old: { dontDisableStatic = true; });
   in mkShell {
     nativeBuildInputs = [
         cabal-install
@@ -19,15 +19,16 @@
         haskellPackages.cabal-fmt
         hlint
         zlib.dev
-        zlib.static
         git
-        glibc.dev
-        glibc.static
         bzip2_static
         bzip2_static.dev
         libffi_static.dev
         gmp_static.dev
         lzma_static.dev
+    ] ++ lib.optionals stdenv.isLinux [
+        zlib.static
+        glibc.dev
+        glibc.static
     ];
     shellHook = ''
       export LANG=C.UTF-8

--- a/test/Node/testdata/lockfileV3/graphing/dev-dependencies-package-lock.json
+++ b/test/Node/testdata/lockfileV3/graphing/dev-dependencies-package-lock.json
@@ -1,0 +1,54 @@
+{
+  "name": "test-dev-deps",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-dev-deps",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "prod-dep": "^1.0.0"
+      },
+      "devDependencies": {
+        "dev-dep": "^1.0.0"
+      }
+    },
+    "node_modules/prod-dep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prod-dep/-/prod-dep-1.0.0.tgz",
+      "integrity": "sha512-example1",
+      "dependencies": {
+        "prod-transitive": "^1.0.0"
+      }
+    },
+    "node_modules/prod-transitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prod-transitive/-/prod-transitive-1.0.0.tgz",
+      "integrity": "sha512-example2"
+    },
+    "node_modules/dev-dep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dev-dep/-/dev-dep-1.0.0.tgz",
+      "integrity": "sha512-example3",
+      "dev": true,
+      "dependencies": {
+        "dev-transitive": "^1.0.0"
+      }
+    },
+    "node_modules/dev-transitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dev-transitive/-/dev-transitive-1.0.0.tgz",
+      "integrity": "sha512-example4",
+      "dependencies": {
+        "shared-dep": "^1.0.0"
+      }
+    },
+    "node_modules/shared-dep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shared-dep/-/shared-dep-1.0.0.tgz",
+      "integrity": "sha512-example5"
+    }
+  }
+}


### PR DESCRIPTION
# Overview

In V3 package-lock files, fossa-cli is not filtering out transitive dev dependencies. This is because it is failing to recognize that transitive deps of dev dependencies are also dev dependencies.

## Acceptance criteria

Transitive dev deps are correctly identified as dev deps and are filtered out of a project's dependencies list.

## Testing plan

1. Download the `package.json` file attached to [ANE-1997](https://fossa.atlassian.net/browse/ANE-1997).
2. Run `npm install` in the directory with the package.json to build the project.
3. Run the currrent production copy of `fossa-cli` on the directory
4. Observe in the FOSSA UI that transitive dev deps like `@angular-devkit/build-angular` are listed
5. Run this version of `fossa-cli` on the directory
6. Observe in the FOSSA UI that transitive dev deps like `@angular-devkit/build-angular` are NOT listed

## Risks

Could miscategorize dependencies if there is a bug in this logic.

## References

- [ANE-1997](https://fossa.atlassian.net/browse/ANE-1997): In NPM projects, some transitive dev dependencies are being shown as direct dependencies

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1997]: https://fossa.atlassian.net/browse/ANE-1997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANE-1997]: https://fossa.atlassian.net/browse/ANE-1997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ