### PR TITLE
Fix cargo workspace members showing as deps

### DIFF
--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -76,7 +76,7 @@ import Effect.Grapher (
 import Effect.ReadFS (ReadFS, doesFileExist, readContentsToml)
 import Errata (Errata (..))
 import GHC.Generics (Generic)
-import Graphing (Graphing, stripRoot)
+import Graphing (Graphing, shrinkRoots)
 import Path (Abs, Dir, File, Path, mkRelFile, parent, parseRelFile, toFilePath, (</>))
 import Text.Megaparsec (
   Parsec,
@@ -434,7 +434,10 @@ addEdge node = do
     edge parentId $ nodePkg dep
 
 buildGraph :: CargoMetadata -> Graphing Dependency
-buildGraph meta = stripRoot $
+-- By construction, workspace members are the root nodes in the graph.
+-- Use shrinkRoots to remove them and promote their direct dependencies to the
+-- direct dependencies we report for the project.
+buildGraph meta = shrinkRoots $
   run . withLabeling toDependency $ do
     traverse_ direct $ metadataWorkspaceMembers meta
     traverse_ addEdge $ resolvedNodes $ metadataResolve meta

--- a/test/Cargo/MetadataSpec.hs
+++ b/test/Cargo/MetadataSpec.hs
@@ -10,7 +10,6 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import DepTypes
 import GraphUtil
-import Graphing
 import Strategy.Cargo
 import Test.Hspec qualified as Test
 
@@ -66,7 +65,7 @@ spec = do
         Right result -> result `Test.shouldBe` expectedMetadataPre1_77
 
     Test.it "should build the correct graph" $ do
-      let graph = pruneUnreachable $ buildGraph expectedMetadataPre1_77
+      let graph = buildGraph expectedMetadataPre1_77
       expectDeps [ansiTermDep, clapDep] graph
       expectEdges [(clapDep, ansiTermDep)] graph
       expectDirect [clapDep] graph
@@ -120,7 +119,7 @@ post1_77MetadataParseSpec =
         Right result -> result `Test.shouldBe` expectedMetadataPost1_77
 
     Test.it "should build the correct graph" $ do
-      let graph = pruneUnreachable $ buildGraph expectedMetadataPost1_77
+      let graph = buildGraph expectedMetadataPost1_77
       expectDeps [ansiTermDep, clapDep, fooDep, barDep] graph
       expectEdges [(clapDep, ansiTermDep)] graph
       expectDirect [clapDep, fooDep, barDep] graph


### PR DESCRIPTION
# Overview
The graph of a cargo project incorrectly reported workspace member packages as dependencies when they are not really dependencies so much as what is being scanned.

From a UI perspective, this was actually fixed by #1599 since the workspace members are all path dependencies and so get filtered already. But the project graph was still technically incorrect so this resolves that.

## Acceptance criteria
Packages defined in a Cargo workspace are not reported as dependencies.

## Testing plan
-  Clone the [test project](https://github.com/jssblck/unempty.git) and check out commit `164eae5e76cc3b17bd9d59f647e62b5b9b10785c`. Run `fossa analyze` and confirm that generated graph is empty in the output json and that no dependencies are displayed in the UI.
- Clone sparkle and run an analyze. Check the generated graph's deps and confirm that none of the packages defined in the repo are present as dependencies.
- Unit tests updated to catch this bug. It was being masked by a call to `pruneUnreachable` which we can now remove.

## Risks

## Metrics

## References
- [ANE-512](https://fossa.atlassian.net/browse/ANE-512) `Cargo` analyzer reports library project as dependency of itself

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-512]: https://fossa.atlassian.net/browse/ANE-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ