### PR TITLE
update tracing-subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,12 +1388,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1461,12 +1460,6 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -2535,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "nu-ansi-term",
  "serde 1.0.219",

--- a/extlib/millhone/Cargo.toml
+++ b/extlib/millhone/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1.0.107"
 serde_yaml = "0.9.25"
 rayon = "1.8.0"
 atty = "0.2.14"
-tracing-subscriber = { version = "0.3.17", features = ["json"] }
+tracing-subscriber = { version = "0.3.20", features = ["json"] }
 lazy-regex = { version = "3.0.2", features = ["std", "regex"] }
 fingerprint = { git = "https://github.com/fossas/lib-fingerprint.git", tag = "v3.0.0", default-features = false, features = ["fp-content-serialize-base64"] }
 tar = "0.4.41"

--- a/tools/diagnose/Cargo.toml
+++ b/tools/diagnose/Cargo.toml
@@ -16,7 +16,7 @@ regex = "1.9.1"
 stable-eyre = "0.2.2"
 strum = { version = "0.25.0", features = ["derive"] }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features = ["json"] }
+tracing-subscriber = { version = "0.3.20", features = ["json"] }
 walkdir = "2.3.3"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
# Overview

There is a vuln in tracing-subscriber that is fixed by upgrading to 0.3.20. This PR does that in the two spots that we use tracing-subscriber in.

FOSSA issue (on FOSSA prod org): https://app.fossa.com/projects/custom%2B1%2Fgithub.com%2Ffossas%2Ffossa-cli/refs/branch/ficus-error-logging/21a531f927a6d6844a1b90e1ecf0f98d641b2137/issues/vulnerability?page=1&count=20&sort=issue_count_desc&grouping=revision&status=active&revisionScanId=88877802

CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-58160

## Acceptance criteria

- We use a patched version of tracing-subscriber
- Everything else still works

## Testing plan

CI passing should be enough to test this

## Risks

## Metrics

## References

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
