### PR TITLE
Expose pnpm and bun workspace packages as individual build targets

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Node.js: Yarn and npm workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`.
+- Node.js: Yarn, npm, pnpm, and bun workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`, `pnpm@./:my-package`, `bun@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`.
 - Project edit: Fix 500 error when running `fossa project edit --policy` on existing projects ([#1688](https://github.com/fossas/fossa-cli/pull/1688))
 
 ## 3.17.0

--- a/docs/references/strategies/languages/nodejs/bun.md
+++ b/docs/references/strategies/languages/nodejs/bun.md
@@ -39,6 +39,12 @@ Workspace entries are keyed by their relative path from the root, with `""`
 representing the root workspace. Each workspace declares its own
 `dependencies`, `devDependencies`, and `optionalDependencies`.
 
+Each workspace package (including the root) is exposed as an individual build
+target (e.g. `bun@./:my-app`, `bun@./:lib-utils`). When a subset of targets
+is selected via `.fossa.yml`, only those packages' dependencies are included
+in the analysis. When no filtering is applied, all targets are selected and
+all dependencies from every workspace package are included.
+
 ### Packages
 
 Package keys use a slash-delimited path for nested `node_modules`:

--- a/docs/references/strategies/languages/nodejs/pnpm.md
+++ b/docs/references/strategies/languages/nodejs/pnpm.md
@@ -152,7 +152,12 @@ CLI will infer the package name and version using `/${dependencyName}/${dependen
 ```
 
 * Peer dependencies will be included in the analysis (they are treated like any other dependency).
-* Pnpm workspaces are supported.
+* Pnpm workspaces are supported. Each workspace package (including the root)
+  is exposed as an individual build target (e.g. `pnpm@./:my-app`,
+  `pnpm@./:lib-utils`). When a subset of targets is selected, only those
+  packages' dependencies are included in the analysis. When no filtering is
+  applied, all targets are selected and all dependencies from every workspace
+  package are included in the analysis.
 * Development dependencies (`dev: true`) are ignored by default from analysis. To include them in the analysis, execute CLI with `--include-unused` flag e.g. `fossa analyze --include-unused`.
 * Optional dependencies are included in the analysis by default. They can be ignored in FOSSA UI.
 * `fossa-cli` supports lockFileVersion: 4.x, 5.x, 6.x, 7.x, 8.x, and 9.x.

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -9,6 +9,8 @@ module Strategy.Node (
   getDeps,
   findWorkspaceBuildTargets,
   extractDepListsForTargets,
+  resolveImporterPaths,
+  resolveBunWorkspacePaths,
 ) where
 
 import Algebra.Graph.AdjacencyMap qualified as AM
@@ -39,7 +41,7 @@ import Data.Maybe (catMaybes, isJust, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Set.NonEmpty qualified as NonEmptySet
-import Data.String.Conversion (decodeUtf8, toString)
+import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Tagged (applyTag)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -73,6 +75,7 @@ import Path (
   Rel,
   mkRelFile,
   parent,
+  stripProperPrefix,
   toFilePath,
   (</>),
  )
@@ -99,6 +102,7 @@ import Strategy.Node.Pnpm.PnpmLock qualified as PnpmLock
 import Strategy.Node.Pnpm.Workspace (PnpmWorkspace (workspaceSpecs))
 import Strategy.Node.YarnV1.YarnLock qualified as V1
 import Strategy.Node.YarnV2.YarnLock qualified as V2
+import System.FilePath.Posix qualified as FP
 import Types (
   BuildTarget (BuildTarget),
   DependencyResults (DependencyResults),
@@ -160,6 +164,8 @@ mkProject project = do
       projectBuildTargets' = case project of
         Yarn _ _ -> findWorkspaceBuildTargets graph
         NPMLock _ _ -> findWorkspaceBuildTargets graph
+        Pnpm _ _ -> findWorkspaceBuildTargets graph
+        Bun _ _ -> findWorkspaceBuildTargets graph
         _ -> ProjectWithoutTargets
   Manifest rootManifest <- fromEitherShow $ findWorkspaceRootManifest graph
   pure $
@@ -204,19 +210,79 @@ getDeps ::
   m DependencyResults
 getDeps targets (Yarn yarnLockFile graph) = analyzeYarn targets yarnLockFile graph
 getDeps targets (NPMLock packageLockFile graph) = analyzeNpmLock targets packageLockFile graph
-getDeps _ (Pnpm pnpmLockFile _) = analyzePnpmLock pnpmLockFile
-getDeps _ (Bun bunLockFile _) = analyzeBunLock bunLockFile
+getDeps targets (Pnpm pnpmLockFile graph) = analyzePnpmLock targets pnpmLockFile graph
+getDeps targets (Bun bunLockFile graph) = analyzeBunLock targets bunLockFile graph
 getDeps _ (NPM graph) = analyzeNpm graph
 
-analyzePnpmLock :: (Has Diagnostics sig m, Has ReadFS sig m, Has Logger sig m) => Manifest -> m DependencyResults
-analyzePnpmLock (Manifest pnpmLockFile) = do
-  result <- PnpmLock.analyze pnpmLockFile
+analyzePnpmLock :: (Has Diagnostics sig m, Has ReadFS sig m, Has Logger sig m) => FoundTargets -> Manifest -> PkgJsonGraph -> m DependencyResults
+analyzePnpmLock targets (Manifest pnpmLockFile) graph = do
+  let selectedImporterPaths = resolveImporterPaths targets graph
+  result <- PnpmLock.analyze selectedImporterPaths pnpmLockFile
   pure $ DependencyResults result Complete [pnpmLockFile]
 
-analyzeBunLock :: (Has Diagnostics sig m, Has ReadFS sig m) => Manifest -> m DependencyResults
-analyzeBunLock (Manifest bunLockFile) = do
-  result <- BunLock.analyze bunLockFile
+analyzeBunLock :: (Has Diagnostics sig m, Has ReadFS sig m) => FoundTargets -> Manifest -> PkgJsonGraph -> m DependencyResults
+analyzeBunLock targets (Manifest bunLockFile) graph = do
+  let selectedWorkspacePaths = resolveBunWorkspacePaths targets graph
+  result <- BunLock.analyze selectedWorkspacePaths bunLockFile
   pure $ DependencyResults result Complete [bunLockFile]
+
+-- | Map selected build targets (package names) to pnpm importer paths
+-- (relative paths from the workspace root like ".", "packages/a").
+-- When 'ProjectWithoutTargets', returns Nothing (no filtering).
+-- When 'FoundTargets', looks up each target's package name in the
+-- PkgJsonGraph to find its manifest path, then computes the relative
+-- path from the workspace root.
+resolveImporterPaths :: FoundTargets -> PkgJsonGraph -> Maybe (Set Text)
+resolveImporterPaths ProjectWithoutTargets _ = Nothing
+resolveImporterPaths (FoundTargets targets) graph@PkgJsonGraph{..} =
+  case findWorkspaceRootManifest graph of
+    Left _ -> Nothing
+    Right (Manifest rootManifest) ->
+      Just $ Set.fromList [p | (name, p) <- namePathPairs, name `Set.member` targetNames]
+      where
+        rootDir = parent rootManifest
+        targetNames = Set.map unBuildTarget (NonEmptySet.toSet targets)
+
+        namePathPairs :: [(Text, Text)]
+        namePathPairs =
+          [ (name, manifestToImporterPath m)
+          | (Manifest m, pj) <- Map.toList jsonLookup
+          , Just name <- [packageName pj]
+          ]
+
+        manifestToImporterPath :: Path Abs File -> Text
+        manifestToImporterPath m =
+          let manifestDir = parent m
+           in if manifestDir == rootDir
+                then "."
+                else maybe "." (toText . FP.dropTrailingPathSeparator . toFilePath) (stripProperPrefix rootDir manifestDir)
+
+-- | Like 'resolveImporterPaths' but for bun lockfiles, which use @""@
+-- for the root workspace instead of @"."@.
+resolveBunWorkspacePaths :: FoundTargets -> PkgJsonGraph -> Maybe (Set Text)
+resolveBunWorkspacePaths ProjectWithoutTargets _ = Nothing
+resolveBunWorkspacePaths (FoundTargets targets) graph@PkgJsonGraph{..} =
+  case findWorkspaceRootManifest graph of
+    Left _ -> Nothing
+    Right (Manifest rootManifest) ->
+      Just $ Set.fromList [p | (name, p) <- namePathPairs, name `Set.member` targetNames]
+      where
+        rootDir = parent rootManifest
+        targetNames = Set.map unBuildTarget (NonEmptySet.toSet targets)
+
+        namePathPairs :: [(Text, Text)]
+        namePathPairs =
+          [ (name, manifestToWorkspacePath m)
+          | (Manifest m, pj) <- Map.toList jsonLookup
+          , Just name <- [packageName pj]
+          ]
+
+        manifestToWorkspacePath :: Path Abs File -> Text
+        manifestToWorkspacePath m =
+          let manifestDir = parent m
+           in if manifestDir == rootDir
+                then ""
+                else maybe "" (toText . FP.dropTrailingPathSeparator . toFilePath) (stripProperPrefix rootDir manifestDir)
 
 analyzeNpmLock :: (Has Diagnostics sig m, Has ReadFS sig m) => FoundTargets -> Manifest -> PkgJsonGraph -> m DependencyResults
 analyzeNpmLock targets (Manifest npmLockFile) graph = do

--- a/src/Strategy/Node/Pnpm/PnpmLock.hs
+++ b/src/Strategy/Node/Pnpm/PnpmLock.hs
@@ -297,23 +297,33 @@ instance FromJSON Resolution where
       gitRes :: Object -> Parser Resolution
       gitRes obj = GitResolve <$> (GitResolution <$> obj .: "repo" <*> obj .: "commit")
 
-analyze :: (Has ReadFS sig m, Has Logger sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
-analyze file = context "Analyzing Npm Lockfile (v3)" $ do
+-- | Analyze a pnpm lockfile. When @selectedImporterPaths@ is 'Nothing',
+-- all importers are included. When @Just paths@, only importers whose
+-- key is in @paths@ are treated as direct dependency sources.
+analyze :: (Has ReadFS sig m, Has Logger sig m, Has Diagnostics sig m) => Maybe (Set.Set Text) -> Path Abs File -> m (Graphing Dependency)
+analyze selectedImporterPaths file = context "Analyzing Npm Lockfile (v3)" $ do
   pnpmLockFile <- context "Parsing pnpm-lock file" $ readContentsYaml file
 
   case lockFileVersion pnpmLockFile of
     PnpmLockLt4 raw -> logWarn . pretty $ "pnpm-lock file is using older lockFileVersion: " <> raw <> " of, which is not officially supported!"
     _ -> pure ()
 
-  context "Building dependency graph" $ pure $ buildGraph pnpmLockFile
+  context "Building dependency graph" $ pure $ buildGraph selectedImporterPaths pnpmLockFile
 
 -- Build the dependency graph, labeling direct deps with their environment
 -- (prod/dev). hydrateDepEnvs then propagates those environments to all
 -- transitive successors.
-buildGraph :: PnpmLockfile -> Graphing Dependency
-buildGraph lockFile = withoutLocalPackages . hydrateDepEnvs $
+--
+-- When @selectedImporterPaths@ is 'Nothing', all importers are included.
+-- When @Just paths@, only importers whose key is in @paths@ are treated as
+-- direct dependency sources (used for workspace build target filtering).
+buildGraph :: Maybe (Set.Set Text) -> PnpmLockfile -> Graphing Dependency
+buildGraph selectedImporterPaths lockFile = withoutLocalPackages . hydrateDepEnvs $
   run . withLabeling applyLabels $ do
-    for_ (toList lockFile.importers) $ \(_, projectImporters) -> do
+    let filteredImporters = case selectedImporterPaths of
+          Nothing -> toList lockFile.importers
+          Just paths -> filter (\(k, _) -> k `Set.member` paths) (toList lockFile.importers)
+    for_ filteredImporters $ \(_, projectImporters) -> do
       for_ (Map.toList $ directDependencies projectImporters) $ \(depName, ProjectMapDepMetadata depVersion) ->
         for_ (toResolvedDependency depName depVersion) $ \dep -> do
           direct dep

--- a/test/Node/NodeSpec.hs
+++ b/test/Node/NodeSpec.hs
@@ -13,7 +13,7 @@ import Data.Tagged (applyTag)
 import Graphing qualified
 import Path (Abs, Dir, Path, mkRelDir, mkRelFile, (</>))
 import Path.IO (getCurrentDir)
-import Strategy.Node (NodeProject (NPMLock), discover, extractDepListsForTargets, findWorkspaceBuildTargets, getDeps)
+import Strategy.Node (NodeProject (NPMLock), discover, extractDepListsForTargets, findWorkspaceBuildTargets, getDeps, resolveBunWorkspacePaths, resolveImporterPaths)
 import Strategy.Node.PackageJson (
   FlatDeps (..),
   Manifest (..),
@@ -57,6 +57,8 @@ spec = do
   npmLockAnalysisSpec currDir
   workspaceBuildTargetsSpec currDir
   extractDepListsForTargetsSpec currDir
+  resolveImporterPathsSpec currDir
+  resolveBunWorkspacePathsSpec currDir
 
 discoveredWorkSpaceProj :: Path Abs Dir -> DiscoveredProject NodeProject
 discoveredWorkSpaceProj currDir =
@@ -237,6 +239,56 @@ extractDepListsForTargetsSpec currDir = describe "extractDepListsForTargets" $ d
             , NodePackage "husky" "^8.0.0"
             ]
     directDeps result `shouldBe` applyTag @Production expectedDirect
+
+resolveImporterPathsSpec :: Path Abs Dir -> Spec
+resolveImporterPathsSpec currDir = describe "resolveImporterPaths" $ do
+  let graph = workspaceGraphWithDeps currDir
+
+  it "returns Nothing for ProjectWithoutTargets" $ do
+    resolveImporterPaths ProjectWithoutTargets graph `shouldBe` Nothing
+
+  it "maps root target to \".\"" $ do
+    let targets =
+          maybe ProjectWithoutTargets FoundTargets . nonEmpty $
+            Set.fromList [BuildTarget "workspace-test"]
+    resolveImporterPaths targets graph `shouldBe` Just (Set.singleton ".")
+
+  it "maps workspace member targets to relative paths" $ do
+    let targets =
+          maybe ProjectWithoutTargets FoundTargets . nonEmpty $
+            Set.fromList [BuildTarget "pkg-a", BuildTarget "pkg-b"]
+    resolveImporterPaths targets graph `shouldBe` Just (Set.fromList ["pkg-a", "nested/pkg-b"])
+
+  it "maps all targets including root" $ do
+    let targets =
+          maybe ProjectWithoutTargets FoundTargets . nonEmpty $
+            Set.fromList [BuildTarget "workspace-test", BuildTarget "pkg-a", BuildTarget "pkg-b"]
+    resolveImporterPaths targets graph `shouldBe` Just (Set.fromList [".", "pkg-a", "nested/pkg-b"])
+
+resolveBunWorkspacePathsSpec :: Path Abs Dir -> Spec
+resolveBunWorkspacePathsSpec currDir = describe "resolveBunWorkspacePaths" $ do
+  let graph = workspaceGraphWithDeps currDir
+
+  it "returns Nothing for ProjectWithoutTargets" $ do
+    resolveBunWorkspacePaths ProjectWithoutTargets graph `shouldBe` Nothing
+
+  it "maps root target to empty string" $ do
+    let targets =
+          maybe ProjectWithoutTargets FoundTargets . nonEmpty $
+            Set.fromList [BuildTarget "workspace-test"]
+    resolveBunWorkspacePaths targets graph `shouldBe` Just (Set.singleton "")
+
+  it "maps workspace member targets to relative paths" $ do
+    let targets =
+          maybe ProjectWithoutTargets FoundTargets . nonEmpty $
+            Set.fromList [BuildTarget "pkg-a", BuildTarget "pkg-b"]
+    resolveBunWorkspacePaths targets graph `shouldBe` Just (Set.fromList ["pkg-a", "nested/pkg-b"])
+
+  it "maps all targets including root" $ do
+    let targets =
+          maybe ProjectWithoutTargets FoundTargets . nonEmpty $
+            Set.fromList [BuildTarget "workspace-test", BuildTarget "pkg-a", BuildTarget "pkg-b"]
+    resolveBunWorkspacePaths targets graph `shouldBe` Just (Set.fromList ["", "pkg-a", "nested/pkg-b"])
 
 -- | A workspace graph with actual dependencies for testing extractDepListsForTargets.
 workspaceGraphWithDeps :: Path Abs Dir -> PkgJsonGraph

--- a/test/Pnpm/PnpmLockSpec.hs
+++ b/test/Pnpm/PnpmLockSpec.hs
@@ -89,10 +89,13 @@ lodash =
     mempty
 
 checkGraph :: Path Abs File -> (Graphing Dependency -> Spec) -> Spec
-checkGraph pathToFixture buildGraphSpec = do
+checkGraph = checkGraphWithFilter Nothing
+
+checkGraphWithFilter :: Maybe (Set.Set Text) -> Path Abs File -> (Graphing Dependency -> Spec) -> Spec
+checkGraphWithFilter importerFilter pathToFixture buildGraphSpec = do
   eitherDecodedLockFile <- runIO $ decodeFileEither (toString pathToFixture)
   case eitherDecodedLockFile of
-    Right pnpmLock -> buildGraphSpec (buildGraph pnpmLock)
+    Right pnpmLock -> buildGraphSpec (buildGraph importerFilter pnpmLock)
     Left err ->
       describe "pnpm-lock" $
         it "should parse lockfile" (expectationFailure $ prettyPrintParseException err)
@@ -105,6 +108,11 @@ spec = do
 
   checkGraph pnpmLockPath pnpmLockGraphSpec
   checkGraph pnpmLockWithoutWorkspacePath pnpmLockGraphWithoutWorkspaceSpec
+
+  -- v5 workspace target filtering
+  describe "workspace target filtering" $ do
+    checkGraphWithFilter (Just (Set.singleton ".")) pnpmLockPath pnpmLockFilteredRootOnlySpec
+    checkGraphWithFilter (Just (Set.singleton "packages/a")) pnpmLockPath pnpmLockFilteredWorkspaceOnlySpec
 
   -- v6 format
   let pnpmLockV6 = currentDir </> $(mkRelFile "test/Pnpm/testdata/pnpm-lock-v6.yaml")
@@ -487,3 +495,31 @@ pnpmLockV9MultiVersionSpec graph = do
       expectDep (mkProdDep "sax@1.2.1") graph
       -- sax@1.4.4 is dev-only (from app-b)
       expectDep (mkDevDep "sax@1.4.4") graph
+
+-- | When filtered to root importer only ("."), workspace package deps
+-- (aws-sdk@1.0.0, commander@9.2.0) should not appear as direct.
+pnpmLockFilteredRootOnlySpec :: Graphing Dependency -> Spec
+pnpmLockFilteredRootOnlySpec graph = do
+  describe "filtered to root importer only" $ do
+    it "should only include root direct deps" $ do
+      expectDirect
+        [ mkProdDep "aws-sdk@2.1148.0"
+        , colors
+        , lodash
+        , mkDevDep "react@18.1.0"
+        , mkProdDep "glob@8.0.3"
+        , mkProdDep "chokidar@1.0.0"
+        ]
+        graph
+
+-- | When filtered to workspace importer only ("packages/a"), root deps
+-- (aws-sdk@2.1148.0, colors, lodash, react) should not appear as direct.
+pnpmLockFilteredWorkspaceOnlySpec :: Graphing Dependency -> Spec
+pnpmLockFilteredWorkspaceOnlySpec graph = do
+  describe "filtered to workspace importer only" $ do
+    it "should only include workspace-a direct deps" $ do
+      expectDirect
+        [ mkProdDep "aws-sdk@1.0.0"
+        , mkProdDep "commander@9.2.0"
+        ]
+        graph


### PR DESCRIPTION
## Summary

Extends workspace build target support to pnpm and bun projects, completing the set for all Node.js lockfile formats (yarn, npm, pnpm, bun). Follow-up to #1643.

- Adds `resolveImporterPaths` to map package names (build targets) to pnpm lockfile importer paths (e.g. `"."`, `"packages/a"`)
- Adds `resolveBunWorkspacePaths` to map package names to bun lockfile workspace keys (uses `""` for root, relative paths for members)
- Updates `buildGraph` in `PnpmLock.hs` and `BunLock.hs` to accept an optional filter, scoping analysis to selected workspace members
- Preserves the existing v9 environment propagation logic in `PnpmLock.buildGraph`, with filtering applied to the importer list

Combines and supersedes #1644 and #1654.

## Test plan

- [x] `resolveImporterPaths` tests: root → `"."`, workspace members → relative paths, `Nothing` for `ProjectWithoutTargets`
- [x] `resolveBunWorkspacePaths` tests: root → `""`, workspace members → relative paths, `Nothing` for `ProjectWithoutTargets`
- [x] `buildGraph` filtering tests for pnpm: root-only filter excludes workspace deps, workspace-only filter excludes root deps
- [x] `buildGraph` filtering tests for bun: root-only filter excludes workspace deps, workspace-only filter excludes root deps
- [x] Existing v9 env propagation tests (shared deps, local dep, multi-version) still pass
- [x] `cabal build` clean
- [ ] Manual test with a real pnpm workspace project
- [ ] Manual test with a real bun workspace project

🤖 Generated with [Claude Code](https://claude.com/claude-code)