### PR TITLE
Mask api key in command logging

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.11.4
+
+- Stops logging a secret under `--x-snippet-scan`. ([#1579](https://github.com/fossas/fossa-cli/pull/1580))
+
 ## 3.11.3
 
 - Picks up the latest version of a dependency for `--x-snippet-scan`. ([#1579](https://github.com/fossas/fossa-cli/pull/1579))

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -39,7 +39,6 @@ import Data.Hashable (Hashable)
 import Data.Maybe (mapMaybe)
 import Data.String.Conversion (ToText (toText), toString)
 import Data.Text (Text)
-import Data.Text qualified as T
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text.Encoding
 import Effect.Exec (AllowErr (Never), Command (..), renderCommand)
@@ -259,14 +258,14 @@ ficusCommand ficusConfig bin = do
 
     maskApiKeyInCommand :: Text -> Text
     maskApiKeyInCommand cmdText =
-      case T.splitOn " --secret " cmdText of
+      case Text.splitOn " --secret " cmdText of
         [before, after] ->
-          case T.words after of
+          case Text.words after of
             (_ : rest) ->
               before
                 <> " --secret "
                 <> "******"
-                <> if null rest then "" else " " <> T.unwords rest
+                <> if null rest then "" else " " <> Text.unwords rest
             [] -> cmdText
         _ -> cmdText
 


### PR DESCRIPTION
# Overview

Masks a logged API secret a la: `--secret ******`. I did not add tests for this because it is purely a logging concern visible locally on run.

## Acceptance criteria

Does not print any secrets in debug logging.

## Testing plan

Ran locally with `make install-local`, `analyze --x-snippet-scan --debug` on a local repo

## Risks

N/A

## Metrics

N/A

## References

N/A

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
