### PR TITLE
[ANE-2653] Prepend ficus config excludes with --exclude flag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # FOSSA CLI Changelog
 
+## 3.11.11
+
+- [Bug]The Ficus command was being constructed incorrectly if there were file exclusions in .fossa.yml ([#1595](https://github.com/fossas/fossa-cli/pull/1595))
+- Update Ficus to fix a bug with Windows paths (No PR)
+
 ## 3.11.10
 
 - Optimize snippet scanning for time and space.([#1591](https://github.com/fossas/fossa-cli/pull/1591))

--- a/docs/features/manual-dependencies.md
+++ b/docs/features/manual-dependencies.md
@@ -54,6 +54,7 @@ Supported dependency types:
 - `hackage` - Haskell dependencies found at [Hackage](https://hackage.haskell.org/).
 - `hex` - Erlang and Elixir dependencies that are found at [Hex.pm](https://hex.pm/).
 - `maven` - Maven dependencies that can be found at many different sources. Specified as `name: javax.xml.bind:jaxb-api` where the convention is `groupId:artifactId`.
+<!-- markdown-link-check-disable-next-line -->
 - `npm` - Javascript dependencies found at [npmjs.com](https://www.npmjs.com/).
 - `nuget` - .NET dependencies found at [NuGet.org](https://www.nuget.org/).
 - `paket` - .NET dependencies found at [fsprojects.github.io/Paket/](https://fsprojects.github.io/Paket/).

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -269,7 +269,7 @@ ficusCommand ficusConfig bin = do
     targetDir = toText $ toFilePath $ ficusConfigRootDir ficusConfig
     secret = maybe "" (toText . unApiKey) $ ficusConfigSecret ficusConfig
     locator = renderLocator $ Locator "custom" (projectName $ ficusConfigRevision ficusConfig) (Just $ projectRevision $ ficusConfigRevision ficusConfig)
-    configExcludes = unGlobFilter <$> ficusConfigExclude ficusConfig
+    configExcludes = concatMap (\path -> ["--exclude", unGlobFilter path]) $ ficusConfigExclude ficusConfig
 
     maskApiKeyInCommand :: Text -> Text
     maskApiKeyInCommand cmdText =


### PR DESCRIPTION
# Overview

Exclude filters in `.fossa.yml` configs were not being respected for snippet scanning. The reason for this is that when the CLI calls ficus, it passed the globs without prefixing them with ficus' `--exclude` flag first.

## Acceptance criteria

* Users can add exclude filters in their `.fossa.yml` configs and have them respected for snippet scanning

## Testing plan


1. Navigate to a directory containing a project with vendored code in a subdirectory.
2. Add a `.fossa.yml` with:
```yml
vendoredDependencies:
  licenseScanPathFilters:
    exclude:
      - path-with-vendored-deps/** # exclude whatever path has the vendored code
```
3. Perform a snippet scan and observe that FOSSA finds all the snippets; `fossa analyze -p my-project -r test --x-snippet-scan`
4. Now run the snippet scan again but using the CLI binary built from this branch and observe that the snippets from the specified directory are excluded as expected.

## Risks

## Metrics

## References

- [ANE-2653](https://fossa.atlassian.net/browse/ANE-2653): Folder exclude directives from the CLI aren't being respected for snippet scanning

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2653]: https://fossa.atlassian.net/browse/ANE-2653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ