### PR TITLE
Switch to ghcr.io image to avoid rate limits

### DIFF
--- a/integration-test/Container/AnalysisSpec.hs
+++ b/integration-test/Container/AnalysisSpec.hs
@@ -25,7 +25,7 @@ registrySourceCfg =
   ContainerAnalyzeConfig
     { scanDestination = OutputStdout
     , revisionOverride = OverrideProject Nothing Nothing Nothing
-    , imageLocator = ImageText "public.ecr.aws/docker/library/alpine:3.19.1"
+    , imageLocator = ImageText "ghcr.io/fossas/haskell-dev-tools:9.8.4"
     , jsonOutput = toFlag' False
     , usesExperimentalScanner = True
     , dockerHost = ""
@@ -50,8 +50,8 @@ registrySourceAnalysis = do
       it "Has the correct OS" $
         \scan -> scan.imageData.imageOs `shouldBe` Just "alpine"
       it "Has the correct OS release version" $
-        \scan -> scan.imageData.imageOsRelease `shouldBe` Just "3.19.1"
+        \scan -> scan.imageData.imageOsRelease `shouldBe` Just "3.18.12"
       it "Has the expected image tag" $
-        \scan -> scan.imageTag `shouldBe` "public.ecr.aws/docker/library/alpine"
+        \scan -> scan.imageTag `shouldBe` "ghcr.io/fossas/haskell-dev-tools"
       it "Has at least one layer" $
         \scan -> scan.imageData.imageLayers `shouldSatisfy` (not . null)


### PR DESCRIPTION
# Overview
This integration test frequestly fails with rate limit errors. Switching to a ghcr.io image seems to make the test more reliable (tests passed 5 times in a row in CI), but I unfortunately couldn't find any info about what the actual rate limits are so it's very possible we'll still hit rate limit errors (but hopefully less often).

## Acceptance criteria

## Testing plan

## Risks

## Metrics

## References

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
