### PR TITLE
Update Changelog for 3.15.4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # FOSSA CLI Changelog
 
+## 3.15.4
+- Scala fix: Prefer `MiniDependencyTreePlugin` over explicit `DependencyTreePlugin` ([#1627](https://github.com/fossas/fossa-cli/pull/1627)).
+
 ## 3.15.3
 - Remove `fossa snippets` subcommand and documentation ([#1623](https://github.com/fossas/fossa-cli/pull/1623)).
   The `fossa snippets` subcommand has been replaced by `fossa analyze --snippet-scan` ([documentation](./docs/features/snippet-scanning.md)). If you are still using `fossa snippets`, you can temporarily keep using it by using versions of the CLI previous to this release. We will eventually be sunsetting the services that back `fossa snippets`, but will keep them running to mid-February at the very earliest. Once those services stop running then `fossa snippets` will no longer work at all, even when using older versions of the CLI. Please reach out to support@fossa.com if you have any questions.


### PR DESCRIPTION
# Overview
Update change log for 3.15.4

## Acceptance criteria

_If this PR is successful, what impact does it have on the user experience?_

_Example: When users do X, Y should now happen._

## Testing plan

_How did you validate that this PR works? What literal steps did you take when manually checking that your code works?_

_Example:_

1. _Set up test case X._
2. _Run command Y. Make sure Z happens._

_This section should list concrete steps that a reviewer can sanity check and repeat on their own machine (and provide any needed test cases)._

## Risks

_Highlight any areas that you're unsure of, want feedback on, or want reviewers to pay particular attention to._

_Example: I'm not sure I did X correctly, can reviewers please double-check that for me?_

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

_Example:_

- _[ANE-123](https://fossa.atlassian.net/browse/ANE-123): Implement X._

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
