### PR TITLE
Support multi line godebug and tool directive statements.

### DIFF
--- a/test/Go/testdata/go.mod.edgecases
+++ b/test/Go/testdata/go.mod.edgecases
@@ -9,7 +9,17 @@ toolchain go1.21.1
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
+tool (
+	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+	github.com/fossa/fossa-cli
+)
+
 godebug asynctimerchan=0
+
+godebug (
+	asynctimerchan=0
+	panicnil=1
+)
 
 require repo/name/A v1.0.0 // indirect
 


### PR DESCRIPTION
# Overview

Closes https://github.com/fossas/fossa-cli/issues/1571

`godebug`, `toolchain`, and `tool` all support multi-line formatted config options. We only support. I outlined this in a [previous PR](https://github.com/fossas/fossa-cli/pull/1553) that added initial support but had to move on to other things. 

```go
module main

go 1.24.0

tool (
	github.com/bufbuild/buf/cmd/buf
	github.com/wadey/gocovmerge
)
```

## Acceptance criteria

- `godebug`, `toolchain`, and `tool` all support multi line config options.

## Testing plan

1. Add correct tests and ensure they pass
2. Build the CLI locally and run it on an example go.mod file that has these multi line comments.

## Risks

I can't think of any for this PR


## References

[_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._
](https://github.com/fossas/fossa-cli/issues/1571)
_Example:_

[ANE-2600](https://fossa.atlassian.net/browse/ANE-2600): Implement multi line toolchain support

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
