### PR TITLE
Allow empty go.mod

### DIFF
--- a/src/Strategy/Go/Gomod.hs
+++ b/src/Strategy/Go/Gomod.hs
@@ -57,6 +57,7 @@ import Text.Megaparsec (
   count,
   many,
   oneOf,
+  option,
   optional,
   parse,
   sepBy,
@@ -218,11 +219,17 @@ parsePackageVersion lexify = parseSemOrPseudo <|> parseNonCanonical
 gomodParser :: Parser Gomod
 gomodParser = do
   _ <- scn
-  _ <- lexeme (chunk "module")
-  name <- modulePath
-  _ <- scn
-  statements <- many (statement <* scn)
-  eof
+  (name, statements) <-
+    option
+      ("empty module", [])
+      ( do
+          _ <- lexeme (chunk "module")
+          name <- modulePath
+          _ <- scn
+          statements <- many (statement <* scn)
+          eof
+          pure (name, statements)
+      )
 
   let statements' = concat statements
 


### PR DESCRIPTION
# Overview
Update the `go.mod` parser to handle an empty file.

## Acceptance criteria
Parsing an empty `go.mod` file should not result in an error

## Testing plan
1. New unit tests added and passing
2. Clone an existing Go repo. Run an analysis and confirm that the go dependencies are detected correctly.
3. Truncate the `go.mod` file and run the analysis again. Confirm that it says the gomod project scan succeeded and discovered no dependencies.

## References
- [ANE-1777](https://fossa.atlassian.net/browse/ANE-1777): Support empty go.mod files

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-1777]: https://fossa.atlassian.net/browse/ANE-1777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ