### PR TITLE
[ANE-2616] Affix the api/proxy routes for ingress reasons

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## 3.11.1
 
 - Better document `--x-snippet-scan`.
+- Fix the route used by `--x-snippet-scan` to account for proxying.
 
 ## 3.11.0
 

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -44,9 +44,9 @@ import Fossa.API.Types (ApiKey (..), ApiOpts (..))
 import Path (Abs, Dir, File, Path, toFilePath)
 import Srclib.Types (Locator (..), renderLocator)
 import Text.URI (render)
-import Text.URI.Builder ()
+import Text.URI.Builder (PathComponent (PathComponent), TrailingSlash (TrailingSlash), setPath)
 import Types (GlobFilter (..), LicenseScanPathFilters (..))
-import Prelude hiding (unwords)
+import Prelude
 
 newtype CustomLicensePath = CustomLicensePath {unCustomLicensePath :: Text}
   deriving (Eq, Ord, Show, Hashable)
@@ -171,7 +171,8 @@ ficusCommand :: Has Diagnostics sig m => FicusConfig -> BinaryPaths -> m Command
 ficusCommand ficusConfig bin = do
   endpoint <- case ficusConfigEndpoint ficusConfig of
     Just baseUri -> do
-      pure $ render baseUri
+      proxyUri <- setPath [PathComponent "api", PathComponent "proxy", PathComponent "analysis"] (TrailingSlash False) baseUri
+      pure $ render proxyUri
     Nothing -> pure ""
   pure $
     Command


### PR DESCRIPTION
# Overview

Fixes the endpoint passed to `ficus` to account for https://github.com/fossas/helm/blob/master/fossa-core/templates/core/ingress.yaml#L39-L52

## Acceptance criteria

Passes the proxied endpoint to ficus.

## Testing plan

- Followed https://github.com/fossas/sparkle/pull/656
- Saw ficus output successfully with analysis_id from the changed branch

## Risks

N/A

## Metrics

N/A

## References

- [ANE-2616](https://fossa.atlassian.net/browse/ANE-2616)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2616]: https://fossa.atlassian.net/browse/ANE-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ