### PR TITLE
make_fossa_deps_conan.py conan 2.22 graph info compatability

### DIFF
--- a/docs/walkthroughs/make_fossa_deps_conan.py
+++ b/docs/walkthroughs/make_fossa_deps_conan.py
@@ -125,9 +125,10 @@ def mk_fossa_deps(graph):
 
     vendored_deps = []
     custom_deps = []
-    for node in graph.get('nodes', []):
+    for nodeName in graph.get('nodes', []):
+        node = graph['nodes'][nodeName]
         label = node.get("label")
-        if label.lower() in ["conanfile.txt", "conanfile.py"]:
+        if label.lower() in ["conanfile.txt", "conanfile.py"] or node.get("recipe") == "Consumer":
             logging.info(f"excluding {label} from fossa-deps, as this is a manifest file, not a dependency")
             continue
 
@@ -140,7 +141,10 @@ def mk_fossa_deps(graph):
             continue
 
         pkg_id = node.get("package_id", "none")
-        name, raw_version = name_version_of(label)
+        name = node.get("name")
+        raw_version = node.get("version")
+        if not name or not raw_version:
+            name, raw_version = name_version_of(label)
         version_params = urllib.parse.urlencode({'package_id': pkg_id}, doseq=True)
         version = f"{raw_version},{version_params}"
 
@@ -181,4 +185,6 @@ def get_graph(user_args = []):
 
 if __name__ == "__main__":
     graph = get_graph(sys.argv[1:])
+    if 'graph' in graph:
+        graph = graph['graph']
     mk_fossa_deps(graph)


### PR DESCRIPTION


# Overview

This PR makes make_fossa_deps_conan.py work with conan 2.22.

Conan now wraps the graph in  a "graph" object and exports the nodes as named objects. Also some more information is directly available.

The changes in this PR correspond to the new structure and are actively used at Miele & Cie. KG in multiple CI pipelines to check license compliance.

## Acceptance criteria

When users use conan 2.22 for their package management, they can now integrate fossa into their workflow.

## Risks

This may break compatibility to earlier conan versions.

## Tests

Defining automated tests for this script is not feasible in the current test setup.

## References

- Direct Customer Support 

## Checklist

- [X] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [X] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [X] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [X] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [X] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.

<hr/>
For questions please contact friedrich.may@miele.com (my work email). Submitted on behalf of Miele.
