### PR TITLE
Handle HTTP errors fetching image manifest

### DIFF
--- a/src/Control/Carrier/ContainerRegistryApi.hs
+++ b/src/Control/Carrier/ContainerRegistryApi.hs
@@ -190,6 +190,7 @@ getImageManifest src = context "Getting Image Manifest" $ do
           (digestOf manifestIndex platformArch)
 
       parseOciManifest
+        =<< fromResponse
         =<< mkRequest manager (registryCred src) (Just supportedManifestKinds)
         =<< (manifestEndpoint $ src{registryContainerRepositoryReference = manifestDigest})
     else do

--- a/src/Control/Carrier/ContainerRegistryApi/Errors.hs
+++ b/src/Control/Carrier/ContainerRegistryApi/Errors.hs
@@ -39,6 +39,7 @@ data ContainerRegistryApiErrorKind
   | Denied
   | Unsupported
   | OtherError
+  | TooManyRequests
   deriving (Eq, Ord)
 
 instance Show ContainerRegistryApiErrorKind where
@@ -49,6 +50,7 @@ instance Show ContainerRegistryApiErrorKind where
   show Unauthorized = "UNAUTHORIZED"
   show Denied = "DENIED"
   show Unsupported = "UNSUPPORTED"
+  show TooManyRequests = "TOOMANYREQUESTS"
   show OtherError = "OTHER_UNKNOWN_ERROR"
 
 instance FromJSON ContainerRegistryApiErrorKind where
@@ -61,6 +63,7 @@ errCodeToErrKind errorKind | show NameInvalid == errorKind = NameInvalid
 errCodeToErrKind errorKind | show NameUnknown == errorKind = NameUnknown
 errCodeToErrKind errorKind | show Unauthorized == errorKind = Unauthorized
 errCodeToErrKind errorKind | show Denied == errorKind = Denied
+errCodeToErrKind errorKind | show TooManyRequests == errorKind = TooManyRequests
 errCodeToErrKind errorKind | show Unsupported == errorKind = Unsupported
 errCodeToErrKind _ = OtherError
 
@@ -103,7 +106,7 @@ instance ToDiagnostic UnknownApiError where
     let header =
           renderIt $
             vsep
-              [ "Caught unexpected error from:" <> pretty ("(" <> show (statusCode status) <> ") " <> show uri)
+              [ "Caught unexpected error from: " <> pretty ("(" <> show (statusCode status) <> ") " <> show uri)
               ]
     Errata (Just header) [] Nothing
 


### PR DESCRIPTION
# Overview
Integration tests frequently fail with the error:
```
  integration-test/Container/AnalysisSpec.hs:52:7: 
  1) Container.Analysis, Container Scanning, Container analysis from registry source, Has the correct OS release version
       uncaught exception: IOException of type UserError
       user error (ErrGroup [] [] [] [] [] (ErrWithStack (Stack ["Getting Image Manifest","Exporting Image","Analyzing via registry"]) (SomeErr "Errata {errataHeader = Just \"Manifest format is not supported: application/json; charset=utf-8\", errataBlocks = [Block {blockStyle = Style {styleLocation = \"\\8594 file:1:1\", styleNumber = \"3\", styleLine = \"text\", styleEllipsis = \".\", styleLinePrefix = \"\\9474\", styleVertical = \"\\9474\", styleHorizontal = \"\\9472\", styleDownRight = \"\\9484\", styleUpRight = \"\\9492\", styleUpDownRight = \"\\9500\", styleTabWidth = 4, styleExtraLinesAfter = 2, styleExtraLinesBefore = 1, stylePaddingTop = True, stylePaddingBottom = False, styleEnableDecorations = True, styleEnableLinePrefix = True}, blockLocation = (\"src/Control/Carrier/ContainerRegistryApi.hs\",216,15), blockHeader = Nothing, blockPointers = [], blockBody = Nothing}], errataBody = Just \"Workaround:\\n\\n  Export the image:\\n\\n\\n  Try using exported container image for analysis instead.\\n\\n\\n      >> docker pull public.ecr.aws/docker/library/alpine:3.19.1\\n      >> docker save public.ecr.aws/docker/library/alpine:3.19.1 > image-exported.tar\\n\\n\\n      fossa container analyze image-exported.tar\"}") :| []))
```

This error is misleading. With this change we see the actual reason for the failure:
```
  integration-test/Container/AnalysisSpec.hs:50:7:
  1) Container.Analysis, Container Scanning, Container analysis from registry source, Has the correct OS
       uncaught exception: IOException of type UserError
       user error (ErrGroup [] [] [] [] [] (ErrWithStack (Stack ["Getting Image Manifest","Exporting Image","Analyzing via registry"]) (SomeErr "Errata {errataHeader = Just \"Caught API error from: https://public.ecr.aws/v2/docker/library/alpine/manifests/sha256:6457d53fb065d6f250e1504b9bc42d5b6c65941d57532c072d929dd0628977d0\", errataBlocks = [], errataBody = Just \"API errors:\\n    Error code: TOOMANYREQUESTS\\n    Error message: Rate exceeded\"}") :| []))
```

We should still fix the test so that we're not getting rate limited, but at least now the error makes it clear what's happening.

## Acceptance criteria

## Testing plan

## Risks

## Metrics

## References

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
