### PR TITLE
[ANE-2900] Omit unset fields from project edit request body

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Project edit: Fix 500 error when running `fossa project edit --policy` on existing projects ([#1688](https://github.com/fossas/fossa-cli/pull/1688))
+
 ## 3.17.0
 
 - Vendetta: Support single-file library dependencies and multi-location vendored dependencies. Locations are now correctly classified as files or directories in vendored metadata. ([#1680](https://github.com/fossas/fossa-cli/pull/1680))

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -661,6 +661,7 @@ test-suite unit-tests
     Extra.TextSpec
     Ficus.FicusSpec
     Fortran.FpmTomlSpec
+    Fossa.API.CoreTypesSpec
     Fossa.API.TypesSpec
     Go.GlideLockSpec
     Go.GoListPackagesSpec

--- a/src/App/Fossa/Project.hs
+++ b/src/App/Fossa/Project.hs
@@ -27,4 +27,4 @@ projectMain ::
   m ()
 projectMain (EditCfg config) = do
   logInfo "Running FOSSA project"
-  context "Add projects to release group" . runStickyLogger SevInfo . ignoreDebug . runFossaApiClient (Edit.apiOpts config) $ editMain config
+  context "Editing project" . runStickyLogger SevInfo . ignoreDebug . runFossaApiClient (Edit.apiOpts config) $ editMain config

--- a/src/Fossa/API/CoreTypes.hs
+++ b/src/Fossa/API/CoreTypes.hs
@@ -33,6 +33,7 @@ import Data.Aeson (
   withText,
   (.:),
  )
+import Data.Maybe (catMaybes)
 import Data.Text (Text)
 
 --- | Data types of Core's main endpoints
@@ -246,13 +247,13 @@ data UpdateProjectRequest = UpdateProjectRequest
 
 instance ToJSON UpdateProjectRequest where
   toJSON UpdateProjectRequest{..} =
-    object
-      [ "title" .= maybe Null toJSON updateProjectTitle
-      , "url" .= maybe Null toJSON updateProjectUrl
-      , "issueTrackerProjectIds" .= maybe Null toJSON updateProjectIssueTrackerIds
-      , "labels" .= maybe Null toJSON updateProjectLabelIds
-      , "policyId" .= maybe Null toJSON updateProjectPolicyId
-      , "default_branch" .= maybe Null toJSON updateProjectDefaultBranch
+    object . catMaybes $
+      [ ("title" .=) <$> updateProjectTitle
+      , ("url" .=) <$> updateProjectUrl
+      , ("issueTrackerProjectIds" .=) <$> updateProjectIssueTrackerIds
+      , ("labels" .=) <$> updateProjectLabelIds
+      , ("policyId" .=) <$> updateProjectPolicyId
+      , ("default_branch" .=) <$> updateProjectDefaultBranch
       ]
 
 -- Revision

--- a/src/Fossa/API/CoreTypes.hs
+++ b/src/Fossa/API/CoreTypes.hs
@@ -27,13 +27,13 @@ import Data.Aeson (
   FromJSON (parseJSON),
   KeyValue ((.=)),
   ToJSON (toJSON),
-  Value (Null),
+  Value (Null, Object),
   object,
   withObject,
   withText,
   (.:),
+  (.?=),
  )
-import Data.Maybe (catMaybes)
 import Data.Text (Text)
 
 --- | Data types of Core's main endpoints
@@ -247,13 +247,13 @@ data UpdateProjectRequest = UpdateProjectRequest
 
 instance ToJSON UpdateProjectRequest where
   toJSON UpdateProjectRequest{..} =
-    object . catMaybes $
-      [ ("title" .=) <$> updateProjectTitle
-      , ("url" .=) <$> updateProjectUrl
-      , ("issueTrackerProjectIds" .=) <$> updateProjectIssueTrackerIds
-      , ("labels" .=) <$> updateProjectLabelIds
-      , ("policyId" .=) <$> updateProjectPolicyId
-      , ("default_branch" .=) <$> updateProjectDefaultBranch
+    Object . mconcat $
+      [ "title" .?= updateProjectTitle
+      , "url" .?= updateProjectUrl
+      , "issueTrackerProjectIds" .?= updateProjectIssueTrackerIds
+      , "labels" .?= updateProjectLabelIds
+      , "policyId" .?= updateProjectPolicyId
+      , "default_branch" .?= updateProjectDefaultBranch
       ]
 
 -- Revision

--- a/test/Fossa/API/CoreTypesSpec.hs
+++ b/test/Fossa/API/CoreTypesSpec.hs
@@ -1,0 +1,45 @@
+module Fossa.API.CoreTypesSpec (spec) where
+
+import Data.Aeson (Value (Object, String), toJSON)
+import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Text (Text)
+import Fossa.API.CoreTypes (UpdateProjectRequest (..))
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = describe "UpdateProjectRequest ToJSON" $ do
+  it "omits Nothing fields rather than emitting JSON null" $ do
+    let req =
+          UpdateProjectRequest
+            { updateProjectTitle = Nothing
+            , updateProjectUrl = Nothing
+            , updateProjectIssueTrackerIds = Nothing
+            , updateProjectLabelIds = Nothing
+            , updateProjectPolicyId = Just 7
+            , updateProjectDefaultBranch = Nothing
+            }
+        expected = Object $ KeyMap.fromList [("policyId", Aeson.Number 7)]
+    toJSON req `shouldBe` expected
+
+  it "includes every Just field with its JSON-encoded value" $ do
+    let req =
+          UpdateProjectRequest
+            { updateProjectTitle = Just "my-title"
+            , updateProjectUrl = Just "https://example.com"
+            , updateProjectIssueTrackerIds = Just ["JIRA-1"]
+            , updateProjectLabelIds = Just [1, 2]
+            , updateProjectPolicyId = Just 7
+            , updateProjectDefaultBranch = Just "main"
+            }
+        expected =
+          Object $
+            KeyMap.fromList
+              [ ("title", String "my-title")
+              , ("url", String "https://example.com")
+              , ("issueTrackerProjectIds", toJSON (["JIRA-1"] :: [Text]))
+              , ("labels", toJSON ([1, 2] :: [Int]))
+              , ("policyId", Aeson.Number 7)
+              , ("default_branch", String "main")
+              ]
+    toJSON req `shouldBe` expected


### PR DESCRIPTION
# Overview

Calling `fossa project edit` without `--title` returns a 500. The CLI's `UpdateProjectRequest` `ToJSON` instance emits every field unconditionally, so unset ones become JSON `null`. Core's `PUT /api/projects/:locator` doesn't like this because it assumes we want to _set_ the title (and other null fields) to null.

This PR makes the instance omit `Nothing` fields instead. It also renames a misleading copy-paste leftover wrapper in `App.Fossa.Project.projectMain` from `context "Add projects to release group"` to `context "Editing project"`; that string was showing up at the bottom of every `fossa project edit` error traceback.

## Acceptance criteria

* `fossa project edit --policy-id N` succeeds against an existing project without requiring `--title`.
* Error tracebacks from `fossa project edit` no longer mention "Add projects to release group".

## Testing plan

1. Pick any existing project in your org and a license policy id you can swap to.
2. Build the CLI from this branch and run:
   ```sh
   cabal run fossa -- project edit \
     --project-locator "<your-locator>" \
     --policy-id <your-policy-id>
   ```
3. The command should succeed and the project's policy in the FOSSA UI should reflect the new value. Before this PR it returned a 500.

## Risks

None that I can think of.

## Metrics

None.

## References

- [ANE-2900](https://fossa.atlassian.net/browse/ANE-2900): \`fossa project edit --policy\` returns 500 (release-group error) on existing projects

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.

[ANE-2900]: https://fossa.atlassian.net/browse/ANE-2900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ