### PR TITLE
Replace the BASIS token with an updated token

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -96,7 +96,7 @@ jobs:
         mkdir vendor-bins
         ./vendor_download.sh
       env:
-        GITHUB_TOKEN: ${{ secrets.BASIS_ACCESS_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.ANALYSIS_VENDOR_DOWNLOAD_TOKEN }}
 
     - name: Build
       env:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -167,7 +167,7 @@ jobs:
         mkdir vendor-bins
         ./vendor_download.sh
       env:
-        GITHUB_TOKEN: ${{ secrets.BASIS_ACCESS_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.ANALYSIS_VENDOR_DOWNLOAD_TOKEN }}
 
     - name: Build and Unit Test (Linux ARM)
       if: ${{ matrix.os == 'LinuxARM' }}

--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -103,7 +103,7 @@ jobs:
         mkdir vendor-bins
         ./vendor_download.sh
       env:
-        GITHUB_TOKEN: ${{ secrets.BASIS_ACCESS_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.ANALYSIS_VENDOR_DOWNLOAD_TOKEN }}
 
     - name: Build
       env:


### PR DESCRIPTION
# Overview

This PR replaces the reference to the BASIS_ACCESS_TOKEN. The token recently expired, and I figured it was a good time to update the name. Basis no longer really exists, and the purpose of the command is to download libraries that have been ripped out from Basis, among other new things like circe. Changing it to ANALYSIS_VENDOR_DOWNLOAD_TOKEN felt appropriate. I'm open to other suggestions.

## Acceptance criteria

This build succeeds.

## Testing plan

I validated that the updated token works by replacing the BASIS_ACCESS_TOKEN with the updated token and retrying another failed build.

## Risks

The only risk is that the permissions could be different for this token than the BASIS_ACCESS_TOKEN was, but it only has read access, so it should be fine.

## References

Failed builds

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
