### PR TITLE
Prep for release 3.11.7

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # FOSSA CLI Changelog
 ## 3.11.7
 
-- Update latest version of a dependency for `--x-snippet-scan`. This change makes snippet scanning more resilient to network errors and ignores the `RUST_LOG` environment variable ([#1585](https://github.com/fossas/fossa-cli/pull/1585))
+- Update latest version of a dependency for `--x-snippet-scan`. This change makes snippet scanning more resilient to errors when POSTing fingerprints and hashes, and ignores the `RUST_LOG` environment variable ([#1585](https://github.com/fossas/fossa-cli/pull/1585))
 
 ## 3.11.6
 - Update latest version of a dependency for `--x-snippet-scan`. This change fixes a bug where snippet scans with large fingerprints were failing ([#1584](https://github.com/fossas/fossa-cli/pull/1584))


### PR DESCRIPTION
# Overview

Update the changelog to prep for release v3.11.7

This release will pull in a change to Ficus that makes it more resilient to errors when posting fingerprints and hashes

It also makes Ficus ignore the `RUST_LOG` environment variable, which was suppressing its output if it was set to "warn"


## Acceptance criteria



## Testing plan



## Risks



## Metrics



## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
