### PR TITLE
[ANE-2484][ANE-2503] Actually call Ficus, use `--x-snippet-scan` as a flag.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.11.0
+
+- Add a dependency on Ficus, a new internal tool.
+
 ## 3.10.14
 
 - gradle: Do not report version constraints, version contraints are contained within an`DependencyResult`, filter out any constraints by checking [`isConstraint()`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/result/DependencyResult.html#isConstraint()). ([#1563](https://github.com/fossas/fossa-cli/pull/1563))

--- a/integration-test/Analysis/FicusSpec.hs
+++ b/integration-test/Analysis/FicusSpec.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Analysis.FicusSpec (spec) where
+
+import App.Fossa.Ficus.Analyze (analyzeWithFicus)
+import App.Fossa.Ficus.Types (FicusSnippetScanResults (..))
+import App.Types (ProjectRevision (..))
+import Control.Carrier.Diagnostics (runDiagnostics)
+import Control.Carrier.Stack (runStack)
+import Control.Carrier.StickyLogger (ignoreStickyLogger)
+import Control.Timeout (Duration (Seconds))
+import Data.List (isInfixOf)
+import Data.String.Conversion (toText)
+import Diag.Result (Result (Failure, Success))
+import Effect.Exec (runExecIO)
+import Effect.Logger (ignoreLogger)
+import Effect.ReadFS (runReadFSIO)
+import Fossa.API.Types (ApiKey (..), ApiOpts (..))
+import Path (Dir, Path, Rel, reldir, (</>))
+import Path.IO qualified as PIO
+import System.Environment (lookupEnv)
+import Test.Hspec
+import Text.URI (mkURI)
+
+fixtureDir :: Path Rel Dir
+fixtureDir = [reldir|integration-test/Analysis/testdata/ficus|]
+
+spec :: Spec
+spec = do
+  describe "Ficus snippet scanning integration" $ do
+    it "should run ficus binary successfully" $ do
+      -- Check for API configuration from environment
+      maybeApiKey <- lookupEnv "FOSSA_API_KEY"
+      maybeEndpoint <- lookupEnv "FOSSA_ENDPOINT"
+
+      apiOpts <- case (maybeApiKey, maybeEndpoint) of
+        (Just keyStr, Just endpointStr) -> do
+          uri <- case mkURI (toText endpointStr) of
+            Just validUri -> pure validUri
+            Nothing -> fail $ "Invalid API endpoint URL: " ++ endpointStr
+          let opts = ApiOpts (Just uri) (ApiKey (toText keyStr)) (Seconds 60)
+          pure (Just opts)
+        _ -> pure Nothing
+
+      currentDir <- PIO.getCurrentDir
+      let testDataDir = currentDir </> fixtureDir
+          revision = ProjectRevision "ficus-integration-test" "testdata-123456" (Just "integration-test")
+
+      -- Check if test data exists
+      testDataExists <- PIO.doesDirExist testDataDir
+      testDataExists `shouldBe` True
+
+      result <- runStack . runDiagnostics . ignoreStickyLogger . ignoreLogger . runExecIO . runReadFSIO $ analyzeWithFicus testDataDir apiOpts revision Nothing
+
+      case result of
+        Success _warnings analysisResult -> do
+          case analysisResult of
+            Just (FicusSnippetScanResults analysisId) -> do
+              analysisId `shouldSatisfy` (> 0)
+            Nothing -> do
+              -- No snippet scan results returned - this is acceptable for integration testing
+              True `shouldBe` True
+        Failure _warnings errors -> do
+          let failureMsg = show errors
+          case apiOpts of
+            Just _ -> do
+              -- With API credentials, accept 404/temp-storage errors as valid connectivity tests
+              if "404" `isInfixOf` failureMsg || "temp-storage" `isInfixOf` failureMsg || "Status(" `isInfixOf` failureMsg
+                then True `shouldBe` True -- Expected API connectivity issue
+                else fail ("Ficus integration test failed unexpectedly: " ++ failureMsg)
+            Nothing -> do
+              -- Without API credentials, analysis failure is expected
+              True `shouldBe` True

--- a/integration-test/Analysis/testdata/ficus/README.md
+++ b/integration-test/Analysis/testdata/ficus/README.md
@@ -1,0 +1,34 @@
+# Ficus Integration Test Project
+
+This is a test project used for integration testing of the ficus snippet scanning functionality in the FOSSA CLI.
+
+## Files
+
+- `main.c` - Main program with various C constructs for snippet analysis
+- `helper.h` - Header file with function declarations and common macros
+- `helper.c` - Implementation of helper functions with typical C patterns
+- `README.md` - This documentation file
+
+## Purpose
+
+These files contain various C programming patterns that might be detected by ficus fingerprinting:
+
+- Standard library usage (`stdio.h`, `stdlib.h`, `string.h`)
+- Memory allocation and deallocation patterns
+- String manipulation functions
+- Mathematical operations
+- Loops and conditionals
+- Macro definitions
+- Struct definitions
+- Common C idioms and patterns
+
+The goal is to provide realistic C code that ficus can analyze for snippets while remaining simple enough for integration testing.
+
+## Building
+
+This is not intended to be built as a real program, but rather analyzed by ficus for snippet detection.
+
+```bash
+# This is what ficus would analyze:
+ficus analyze --endpoint <endpoint> --secret <api-key> --locator <project-locator>
+```

--- a/integration-test/Analysis/testdata/ficus/helper.c
+++ b/integration-test/Analysis/testdata/ficus/helper.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "helper.h"
+
+/**
+ * Implementation file for helper functions
+ * Contains common C patterns for snippet analysis
+ */
+
+int helper_function(int value) {
+    // Simple mathematical operation
+    if (value < 0) {
+        return -1;
+    }
+    
+    // Common algorithm pattern
+    int result = 1;
+    for (int i = 1; i <= value; i++) {
+        result += i * 2;
+    }
+    
+    return result % 1000;  // Keep result manageable
+}
+
+void process_data(const char* input, char* output, size_t max_len) {
+    if (input == NULL || output == NULL || max_len == 0) {
+        return;
+    }
+    
+    // String processing pattern
+    size_t input_len = strlen(input);
+    size_t copy_len = MIN(input_len, max_len - 1);
+    
+    strncpy(output, input, copy_len);
+    output[copy_len] = '\0';
+    
+    // Convert to uppercase
+    for (size_t i = 0; i < copy_len; i++) {
+        if (output[i] >= 'a' && output[i] <= 'z') {
+            output[i] = output[i] - 'a' + 'A';
+        }
+    }
+}
+
+double calculate_average(int* numbers, int count) {
+    if (numbers == NULL || count <= 0) {
+        return 0.0;
+    }
+    
+    long long sum = 0;
+    for (int i = 0; i < count; i++) {
+        sum += numbers[i];
+    }
+    
+    return (double)sum / count;
+}

--- a/integration-test/Analysis/testdata/ficus/helper.h
+++ b/integration-test/Analysis/testdata/ficus/helper.h
@@ -1,0 +1,35 @@
+#ifndef HELPER_H
+#define HELPER_H
+
+/**
+ * Helper header file for ficus integration testing
+ * Contains function declarations and common patterns
+ * that might be detected by snippet analysis.
+ */
+
+// Function declarations
+int helper_function(int value);
+void process_data(const char* input, char* output, size_t max_len);
+double calculate_average(int* numbers, int count);
+
+// Common macros that might be fingerprinted
+#define MAX_BUFFER_SIZE 1024
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+
+// Struct definition
+typedef struct {
+    int id;
+    char name[64];
+    double value;
+} data_record_t;
+
+// Function-like macro
+#define SAFE_FREE(ptr) do { \
+    if ((ptr) != NULL) { \
+        free(ptr); \
+        (ptr) = NULL; \
+    } \
+} while(0)
+
+#endif // HELPER_H

--- a/integration-test/Analysis/testdata/ficus/main.c
+++ b/integration-test/Analysis/testdata/ficus/main.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "helper.h"
+
+/* 
+ * Simple C program for ficus snippet analysis testing
+ * This file contains various C constructs that might be detected
+ * by ficus fingerprinting algorithms.
+ */
+
+int main(int argc, char *argv[]) {
+    printf("Hello, World!\n");
+    
+    // String manipulation that might be fingerprinted
+    char buffer[256];
+    strncpy(buffer, "Test string for analysis", sizeof(buffer) - 1);
+    buffer[sizeof(buffer) - 1] = '\0';
+    
+    // Function call to helper
+    int result = helper_function(42);
+    
+    // Memory allocation pattern
+    int *data = malloc(10 * sizeof(int));
+    if (data != NULL) {
+        for (int i = 0; i < 10; i++) {
+            data[i] = i * i;
+        }
+        free(data);
+    }
+    
+    printf("Result: %d\n", result);
+    return EXIT_SUCCESS;
+}

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -245,6 +245,8 @@ library
     App.Fossa.DependencyMetadata
     App.Fossa.DumpBinaries
     App.Fossa.EmbeddedBinary
+    App.Fossa.Ficus.Analyze
+    App.Fossa.Ficus.Types
     App.Fossa.FirstPartyScan
     App.Fossa.Init
     App.Fossa.Lernie.Analyze

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -754,6 +754,7 @@ test-suite integration-tests
     Analysis.CocoapodsSpec
     Analysis.ElixirSpec
     Analysis.ErlangSpec
+    Analysis.FicusSpec
     Analysis.FixtureExpectationUtils
     Analysis.FixtureUtils
     Analysis.GoSpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -110,7 +110,7 @@ import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text.Extra (showT)
 import Data.Traversable (for)
 import Diag.Diagnostic as DI
-import Diag.Result (resultToMaybe)
+import Diag.Result (Result (Success), resultToMaybe)
 import Discovery.Archive qualified as Archive
 import Discovery.Filters (AllFilters, MavenScopeFilters, applyFilters, filterIsVSIOnly, ignoredPaths, isDefaultNonProductionPath)
 import Discovery.Projects (withDiscoveredProjects)
@@ -432,7 +432,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
           $ analyzeForReachability projectScans
   let reachabilityUnits = onlyFoundUnits reachabilityUnitsResult
 
-  let analysisResult = AnalysisScanResult projectScans vsiResults binarySearchResults manualSrcUnits dynamicLinkedResults maybeLernieResults reachabilityUnitsResult
+  let analysisResult = AnalysisScanResult projectScans vsiResults binarySearchResults (Success [] Nothing) manualSrcUnits dynamicLinkedResults maybeLernieResults reachabilityUnitsResult
   renderScanSummary (severity cfg) maybeEndpointAppVersion analysisResult cfg
 
   -- Need to check if vendored is empty as well, even if its a boolean that vendoredDeps exist

--- a/src/App/Fossa/Analyze/ScanSummary.hs
+++ b/src/App/Fossa/Analyze/ScanSummary.hs
@@ -193,7 +193,7 @@ renderDefaultSkippedTargetHelp =
   ]
 
 summarize :: Config.AnalyzeConfig -> Text -> AnalysisScanResult -> Maybe ([Doc AnsiStyle])
-summarize cfg endpointVersion (AnalysisScanResult dps vsi binary manualDeps dynamicLinkingDeps lernie reachabilityAttempts) =
+summarize cfg endpointVersion (AnalysisScanResult dps vsi binary ficus manualDeps dynamicLinkingDeps lernie reachabilityAttempts) =
   if (numProjects totalScanCount <= 0)
     then Nothing
     else
@@ -426,7 +426,7 @@ countWarnings ws =
     isIgnoredErrGroup _ = False
 
 dumpResultLogsToTempFile :: (Has (Lift IO) sig m) => Config.AnalyzeConfig -> Text -> AnalysisScanResult -> m (Path Abs File)
-dumpResultLogsToTempFile cfg endpointVersion (AnalysisScanResult projects vsi binary manualDeps dynamicLinkingDeps lernieResults reachabilityAttempts) = do
+dumpResultLogsToTempFile cfg endpointVersion (AnalysisScanResult projects vsi binary ficus manualDeps dynamicLinkingDeps lernieResults reachabilityAttempts) = do
   let doc =
         stripAnsiEscapeCodes
           . renderStrict
@@ -449,7 +449,7 @@ dumpResultLogsToTempFile cfg endpointVersion (AnalysisScanResult projects vsi bi
   pure (tmpDir </> scanSummaryFileName)
   where
     scanSummary :: [Doc AnsiStyle]
-    scanSummary = maybeToList (vsep <$> summarize cfg endpointVersion (AnalysisScanResult projects vsi binary manualDeps dynamicLinkingDeps lernieResults reachabilityAttempts))
+    scanSummary = maybeToList (vsep <$> summarize cfg endpointVersion (AnalysisScanResult projects vsi binary ficus manualDeps dynamicLinkingDeps lernieResults reachabilityAttempts))
 
     renderSourceUnit :: Doc AnsiStyle -> Result (Maybe a) -> Maybe (Doc AnsiStyle)
     renderSourceUnit header (Failure ws eg) = Just $ renderFailure ws eg $ vsep $ summarizeSrcUnit header Nothing (Failure ws eg)

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -12,7 +12,7 @@ module App.Fossa.Analyze.Types (
 
 import App.Fossa.Analyze.Project (ProjectResult)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig)
-import App.Fossa.Ficus.Types (FicusResults)
+import App.Fossa.Ficus.Types (FicusSnippetScanResults)
 import App.Fossa.Lernie.Types (LernieResults)
 import App.Fossa.Reachability.Types (SourceUnitReachability (..))
 import App.Types (Mode)
@@ -81,7 +81,7 @@ data AnalysisScanResult = AnalysisScanResult
   { analyzersScanResult :: [DiscoveredProjectScan]
   , vsiScanResult :: Result (Maybe [SourceUnit])
   , binaryDepsScanResult :: Result (Maybe SourceUnit)
-  , ficusResult :: Result (Maybe FicusResults)
+  , ficusResult :: Result (Maybe FicusSnippetScanResults)
   , fossaDepsScanResult :: Result (Maybe SourceUnit)
   , dynamicLinkingResult :: Result (Maybe SourceUnit)
   , lernieResult :: Result (Maybe LernieResults)

--- a/src/App/Fossa/Analyze/Types.hs
+++ b/src/App/Fossa/Analyze/Types.hs
@@ -12,6 +12,7 @@ module App.Fossa.Analyze.Types (
 
 import App.Fossa.Analyze.Project (ProjectResult)
 import App.Fossa.Config.Analyze (ExperimentalAnalyzeConfig)
+import App.Fossa.Ficus.Types (FicusResults)
 import App.Fossa.Lernie.Types (LernieResults)
 import App.Fossa.Reachability.Types (SourceUnitReachability (..))
 import App.Types (Mode)
@@ -80,6 +81,7 @@ data AnalysisScanResult = AnalysisScanResult
   { analyzersScanResult :: [DiscoveredProjectScan]
   , vsiScanResult :: Result (Maybe [SourceUnit])
   , binaryDepsScanResult :: Result (Maybe SourceUnit)
+  , ficusResult :: Result (Maybe FicusResults)
   , fossaDepsScanResult :: Result (Maybe SourceUnit)
   , dynamicLinkingResult :: Result (Maybe SourceUnit)
   , lernieResult :: Result (Maybe LernieResults)

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -114,6 +114,7 @@ import Options.Applicative (
   InfoMod,
   Parser,
   eitherReader,
+  help,
   helpDoc,
   hidden,
   long,
@@ -233,6 +234,7 @@ data AnalyzeCliOpts = AnalyzeCliOpts
   , analyzeStaticOnlyTactics :: Flag StaticOnlyTactics
   , analyzeWithoutDefaultFilters :: Flag WithoutDefaultFilters
   , analyzeStrictMode :: Flag StrictMode
+  , analyzeSnippetScan :: Bool
   }
   deriving (Eq, Ord, Show)
 
@@ -272,6 +274,7 @@ data AnalyzeConfig = AnalyzeConfig
   , reachabilityConfig :: ReachabilityConfig
   , withoutDefaultFilters :: Flag WithoutDefaultFilters
   , mode :: Mode
+  , xSnippetScan :: Bool
   }
   deriving (Eq, Ord, Show, Generic)
 
@@ -342,6 +345,7 @@ cliParser =
     <*> flagOpt StaticOnlyTactics (applyFossaStyle <> long "static-only-analysis" <> stringToHelpDoc "Only analyze the project using static strategies.")
     <*> withoutDefaultFilterParser fossaAnalyzeDefaultFilterDocUrl
     <*> flagOpt StrictMode (applyFossaStyle <> long "strict" <> stringToHelpDoc "Enforces strict analysis to ensure the most accurate results by rejecting fallbacks.")
+    <*> switch (applyFossaStyle <> long "x-snippet-scan" <> help "Enable ficus snippet scanning")
   where
     fossaDepsFileHelp :: Maybe (Doc AnsiStyle)
     fossaDepsFileHelp =
@@ -556,6 +560,7 @@ mergeStandardOpts maybeConfig envvars cliOpts@AnalyzeCliOpts{..} = do
     <*> resolveReachabilityOptions reachabilityConfig
     <*> pure analyzeWithoutDefaultFilters
     <*> pure mode
+    <*> pure analyzeSnippetScan
 
 collectMavenScopeFilters ::
   (Has Diagnostics sig m) =>

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -139,7 +139,6 @@ cleanupExtractedBinaries (BinaryPaths binPath _) = sendIO $ removeDirRecur binPa
 extractEmbeddedBinary :: (Has (Lift IO) sig m) => PackagedBinary -> m BinaryPaths
 extractEmbeddedBinary bin = do
   container <- sendIO extractDir
-  -- Determine paths to which we should write the binaries
   let binPath = extractedPath bin
   -- Write the binary
   sendIO $ writeBinary (container </> binPath) bin
@@ -152,14 +151,15 @@ dumpEmbeddedBinary dir bin = writeBinary path bin
     path = dir </> extractedPath bin
 
 writeBinary :: (Has (Lift IO) sig m) => Path Abs File -> PackagedBinary -> m ()
-writeBinary dest bin = sendIO . writeExecutable dest $ case bin of
-  Themis -> embeddedBinaryThemis
-  ThemisIndex -> embeddedBinaryThemisIndex
-  BerkeleyDB -> embeddedBinaryBerkeleyDB
-  Ficus -> embeddedBinaryFicus
-  Lernie -> embeddedBinaryLernie
-  Millhone -> embeddedBinaryMillhone
-  Circe -> embeddedBinaryCirce
+writeBinary dest bin = do
+  sendIO . writeExecutable dest $ case bin of
+    Themis -> embeddedBinaryThemis
+    ThemisIndex -> embeddedBinaryThemisIndex
+    BerkeleyDB -> embeddedBinaryBerkeleyDB
+    Ficus -> embeddedBinaryFicus
+    Lernie -> embeddedBinaryLernie
+    Millhone -> embeddedBinaryMillhone
+    Circe -> embeddedBinaryCirce
 
 writeExecutable :: Path Abs File -> ByteString -> IO ()
 writeExecutable path content = do

--- a/src/App/Fossa/EmbeddedBinary.hs
+++ b/src/App/Fossa/EmbeddedBinary.hs
@@ -4,12 +4,14 @@
 
 module App.Fossa.EmbeddedBinary (
   BinaryPaths,
+  Ficus,
   Lernie,
   ThemisIndex,
   ThemisBins (..),
   toPath,
   withThemisAndIndex,
   withBerkeleyBinary,
+  withFicusBinary,
   withLernieBinary,
   withMillhoneBinary,
   withCirceBinary,
@@ -57,6 +59,7 @@ data PackagedBinary
   = Themis
   | ThemisIndex
   | BerkeleyDB
+  | Ficus
   | Lernie
   | Millhone
   | Circe
@@ -76,6 +79,8 @@ data ThemisBinary
 data ThemisIndex
 
 data Lernie
+
+data Ficus
 
 data Circe
 
@@ -116,6 +121,9 @@ withBerkeleyBinary = withEmbeddedBinary BerkeleyDB
 withLernieBinary :: (Has (Lift IO) sig m) => (BinaryPaths -> m c) -> m c
 withLernieBinary = withEmbeddedBinary Lernie
 
+withFicusBinary :: (Has (Lift IO) sig m) => (BinaryPaths -> m c) -> m c
+withFicusBinary = withEmbeddedBinary Ficus
+
 withMillhoneBinary :: (Has (Lift IO) sig m) => (BinaryPaths -> m c) -> m c
 withMillhoneBinary = withEmbeddedBinary Millhone
 
@@ -148,6 +156,7 @@ writeBinary dest bin = sendIO . writeExecutable dest $ case bin of
   Themis -> embeddedBinaryThemis
   ThemisIndex -> embeddedBinaryThemisIndex
   BerkeleyDB -> embeddedBinaryBerkeleyDB
+  Ficus -> embeddedBinaryFicus
   Lernie -> embeddedBinaryLernie
   Millhone -> embeddedBinaryMillhone
   Circe -> embeddedBinaryCirce
@@ -163,6 +172,7 @@ extractedPath bin = case bin of
   Themis -> $(mkRelFile "themis-cli")
   ThemisIndex -> $(mkRelFile "index.gob.xz")
   BerkeleyDB -> $(mkRelFile "berkeleydb-plugin")
+  Ficus -> $(mkRelFile "ficus")
   Lernie -> $(mkRelFile "lernie")
   Millhone -> $(mkRelFile "millhone")
   Circe -> $(mkRelFile "circe")
@@ -210,6 +220,9 @@ embeddedBinaryLernie = $(embedFileIfExists "vendor-bins/lernie")
 
 embeddedBinaryCirce :: ByteString
 embeddedBinaryCirce = $(embedFileIfExists "vendor-bins/circe")
+
+embeddedBinaryFicus :: ByteString
+embeddedBinaryFicus = $(embedFileIfExists "vendor-bins/ficus")
 
 -- To build this, run `make build` or `cargo build --release`.
 #ifdef mingw32_HOST_OS

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -5,58 +5,48 @@ module App.Fossa.Ficus.Analyze (
   -- Exported for use in hubble
   analyzeWithFicusMain,
   -- Exported for testing
-  analyzeWithFicusWithOrgInfo,
   singletonFicusMessage,
-  ficusMessagesToFicusResults,
-  grepOptionsToFicusConfig,
 ) where
 
 import App.Fossa.EmbeddedBinary (BinaryPaths, toPath, withFicusBinary)
 import App.Fossa.Ficus.Types (
-  FicusResults (..),
+  FicusAllFlag (..),
+  FicusAnalysisFlag (..),
   FicusConfig (..),
-  FicusRegex (..),
-  FicusScanType (..),
-  FicusMessage (..),
-  FicusMessages (..),
-  FicusMatch (..),
-  FicusMatchData (..),
-  FicusWarning (..),
+  FicusDebug (..),
   FicusError (..),
+  FicusFinding (..),
+  FicusMessage (..),
+  FicusMessageData (..),
+  FicusMessages (..),
+  FicusPerStrategyFlag (..),
+  FicusSnippetScanResults (..),
  )
-import App.Fossa.Lernie.Types (
-  GrepEntry (..),
-  GrepOptions (..),
-  OrgWideCustomLicenseConfigPolicy (..),
- )
-import App.Types (FileUpload (..))
-import Control.Carrier.Debug (Debug)
-import Control.Carrier.Diagnostics (Diagnostics, fatal, warn)
-import Control.Carrier.FossaApiClient (runFossaApiClient)
-import Control.Carrier.Telemetry.Types
-import Control.Effect.FossaApiClient (FossaApiClient, getOrganization)
+import App.Types (ProjectRevision (..))
+import Control.Carrier.Diagnostics (Diagnostics)
 import Control.Effect.Lift (Has, Lift)
-import Control.Effect.Telemetry (Telemetry, trackUsage)
-import Control.Monad (join, unless)
-import Data.Aeson (decode)
-import Data.Aeson qualified as Aeson
+import Effect.Logger (Logger, logDebug, logInfo, logWarn)
+import Prettyprinter (pretty)
+
+import Data.Aeson (Object, decode, (.:))
+import Data.Aeson.Types (parseMaybe)
 import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (fold, traverse_)
-import Data.HashMap.Internal.Strict (HashMap)
-import Data.HashMap.Strict qualified as H
-import Data.HashMap.Strict qualified as HashMap
 import Data.Hashable (Hashable)
-import Data.List (nub)
-import Data.List.NonEmpty qualified as NE
 import Data.Maybe (mapMaybe)
-import Data.String.Conversion (ToText (toText), decodeUtf8)
+import Data.String.Conversion (ToText (toText))
 import Data.Text (Text)
-import Effect.Exec (AllowErr (Never), Command (..), Exec, execCurrentDirStdinThrow)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text.Encoding
+import Effect.Exec (AllowErr (Never), Command (..), Exec, execThrow')
 import Effect.ReadFS (ReadFS)
-import Fossa.API.Types (ApiOpts, Organization (..), orgFileUpload)
-import Path (Abs, Dir, File, Path)
-import Srclib.Types (LicenseScanType (..), LicenseSourceUnit (..), LicenseUnit (..), LicenseUnitData (..), LicenseUnitInfo (..), LicenseUnitMatchData (..))
-import Types (LicenseScanPathFilters)
+import Fossa.API.Types (ApiKey (..), ApiOpts (..))
+import Path (Abs, Dir, File, Path, toFilePath)
+import Srclib.Types (Locator (..), renderLocator)
+import Text.URI (render)
+import Text.URI.Builder (PathComponent (..), TrailingSlash (..), setPath)
+import Types (GlobFilter (..), LicenseScanPathFilters (..))
+import Prelude hiding (unwords)
 
 newtype CustomLicensePath = CustomLicensePath {unCustomLicensePath :: Text}
   deriving (Eq, Ord, Show, Hashable)
@@ -67,237 +57,144 @@ newtype CustomLicenseTitle = CustomLicenseTitle {unCustomLicenseTitle :: Text}
 analyzeWithFicus ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
-  , Has Debug sig m
   , Has Exec sig m
   , Has ReadFS sig m
-  , Has Telemetry sig m
+  , Has Logger sig m
   ) =>
   Path Abs Dir ->
   Maybe ApiOpts ->
-  GrepOptions ->
+  ProjectRevision ->
   Maybe LicenseScanPathFilters ->
-  m (Maybe FicusResults)
-analyzeWithFicus rootDir maybeApiOpts grepOptions filters = do
-  case (maybeApiOpts, orgWideCustomLicenseScanConfigPolicy grepOptions) of
-    (_, Ignore) -> analyzeWithFicusMain rootDir grepOptions filters
-    (Nothing, Use) -> analyzeWithFicusMain rootDir grepOptions filters
-    (Just apiOpts, Use) -> runFossaApiClient apiOpts $ analyzeWithFicusWithOrgInfo rootDir grepOptions filters
+  m (Maybe FicusSnippetScanResults)
+analyzeWithFicus rootDir apiOpts revision filters = do
+  analyzeWithFicusMain rootDir apiOpts revision filters
 
 analyzeWithFicusMain ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
   , Has Exec sig m
   , Has ReadFS sig m
-  , Has Telemetry sig m
+  , Has Logger sig m
   ) =>
   Path Abs Dir ->
-  GrepOptions ->
+  Maybe ApiOpts ->
+  ProjectRevision ->
   Maybe LicenseScanPathFilters ->
-  m (Maybe FicusResults)
-analyzeWithFicusMain rootDir grepOptions filters = do
-  let maybeFicusConfig = grepOptionsToFicusConfig rootDir grepOptions filters
-  case maybeFicusConfig of
-    Just ficusConfig -> do
-      unless (null $ customLicenseSearch grepOptions) $ trackUsage CustomLicenseSearchUsage
-      unless (null $ keywordSearch grepOptions) $ trackUsage ExperimentalKeywordSearchUsage
-      messages <- runFicus ficusConfig (configFilePath grepOptions)
-      let ficusResults = ficusMessagesToFicusResults messages rootDir
-      pure $ Just ficusResults
-    Nothing -> pure Nothing
-
-grepOptionsToFicusConfig :: Path Abs Dir -> GrepOptions -> Maybe LicenseScanPathFilters -> FileUpload -> Maybe FicusConfig
-grepOptionsToFicusConfig rootDir grepOptions filters uploadKind =
-  case (customLicenseSearches <> keywordSearches) of
-    [] -> Nothing
-    res -> Just $ FicusConfig
-      { ficusRootDir = rootDir
-      , ficusRegexes = res
-      , ficusLicenseScanPathFilters = filters
-      , ficusFullFiles = case uploadKind of
-          FileUploadMatchData -> False
-          FileUploadFullContent -> True
-      }
+  m (Maybe FicusSnippetScanResults)
+analyzeWithFicusMain rootDir apiOpts revision filters = do
+  logInfo $ "Running Ficus analysis on " <> pretty (toFilePath rootDir)
+  messages <- runFicus ficusConfig
+  let ficusResults = ficusMessagesToFicusSnippetScanResults messages
+  case ficusResults of
+    Just results -> do
+      logInfo $ "Ficus analysis completed successfully with analysis ID: " <> pretty (ficusSnippetScanResultsAnalysisId results)
+      logDebug $ "Found " <> pretty (length $ ficusMessageFindings messages) <> " findings from Ficus"
+    Nothing -> logInfo "Ficus analysis completed but no fingerprint findings were found"
+  pure ficusResults
   where
-    customLicenseSearches = map (grepEntryToFicusRegex FicusCustomLicense) (customLicenseSearch grepOptions)
-    keywordSearches = map (grepEntryToFicusRegex FicusKeywordSearch) (keywordSearch grepOptions)
+    ficusConfig =
+      FicusConfig
+        { ficusConfigRootDir = rootDir
+        , ficusConfigExclude = maybe [] licenseScanPathFiltersExclude filters
+        , ficusConfigEndpoint = apiOptsUri =<< apiOpts
+        , ficusConfigSecret = apiOptsApiKey <$> apiOpts
+        , ficusConfigRevision = revision
+        , ficusConfigFlags = [All $ FicusAllFlag SkipHiddenFiles, All $ FicusAllFlag Gitignore]
+        }
 
-grepEntryToFicusRegex :: FicusScanType -> GrepEntry -> FicusRegex
-grepEntryToFicusRegex scanType grepEntry =
-  FicusRegex
-    { ficusPat = grepEntryMatchCriteria grepEntry
-    , ficusName = grepEntryName grepEntry
-    , ficusScanType = scanType
-    }
+ficusMessagesToFicusSnippetScanResults :: FicusMessages -> Maybe FicusSnippetScanResults
+ficusMessagesToFicusSnippetScanResults messages =
+  let isFingerprintStrategy :: FicusFinding -> Bool
+      isFingerprintStrategy (FicusFinding (FicusMessageData strategy _)) =
+        Text.toLower strategy == "fingerprint"
+
+      extractAnalysisId :: FicusFinding -> Maybe Int
+      extractAnalysisId (FicusFinding (FicusMessageData _ payload)) =
+        case decode (BL.fromStrict $ Text.Encoding.encodeUtf8 payload) :: Maybe Object of
+          Just obj -> parseMaybe (.: "analysis_id") obj
+          Nothing -> Nothing
+
+      matchingFinding = filter isFingerprintStrategy (ficusMessageFindings messages)
+      analysisId = mapMaybe extractAnalysisId matchingFinding
+   in case analysisId of
+        (aid : _) -> Just $ FicusSnippetScanResults{ficusSnippetScanResultsAnalysisId = aid}
+        [] -> Nothing
 
 runFicus ::
   ( Has Diagnostics sig m
   , Has (Lift IO) sig m
   , Has ReadFS sig m
   , Has Exec sig m
+  , Has Logger sig m
   ) =>
   FicusConfig ->
-  Maybe (Path Abs File) ->
   m FicusMessages
-runFicus ficusConfig configFilePath = withFicusBinary $ \bin -> do
-  let ficusConfigJSON = decodeUtf8 $ Aeson.encode ficusConfig
-  result <- execCurrentDirStdinThrow (ficusCommand bin) ficusConfigJSON
-  let messages = parseFicusJson result configFilePath
-  traverse_ (fatal . displayFicusError) $ ficusMessageErrors messages
-  traverse_ (warn . displayFicusWarning) $ ficusMessageWarnings messages
-  pure messages
-  where
-    displayFicusWarning :: FicusWarning -> Text
-    displayFicusWarning FicusWarning{..} = ficusWarningType <> ": " <> ficusWarningMessage
-    displayFicusError :: FicusError -> Text
-    displayFicusError FicusError{..} = ficusErrorType <> ": " <> ficusErrorMessage
+runFicus ficusConfig = do
+  withFicusBinary $ \bin -> do
+    cmd <- ficusCommand ficusConfig bin
+    logDebug $ "Executing ficus"
+    result <- execThrow' cmd
+    let messages = parseFicusJson result Nothing
 
--- Run Ficus, passing "x-walk --config -" as its arg so that it gets its config from STDIN
-ficusCommand :: BinaryPaths -> Command
-ficusCommand bin =
-  Command
+    -- Log summary of results
+    logDebug $ "Ficus returned " <> pretty (length $ ficusMessageErrors messages) <> " errors, "
+             <> pretty (length $ ficusMessageDebugs messages) <> " debug messages, "
+             <> pretty (length $ ficusMessageFindings messages) <> " findings"
+
+    -- Handle errors - log them as warnings instead of fatal errors
+    -- Many ficus errors are expected (like binary file detection) and shouldn't stop analysis
+    traverse_ (logWarn . pretty . displayFicusError) $ ficusMessageErrors messages
+
+    -- Handle debug messages - log them as debug
+    traverse_ (logDebug . pretty . displayFicusDebug) $ ficusMessageDebugs messages
+
+    -- Log findings at info level for visibility since these are the actual results
+    traverse_ (logInfo . pretty . displayFicusFinding) $ ficusMessageFindings messages
+
+    pure messages
+  where
+    displayFicusDebug :: FicusDebug -> Text
+    displayFicusDebug (FicusDebug FicusMessageData{..}) = "DEBUG " <> ficusMessageDataStrategy <> ": " <> ficusMessageDataPayload
+    displayFicusError :: FicusError -> Text
+    displayFicusError (FicusError FicusMessageData{..}) = "ERROR " <> ficusMessageDataStrategy <> ": " <> ficusMessageDataPayload
+    displayFicusFinding :: FicusFinding -> Text
+    displayFicusFinding (FicusFinding FicusMessageData{..}) = "FINDING " <> ficusMessageDataStrategy <> ": " <> ficusMessageDataPayload
+
+-- Run Ficus, passing config-based args as configuration.
+-- Caveat! This hard-codes some flags currently which may later need to be set on a strategy-by-strategy basis.
+ficusCommand :: Has Diagnostics sig m => FicusConfig -> BinaryPaths -> m Command
+ficusCommand ficusConfig bin = do
+  endpoint <- case ficusConfigEndpoint ficusConfig of
+    Just baseUri -> do
+      pure $ render baseUri
+    Nothing -> pure ""
+  pure $ Command
     { cmdName = toText $ toPath bin
-    , cmdArgs = ["x-walk", "--config", "-"]
+    , cmdArgs = configArgs endpoint
     , cmdAllowErr = Never
     }
+  where
+    configArgs endpoint = ["analyze", "--secret", secret, "--endpoint", endpoint, "--locator", locator, "--set", "all:skip-hidden-files", "--set", "all:gitignore"] ++ configExcludes ++ [targetDir]
+    targetDir = toText $ toFilePath $ ficusConfigRootDir ficusConfig
+    secret = maybe "" (toText . unApiKey) $ ficusConfigSecret ficusConfig
+    locator = renderLocator $ Locator "custom" (projectName $ ficusConfigRevision ficusConfig) (Just $ projectRevision $ ficusConfigRevision ficusConfig)
+    configExcludes = unGlobFilter <$> ficusConfigExclude ficusConfig
 
 -- Parse Ficus's NDJson output by splitting on newlines (character 10) and
 -- then decoding each line
 parseFicusJson :: BL.ByteString -> Maybe (Path Abs File) -> FicusMessages
-parseFicusJson out configFilePath =
+parseFicusJson out _configFile =
   fold messages
   where
     messageLines = BL.splitWith (== 10) out
     -- Once Ficus supports file filtering we'll do this by passing the config file path into Ficus
     -- and Ficus will skip scanning the config file. But for now let's just filter post-scan
-    parsedLines = filter (notConfigFile configFilePath) $ mapMaybe decode messageLines
+    parsedLines = mapMaybe decode messageLines
     messages = map singletonFicusMessage parsedLines
-
-notConfigFile :: Maybe (Path Abs File) -> FicusMessage -> Bool
-notConfigFile (Just configFilePath) (FicusMessageFicusMatch ficusMessage) = ficusMatchPath ficusMessage /= toText configFilePath
-notConfigFile _ _ = True
-
-ficusMessagesToFicusResults :: FicusMessages -> Path Abs Dir -> FicusResults
-ficusMessagesToFicusResults FicusMessages{..} rootDir =
-  FicusResults
-    { ficusResultsKeywordSearches = keywordSearches
-    , ficusResultsCustomLicenses = customLicenses
-    , ficusResultsSourceUnit = sourceUnit
-    }
-  where
-    keywordSearches = filterFicusMessages ficusMessageMatches FicusKeywordSearch
-    customLicenses = filterFicusMessages ficusMessageMatches FicusCustomLicense
-    sourceUnit = case NE.nonEmpty customLicenses of
-      Nothing -> Nothing
-      Just licenses -> ficusMatchToSourceUnit (NE.toList licenses) rootDir
 
 -- add a FicusMessage to the corresponding entry of an empty FicusMessages
 singletonFicusMessage :: FicusMessage -> FicusMessages
 singletonFicusMessage message = case message of
-  FicusMessageFicusMatch msg -> mempty{ficusMessageMatches = [msg]}
-  FicusMessageFicusWarning msg -> mempty{ficusMessageWarnings = [msg]}
-  FicusMessageFicusError msg -> mempty{ficusMessageErrors = [msg]}
-
--- filter ficus matches to a specific scan type, filtering out any ficus matches with no messages after they have been filtered out
-filterFicusMessages :: [FicusMatch] -> FicusScanType -> [FicusMatch]
-filterFicusMessages matches scanType =
-  ficusMatchesWithoutEmpties
-  where
-    byScanType :: FicusMatchData -> Bool
-    byScanType m = scanType == ficusMatchDataScanType m
-    ficusMatchesFilteredToScanType = map (\fm -> FicusMatch (ficusMatchPath fm) (filter byScanType $ ficusMatchMatches fm) (ficusMatchContents fm)) matches
-    ficusMatchesWithoutEmpties = filter (not . null . ficusMatchMatches) ficusMatchesFilteredToScanType
-
--- Convert a list of ficus matches into a LicenseSourceUnit
--- The hard part is constructing the licenseSourceUnitLicenseUnits. This is an array of LicenseUnit, one per license found.
--- A LicenseUnit contains info about multiple files. Each file shows up in the Files attribute and in the
--- same position in the Data attribute.
--- So this function takes all of the Ficus Messages, which contain information about a single match in a single file,
--- and flips it around to get a list of licenses and the files they apply to.
-ficusMatchToSourceUnit :: [FicusMatch] -> Path Abs Dir -> Maybe LicenseSourceUnit
-ficusMatchToSourceUnit matches rootDir =
-  case NE.nonEmpty licenseUnits of
-    Just units ->
-      Just
-        LicenseSourceUnit
-          { licenseSourceUnitName = toText rootDir
-          , licenseSourceUnitType = CliLicenseScanned
-          , licenseSourceUnitLicenseUnits = units
-          }
-    Nothing -> Nothing
-  where
-    licenseUnits = licenseUnitsFromFicusMatches matches
-
--- Create LicenseUnits from the FicusMatches. All LicenseUnits will have a license ID of "custom-license".
--- There will be one LicenseUnit per custom-license title, and each LicenseUnit can contain results from multiple files.
--- A licenseUnitMatchData can be built from a FicusMatch
--- A LicenseUnitData has many LicenseUnitMatchData. There will be one
--- LicenseUnitData per (path, title) pair, containing all of the
--- LicenseUnitMatchData for that pair
--- A LicenseUnit has many LicenseUnitData
-licenseUnitsFromFicusMatches :: [FicusMatch] -> [LicenseUnit]
-licenseUnitsFromFicusMatches matches = do
-  let allLicenseUnitMatchData = concatMap ficusMatchToLicenseUnitMatchData matches
-  let fileContents = HashMap.fromList $ map getContentsFromFicusMatch matches
-  let allLicenseUnitData = map (createLicenseUnitDataSingles fileContents) allLicenseUnitMatchData
-  -- collectedLicenseUnitData has one LicenseUnitData per (path, title) pair, each one containing
-  -- all of the LicenseUnitMatchData for that (path, title) pair
-  let collectedLicenseUnitData = HashMap.fromListWith (<>) allLicenseUnitData
-  -- Now that we have all of the LicenseUnitData, we need to create LicenseUnits for them.
-  -- LicenseUnits do not have paths on them, so we group them up by title
-  let allLicenseUnits = map createLicenseUnitSingles $ HashMap.toList collectedLicenseUnitData
-  let licenseUnitsByTitle = map (\((_, title), lu) -> (title, lu)) allLicenseUnits
-  H.elems $ HashMap.fromListWith (<>) licenseUnitsByTitle
-
-getContentsFromFicusMatch :: FicusMatch -> (CustomLicensePath, Maybe Text)
-getContentsFromFicusMatch FicusMatch{..} = (CustomLicensePath ficusMatchPath, ficusMatchContents)
-
--- Create a list with keys of (path, title) and a value of a single LicenseUnitMatchData
-ficusMatchToLicenseUnitMatchData :: FicusMatch -> [((CustomLicensePath, CustomLicenseTitle), LicenseUnitMatchData)]
-ficusMatchToLicenseUnitMatchData FicusMatch{..} =
-  map (createLicenseUnitMatchData $ CustomLicensePath ficusMatchPath) ficusMatchMatches
-
--- Given a path and a FicusMatchData, create a single LicenseUnitMatchData
-createLicenseUnitMatchData :: CustomLicensePath -> FicusMatchData -> ((CustomLicensePath, CustomLicenseTitle), LicenseUnitMatchData)
-createLicenseUnitMatchData path FicusMatchData{..} =
-  ((path, title), licenseUnitMatchData)
-  where
-    title = CustomLicenseTitle ficusMatchDataName
-    licenseUnitMatchData =
-      LicenseUnitMatchData
-        { licenseUnitMatchDataMatchString = Just ficusMatchDataMatchString
-        , licenseUnitMatchDataLocation = ficusMatchDataStartByte
-        , licenseUnitMatchDataLength = ficusMatchDataEndByte - ficusMatchDataStartByte
-        , licenseUnitMatchDataIndex = 1
-        , licenseUnitDataStartLine = ficusMatchDataStartLine
-        , licenseUnitDataEndLine = ficusMatchDataEndLine
-        }
-
-createLicenseUnitDataSingles :: HashMap CustomLicensePath (Maybe Text) -> ((CustomLicensePath, CustomLicenseTitle), LicenseUnitMatchData) -> ((CustomLicensePath, CustomLicenseTitle), LicenseUnitData)
-createLicenseUnitDataSingles contents ((path, title), licenseUnitMatchData) =
-  ((path, title), newLicenseUnitData)
-  where
-    newLicenseUnitData =
-      LicenseUnitData
-        { licenseUnitDataPath = unCustomLicensePath path
-        , licenseUnitDataCopyright = Nothing
-        , licenseUnitDataThemisVersion = ""
-        , licenseUnitDataMatchData = Just $ NE.singleton licenseUnitMatchData
-        , licenseUnitDataCopyrights = Nothing
-        , licenseUnitDataContents = join $ HashMap.lookup path contents
-        }
-
-createLicenseUnitSingles :: ((CustomLicensePath, CustomLicenseTitle), LicenseUnitData) -> ((CustomLicensePath, CustomLicenseTitle), LicenseUnit)
-createLicenseUnitSingles ((path, title), licenseUnitData) =
-  ((path, title), lu)
-  where
-    lu =
-      LicenseUnit
-        { licenseUnitName = "custom-license"
-        , licenseUnitType = "LicenseUnit"
-        , licenseUnitTitle = Just $ unCustomLicenseTitle title
-        , licenseUnitDir = ""
-        , licenseUnitFiles = NE.singleton (unCustomLicensePath path)
-        , licenseUnitData = NE.singleton licenseUnitData
-        , licenseUnitNoticeFiles = []
-        , licenseUnitInfo = LicenseUnitInfo{licenseUnitInfoDescription = Just $ "custom license search " <> unCustomLicenseTitle title}
-        }
+  FicusMessageFinding msg -> mempty{ficusMessageFindings = [msg]}
+  FicusMessageDebug msg -> mempty{ficusMessageDebugs = [msg]}
+  FicusMessageError msg -> mempty{ficusMessageErrors = [msg]}

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -1,0 +1,301 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.Ficus.Analyze (
+  analyzeWithFicus,
+  -- Exported for use in hubble
+  analyzeWithFicusMain,
+  -- Exported for testing
+  analyzeWithFicusWithOrgInfo,
+  singletonFicusMessage,
+  ficusMessagesToFicusResults,
+  grepOptionsToFicusConfig,
+) where
+
+import App.Fossa.EmbeddedBinary (BinaryPaths, toPath, withFicusBinary)
+import App.Fossa.Ficus.Types (
+  FicusResults (..),
+ )
+import App.Types (FileUpload (..))
+import Control.Carrier.Debug (Debug)
+import Control.Carrier.Diagnostics (Diagnostics, fatal, warn)
+import Control.Carrier.FossaApiClient (runFossaApiClient)
+import Control.Carrier.Telemetry.Types
+import Control.Effect.FossaApiClient (FossaApiClient, getOrganization)
+import Control.Effect.Lift (Has, Lift)
+import Control.Effect.Telemetry (Telemetry, trackUsage)
+import Control.Monad (join, unless)
+import Data.Aeson (decode)
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as BL
+import Data.Foldable (fold, traverse_)
+import Data.HashMap.Internal.Strict (HashMap)
+import Data.HashMap.Strict qualified as H
+import Data.HashMap.Strict qualified as HashMap
+import Data.Hashable (Hashable)
+import Data.List (nub)
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (mapMaybe)
+import Data.String.Conversion (ToText (toText), decodeUtf8)
+import Data.Text (Text)
+import Effect.Exec (AllowErr (Never), Command (..), Exec, execCurrentDirStdinThrow)
+import Effect.ReadFS (ReadFS)
+import Fossa.API.Types (ApiOpts, Organization (..), orgFileUpload)
+import Path (Abs, Dir, File, Path)
+import Srclib.Types (LicenseScanType (..), LicenseSourceUnit (..), LicenseUnit (..), LicenseUnitData (..), LicenseUnitInfo (..), LicenseUnitMatchData (..))
+import Types (LicenseScanPathFilters)
+
+newtype CustomLicensePath = CustomLicensePath {unCustomLicensePath :: Text}
+  deriving (Eq, Ord, Show, Hashable)
+newtype CustomLicenseTitle = CustomLicenseTitle {unCustomLicenseTitle :: Text}
+  deriving (Eq, Ord, Show, Hashable)
+
+-- | scan rootDir with Ficus, using the given GrepOptions. This is the main entry point to this module
+analyzeWithFicus ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Debug sig m
+  , Has Exec sig m
+  , Has ReadFS sig m
+  , Has Telemetry sig m
+  ) =>
+  Path Abs Dir ->
+  Maybe ApiOpts ->
+  GrepOptions ->
+  Maybe LicenseScanPathFilters ->
+  m (Maybe FicusResults)
+analyzeWithFicus rootDir maybeApiOpts grepOptions filters = do
+  case (maybeApiOpts, orgWideCustomLicenseScanConfigPolicy grepOptions) of
+    (_, Ignore) -> analyzeWithFicusMain rootDir grepOptions filters FileUploadMatchData
+    (Nothing, Use) -> analyzeWithFicusMain rootDir grepOptions filters FileUploadMatchData
+    (Just apiOpts, Use) -> runFossaApiClient apiOpts $ analyzeWithFicusWithOrgInfo rootDir grepOptions filters
+
+analyzeWithFicusWithOrgInfo ::
+  ( Has Diagnostics sig m
+  , Has FossaApiClient sig m
+  , Has (Lift IO) sig m
+  , Has Exec sig m
+  , Has ReadFS sig m
+  , Has Telemetry sig m
+  ) =>
+  Path Abs Dir ->
+  GrepOptions ->
+  Maybe LicenseScanPathFilters ->
+  m (Maybe FicusResults)
+analyzeWithFicusWithOrgInfo rootDir grepOptions filters = do
+  org <- getOrganization
+  let orgWideCustomLicenses = orgCustomLicenseScanConfigs org
+      uploadKind = orgFileUpload org
+
+  let options = grepOptions{customLicenseSearch = nub $ orgWideCustomLicenses <> customLicenseSearch grepOptions}
+  analyzeWithFicusMain rootDir options filters uploadKind
+
+analyzeWithFicusMain ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Exec sig m
+  , Has ReadFS sig m
+  , Has Telemetry sig m
+  ) =>
+  Path Abs Dir ->
+  GrepOptions ->
+  Maybe LicenseScanPathFilters ->
+  FileUpload ->
+  m (Maybe FicusResults)
+analyzeWithFicusMain rootDir grepOptions filters uploadKind = do
+  let maybeFicusConfig = grepOptionsToFicusConfig rootDir grepOptions filters uploadKind
+  case maybeFicusConfig of
+    Just ficusConfig -> do
+      unless (null $ customLicenseSearch grepOptions) $ trackUsage CustomLicenseSearchUsage
+      unless (null $ keywordSearch grepOptions) $ trackUsage ExperimentalKeywordSearchUsage
+      messages <- runFicus ficusConfig (configFilePath grepOptions)
+      let ficusResults = ficusMessagesToFicusResults messages rootDir
+      pure $ Just ficusResults
+    Nothing -> pure Nothing
+
+grepOptionsToFicusConfig :: Path Abs Dir -> GrepOptions -> Maybe LicenseScanPathFilters -> FileUpload -> Maybe FicusConfig
+grepOptionsToFicusConfig rootDir grepOptions filters uploadKind =
+  case (customLicenseSearches <> keywordSearches) of
+    [] -> Nothing
+    res -> Just . FicusConfig rootDir res filters $ case uploadKind of
+      FileUploadMatchData -> False
+      FileUploadFullContent -> True
+  where
+    customLicenseSearches = map (grepEntryToFicusRegex CustomLicense) (customLicenseSearch grepOptions)
+    keywordSearches = map (grepEntryToFicusRegex KeywordSearch) (keywordSearch grepOptions)
+
+grepEntryToFicusRegex :: FicusScanType -> GrepEntry -> FicusRegex
+grepEntryToFicusRegex scanType grepEntry =
+  FicusRegex (grepEntryMatchCriteria grepEntry) (grepEntryName grepEntry) scanType
+
+runFicus ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has ReadFS sig m
+  , Has Exec sig m
+  ) =>
+  FicusConfig ->
+  Maybe (Path Abs File) ->
+  m FicusMessages
+runFicus ficusConfig configFilePath = withFicusBinary $ \bin -> do
+  let ficusConfigJSON = decodeUtf8 $ Aeson.encode ficusConfig
+  result <- execCurrentDirStdinThrow (ficusCommand bin) ficusConfigJSON
+  let messages = parseFicusJson result configFilePath
+  traverse_ (fatal . displayFicusError) $ ficusMessageErrors messages
+  traverse_ (warn . displayFicusWarning) $ ficusMessageWarnings messages
+  pure messages
+  where
+    displayFicusWarning :: FicusWarning -> Text
+    displayFicusWarning FicusWarning{..} = ficusWarningType <> ": " <> ficusWarningMessage
+    displayFicusError :: FicusError -> Text
+    displayFicusError FicusError{..} = ficusErrorType <> ": " <> ficusErrorMessage
+
+-- Run Ficus, passing "x-walk --config -" as its arg so that it gets its config from STDIN
+ficusCommand :: BinaryPaths -> Command
+ficusCommand bin =
+  Command
+    { cmdName = toText $ toPath bin
+    , cmdArgs = ["x-walk", "--config", "-"]
+    , cmdAllowErr = Never
+    }
+
+-- Parse Ficus's NDJson output by splitting on newlines (character 10) and
+-- then decoding each line
+parseFicusJson :: BL.ByteString -> Maybe (Path Abs File) -> FicusMessages
+parseFicusJson out configFilePath =
+  fold messages
+  where
+    messageLines = BL.splitWith (== 10) out
+    -- Once Ficus supports file filtering we'll do this by passing the config file path into Ficus
+    -- and Ficus will skip scanning the config file. But for now let's just filter post-scan
+    parsedLines = filter (notConfigFile configFilePath) $ mapMaybe decode messageLines
+    messages = map singletonFicusMessage parsedLines
+
+notConfigFile :: Maybe (Path Abs File) -> FicusMessage -> Bool
+notConfigFile (Just configFilePath) (FicusMessageFicusMatch ficusMessage) = ficusMatchPath ficusMessage /= toText configFilePath
+notConfigFile _ _ = True
+
+ficusMessagesToFicusResults :: FicusMessages -> Path Abs Dir -> FicusResults
+ficusMessagesToFicusResults FicusMessages{..} rootDir =
+  FicusResults
+    { ficusResultsKeywordSearches = keywordSearches
+    , ficusResultsCustomLicenses = customLicenses
+    , ficusResultsSourceUnit = sourceUnit
+    }
+  where
+    keywordSearches = filterFicusMessages ficusMessageMatches KeywordSearch
+    customLicenses = filterFicusMessages ficusMessageMatches CustomLicense
+    sourceUnit = case NE.nonEmpty customLicenses of
+      Nothing -> Nothing
+      Just licenses -> ficusMatchToSourceUnit (NE.toList licenses) rootDir
+
+-- add a FicusMessage to the corresponding entry of an empty FicusMessages
+singletonFicusMessage :: FicusMessage -> FicusMessages
+singletonFicusMessage message = case message of
+  FicusMessageFicusMatch msg -> mempty{ficusMessageMatches = [msg]}
+  FicusMessageFicusWarning msg -> mempty{ficusMessageWarnings = [msg]}
+  FicusMessageFicusError msg -> mempty{ficusMessageErrors = [msg]}
+
+-- filter ficus matches to a specific scan type, filtering out any ficus matches with no messages after they have been filtered out
+filterFicusMessages :: [FicusMatch] -> FicusScanType -> [FicusMatch]
+filterFicusMessages matches scanType =
+  ficusMatchesWithoutEmpties
+  where
+    byScanType :: FicusMatchData -> Bool
+    byScanType m = scanType == ficusMatchDataScanType m
+    ficusMatchesFilteredToScanType = map (\fm -> FicusMatch (ficusMatchPath fm) (filter byScanType $ ficusMatchMatches fm) (ficusMatchContents fm)) matches
+    ficusMatchesWithoutEmpties = filter (not . null . ficusMatchMatches) ficusMatchesFilteredToScanType
+
+-- Convert a list of ficus matches into a LicenseSourceUnit
+-- The hard part is constructing the licenseSourceUnitLicenseUnits. This is an array of LicenseUnit, one per license found.
+-- A LicenseUnit contains info about multiple files. Each file shows up in the Files attribute and in the
+-- same position in the Data attribute.
+-- So this function takes all of the Ficus Messages, which contain information about a single match in a single file,
+-- and flips it around to get a list of licenses and the files they apply to.
+ficusMatchToSourceUnit :: [FicusMatch] -> Path Abs Dir -> Maybe LicenseSourceUnit
+ficusMatchToSourceUnit matches rootDir =
+  case NE.nonEmpty licenseUnits of
+    Just units ->
+      Just
+        LicenseSourceUnit
+          { licenseSourceUnitName = toText rootDir
+          , licenseSourceUnitType = CliLicenseScanned
+          , licenseSourceUnitLicenseUnits = units
+          }
+    Nothing -> Nothing
+  where
+    licenseUnits = licenseUnitsFromFicusMatches matches
+
+-- Create LicenseUnits from the FicusMatches. All LicenseUnits will have a license ID of "custom-license".
+-- There will be one LicenseUnit per custom-license title, and each LicenseUnit can contain results from multiple files.
+-- A licenseUnitMatchData can be built from a FicusMatch
+-- A LicenseUnitData has many LicenseUnitMatchData. There will be one
+-- LicenseUnitData per (path, title) pair, containing all of the
+-- LicenseUnitMatchData for that pair
+-- A LicenseUnit has many LicenseUnitData
+licenseUnitsFromFicusMatches :: [FicusMatch] -> [LicenseUnit]
+licenseUnitsFromFicusMatches matches = do
+  let allLicenseUnitMatchData = concatMap ficusMatchToLicenseUnitMatchData matches
+  let fileContents = HashMap.fromList $ map getContentsFromFicusMatch matches
+  let allLicenseUnitData = map (createLicenseUnitDataSingles fileContents) allLicenseUnitMatchData
+  -- collectedLicenseUnitData has one LicenseUnitData per (path, title) pair, each one containing
+  -- all of the LicenseUnitMatchData for that (path, title) pair
+  let collectedLicenseUnitData = HashMap.fromListWith (<>) allLicenseUnitData
+  -- Now that we have all of the LicenseUnitData, we need to create LicenseUnits for them.
+  -- LicenseUnits do not have paths on them, so we group them up by title
+  let allLicenseUnits = map createLicenseUnitSingles $ HashMap.toList collectedLicenseUnitData
+  let licenseUnitsByTitle = map (\((_, title), lu) -> (title, lu)) allLicenseUnits
+  H.elems $ HashMap.fromListWith (<>) licenseUnitsByTitle
+
+getContentsFromFicusMatch :: FicusMatch -> (CustomLicensePath, Maybe Text)
+getContentsFromFicusMatch FicusMatch{..} = (CustomLicensePath ficusMatchPath, ficusMatchContents)
+
+-- Create a list with keys of (path, title) and a value of a single LicenseUnitMatchData
+ficusMatchToLicenseUnitMatchData :: FicusMatch -> [((CustomLicensePath, CustomLicenseTitle), LicenseUnitMatchData)]
+ficusMatchToLicenseUnitMatchData FicusMatch{..} =
+  map (createLicenseUnitMatchData $ CustomLicensePath ficusMatchPath) ficusMatchMatches
+
+-- Given a path and a FicusMatchData, create a single LicenseUnitMatchData
+createLicenseUnitMatchData :: CustomLicensePath -> FicusMatchData -> ((CustomLicensePath, CustomLicenseTitle), LicenseUnitMatchData)
+createLicenseUnitMatchData path FicusMatchData{..} =
+  ((path, title), licenseUnitMatchData)
+  where
+    title = CustomLicenseTitle ficusMatchDataName
+    licenseUnitMatchData =
+      LicenseUnitMatchData
+        { licenseUnitMatchDataMatchString = Just ficusMatchDataMatchString
+        , licenseUnitMatchDataLocation = ficusMatchDataStartByte
+        , licenseUnitMatchDataLength = ficusMatchDataEndByte - ficusMatchDataStartByte
+        , licenseUnitMatchDataIndex = 1
+        , licenseUnitDataStartLine = ficusMatchDataStartLine
+        , licenseUnitDataEndLine = ficusMatchDataEndLine
+        }
+
+createLicenseUnitDataSingles :: HashMap CustomLicensePath (Maybe Text) -> ((CustomLicensePath, CustomLicenseTitle), LicenseUnitMatchData) -> ((CustomLicensePath, CustomLicenseTitle), LicenseUnitData)
+createLicenseUnitDataSingles contents ((path, title), licenseUnitMatchData) =
+  ((path, title), newLicenseUnitData)
+  where
+    newLicenseUnitData =
+      LicenseUnitData
+        { licenseUnitDataPath = unCustomLicensePath path
+        , licenseUnitDataCopyright = Nothing
+        , licenseUnitDataThemisVersion = ""
+        , licenseUnitDataMatchData = Just $ NE.singleton licenseUnitMatchData
+        , licenseUnitDataCopyrights = Nothing
+        , licenseUnitDataContents = join $ HashMap.lookup path contents
+        }
+
+createLicenseUnitSingles :: ((CustomLicensePath, CustomLicenseTitle), LicenseUnitData) -> ((CustomLicensePath, CustomLicenseTitle), LicenseUnit)
+createLicenseUnitSingles ((path, title), licenseUnitData) =
+  ((path, title), lu)
+  where
+    lu =
+      LicenseUnit
+        { licenseUnitName = "custom-license"
+        , licenseUnitType = "LicenseUnit"
+        , licenseUnitTitle = Just $ unCustomLicenseTitle title
+        , licenseUnitDir = ""
+        , licenseUnitFiles = NE.singleton (unCustomLicensePath path)
+        , licenseUnitData = NE.singleton licenseUnitData
+        , licenseUnitNoticeFiles = []
+        , licenseUnitInfo = LicenseUnitInfo{licenseUnitInfoDescription = Just $ "custom license search " <> unCustomLicenseTitle title}
+        }

--- a/src/App/Fossa/Ficus/Types.hs
+++ b/src/App/Fossa/Ficus/Types.hs
@@ -1,7 +1,190 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module App.Fossa.Ficus.Types (
-    FicusResults(..)
+  FicusResults (..),
+  FicusConfig (..),
+  FicusRegex (..),
+  FicusScanType (..),
+  FicusMessage (..),
+  FicusMessages (..),
+  FicusMatch (..),
+  FicusMatchData (..),
+  FicusWarning (..),
+  FicusError (..),
 ) where
 
-data FicusResults = FicusResults { ficusAnalysisId :: Int }
+import Data.Aeson (FromJSON, KeyValue ((.=)), ToJSON (toJSON), Value (Object), object, withObject, withText, (.:?))
+import Data.Aeson qualified as A
+import Data.Aeson.Types ((.:))
+import Data.String.Conversion (ToText (toText))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Path (Abs, Dir, Path)
+import Srclib.Types (LicenseSourceUnit)
+import Types (LicenseScanPathFilters (..))
+
+data FicusResults = FicusResults { ficusAnalysisId :: Int } deriving (Eq, Ord, Show, Generic)
+
+-- FOSSA_API_TOKEN=foobar cargo run -- analyze --exclude ".git/**" --exclude "target/**" --endpoint http://localhost:3000 --locator "pip+flask$1.2.3" --set snippet-scanning:batch-length=123
+
+data FicusConfig = FicusConfig
+  { ficusRootDir :: Path Abs Dir
+  , ficusFossaToken :: Text
+  , ficusLocator :: Text
+  , ficusGitignore :: Bool
+  , ficusSkipHidden :: Bool
+  , ficusAllExtensions :: Bool
+  , ficusExcludes :: [Text]
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+data FicusRegex = FicusRegex
+  { ficusPat :: Text
+  , ficusName :: Text
+  , ficusScanType :: FicusScanType
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON FicusRegex where
+  toJSON FicusRegex{..} =
+    object
+      [ "pattern" .= toText ficusPat
+      , "name" .= toText ficusName
+      , "scan_type" .= toText ficusScanType
+      ]
+
+data FicusScanType = FicusCustomLicense | FicusKeywordSearch
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToText FicusScanType where
+  toText FicusCustomLicense = "CustomLicense"
+  toText FicusKeywordSearch = "KeywordSearch"
+
+instance ToJSON FicusScanType where
+  toJSON = toJSON . toText
+
+instance FromJSON FicusScanType
+
+data FicusMessageType = FicusMessageTypeMatch | FicusMessageTypeError | FicusMessageTypeWarning
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToText FicusMessageType where
+  toText FicusMessageTypeMatch = "Match"
+  toText FicusMessageTypeError = "Error"
+  toText FicusMessageTypeWarning = "Warning"
+
+instance ToJSON FicusMessageType where
+  toJSON = toJSON . toText
+
+instance FromJSON FicusMessageType where
+  parseJSON = withText "FicusMessageType" $ \msg -> do
+    case msg of
+      "Match" -> pure FicusMessageTypeMatch
+      "Error" -> pure FicusMessageTypeError
+      "Warning" -> pure FicusMessageTypeWarning
+      _ -> fail "invalid Ficus message type"
+
+data FicusMatch = FicusMatch
+  { ficusMatchPath :: Text
+  , ficusMatchMatches :: [FicusMatchData]
+  , ficusMatchContents :: Maybe Text
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON FicusMatch where
+  parseJSON = withObject "FicusMatch" $ \obj ->
+    FicusMatch
+      <$> (obj .: "path")
+      <*> (obj .: "matches")
+      <*> (obj .:? "contents")
+
+data FicusWarning = FicusWarning
+  { ficusWarningMessage :: Text
+  , ficusWarningType :: Text
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON FicusWarning where
+  parseJSON = withObject "FicusWarning" $ \obj ->
+    FicusWarning
+      <$> (obj .: "message")
+      <*> (obj .: "type")
+
+data FicusError = FicusError
+  { ficusErrorMessage :: Text
+  , ficusErrorType :: Text
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON FicusError where
+  parseJSON = withObject "FicusError" $ \obj ->
+    FicusError
+      <$> (obj .: "message")
+      <*> (obj .: "type")
+
+data FicusMatchData = FicusMatchData
+  { ficusMatchDataPattern :: Text
+  , ficusMatchDataMatchString :: Text
+  , ficusMatchDataScanType :: FicusScanType
+  , ficusMatchDataName :: Text
+  , ficusMatchDataStartByte :: Integer
+  , ficusMatchDataEndByte :: Integer
+  , ficusMatchDataStartLine :: Integer
+  , ficusMatchDataEndLine :: Integer
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON FicusMatchData where
+  parseJSON = withObject "FicusMatchData" $ \obj ->
+    FicusMatchData
+      <$> (obj .: "pattern")
+      <*> (obj .: "match_str")
+      <*> (obj .: "scan_type")
+      <*> (obj .: "name")
+      <*> (obj .: "start_byte")
+      <*> (obj .: "end_byte")
+      <*> (obj .: "start_line")
+      <*> (obj .: "end_line")
+
+instance ToJSON FicusMatchData
+
+data FicusMessages = FicusMessages
+  { ficusMessageWarnings :: [FicusWarning]
+  , ficusMessageErrors :: [FicusError]
+  , ficusMessageMatches :: [FicusMatch]
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+instance Semigroup FicusMessages where
+  FicusMessages w1 e1 m1 <> FicusMessages w2 e2 m2 = FicusMessages (w1 <> w2) (e1 <> e2) (m1 <> m2)
+
+instance Monoid FicusMessages where
+  mempty = FicusMessages [] [] []
+
+data FicusMessage = FicusMessageFicusMatch FicusMatch | FicusMessageFicusWarning FicusWarning | FicusMessageFicusError FicusError
+  deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON FicusMessage where
+  parseJSON (Object o) = do
+    messageType <- o .: "type"
+    case messageType of
+      FicusMessageTypeWarning -> do
+        Object d <- o .: "data"
+        let message = d .: "message"
+        let warningType = d .: "type"
+        warning <- FicusWarning <$> warningType <*> message
+        pure $ FicusMessageFicusWarning warning
+      FicusMessageTypeError -> do
+        Object d <- o .: "data"
+        let errorType = d .: "type"
+        let message = d .: "message"
+        err <- FicusError <$> errorType <*> message
+        pure $ FicusMessageFicusError err
+      FicusMessageTypeMatch -> do
+        Object d <- o .: "data"
+        let path = d .: "path"
+        let matches = d .: "matches"
+        let contents = d .:? "contents"
+        match <- FicusMatch <$> path <*> matches <*> contents
+        pure $ FicusMessageFicusMatch match
+  parseJSON _ = fail "Invalid schema for FicusMessage. It must be an object"

--- a/src/App/Fossa/Ficus/Types.hs
+++ b/src/App/Fossa/Ficus/Types.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module App.Fossa.Ficus.Types (
+    FicusResults(..)
+) where
+
+data FicusResults = FicusResults { ficusAnalysisId :: Int }

--- a/src/App/Fossa/Ficus/Types.hs
+++ b/src/App/Fossa/Ficus/Types.hs
@@ -1,157 +1,38 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module App.Fossa.Ficus.Types (
-  FicusResults (..),
   FicusConfig (..),
-  FicusRegex (..),
-  FicusScanType (..),
   FicusMessage (..),
   FicusMessages (..),
-  FicusMatch (..),
-  FicusMatchData (..),
-  FicusWarning (..),
+  FicusMessageData (..),
+  FicusFinding (..),
+  FicusDebug (..),
   FicusError (..),
+  FicusAnalysisFlag (..),
+  FicusAllFlag (..),
+  FicusWalkFlag (..),
+  FicusNoopFlag (..),
+  FicusHashFlag (..),
+  FicusSnippetScanFlag,
+  FicusSnippetScanResults (..),
+  FicusPerStrategyFlag (..),
 ) where
 
-import Data.Aeson (FromJSON, KeyValue ((.=)), ToJSON (toJSON), Value (Object), object, withObject, withText, (.:?))
+import App.Types (ProjectRevision)
+import Data.Aeson (FromJSON, Value (Object), withText)
 import Data.Aeson qualified as A
-import Data.Aeson.Types ((.:))
-import Data.String.Conversion (ToText (toText))
+import Data.Aeson.Types (Parser, (.:))
 import Data.Text (Text)
+import Fossa.API.Types
 import GHC.Generics (Generic)
 import Path (Abs, Dir, Path)
-import Srclib.Types (LicenseSourceUnit)
-import Types (LicenseScanPathFilters (..))
+import Text.URI
+import Types (GlobFilter)
 
-data FicusResults = FicusResults { ficusAnalysisId :: Int } deriving (Eq, Ord, Show, Generic)
-
--- FOSSA_API_TOKEN=foobar cargo run -- analyze --exclude ".git/**" --exclude "target/**" --endpoint http://localhost:3000 --locator "pip+flask$1.2.3" --set snippet-scanning:batch-length=123
-
-data FicusConfig = FicusConfig
-  { ficusRootDir :: Path Abs Dir
-  , ficusFossaToken :: Text
-  , ficusLocator :: Text
-  , ficusGitignore :: Bool
-  , ficusSkipHidden :: Bool
-  , ficusAllExtensions :: Bool
-  , ficusExcludes :: [Text]
-  }
-  deriving (Eq, Ord, Show, Generic)
-
-data FicusRegex = FicusRegex
-  { ficusPat :: Text
-  , ficusName :: Text
-  , ficusScanType :: FicusScanType
-  }
-  deriving (Eq, Ord, Show, Generic)
-
-instance ToJSON FicusRegex where
-  toJSON FicusRegex{..} =
-    object
-      [ "pattern" .= toText ficusPat
-      , "name" .= toText ficusName
-      , "scan_type" .= toText ficusScanType
-      ]
-
-data FicusScanType = FicusCustomLicense | FicusKeywordSearch
-  deriving (Eq, Ord, Show, Generic)
-
-instance ToText FicusScanType where
-  toText FicusCustomLicense = "CustomLicense"
-  toText FicusKeywordSearch = "KeywordSearch"
-
-instance ToJSON FicusScanType where
-  toJSON = toJSON . toText
-
-instance FromJSON FicusScanType
-
-data FicusMessageType = FicusMessageTypeMatch | FicusMessageTypeError | FicusMessageTypeWarning
-  deriving (Eq, Ord, Show, Generic)
-
-instance ToText FicusMessageType where
-  toText FicusMessageTypeMatch = "Match"
-  toText FicusMessageTypeError = "Error"
-  toText FicusMessageTypeWarning = "Warning"
-
-instance ToJSON FicusMessageType where
-  toJSON = toJSON . toText
-
-instance FromJSON FicusMessageType where
-  parseJSON = withText "FicusMessageType" $ \msg -> do
-    case msg of
-      "Match" -> pure FicusMessageTypeMatch
-      "Error" -> pure FicusMessageTypeError
-      "Warning" -> pure FicusMessageTypeWarning
-      _ -> fail "invalid Ficus message type"
-
-data FicusMatch = FicusMatch
-  { ficusMatchPath :: Text
-  , ficusMatchMatches :: [FicusMatchData]
-  , ficusMatchContents :: Maybe Text
-  }
-  deriving (Eq, Ord, Show, Generic)
-
-instance FromJSON FicusMatch where
-  parseJSON = withObject "FicusMatch" $ \obj ->
-    FicusMatch
-      <$> (obj .: "path")
-      <*> (obj .: "matches")
-      <*> (obj .:? "contents")
-
-data FicusWarning = FicusWarning
-  { ficusWarningMessage :: Text
-  , ficusWarningType :: Text
-  }
-  deriving (Eq, Ord, Show, Generic)
-
-instance FromJSON FicusWarning where
-  parseJSON = withObject "FicusWarning" $ \obj ->
-    FicusWarning
-      <$> (obj .: "message")
-      <*> (obj .: "type")
-
-data FicusError = FicusError
-  { ficusErrorMessage :: Text
-  , ficusErrorType :: Text
-  }
-  deriving (Eq, Ord, Show, Generic)
-
-instance FromJSON FicusError where
-  parseJSON = withObject "FicusError" $ \obj ->
-    FicusError
-      <$> (obj .: "message")
-      <*> (obj .: "type")
-
-data FicusMatchData = FicusMatchData
-  { ficusMatchDataPattern :: Text
-  , ficusMatchDataMatchString :: Text
-  , ficusMatchDataScanType :: FicusScanType
-  , ficusMatchDataName :: Text
-  , ficusMatchDataStartByte :: Integer
-  , ficusMatchDataEndByte :: Integer
-  , ficusMatchDataStartLine :: Integer
-  , ficusMatchDataEndLine :: Integer
-  }
-  deriving (Eq, Ord, Show, Generic)
-
-instance FromJSON FicusMatchData where
-  parseJSON = withObject "FicusMatchData" $ \obj ->
-    FicusMatchData
-      <$> (obj .: "pattern")
-      <*> (obj .: "match_str")
-      <*> (obj .: "scan_type")
-      <*> (obj .: "name")
-      <*> (obj .: "start_byte")
-      <*> (obj .: "end_byte")
-      <*> (obj .: "start_line")
-      <*> (obj .: "end_line")
-
-instance ToJSON FicusMatchData
+newtype FicusSnippetScanResults = FicusSnippetScanResults {ficusSnippetScanResultsAnalysisId :: Int} deriving (Eq, Ord, Show, Generic)
 
 data FicusMessages = FicusMessages
-  { ficusMessageWarnings :: [FicusWarning]
+  { ficusMessageDebugs :: [FicusDebug]
   , ficusMessageErrors :: [FicusError]
-  , ficusMessageMatches :: [FicusMatch]
+  , ficusMessageFindings :: [FicusFinding]
   }
   deriving (Eq, Ord, Show, Generic)
 
@@ -161,30 +42,133 @@ instance Semigroup FicusMessages where
 instance Monoid FicusMessages where
   mempty = FicusMessages [] [] []
 
-data FicusMessage = FicusMessageFicusMatch FicusMatch | FicusMessageFicusWarning FicusWarning | FicusMessageFicusError FicusError
+data FicusMessageData = FicusMessageData
+  { ficusMessageDataStrategy :: Text
+  , ficusMessageDataPayload :: Text
+  }
   deriving (Eq, Ord, Show, Generic)
+
+newtype FicusDebug = FicusDebug FicusMessageData deriving (Eq, Ord, Show, Generic)
+
+newtype FicusFinding = FicusFinding FicusMessageData deriving (Eq, Ord, Show, Generic)
+
+newtype FicusError = FicusError FicusMessageData deriving (Eq, Ord, Show, Generic)
+
+data FicusMessage
+  = FicusMessageFinding FicusFinding
+  | FicusMessageDebug FicusDebug
+  | FicusMessageError FicusError
+  deriving (Eq, Ord, Show, Generic)
+
+data FicusMessageKind = FicusMessageKindFinding | FicusMessageKindDebug | FicusMessageKindError
+  deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON FicusMessageKind where
+  parseJSON = withText "FicusMessageKind" $ \msg -> do
+    case msg of
+      "finding" -> pure FicusMessageKindFinding
+      "error" -> pure FicusMessageKindError
+      "debug" -> pure FicusMessageKindDebug
+      _ -> fail "invalid Ficus message type"
+
+-- Ficus observations follow the pattern:
+-- ```json
+-- {
+--   "version": 1,
+--   "level": "INFO",
+--   "observation": {
+--     "kind": "finding",
+--     "payload": "oiyOd12FYglo6gJu8gnNyytDfZDNGe83yF4rOds7YxU=",
+--     "strategy": "hash"
+--   }
+-- }
+--
+-- {
+--   "version": 1,
+--   "level": "DEBUG",
+--   "observation": {
+--     "kind": "debug",
+--     "payload": "A potentially useful but not finding-worthy note",
+--     "strategy": "hash"
+--   }
+-- }
+--
+-- {
+--   "version": 1,
+--   "level": "ERROR",
+--   "observation": {
+--     "kind": "error",
+--     "payload": "Something bad happened",
+--     "strategy": "hash"
+--   }
+-- }
+-- ```
+--
+-- Each ficus observation is either:
+-- - A finding; at least somewhat likely to be consumed and used by the CLI.
+-- - A debug; over-communicative and generally for human eyes.
+-- - An error; error messages which ought to be propagated.
 
 instance FromJSON FicusMessage where
   parseJSON (Object o) = do
-    messageType <- o .: "type"
-    case messageType of
-      FicusMessageTypeWarning -> do
-        Object d <- o .: "data"
-        let message = d .: "message"
-        let warningType = d .: "type"
-        warning <- FicusWarning <$> warningType <*> message
-        pure $ FicusMessageFicusWarning warning
-      FicusMessageTypeError -> do
-        Object d <- o .: "data"
-        let errorType = d .: "type"
-        let message = d .: "message"
-        err <- FicusError <$> errorType <*> message
-        pure $ FicusMessageFicusError err
-      FicusMessageTypeMatch -> do
-        Object d <- o .: "data"
-        let path = d .: "path"
-        let matches = d .: "matches"
-        let contents = d .:? "contents"
-        match <- FicusMatch <$> path <*> matches <*> contents
-        pure $ FicusMessageFicusMatch match
+    observationVersion <- o .: "version" :: Parser Int
+    if observationVersion /= 1
+      then
+        fail "Invalid version for FicusMessage. It must be 1."
+      else do
+        Object observation <- o .: "observation"
+        kind <- observation .: "kind"
+        strategy <- observation .: "strategy"
+        payload <- observation .: "payload"
+        let messageData = FicusMessageData{ficusMessageDataStrategy = strategy, ficusMessageDataPayload = payload}
+        case kind of
+          FicusMessageKindFinding -> do
+            let finding = FicusFinding messageData
+            pure $ FicusMessageFinding finding
+          FicusMessageKindDebug -> do
+            let debug = FicusDebug messageData
+            pure $ FicusMessageDebug debug
+          FicusMessageKindError -> do
+            let ficusError = FicusError messageData
+            pure $ FicusMessageError ficusError
   parseJSON _ = fail "Invalid schema for FicusMessage. It must be an object"
+
+data FicusConfig = FicusConfig
+  { ficusConfigRootDir :: Path Abs Dir
+  , ficusConfigExclude :: [GlobFilter]
+  , ficusConfigEndpoint :: Maybe URI
+  , ficusConfigSecret :: Maybe ApiKey
+  , ficusConfigRevision :: ProjectRevision -- TODO: get this from `projectRevision AnalyzeConfig`
+  , ficusConfigFlags :: [FicusPerStrategyFlag]
+  }
+  deriving (Show, Eq, Generic)
+
+-- A flag for ficus paired with a proper strategy or pseudo-strategy.
+-- @Walk@ and @All@ are pseudo-strategies which accept similar flags,
+-- but expand into a subset of strategies in ficus.
+data FicusPerStrategyFlag
+  = Walk FicusWalkFlag
+  | All FicusAllFlag
+  | SnippetScan FicusSnippetScanFlag
+  | Noop FicusNoopFlag
+  | Hash FicusHashFlag
+  deriving (Show, Eq, Generic)
+
+data FicusAnalysisFlag
+  = AllExtensions
+  | SkipHiddenFiles
+  | Gitignore
+  deriving (Show, Eq)
+
+newtype FicusAllFlag = FicusAllFlag FicusAnalysisFlag deriving (Show, Eq)
+
+newtype FicusWalkFlag = FicusWalkFlag FicusAnalysisFlag deriving (Show, Eq)
+
+newtype FicusNoopFlag = FicusNoopFlag FicusAnalysisFlag deriving (Show, Eq)
+
+newtype FicusHashFlag = FicusHashFlag FicusAnalysisFlag deriving (Show, Eq)
+
+data FicusSnippetScanFlag
+  = CommonFlag FicusAnalysisFlag
+  | BatchLen Int
+  deriving (Show, Eq)

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -87,8 +87,8 @@ runFossaApiClient apiOpts action = do
             QueueSBOMBuild archive team rebuild -> Core.queueSBOMBuild archive team rebuild
             ResolveProjectDependencies locator -> VSI.resolveProjectDependencies locator
             ResolveUserDefinedBinary deps -> VSI.resolveUserDefinedBinary deps
-            UploadAnalysis rev metadata units -> Core.uploadAnalysis rev metadata units
-            UploadAnalysisWithFirstPartyLicenses rev metadata uploadKind -> Core.uploadAnalysisWithFirstPartyLicenses rev metadata uploadKind
+            UploadAnalysis rev metadata units ficusResults -> Core.uploadAnalysis rev metadata units ficusResults
+            UploadAnalysisWithFirstPartyLicenses rev metadata uploadKind ficusResults -> Core.uploadAnalysisWithFirstPartyLicenses rev metadata uploadKind ficusResults
             UploadArchive url path -> Core.uploadArchive url path
             UploadNativeContainerScan revision metadata scan -> Core.uploadNativeContainerScan revision metadata scan
             UploadContributors locator contributors -> Core.uploadContributors locator contributors

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -68,6 +68,7 @@ import Fossa.API.Types (
 
 import Fossa.API.CoreTypes qualified as CoreTypes
 
+import App.Fossa.Ficus.Types (FicusSnippetScanResults (..))
 import Srclib.Types (Locator, SourceUnit, renderLocator)
 
 -- Fetches an organization from the API
@@ -130,10 +131,11 @@ uploadAnalysis ::
   ProjectRevision ->
   ProjectMetadata ->
   [SourceUnit] ->
+  Maybe FicusSnippetScanResults ->
   m UploadResponse
-uploadAnalysis revision metadata units = do
+uploadAnalysis revision metadata units ficusResults = do
   apiOpts <- ask
-  API.uploadAnalysis apiOpts revision metadata units
+  API.uploadAnalysis apiOpts revision metadata units ficusResults
 
 uploadAnalysisWithFirstPartyLicenses ::
   ( API.APIClientEffs sig m
@@ -142,10 +144,11 @@ uploadAnalysisWithFirstPartyLicenses ::
   ProjectRevision ->
   ProjectMetadata ->
   FileUpload ->
+  Maybe FicusSnippetScanResults ->
   m UploadResponse
-uploadAnalysisWithFirstPartyLicenses revision metadata uploadKind = do
+uploadAnalysisWithFirstPartyLicenses revision metadata uploadKind ficusResults = do
   apiOpts <- ask
-  API.uploadAnalysisWithFirstPartyLicenses apiOpts revision metadata uploadKind
+  API.uploadAnalysisWithFirstPartyLicenses apiOpts revision metadata uploadKind ficusResults
 
 uploadNativeContainerScan ::
   ( API.APIClientEffs sig m

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -95,6 +95,7 @@ import Fossa.API.Types (
 
 import Fossa.API.CoreTypes qualified as CoreTypes
 
+import App.Fossa.Ficus.Types (FicusSnippetScanResults)
 import Path (File, Path, Rel)
 import Srclib.Types (FullSourceUnit, LicenseSourceUnit, Locator, SourceUnit)
 
@@ -147,11 +148,13 @@ data FossaApiClientF a where
     ProjectRevision ->
     ProjectMetadata ->
     [SourceUnit] ->
+    Maybe FicusSnippetScanResults ->
     FossaApiClientF UploadResponse
   UploadAnalysisWithFirstPartyLicenses ::
     ProjectRevision ->
     ProjectMetadata ->
     FileUpload ->
+    Maybe FicusSnippetScanResults ->
     FossaApiClientF UploadResponse
   UploadArchive :: SignedURL -> FilePath -> FossaApiClientF ByteString
   UploadNativeContainerScan ::
@@ -199,12 +202,12 @@ getApiOpts :: (Has FossaApiClient sig m) => m ApiOpts
 getApiOpts = sendSimple GetApiOpts
 
 -- | Uploads the results of an analysis and associates it to a project
-uploadAnalysis :: (Has FossaApiClient sig m) => ProjectRevision -> ProjectMetadata -> [SourceUnit] -> m UploadResponse
-uploadAnalysis revision metadata units = sendSimple (UploadAnalysis revision metadata units)
+uploadAnalysis :: (Has FossaApiClient sig m) => ProjectRevision -> ProjectMetadata -> [SourceUnit] -> Maybe FicusSnippetScanResults -> m UploadResponse
+uploadAnalysis revision metadata units ficusResults = sendSimple (UploadAnalysis revision metadata units ficusResults)
 
 -- | Uploads the results of a first-party analysis and associates it to a project
-uploadAnalysisWithFirstPartyLicenses :: (Has FossaApiClient sig m) => ProjectRevision -> ProjectMetadata -> FileUpload -> m UploadResponse
-uploadAnalysisWithFirstPartyLicenses revision metadata uploadKind = sendSimple (UploadAnalysisWithFirstPartyLicenses revision metadata uploadKind)
+uploadAnalysisWithFirstPartyLicenses :: (Has FossaApiClient sig m) => ProjectRevision -> ProjectMetadata -> FileUpload -> Maybe FicusSnippetScanResults -> m UploadResponse
+uploadAnalysisWithFirstPartyLicenses revision metadata uploadKind ficusResults = sendSimple (UploadAnalysisWithFirstPartyLicenses revision metadata uploadKind ficusResults)
 
 -- | Uploads results of container analysis performed by native scanner to a project
 uploadNativeContainerScan :: (Has FossaApiClient sig m) => ProjectRevision -> ProjectMetadata -> NativeContainer.ContainerScan -> m UploadResponse

--- a/test/App/Fossa/Analyze/UploadSpec.hs
+++ b/test/App/Fossa/Analyze/UploadSpec.hs
@@ -54,7 +54,7 @@ expectGetApiOpts :: Has MockApi sig m => m ()
 expectGetApiOpts = GetApiOpts `alwaysReturns` Fixtures.apiOpts
 
 expectAnalysisUploadSuccess :: Has MockApi sig m => m ()
-expectAnalysisUploadSuccess = UploadAnalysis Fixtures.projectRevision Fixtures.projectMetadata Fixtures.sourceUnits `alwaysReturns` Fixtures.uploadResponse
+expectAnalysisUploadSuccess = UploadAnalysis Fixtures.projectRevision Fixtures.projectMetadata Fixtures.sourceUnits Nothing `alwaysReturns` Fixtures.uploadResponse
 
 expectContributorUploadSuccess :: Has MockApi sig m => m ()
 expectContributorUploadSuccess =
@@ -62,7 +62,7 @@ expectContributorUploadSuccess =
 
 expectFirstPartyAnalysisUploadSuccess :: FileUpload -> Has MockApi sig m => m ()
 expectFirstPartyAnalysisUploadSuccess uploadKind = do
-  UploadAnalysisWithFirstPartyLicenses Fixtures.projectRevision Fixtures.projectMetadata uploadKind `alwaysReturns` Fixtures.uploadResponse
+  UploadAnalysisWithFirstPartyLicenses Fixtures.projectRevision Fixtures.projectMetadata uploadKind Nothing `alwaysReturns` Fixtures.uploadResponse
 
 expectGetFirstPartySignedUrl :: Has MockApi sig m => PackageRevision -> m ()
 expectGetFirstPartySignedUrl packageRevision = GetSignedFirstPartyScanUrl packageRevision `alwaysReturns` Fixtures.signedUrl
@@ -140,6 +140,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
+              Nothing
           locator `shouldBe'` expectedLocator
       -- Currently our StdOut logging just writes directly to StdOut, so this is
       -- just checking it doesn't fail.  In the future we should extract that so
@@ -158,6 +159,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
+              Nothing
           locator `shouldBe'` expectedLocator
       it' "performs reachability upload, if organization supports reachability"
         . withGit mockGit
@@ -174,6 +176,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
+              Nothing
           locator `shouldBe'` expectedLocator
 
       it' "aborts when uploading to a monorepo"
@@ -188,6 +191,7 @@ uploadSuccessfulAnalysisSpec = do
             Fixtures.projectRevision
             (SourceUnitOnly Fixtures.sourceUnits)
             mempty
+            Nothing
       it' "continues if fetching the project fails"
         . withGit mockGit
         $ do
@@ -205,6 +209,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
+              Nothing
           locator `shouldBe'` expectedLocator
       it' "continues if fetching contributors fails"
         . withGit (\_ -> fatalText "Mocked failure of fetching contributors from git")
@@ -219,6 +224,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
+              Nothing
           locator `shouldBe'` expectedLocator
       it' "continues if uploading contributors fails"
         . withGit mockGit
@@ -234,6 +240,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
+              Nothing
           locator `shouldBe'` expectedLocator
       it' "uploads to S3 and to /api/builds/custom_with_first_party_licenses if there are licenses"
         . withGit mockGit
@@ -251,6 +258,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (SourceAndLicenseUnits Fixtures.sourceUnits Fixtures.firstLicenseSourceUnit)
               mempty
+              Nothing
           locator `shouldBe'` expectedLocator
 
       it' "uploads to S3 and to /api/builds/custom_with_first_party_licenses if there are licenses and no targets were found"
@@ -269,6 +277,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (LicenseSourceUnitOnly Fixtures.firstLicenseSourceUnit)
               mempty
+              Nothing
           locator `shouldBe'` expectedLocator
 
       it' "uploads to S3 and to /api/builds/custom_with_first_party_licenses if there are licenses and full file uploads is set on the org"
@@ -289,6 +298,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (SourceAndLicenseUnits Fixtures.sourceUnits Fixtures.firstLicenseSourceUnit)
               mempty
+              Nothing
           locator `shouldBe'` expectedLocator
 
 mergeSourceAndLicenseUnitsSpec :: Spec

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -672,6 +672,7 @@ standardAnalyzeConfig =
     , ANZ.reachabilityConfig = mempty
     , ANZ.withoutDefaultFilters = toFlag WithoutDefaultFilters False
     , ANZ.mode = NonStrict
+    , ANZ.xSnippetScan = False
     }
 
 sampleJarParsedContent :: Text


### PR DESCRIPTION
# Overview

Calls ficus, uses the `analysis_id` as the query param `snippetAnalysisId` in `uploadAnalysis` &co.

## Acceptance criteria

- Grabs the analysis-id and uses it

## Testing plan

So far *mostly* through manual testing. I still aim to get a better integration testing story, but that can happen during review. I'm quite open to suggestions.

## Risks

I think the error handling is a little weak here. Again open to guidance.

## Metrics

N/A

## References

- [ANE-2484](https://fossa.atlassian.net/browse/ANE-2484)
- [ANE-2503](https://fossa.atlassian.net/browse/ANE-24503)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
