### PR TITLE
CI Improvements - Parallelize integration tests, cache ghcup, fix tag caching

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Update badge
         run: |
           CLI_DOWNLOADS=$(gh api /repos/fossas/fossa-cli/releases --paginate --cache 1h | jq '.[] | .assets | .[] | .download_count' | jq --slurp 'add')

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,7 +20,9 @@ jobs:
 
     - name: Get latest release tag
       id: latest-tag
-      run: echo "tag=$(git tag --sort=-v:refname | head -1 2>/dev/null || echo none)" >> $GITHUB_OUTPUT
+      run: |
+        tag="$(git tag --sort=-v:refname 2>/dev/null | head -1 || true)"
+        echo "tag=${tag:-none}" >> "$GITHUB_OUTPUT"
 
     # Adding the "git config ..." line ensures git doesn't fail during our build.
     - name: Configure Git

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Get latest release tag
       id: latest-tag
-      run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo none)" >> $GITHUB_OUTPUT
+      run: echo "tag=$(git tag --sort=-v:refname | head -1 2>/dev/null || echo none)" >> $GITHUB_OUTPUT
 
     # Adding the "git config ..." line ensures git doesn't fail during our build.
     - name: Configure Git
@@ -55,7 +55,7 @@ jobs:
 
     # Benchmarks build at a different optimization level, so they use
     # their own cache prefix to avoid collisions with the main build.
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       name: Cache cabal store
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.local/state/cabal' }}
@@ -63,7 +63,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ env.GHC_VERSION }}-benchmarks-cabal-cache-
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       name: Cache dist-newstyle
       with:
         path: ${{ github.workspace }}/dist-newstyle

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: dtolnay/rust-toolchain@stable
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         fetch-tags: true

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -41,16 +41,19 @@ jobs:
           os-name: macOS-intel
           project-file: cabal.project.ci.macos
           ghc: '9.8.4'
+          cabal: '3.10.3.0'
 
         - os: windows-latest
           os-name: Windows
           project-file: cabal.project.ci.windows
           ghc: '9.8.4'
+          cabal: '3.10.3.0'
 
         - os: macos-latest
           os-name: macOS-arm64
           project-file: cabal.project.ci.macos
           ghc: '9.8.4'
+          cabal: '3.10.3.0'
 
     steps:
 
@@ -62,7 +65,7 @@ jobs:
 
     - name: Get latest release tag
       id: latest-tag
-      run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo none)" >> $GITHUB_OUTPUT
+      run: echo "tag=$(git tag --sort=-v:refname | head -1 2>/dev/null || echo none)" >> $GITHUB_OUTPUT
 
     - name: Install MacOS binary dependencies
       if: ${{ contains(matrix.os, 'macos') }}
@@ -70,13 +73,24 @@ jobs:
         brew install jq
 
     # Set up Haskell.
+    # Cache ghcup installations so the setup action skips downloading GHC (~500 MB).
+    - uses: actions/cache@v5
+      if: ${{ !contains(matrix.os-name, 'Linux') }}
+      name: Cache ghcup
+      with:
+        path: |
+          ~/.ghcup/bin
+          ~/.ghcup/ghc/${{ matrix.ghc }}
+          ~/.ghcup/cache
+        key: ${{ matrix.os-name }}-ghcup-${{ matrix.ghc }}-${{ matrix.cabal }}
+
     - uses: haskell-actions/setup@v2
       id: setup-haskell
       name: Setup ghc/cabal (non-alpine)
       if: ${{ !contains(matrix.os-name, 'Linux') }}
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.10.3.0'
+        cabal-version: ${{ matrix.cabal }}
 
     # Set up Rust.
     # This action installs the 'minimal' profile.
@@ -129,7 +143,7 @@ jobs:
     # The home directory inside a github container run during a step is different than one run outside of it.
     # This is why there is special logic for 'LinuxARM'.
     # Its builds run inside a container but are cached by an action outside of it.
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       name: Cache cabal store
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store || ( matrix.os == 'LinuxARM' && format('{0}/_github_home/.local/state/cabal', runner.temp) || '~/.local/state/cabal') }}
@@ -137,7 +151,7 @@ jobs:
         restore-keys: |
           ${{ matrix.os-name }}-${{ matrix.ghc }}-cabal-cache-
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       name: Cache dist-newstyle
       with:
         path: ${{ github.workspace }}/dist-newstyle

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -78,9 +78,9 @@ jobs:
       name: Cache ghcup
       with:
         path: |
-          ~/.ghcup/bin
-          ~/.ghcup/ghc/${{ matrix.ghc }}
-          ~/.ghcup/cache
+          ${{ runner.os == 'Windows' && 'C:\ghcup\bin' || '~/.ghcup/bin' }}
+          ${{ runner.os == 'Windows' && format('C:\ghcup\ghc\{0}', matrix.ghc) || format('~/.ghcup/ghc/{0}', matrix.ghc) }}
+          ${{ runner.os == 'Windows' && 'C:\ghcup\cache' || '~/.ghcup/cache' }}
         key: ${{ matrix.os-name }}-ghcup-${{ matrix.ghc }}-3.10.3.0
 
     - uses: haskell-actions/setup@v2

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Get latest release tag
       id: latest-tag
       run: |
-        tag="$(git tag --sort=-v:refname 2>/dev/null | head -1)"
+        tag="$(git tag --sort=-v:refname 2>/dev/null | head -1 || true)"
         echo "tag=${tag:-none}" >> "$GITHUB_OUTPUT"
 
     - name: Install MacOS binary dependencies

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         fetch-depth: 2
@@ -65,7 +65,9 @@ jobs:
 
     - name: Get latest release tag
       id: latest-tag
-      run: echo "tag=$(git tag --sort=-v:refname | head -1 2>/dev/null || echo none)" >> $GITHUB_OUTPUT
+      run: |
+        tag="$(git tag --sort=-v:refname 2>/dev/null | head -1)"
+        echo "tag=${tag:-none}" >> "$GITHUB_OUTPUT"
 
     - name: Install MacOS binary dependencies
       if: ${{ contains(matrix.os, 'macos') }}
@@ -263,7 +265,7 @@ jobs:
            exit 1
         fi
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       with:
         name: ${{ matrix.os-name }}-binaries
         path: release
@@ -277,7 +279,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
 
     # Sets VERSION from git's tag or sha.
     # refer to: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter
@@ -452,7 +454,7 @@ jobs:
     # need to run for tagged release versions.
     - name: Upload release archives
       if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: release-archives
         path: release

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -41,19 +41,16 @@ jobs:
           os-name: macOS-intel
           project-file: cabal.project.ci.macos
           ghc: '9.8.4'
-          cabal: '3.10.3.0'
 
         - os: windows-latest
           os-name: Windows
           project-file: cabal.project.ci.windows
           ghc: '9.8.4'
-          cabal: '3.10.3.0'
 
         - os: macos-latest
           os-name: macOS-arm64
           project-file: cabal.project.ci.macos
           ghc: '9.8.4'
-          cabal: '3.10.3.0'
 
     steps:
 
@@ -84,7 +81,7 @@ jobs:
           ~/.ghcup/bin
           ~/.ghcup/ghc/${{ matrix.ghc }}
           ~/.ghcup/cache
-        key: ${{ matrix.os-name }}-ghcup-${{ matrix.ghc }}-${{ matrix.cabal }}
+        key: ${{ matrix.os-name }}-ghcup-${{ matrix.ghc }}-3.10.3.0
 
     - uses: haskell-actions/setup@v2
       id: setup-haskell
@@ -92,7 +89,7 @@ jobs:
       if: ${{ !contains(matrix.os-name, 'Linux') }}
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: ${{ matrix.cabal }}
+        cabal-version: '3.10.3.0'
 
     # Set up Rust.
     # This action installs the 'minimal' profile.

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -9,7 +9,7 @@ jobs:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install and set GHC and Cabal versions
         # The first line works around a ghcup issue:

--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest-large]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: install script performs installation
         shell: bash
@@ -61,7 +61,7 @@ jobs:
   test-macos-arm:
     runs-on: "macos-latest"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: install latest script can install a specific version
         shell: bash
         run: |
@@ -80,7 +80,7 @@ jobs:
   test-windows:
     runs-on: "windows-latest"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: get latest release version from github
         shell: pwsh

--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -1,20 +1,36 @@
 name: Integration Tests
 
-# Only run workflow manually
-# Refer to https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_dispatch
 on:
   push:
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * *" # At 05:00 on every day.
 
-jobs:
-  integration-test:
-    name: integration-test
-    runs-on: "fossa-cli-integration-runner"
-    # Be sure to update the env below too
-    container: fossa/haskell-static-alpine:ghc-9.8.4
+# Cancel in-progress runs for the same branch so stale runs don't block the runner.
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
 
+# All match patterns for integration test groups. Each group runs a subset;
+# the build job validates that every test belongs to exactly one group.
+env:
+  TEST_GROUPS: >-
+    Analysis.Maven Analysis.Gradle Analysis.Scala Analysis.Clojure
+    Analysis.Go Analysis.Rust Analysis.Erlang Analysis.Elixir
+    Analysis.Python Analysis.Ruby Analysis.Swift Analysis.Cocoapods
+    Analysis.Pnpm Analysis.Nuget Analysis.Carthage Analysis.LicenseScanner
+    Container.Analysis Reachability.Upload
+
+jobs:
+  # Build once, then run test groups in parallel.
+  # The build job populates the cabal and dist-newstyle caches.
+  # Each test job restores those caches so it doesn't need to rebuild.
+  build:
+    name: build
+    runs-on: "fossa-cli-integration-runner"
+    container: fossa/haskell-static-alpine:ghc-9.8.4
+    outputs:
+      latest-tag: ${{ steps.latest-tag.outputs.tag }}
     env:
       GHC_VERSION: '9.8.4'
 
@@ -29,13 +45,11 @@ jobs:
 
     - name: Get latest release tag
       id: latest-tag
-      run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo none)" >> $GITHUB_OUTPUT
+      run: echo "tag=$(git tag --sort=-v:refname | head -1 2>/dev/null || echo none)" >> $GITHUB_OUTPUT
 
     - name: Ensures git ownership check does not lead to compile error (we run git during compile for version tagging, etc.)
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-    # adduser cannot add users to group: https://unix.stackexchange.com/a/397733
-    # so we edit /etc/group directly
     - name: Create nixbuild users/group
       run: |
         addgroup nixbld
@@ -60,11 +74,7 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
 
-    # Cache cabal store and dist-newstyle keyed on spectrometer.cabal + project file.
-    # cabal build handles staleness internally — if a transitive dep changed,
-    # it recompiles only what's needed. This avoids the 8-min cabal update +
-    # dry-run solver step that the plan-hash approach requires.
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       name: Cache cabal store
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.local/state/cabal' }}
@@ -72,7 +82,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ env.GHC_VERSION }}-cabal-cache-
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       name: Cache dist-newstyle
       with:
         path: ${{ github.workspace }}/dist-newstyle
@@ -98,8 +108,132 @@ jobs:
         cabal update
         $RUN_CMD || $RUN_CMD
 
-    # This is set up to run integration tests in parallel.
-    # If that becomes a problem disable it by removing the "+RTS -N -RTS" test options.
-    - name: Run all integration tests
+    # Verify every integration test is covered by at least one group pattern.
+    # Counts tests from an unfiltered --dry-run vs the union of all --match
+    # patterns. Fails if any tests would be silently skipped.
+    - name: Validate test groups cover all tests
       run: |
-        cabal test --project-file=cabal.project.ci.linux --test-show-details=direct --test-option=--times integration-tests --test-options="+RTS -N -RTS"
+        TOTAL=$(cabal test --project-file=cabal.project.ci.linux \
+          --test-show-details=direct \
+          integration-tests \
+          --test-option=--dry-run 2>&1 | grep -c "^  " || echo 0)
+
+        MATCH_ARGS=""
+        for pattern in $TEST_GROUPS; do
+          MATCH_ARGS="$MATCH_ARGS --test-option=--match --test-option=$pattern"
+        done
+        MATCHED=$(cabal test --project-file=cabal.project.ci.linux \
+          --test-show-details=direct \
+          $MATCH_ARGS \
+          integration-tests \
+          --test-option=--dry-run 2>&1 | grep -c "^  " || echo 0)
+
+        echo "Total tests: $TOTAL"
+        echo "Matched tests: $MATCHED"
+        if [ "$TOTAL" -ne "$MATCHED" ]; then
+          echo "ERROR: $((TOTAL - MATCHED)) integration tests are not covered by any group pattern."
+          echo "Update TEST_GROUPS in integrations-test.yml to include the missing patterns."
+          exit 1
+        fi
+
+    # Upload artifacts that test jobs need so they don't have to rebuild
+    # Rust or re-download vendor binaries.
+    - uses: actions/upload-artifact@v4
+      with:
+        name: vendor-bins
+        path: vendor-bins/
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: rust-release-bins
+        path: |
+          target/release/berkeleydb
+          target/release/millhone
+
+  integration-test:
+    name: test-${{ matrix.group }}
+    needs: build
+    runs-on: "fossa-cli-integration-runner"
+    container: fossa/haskell-static-alpine:ghc-9.8.4
+    env:
+      GHC_VERSION: '9.8.4'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: jvm
+            matches: "Analysis.Maven Analysis.Gradle Analysis.Scala Analysis.Clojure"
+
+          - group: compiled
+            matches: "Analysis.Go Analysis.Rust Analysis.Erlang Analysis.Elixir"
+
+          - group: scripting-and-other
+            matches: "Analysis.Python Analysis.Ruby Analysis.Swift Analysis.Cocoapods Analysis.Pnpm Analysis.Nuget Analysis.Carthage Analysis.LicenseScanner Container.Analysis Reachability.Upload"
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        lfs: true
+        fetch-depth: 2
+
+    - name: Ensures git ownership check does not lead to compile error
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    - name: Create nixbuild users/group
+      run: |
+        addgroup nixbld
+        adduser -D nixbld-1
+        adduser -D nixbld-2
+        adduser -D nixbld-3
+        sed 's/nixbld:x:\([[:digit:]]*\):$/nixbld:x:\1:nixbld-1,nixbld-2,nixbld-3/' /etc/group > group-changed
+        mv group-changed /etc/group
+
+    - uses: cachix/install-nix-action@v25
+      with:
+        nix_path: nixpkgs=channel:nixos-25.05
+        extra_nix_config: "build-users-group = nixbld"
+
+    # Restore caches populated by the build job.
+    - uses: actions/cache@v5
+      name: Cache cabal store
+      with:
+        path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.local/state/cabal' }}
+        key: ${{ runner.os }}-${{ env.GHC_VERSION }}-cabal-cache-${{ hashFiles('spectrometer.cabal', 'cabal.project.ci.linux', 'cabal.project.common') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.GHC_VERSION }}-cabal-cache-
+
+    - uses: actions/cache@v5
+      name: Cache dist-newstyle
+      with:
+        path: ${{ github.workspace }}/dist-newstyle
+        key: ${{ runner.os }}-${{ env.GHC_VERSION }}-dist-newstyle-${{ needs.build.outputs.latest-tag }}-${{ hashFiles('spectrometer.cabal', 'cabal.project.ci.linux', 'cabal.project.common') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.GHC_VERSION }}-dist-newstyle-${{ needs.build.outputs.latest-tag }}-
+          ${{ runner.os }}-${{ env.GHC_VERSION }}-dist-newstyle-
+
+    # extra-source-files (vendor-bins/*, target/release/*) must exist on
+    # disk or cabal recompiles EmbeddedBinary.hs (fails under -Werror).
+    - uses: actions/download-artifact@v4
+      with:
+        name: vendor-bins
+        path: vendor-bins/
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: rust-release-bins
+        path: target/release/
+
+    - name: Run integration tests (${{ matrix.group }})
+      run: |
+        cabal update
+        MATCH_ARGS=""
+        for pattern in ${{ matrix.matches }}; do
+          MATCH_ARGS="$MATCH_ARGS --test-option=--match --test-option=$pattern"
+        done
+        cabal test --project-file=cabal.project.ci.linux \
+          --test-show-details=direct \
+          --test-option=--times \
+          $MATCH_ARGS \
+          integration-tests \
+          --test-options="+RTS -N -RTS"

--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -31,6 +31,7 @@ jobs:
     container: fossa/haskell-static-alpine:ghc-9.8.4
     outputs:
       latest-tag: ${{ steps.latest-tag.outputs.tag }}
+      test-matrix: ${{ env.TEST_MATRIX }}
     env:
       GHC_VERSION: '9.8.4'
 
@@ -79,7 +80,7 @@ jobs:
     - uses: actions/cache@v5
       name: Cache cabal store
       with:
-        path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.local/state/cabal' }}
+        path: ~/.local/state/cabal
         key: ${{ runner.os }}-${{ env.GHC_VERSION }}-cabal-cache-${{ hashFiles('spectrometer.cabal', 'cabal.project.ci.linux', 'cabal.project.common') }}
         restore-keys: |
           ${{ runner.os }}-${{ env.GHC_VERSION }}-cabal-cache-
@@ -166,7 +167,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(env.TEST_MATRIX) }}
+        include: ${{ fromJson(needs.build.outputs.test-matrix) }}
 
     steps:
     - uses: actions/checkout@v5
@@ -195,7 +196,7 @@ jobs:
     - uses: actions/cache@v5
       name: Cache cabal store
       with:
-        path: ${{ steps.setup-haskell.outputs.cabal-store || '~/.local/state/cabal' }}
+        path: ~/.local/state/cabal
         key: ${{ runner.os }}-${{ env.GHC_VERSION }}-cabal-cache-${{ hashFiles('spectrometer.cabal', 'cabal.project.ci.linux', 'cabal.project.common') }}
         restore-keys: |
           ${{ runner.os }}-${{ env.GHC_VERSION }}-cabal-cache-

--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -45,7 +45,9 @@ jobs:
 
     - name: Get latest release tag
       id: latest-tag
-      run: echo "tag=$(git tag --sort=-v:refname | head -1 2>/dev/null || echo none)" >> $GITHUB_OUTPUT
+      run: |
+        tag="$(git tag --sort=-v:refname 2>/dev/null | head -1 || true)"
+        echo "tag=${tag:-none}" >> "$GITHUB_OUTPUT"
 
     - name: Ensures git ownership check does not lead to compile error (we run git during compile for version tagging, etc.)
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: dtolnay/rust-toolchain@stable
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         fetch-depth: 2
@@ -138,17 +138,19 @@ jobs:
 
     # Upload artifacts that test jobs need so they don't have to rebuild
     # Rust or re-download vendor binaries.
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       with:
         name: vendor-bins
         path: vendor-bins/
+        if-no-files-found: error
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       with:
         name: rust-release-bins
         path: |
           target/release/berkeleydb
           target/release/millhone
+        if-no-files-found: error
 
   integration-test:
     name: test-${{ matrix.group }}
@@ -172,7 +174,7 @@ jobs:
             matches: "Analysis.Python Analysis.Ruby Analysis.Swift Analysis.Cocoapods Analysis.Pnpm Analysis.Nuget Analysis.Carthage Analysis.LicenseScanner Container.Analysis Reachability.Upload"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         lfs: true
         fetch-depth: 2
@@ -214,12 +216,12 @@ jobs:
 
     # extra-source-files (vendor-bins/*, target/release/*) must exist on
     # disk or cabal recompiles EmbeddedBinary.hs (fails under -Werror).
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         name: vendor-bins
         path: vendor-bins/
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         name: rust-release-bins
         path: target/release/

--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -11,15 +11,15 @@ concurrency:
   group: integration-${{ github.ref }}
   cancel-in-progress: true
 
-# All match patterns for integration test groups. Each group runs a subset;
-# the build job validates that every test belongs to exactly one group.
+# Single source of truth for integration test groups. Used by both the
+# matrix strategy and the build job's coverage validation step.
 env:
-  TEST_GROUPS: >-
-    Analysis.Maven Analysis.Gradle Analysis.Scala Analysis.Clojure
-    Analysis.Go Analysis.Rust Analysis.Erlang Analysis.Elixir
-    Analysis.Python Analysis.Ruby Analysis.Swift Analysis.Cocoapods
-    Analysis.Pnpm Analysis.Nuget Analysis.Carthage Analysis.LicenseScanner
-    Container.Analysis Reachability.Upload
+  TEST_MATRIX: >-
+    [
+      {"group": "jvm", "matches": "Analysis.Maven Analysis.Gradle Analysis.Scala Analysis.Clojure"},
+      {"group": "compiled", "matches": "Analysis.Go Analysis.Rust Analysis.Erlang Analysis.Elixir"},
+      {"group": "scripting-and-other", "matches": "Analysis.Python Analysis.Ruby Analysis.Swift Analysis.Cocoapods Analysis.Pnpm Analysis.Nuget Analysis.Carthage Analysis.LicenseScanner Container.Analysis Reachability.Upload"}
+    ]
 
 jobs:
   # Build once, then run test groups in parallel.
@@ -120,8 +120,9 @@ jobs:
           integration-tests \
           --test-option=--dry-run 2>&1 | grep -c "^  " || echo 0)
 
+        ALL_PATTERNS=$(echo '${{ env.TEST_MATRIX }}' | jq -r '.[].matches' | tr ' ' '\n' | sort -u | tr '\n' ' ')
         MATCH_ARGS=""
-        for pattern in $TEST_GROUPS; do
+        for pattern in $ALL_PATTERNS; do
           MATCH_ARGS="$MATCH_ARGS --test-option=--match --test-option=$pattern"
         done
         MATCHED=$(cabal test --project-file=cabal.project.ci.linux \
@@ -134,7 +135,7 @@ jobs:
         echo "Matched tests: $MATCHED"
         if [ "$TOTAL" -ne "$MATCHED" ]; then
           echo "ERROR: $((TOTAL - MATCHED)) integration tests are not covered by any group pattern."
-          echo "Update TEST_GROUPS in integrations-test.yml to include the missing patterns."
+          echo "Update TEST_MATRIX in integrations-test.yml to include the missing patterns."
           exit 1
         fi
 
@@ -165,15 +166,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - group: jvm
-            matches: "Analysis.Maven Analysis.Gradle Analysis.Scala Analysis.Clojure"
-
-          - group: compiled
-            matches: "Analysis.Go Analysis.Rust Analysis.Erlang Analysis.Elixir"
-
-          - group: scripting-and-other
-            matches: "Analysis.Python Analysis.Ruby Analysis.Swift Analysis.Cocoapods Analysis.Pnpm Analysis.Nuget Analysis.Carthage Analysis.LicenseScanner Container.Analysis Reachability.Upload"
+        include: ${{ fromJson(env.TEST_MATRIX) }}
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           components: "clippy,rustfmt"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run hlint
         run: |
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check Markdown links
         uses: tcort/github-action-markdown-link-check@v1.1.0
@@ -46,7 +46,7 @@ jobs:
         with:
           components: "clippy,rustfmt"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Run the formatter
       - name: run fourmolu
@@ -59,7 +59,7 @@ jobs:
     container: ghcr.io/fossas/haskell-dev-tools:9.8.4
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Run the formatter
       - name: "run cabal-fmt"
@@ -70,7 +70,7 @@ jobs:
     name: "schema lint check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: json-syntax-check
         uses: limitusus/json-syntax-check@v1
         with:
@@ -80,7 +80,7 @@ jobs:
     name: "Check for correct spelling of FOSSA"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: "Check for incorrect FOSSA wording"
         run: |
           ! grep 'Fossa ' **/*.md
@@ -89,7 +89,7 @@ jobs:
     name: "Lint bash scripts"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: run shellcheck
         uses: sudo-bot/action-shellcheck@latest
         with:

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write 
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install fossa-cli
         run: |
           ./install-latest.sh -d


### PR DESCRIPTION
# Overview

Four CI improvements across integration tests, build-all, and benchmarks workflows.

Impact
- Build times when fully cached are reliably in the single digits, as low as 5m.
- Integration tests can be more aggressively added to without adding more absolute test run time.

## 1. Parallelize integration tests

Split the single integration test job into a build job + 3 parallel test matrix jobs:
- **jvm**: Maven, Gradle, Scala, Clojure
- **compiled**: Go, Rust, Erlang, Elixir
- **scripting-and-other**: Python, Ruby, Swift, Cocoapods, Pnpm, Nuget, Carthage, LicenseScanner, Container, Reachability

Build job compiles once and populates caches. Test jobs restore caches and run their subset via `--match`. Adds a concurrency group to cancel stale in-progress runs on the same branch.

A `TEST_GROUPS` env var at the workflow level lists all match patterns. After building, a validation step runs `--dry-run` to count total tests vs matched tests and fails if any test is uncovered by a group. This prevents new tests from not being added to the matrix.

Vendor binaries and Rust release binaries are uploaded as artifacts from the build job and downloaded in test jobs, avoiding redundant `cargo build --release` (~1m) and `vendor_download.sh` (~20s) per test job.

The build job exports the release tag via job outputs so test jobs use the same tag for cache keys (avoids a race if a release happens mid-run).

**Note** This update also stops previous integration tests from running if a new commit is pushed. We have limited runner space, and I've been seeing a lot of tests in the "Waiting to run this spec" state. This should fix that.

## 2. Cache ghcup in build-all.yml

Cache `~/.ghcup/{bin,ghc,cache}` on macOS and Windows. Skips the ~500 MB GHC download on cache hit, reducing the `Setup ghc/cabal` step from ~4m to ~30s. Cache key includes both GHC and cabal versions.

## 3. Fix release tag resolution

`git describe --tags --abbrev=0` requires the tagged commit to be reachable in local history. With `fetch-depth: 2`, the tag is never reachable and always resolves to `none`. Switched to `git tag --sort=-v:refname | head -1` which lists fetched tag refs regardless of shallow clone depth.

## 4. Upgrade actions/cache to v5

Upgrade `actions/cache` from v4 to v5 across all workflows (integration tests, build-all, benchmarks). v5 uses the node22 runtime. v4 uses node20 which GitHub is deprecating (forced migration to node24 starts June 2, 2026). Self-hosted runner is on v2.332.0, above the v2.327.1 minimum.

## Testing plan

1. Pushed to branch, verified all 3 test matrix jobs pass.
2. Verified cache hits on subsequent push (exact key match, no recompilation beyond `App.Version.TH` chain).
3. Verified ghcup cache hit on macOS — `Setup ghc/cabal` dropped from ~4m to ~30s.

## Risks

- Test groups may become unbalanced as tests are added/removed. Rebalance by moving patterns between groups.
- The `--dry-run` grep pattern (`grep -c "^  "`) depends on hspec's output format. If hspec changes its dry-run output, the validation step may need updating.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.