### PR TITLE
Fix some failing Gradle integration tests

### DIFF
--- a/integration-test/Analysis/GradleSpec.hs
+++ b/integration-test/Analysis/GradleSpec.hs
@@ -19,7 +19,7 @@ import Test.Hspec (Spec, aroundAll, describe, it, shouldBe)
 import Types (DiscoveredProjectType (..))
 
 gradleEnv :: FixtureEnvironment
-gradleEnv = NixEnv ["gradle_7"]
+gradleEnv = NixEnv ["gradle"]
 
 springBoot :: AnalysisTestFixture (Gradle.GradleProject)
 springBoot =


### PR DESCRIPTION
# Overview

Some gradle tests started breaking. I fixed this by changing the gradle version we are using and updating one of the repositories we are testing against.

## Acceptance criteria

- The integration tests pass

## Testing plan



## Risks


## Metrics


## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
