### PR TITLE
CI: Cache Hackage package index in integration tests

### DIFF
--- a/.github/workflows/integrations-test.yml
+++ b/.github/workflows/integrations-test.yml
@@ -76,6 +76,17 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
 
+    # Cache the Hackage package index so cabal update does an incremental
+    # update (~seconds) instead of a full download (~3.5 min).
+    # Shared across all jobs; refreshed daily.
+    - uses: actions/cache@v5
+      name: Cache Hackage index
+      with:
+        path: ~/.cache/cabal/packages
+        key: hackage-index-${{ runner.os }}-${{ steps.latest-tag.outputs.tag }}
+        restore-keys: |
+          hackage-index-${{ runner.os }}-
+
     - uses: actions/cache@v5
       name: Cache cabal store
       with:
@@ -199,6 +210,14 @@ jobs:
         extra_nix_config: "build-users-group = nixbld"
 
     # Restore caches populated by the build job.
+    - uses: actions/cache@v5
+      name: Cache Hackage index
+      with:
+        path: ~/.cache/cabal/packages
+        key: hackage-index-${{ runner.os }}-${{ needs.build.outputs.latest-tag }}
+        restore-keys: |
+          hackage-index-${{ runner.os }}-
+
     - uses: actions/cache@v5
       name: Cache cabal store
       with:


### PR DESCRIPTION
# Overview

Cache the Hackage package index (`~/.cache/cabal/packages`) in integration test workflows. `cabal update` currently downloads the full index (~500 MB) from scratch on every run, taking ~3.5 minutes. With the cache, subsequent runs do an incremental update in seconds.

## Acceptance criteria

`cabal update` in integration test jobs completes in seconds instead of ~3.5 minutes when the cache is warm.

## Testing plan

1. First run populates the cache (still ~3.5 min).
2. Subsequent runs restore the cached index — `cabal update` does an incremental update (~seconds).
3. Verify all 3 test matrix jobs still pass.

## Risks

- The cache path (`~/.cache/cabal/packages`) assumes XDG layout, which is what the Alpine container uses (`/github/home/.cache/cabal/packages`). If cabal's config changes the index location, the cache would miss.
- Cache key rotates with the release tag. Between releases, the same cache entry is reused and incrementally updated by `cabal update`.

## Metrics

~3.5 min saved per integration test job (4 jobs total: build + 3 test shards = ~14 min saved per push on warm cache).

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.