### PR TITLE
Add user-facing documentation around fingerprinting snippet-scans

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.11.1
+
+- Better document `--x-snippet-scan`.
+
 ## 3.11.0
 
 - Add a dependency on Ficus, a new internal tool.

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -114,7 +114,6 @@ import Options.Applicative (
   InfoMod,
   Parser,
   eitherReader,
-  help,
   helpDoc,
   hidden,
   long,
@@ -345,7 +344,7 @@ cliParser =
     <*> flagOpt StaticOnlyTactics (applyFossaStyle <> long "static-only-analysis" <> stringToHelpDoc "Only analyze the project using static strategies.")
     <*> withoutDefaultFilterParser fossaAnalyzeDefaultFilterDocUrl
     <*> flagOpt StrictMode (applyFossaStyle <> long "strict" <> stringToHelpDoc "Enforces strict analysis to ensure the most accurate results by rejecting fallbacks.")
-    <*> switch (applyFossaStyle <> long "x-snippet-scan" <> help "Enable ficus snippet scanning")
+    <*> switch (applyFossaStyle <> long "x-snippet-scan" <> stringToHelpDoc "Experimental flag to enable snippet scanning to identify open source code snippets using fingerprinting.")
   where
     fossaDepsFileHelp :: Maybe (Doc AnsiStyle)
     fossaDepsFileHelp =

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -44,9 +44,9 @@ import Fossa.API.Types (ApiKey (..), ApiOpts (..))
 import Path (Abs, Dir, File, Path, toFilePath)
 import Srclib.Types (Locator (..), renderLocator)
 import Text.URI (render)
-import Text.URI.Builder ()
+import Text.URI.Builder (PathComponent (PathComponent), TrailingSlash (TrailingSlash), setPath)
 import Types (GlobFilter (..), LicenseScanPathFilters (..))
-import Prelude hiding (unwords)
+import Prelude
 
 newtype CustomLicensePath = CustomLicensePath {unCustomLicensePath :: Text}
   deriving (Eq, Ord, Show, Hashable)
@@ -173,7 +173,7 @@ ficusCommand ficusConfig bin = do
     Just baseUri -> do
       proxyUri <- setPath [PathComponent "api", PathComponent "proxy", PathComponent "analysis"] (TrailingSlash False) baseUri
       pure $ render proxyUri
-    Nothing -> pure "https://app.fossa.com"
+    Nothing -> pure "https://app.fossa.com/api/proxy/analysis"
   pure $
     Command
       { cmdName = toText $ toPath bin

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -171,8 +171,9 @@ ficusCommand :: Has Diagnostics sig m => FicusConfig -> BinaryPaths -> m Command
 ficusCommand ficusConfig bin = do
   endpoint <- case ficusConfigEndpoint ficusConfig of
     Just baseUri -> do
-      pure $ render baseUri
-    Nothing -> pure ""
+      proxyUri <- setPath [PathComponent "api", PathComponent "proxy", PathComponent "analysis"] (TrailingSlash False) baseUri
+      pure $ render proxyUri
+    Nothing -> pure "https://app.fossa.com"
   pure $
     Command
       { cmdName = toText $ toPath bin


### PR DESCRIPTION
Also, add a proper `analyze --help` message around `x-snippet-scan`:
```
--x-snippet-scan
    Experimental flag to enable snippet scanning to identify open source code snippets using fingerprinting.
```

# Overview

Documentation and help-string additions.

## Acceptance criteria

We deem the documentation sufficient and sufficiently correct.

## Testing plan

Ran with `--help`, liked what I saw.

## Risks

Wondering if we ought to rename `--x-snippet-scan` to use the `experimental` prefix for consistency, or keep `x` for internal API versioning consistency?

## Metrics

N/A

## References

[ANE-2616](https://fossa.atlassian.net/browse/ANE-2616)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2616]: https://fossa.atlassian.net/browse/ANE-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ