### PR TITLE
Update changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,11 +2,11 @@
 
 ## 3.11.3
 
-- Picks up the latest version of a dependency for `--x-snippet-scan`.
+- Picks up the latest version of a dependency for `--x-snippet-scan`. ([#1579](https://github.com/fossas/fossa-cli/pull/1579))
 
 ## 3.11.2
 
-- A performance fix for `--x-snippet-scan`.
+- A performance fix for `--x-snippet-scan`. ([#1578](https://github.com/fossas/fossa-cli/pull/1578))
 
 ## 3.11.1
 


### PR DESCRIPTION
# Overview

- Picks up the latest version of ficus.
- Backfills the changelog for 3.11.2, which is absent but should not be.

## Acceptance criteria

Contains the latest ficus embedded binary for `--x-snippet-scan`.

## Testing plan

I've run the latest ficus version locally and seen the issue of too-large post bodies cease.
In addition, once this builds I'll pull down an artifact and recreate the selfsame.

## Risks

N/A

## Metrics

N/A

## References

N/A

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
