### PR TITLE
Cut release for themis 1.0.41

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
 # FOSSA CLI Changelog
+
+## 3.15.2
+- Licensing: applies a fix for public domain detection ([#1625](https://github.com/fossas/fossa-cli/pull/1625))
+
 ## 3.15.1
 - A small tweak in format for `--x-vendetta` ([#1624](https://github.com/fossas/fossa-cli/pull/1624))
 


### PR DESCRIPTION
# Overview

Cut a release so we incorporate v1.0.41 of themis, which addresses ANE-2737.

## Acceptance criteria

We use the new version of themis for license scanning.

## Testing plan

Please refer to the testing plan in https://github.com/fossas/themis/pull/148.

## Risks

## Metrics

## References

- [ANE-2737](https://fossa.atlassian.net/browse/ANE-2737)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2737]: https://fossa.atlassian.net/browse/ANE-2737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ