### PR TITLE
Remove reachability output from scan summary

### DIFF
--- a/docs/features/vuln_reachability.md
+++ b/docs/features/vuln_reachability.md
@@ -201,20 +201,3 @@ Organization: (your orgId) does not support reachability! skipping reachability 
 ```
 
 To enable, `reachability` please contact your FOSSA account manager, or [FOSSA support](https://support.fossa.com).
-
-
-3. How do I know if my project was analyzed for reachability by FOSSA CLI?
-
-FOSSA CLI will include scan summary for reachability analysis, as part of `fossa analyze` output.
-
-```text
-Reachability analysis
-  ** maven project in "/Users/dev/code/example-projects/reachability/maven/vuln-function-used/": succeeded
-```
-
-| Summary                          | Meaning                                                                      |
-|----------------------------------|------------------------------------------------------------------------------|
-| succeeded                        | Reachability analysis was successful                                         |
-| skipped (partial graph)          | Project has partial dependency graph (e.g. missing transitive dependencies)  |
-| skipped (not supported)          | Project is not supported for reachability analysis                           |
-| skipped (no dependency analysis) | Project's dependencies were not analyzed, so reachability cannot be computed |

--- a/src/App/Fossa/Reachability/Upload.hs
+++ b/src/App/Fossa/Reachability/Upload.hs
@@ -39,7 +39,7 @@ import Data.Maybe (mapMaybe)
 import Diag.Result (Result (..))
 import Discovery.Filters (AllFilters)
 import Effect.Exec (Exec)
-import Effect.Logger (Logger, logDebug, logInfo, pretty)
+import Effect.Logger (Logger, logDebug, pretty)
 import Effect.ReadFS (ReadFS)
 import Srclib.Converter (projectToSourceUnit)
 import Srclib.Types (
@@ -134,7 +134,7 @@ callGraphOf (Scanned dpi (Success _ projectResult)) = do
     -- it is impossible to perform reachability, as we may not have all symbols
     -- used in the application to perform accurate analysis
     (Partial, _) -> do
-      logInfo . pretty $ "FOSSA CLI does not support reachability analysis, with partial dependencies graph (skipping: " <> displayId <> ")"
+      logDebug . pretty $ "FOSSA CLI does not support reachability analysis, with partial dependencies graph (skipping: " <> displayId <> ")"
       pure . SourceUnitReachabilitySkippedPartialGraph $ dpi
     (Complete, MavenProjectType) -> context "maven" $ do
       analysis <- Diag.errorBoundaryIO . diagToDebug $ case Map.lookup projectPath reachabilityJarsByProject of
@@ -163,7 +163,7 @@ callGraphOf (Scanned dpi (Success _ projectResult)) = do
     -- Exclude units for package manager/language we cannot support yet!
     _ -> do
       -- Update docs: ./docs/features/vuln_reachability.md
-      logInfo . pretty $ "FOSSA CLI does not support reachability analysis for: " <> displayId <> " yet. (skipping)"
+      logDebug . pretty $ "FOSSA CLI does not support reachability analysis for: " <> displayId <> " yet. (skipping)"
       pure . SourceUnitReachabilitySkippedNotSupported $ dpi
 -- Not possible to perform reachability analysis for projects
 -- which were not scanned (skipped due to filter), as we do not


### PR DESCRIPTION
# Overview
Remove reachability log output from the scan summary as the feature is in an alpha state and having the scan summary indicate most projects were skipped is misleading/confusing. The reachability code still runs, it's just not included in the summary. The info level log messages when uploading reachability results have been changed to debug rather than being removed.

## Acceptance criteria
There are no reachability logs in the scan summary.

## Testing plan
Run `fossa analyze` on a project and confirm there are no reachability logs in the scan summary.

## Risks

## Metrics

## References
- [ANE-2658](https://fossa.atlassian.net/browse/ANE-2658): Remove "reachability" logs from the CLI

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2658]: https://fossa.atlassian.net/browse/ANE-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ