### PR TITLE
Add "exclude manifest strategies" option

### DIFF
--- a/docs/contributing/effects-tutorial.md
+++ b/docs/contributing/effects-tutorial.md
@@ -625,7 +625,7 @@ necessary for understanding how the `Member` typeclass works fundamentally.
 
 [Haskell101]: http://youtu.be/cTN1Qar4HSw
 [Haskell102]: http://youtu.be/Ug9yJnOYR4U
-[MTLTutorial]: http://two-wrongs.com/a-gentle-introduction-to-monad-transformers
+[MTLTutorial]: https://web.cs.dal.ca/~nzeh/Teaching/3137/haskell/monads/transformers/
 [fused-talk]: http://youtu.be/vfDazZfxlNs
 [eff-tutorial]: https://github.com/fused-effects/fused-effects/blob/36bec2d6c0e97f7e01df97acd15012e1735c28bf/docs/defining_effects.md
 [simple-file]: https://github.com/fossas/fossa-cli/blob/aafe05624d102eb746b85c78027983e8c128bf24/src/Control/Carrier/Simple.hs

--- a/docs/references/files/fossa-yml.md
+++ b/docs/references/files/fossa-yml.md
@@ -305,6 +305,9 @@ targets:
       path: prod/docker
 ```
 
+#### `targets.excludeManifestStrategies:`
+If set to true, all manifest-based strategies for discovering targets will be skipped. This has the effect of only searching dependencies explicitly specified in `fossa-deps.yml`. This setting will override any target filters or path filters.
+
 ### `paths:`
 The paths filtering section allows you to specify which paths should be scanned and which should not. The paths should be listed as their location from the root of your project.
 

--- a/docs/references/files/fossa-yml.v3.schema.json
+++ b/docs/references/files/fossa-yml.v3.schema.json
@@ -514,11 +514,11 @@
                     "items": {
                         "$ref": "#/$defs/targetFilter"
                     }
-                }
+                },
                 "excludeManifestStrategies": {
                     "type": "boolean",
                     "description": "If set to true, all manifest-based strategies for discovering targets will be skipped. This has the effect of only searching dependencies explicitly specified in fossa-deps.yml. This setting will override any target filters or path filters.",
-                    "default": false,
+                    "default": false
                 }
             }
         },

--- a/docs/references/files/fossa-yml.v3.schema.json
+++ b/docs/references/files/fossa-yml.v3.schema.json
@@ -515,6 +515,11 @@
                         "$ref": "#/$defs/targetFilter"
                     }
                 }
+                "excludeManifestStrategies": {
+                    "type": "boolean",
+                    "description": "If set to true, all manifest-based strategies for discovering targets will be skipped. This has the effect of only searching dependencies explicitly specified in fossa-deps.yml. This setting will override any target filters or path filters.",
+                    "default": false,
+                }
             }
         },
         "paths": {

--- a/docs/walkthroughs/aosp.md
+++ b/docs/walkthroughs/aosp.md
@@ -96,10 +96,7 @@ Create this `.fossa.yml` configuration file in the same directory:
 version: 3
 
 targets:
-  only:
-    - type: npm
-  exclude:
-    - type: npm
+  excludeManifestStrategies: true
 ```
 
 Then, run `fossa analyze` in the same directory.
@@ -108,7 +105,7 @@ Then, run `fossa analyze` in the same directory.
 If you cannot create or modify a `.fossa.yml` configuration file, you can achieve the same result with this command:
 
 ```sh
-fossa analyze --only-target npm --exclude-target npm
+fossa analyze --exclude-manifest-strategies
 ```
 
 ## Explanation
@@ -120,6 +117,4 @@ If you need to analyze a different set of directories, you should modify this fi
 However, omitting this field causes the FOSSA CLI to compress each vendored directory to calculate a hash to use as a placeholder version.
 AOSP directory trees are too transitive for zip files, so we manually define a dummy version to avoid having to compress each subdirectory.
 
-Running `fossa analyze` without any other flags or configuration files causes all [analysis strategies](../references/strategies/README.md) to be executed, which requires significantly more resources. This is likely to fail or take an excessive amount of time due to the size and number of subprojects discovered in the AOSP source tree.
-
-The FOSSA CLI does not currently have a specific configuration to only run license analysis, but we can work around this by specifying intentionally contradicting exclusions, i.e. `--only-target npm --exclude-target npm`. The choice of `npm` here is arbitrary; any analysis strategy name can be used.
+Running `fossa analyze` without any other flags or configuration files causes all [analysis strategies](../references/strategies/README.md) to be executed, which requires significantly more resources. This is likely to fail or take an excessive amount of time due to the size and number of subprojects discovered in the AOSP source tree. The flag `--exclude-manifest-strategies` is set to avoid the use of such strategies and to only look at the dependencies in `fossa-deps.yml`.

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -82,7 +82,6 @@ import App.Types (
   ProjectMetadata (projectLabel),
   ProjectRevision,
  )
-import Codec.RPM.Tags (Tag (Exclude))
 import Control.Effect.Diagnostics (
   Diagnostics,
   Has,

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -43,7 +43,6 @@ import App.Fossa.Config.Common (
   baseDirArg,
   collectApiOpts,
   collectBaseDir,
-  collectConfigExcludeManifestStrategies,
   collectConfigFileFilters,
   collectConfigMavenScopeFilters,
   collectRevisionData',
@@ -59,6 +58,7 @@ import App.Fossa.Config.Common (
 import App.Fossa.Config.ConfigFile (
   ConfigFile (..),
   ConfigGrepEntry (..),
+  ConfigTargets (targetsExcludeManifestStrategies),
   ConfigTelemetryScope (NoTelemetry),
   ExperimentalConfigs (..),
   ExperimentalGradleConfigs (..),

--- a/src/App/Fossa/Config/ConfigFile.hs
+++ b/src/App/Fossa/Config/ConfigFile.hs
@@ -252,6 +252,7 @@ data ConfigRevision = ConfigRevision
 data ConfigTargets = ConfigTargets
   { targetsOnly :: [TargetFilter]
   , targetsExclude :: [TargetFilter]
+  , targetsExcludeManifestStrategies :: Bool
   }
   deriving (Eq, Ord, Show)
 
@@ -346,6 +347,7 @@ instance FromJSON ConfigTargets where
     ConfigTargets
       <$> (obj .:? "only" .!= [])
       <*> (obj .:? "exclude" .!= [])
+      <*> (obj .:? "excludeManifestStrategies" .!= False)
 
 instance FromJSON ConfigPaths where
   parseJSON = withObject "ConfigPaths" $ \obj ->

--- a/src/App/Fossa/Init/.fossa.yml
+++ b/src/App/Fossa/Init/.fossa.yml
@@ -198,6 +198,11 @@ version: 3
 #     - type: bundler
 #       path: prod/docker
 #
+#   # Don't use any manifest-based strategies when locating targets.
+#   # This has the effect of only looking for targets specified in fossa-deps.yaml.
+#   # This option will override any other filters, both target filters and path filters.
+#   excludeManifestStrategies: true
+#
 #
 # # Paths Configuration
 # # Filtering section to specify which paths should be scanned or excluded.

--- a/test/App/Fossa/Config/AnalyzeSpec.hs
+++ b/test/App/Fossa/Config/AnalyzeSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module App.Fossa.Config.AnalyzeSpec (spec) where
@@ -14,7 +15,7 @@ import App.Fossa.Config.Utils (itShouldFailWhenLabelsExceedFive, itShouldLoadFro
 import App.Fossa.Lernie.Types (OrgWideCustomLicenseConfigPolicy (..))
 import Data.Text (Text)
 import Discovery.Filters (AllFilters (..), combinedTargets)
-import Path (mkAbsFile)
+import Path (Abs, File, Path, mkAbsFile)
 import Test.Effect (expectationFailure', it', shouldBe')
 import Test.Hspec (Spec, describe)
 import Types (TargetFilter (TypeTarget))
@@ -29,6 +30,13 @@ envVars =
     , envDockerHost = Nothing
     , envCmdOverrides = mempty
     }
+
+configPath :: Path Abs File
+#ifdef mingw32_HOST_OS
+configPath = $(mkAbsFile "C:/.fossa.yml")
+#else
+configPath = $(mkAbsFile "/tmp/.fossa.yml")
+#endif
 
 configFileWithTargets :: [Text] -> [Text] -> Bool -> ConfigFile
 configFileWithTargets only exclude excludeManifestStrategies =
@@ -51,7 +59,7 @@ configFileWithTargets only exclude excludeManifestStrategies =
     , configKeywordSearch = Nothing
     , configReachability = Nothing
     , configOrgWideCustomLicenseConfigPolicy = Use
-    , configConfigFilePath = $(mkAbsFile "/test/fake.yml")
+    , configConfigFilePath = configPath
     }
 
 numberOfStrategies :: Int

--- a/test/App/Fossa/Config/AnalyzeSpec.hs
+++ b/test/App/Fossa/Config/AnalyzeSpec.hs
@@ -18,7 +18,7 @@ import Discovery.Filters (AllFilters (..), combinedTargets)
 import Path (Abs, File, Path, mkAbsFile)
 import Test.Effect (expectationFailure', it', shouldBe')
 import Test.Hspec (Spec, describe)
-import Types (TargetFilter (TypeTarget))
+import Types (DiscoveredProjectType, TargetFilter (TypeTarget))
 
 envVars :: EnvVars
 envVars =
@@ -63,7 +63,10 @@ configFileWithTargets only exclude excludeManifestStrategies =
     }
 
 numberOfStrategies :: Int
-numberOfStrategies = 47
+numberOfStrategies = length allProjectTypes
+  where
+    allProjectTypes :: [DiscoveredProjectType]
+    allProjectTypes = enumFromTo minBound maxBound
 
 spec :: Spec
 spec = do

--- a/test/App/Fossa/Config/AnalyzeSpec.hs
+++ b/test/App/Fossa/Config/AnalyzeSpec.hs
@@ -1,15 +1,101 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module App.Fossa.Config.AnalyzeSpec (spec) where
 
 import App.Fossa.Config.Analyze (
+  AnalyzeConfig (filterSet),
   cliParser,
   loadConfig,
+  mergeOpts,
  )
-import App.Fossa.Config.Utils (itShouldFailWhenLabelsExceedFive, itShouldLoadFromTheConfiguredBaseDir)
+import App.Fossa.Config.ConfigFile (ConfigFile (..), ConfigTargets (..))
+import App.Fossa.Config.EnvironmentVars (EnvVars (..))
+import App.Fossa.Config.Utils (itShouldFailWhenLabelsExceedFive, itShouldLoadFromTheConfiguredBaseDir, parseArgString)
+import App.Fossa.Lernie.Types (OrgWideCustomLicenseConfigPolicy (..))
+import Data.Text (Text)
+import Discovery.Filters (AllFilters (..), combinedTargets)
+import Path (mkAbsFile)
+import Test.Effect (it', shouldBe')
 import Test.Hspec (Spec, describe)
+import Types (TargetFilter (TypeTarget))
+
+envVars :: EnvVars
+envVars =
+  EnvVars
+    { envApiKey = Just "aoeu"
+    , envConfigDebug = False
+    , envTelemetryDebug = False
+    , envTelemetryScope = Nothing
+    , envDockerHost = Nothing
+    , envCmdOverrides = mempty
+    }
+
+configFileWithTargets :: [Text] -> [Text] -> Bool -> ConfigFile
+configFileWithTargets only exclude excludeManifestStrategies =
+  ConfigFile
+    { configVersion = 3
+    , configServer = Nothing
+    , configApiKey = Nothing
+    , configReleaseGroup = Nothing
+    , configProject = Nothing
+    , configRevision = Nothing
+    , configTargets =
+        Just $
+          ConfigTargets (map TypeTarget only) (map TypeTarget exclude) excludeManifestStrategies
+    , configPaths = Nothing
+    , configExperimental = Nothing
+    , configMavenScope = Nothing
+    , configVendoredDependencies = Nothing
+    , configTelemetry = Nothing
+    , configCustomLicenseSearch = Nothing
+    , configKeywordSearch = Nothing
+    , configReachability = Nothing
+    , configOrgWideCustomLicenseConfigPolicy = Use
+    , configConfigFilePath = $(mkAbsFile "/test/fake.yml")
+    }
+
+numberOfStrategies :: Int
+numberOfStrategies = 47
 
 spec :: Spec
 spec = do
   describe "loadConfig" $ do
     itShouldLoadFromTheConfiguredBaseDir cliParser loadConfig
+
   describe "5 labels are the max" $
     itShouldFailWhenLabelsExceedFive cliParser
+
+  describe "target filters" $ do
+    describe "only CLI options" $ do
+      it' "should set correct filters when --exclude-manifest-strategies is set" $ do
+        let cfgFile = Nothing
+        cliOpts <- parseArgString cliParser "--exclude-manifest-strategies"
+        filters <- filterSet <$> mergeOpts cfgFile envVars cliOpts
+        case (combinedTargets $ includeFilters filters, combinedTargets $ excludeFilters filters) of
+          ([], excludedTargets) -> length excludedTargets `shouldBe'` numberOfStrategies
+          _ -> error ("Incorrect filters. Got " ++ show filters)
+
+      it' "should set correct filters when only filter is set" $ do
+        let cfgFile = Nothing
+        cliOpts <- parseArgString cliParser "--only-target npm"
+        filters <- filterSet <$> mergeOpts cfgFile envVars cliOpts
+        case (combinedTargets $ includeFilters filters, combinedTargets $ excludeFilters filters) of
+          (includedTargets, []) -> includedTargets `shouldBe'` [TypeTarget "npm"]
+          _ -> error ("Incorrect filters. Got " ++ show filters)
+
+    describe "only config file" $ do
+      it' "should set correct filters when targets.excludeManifestStrategies is set" $ do
+        let cfgFile = Just $ configFileWithTargets [] [] True
+        cliOpts <- parseArgString cliParser ""
+        filters <- filterSet <$> mergeOpts cfgFile envVars cliOpts
+        case (combinedTargets $ includeFilters filters, combinedTargets $ excludeFilters filters) of
+          ([], excludedTargets) -> length excludedTargets `shouldBe'` numberOfStrategies
+          _ -> error ("Incorrect filters. Got " ++ show filters)
+
+      it' "should set correct filters when targets.only is set" $ do
+        let cfgFile = Just $ configFileWithTargets ["npm"] [] False
+        cliOpts <- parseArgString cliParser ""
+        filters <- filterSet <$> mergeOpts cfgFile envVars cliOpts
+        case (combinedTargets $ includeFilters filters, combinedTargets $ excludeFilters filters) of
+          (includedTargets, []) -> includedTargets `shouldBe'` [TypeTarget "npm"]
+          _ -> error ("Incorrect filters. Got " ++ show filters)

--- a/test/App/Fossa/Configuration/ConfigurationSpec.hs
+++ b/test/App/Fossa/Configuration/ConfigurationSpec.hs
@@ -114,6 +114,7 @@ expectedConfigTargets =
   ConfigTargets
     { targetsOnly = [directoryTarget, simpleTarget, complexTarget]
     , targetsExclude = []
+    , targetsExcludeManifestStrategies = False
     }
 
 expectedExperimentalConfig :: ExperimentalConfigs


### PR DESCRIPTION
# Overview
- Added a new option to skip any manifest-based strategies for discovering targets, replacing the old workaround of using `--only-target npm --exclude-target npm`. This option can be enabled via the CLI flag `--exclude-manifest-strategies` or in the config file under `targets.excludeManifestStrategies`.
- The logic to resolve the various ways of setting (possibly conflicting) options in the config file and CLI is as follows
  - The options for target filters, path filters, and exclude manifest strategies are applied as a group from a single source, either CLI options or the config file. I.e. we won't take some of those options from the config file and some from CLI arguments. This matches the previous behaviour, with the logic extended to include the new exclude manifest strategies option.
  - If any CLI arguments for options in this group are set, we use the CLI options only and disregard the config file options.
  - Otherwise we will use the config file's options.
  - If exclude manifest strategies is set alongside any other filters, then exclude manifest strategies applies, and a warning is displayed that the other filters are being ignored.

## Acceptance criteria
Users can set `--exclude-manifest-strategies` or `targets.excludeManifestStrategies` to avoid the use of any manifest-based strategies for discovering targets.

## Testing plan
- New unit tests added.
- Test a few combinations of CLI filter options and config file filter options:
  - `--exclude-manifest-filters` and `targets.only` in config. CLI option should apply.
  - `--exclude-manifest-filters` and `--only-target npm`. The `--exclude-manifest-filters` flag should apply.
  - `--only-target npm` and `targets.excludeManifestFilters` in config. Cli option should apply.
  - `targets.excludeManifestFilters` and `targets.only` set to `npm` in config. `targets.excludeManifestFilters` should apply.
  - Any other combinations you can think of.

## Risks

## Metrics

## References
- [ANE-767](https://fossa.atlassian.net/browse/ANE-767): Add new flag for fossa-deps only scan

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
