### PR TITLE
When reachability is not enabled for an org, stay silent.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.11.5
+
+- Remove spurious log message. ([#1582](https://github.com/fossas/fossa-cli/pull/1582))
+
 ## 3.11.4
 
 - Stops logging a secret under `--x-snippet-scan`. ([#1579](https://github.com/fossas/fossa-cli/pull/1580))

--- a/src/App/Fossa/Analyze/Upload.hs
+++ b/src/App/Fossa/Analyze/Upload.hs
@@ -115,11 +115,8 @@ uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnit
     dieOnMonorepoUpload revision
     org <- getOrganization
 
-    if (orgSupportsReachability org)
-      then void $ upload revision metadata reachabilityUnits
-      else do
-        logInfo . pretty $ "Organization: (" <> show (organizationId org) <> ") does not support reachability. Skipping reachability analysis upload."
-        logInfo . pretty $ "For reachability, refer to: " <> vulnReachabilityProductDocsUrl
+    when (orgSupportsReachability org) $
+      void $ upload revision metadata reachabilityUnits
 
     logInfo ""
     logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")

--- a/src/App/Fossa/Analyze/Upload.hs
+++ b/src/App/Fossa/Analyze/Upload.hs
@@ -7,7 +7,6 @@ module App.Fossa.Analyze.Upload (
   ScanUnits (..),
 ) where
 
-import App.Docs (vulnReachabilityProductDocsUrl)
 import App.Fossa.API.BuildLink (getFossaBuildUrl)
 import App.Fossa.Config.Analyze (JsonOutput (JsonOutput))
 import App.Fossa.Ficus.Types (FicusSnippetScanResults)
@@ -63,7 +62,7 @@ import Effect.Logger (
   logStdout,
   viaShow,
  )
-import Fossa.API.Types (Organization (orgSupportsReachability, organizationId), Project (projectIsMonorepo), UploadResponse (..), orgFileUpload)
+import Fossa.API.Types (Organization (orgSupportsReachability), Project (projectIsMonorepo), UploadResponse (..), orgFileUpload)
 import Path (Abs, Dir, Path)
 import Srclib.Types (
   FullSourceUnit,

--- a/src/App/Fossa/Analyze/Upload.hs
+++ b/src/App/Fossa/Analyze/Upload.hs
@@ -115,7 +115,8 @@ uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnit
     org <- getOrganization
 
     when (orgSupportsReachability org) $
-      void $ upload revision metadata reachabilityUnits
+      void $
+        upload revision metadata reachabilityUnits
 
     logInfo ""
     logInfo ("Using project name: `" <> pretty (projectName revision) <> "`")


### PR DESCRIPTION
# Overview

Right now we output a spurious message about reachability not being enabled for an org if it isn't. This PR removes it.

## Acceptance criteria

Before:
<img width="904" height="201" alt="Screenshot From 2025-08-22 14-16-32" src="https://github.com/user-attachments/assets/b4ac61ef-f5e4-4747-a74d-9c160d016a85" />

After:
<img width="904" height="201" alt="Screenshot From 2025-08-22 14-16-45" src="https://github.com/user-attachments/assets/b77b5339-769f-46c7-ac89-d8a492aa7a70" />

## Testing plan

I manually tested by disabling reachability in my org, then runninig `cabal run fossa -- analyze <project>` and also `fossa analyze <project>`.

## Risks

None

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

[conversation](https://teamfossa.slack.com/archives/C0155DTGWB1/p1755885490982159)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
