### PR TITLE
feat(uv): add directory source type to uv.lock parser

### DIFF
--- a/src/Strategy/Python/Uv.hs
+++ b/src/Strategy/Python/Uv.hs
@@ -196,6 +196,15 @@ buildGraph lock = removeWorkspacePackages . processGraph $ run . evalGrapher $ d
             , dependencyEnvironments = envs
             , dependencyTags = Map.empty
             }
+        SourceDirectory path ->
+          Dependency
+            { dependencyType = UnresolvedPathType
+            , dependencyName = path
+            , dependencyVersion = CEq <$> uvlockPackageVersion
+            , dependencyLocations = []
+            , dependencyEnvironments = envs
+            , dependencyTags = Map.empty
+            }
         SourceUrl url ->
           Dependency
             { dependencyType = URLType
@@ -305,6 +314,7 @@ data UvLockPackageSource
   | SourceGit Text
   | SourceUrl Text
   | SourcePath Text
+  | SourceDirectory Text
   deriving (Eq, Ord, Show)
 
 instance Toml.Schema.FromValue UvLockPackageSource where
@@ -317,6 +327,7 @@ instance Toml.Schema.FromValue UvLockPackageSource where
         , Toml.Schema.Key "git" (fmap SourceGit . Toml.Schema.fromValue)
         , Toml.Schema.Key "url" (fmap SourceUrl . Toml.Schema.fromValue)
         , Toml.Schema.Key "path" (fmap SourcePath . Toml.Schema.fromValue)
+        , Toml.Schema.Key "directory" (fmap SourceDirectory . Toml.Schema.fromValue)
         ]
 
 isWorkspacePackage :: UvLockPackageSource -> Bool

--- a/test/Python/UvSpec.hs
+++ b/test/Python/UvSpec.hs
@@ -174,6 +174,40 @@ lockEditableNoVersion =
         ]
     }
 
+--     my-project
+--     /    \
+--   dep1  local-lib (directory dep)
+lockWithDirectory :: UvLock
+lockWithDirectory =
+  UvLock
+    { uvlockPackages =
+        [ UvLockPackage
+            { uvlockPackageName = "my-project"
+            , uvlockPackageVersion = Just "0.1.0"
+            , uvlockPackageSource = SourceVirtual "."
+            , uvlockPackageDependencies = ["dep1", "local-lib"]
+            , uvlockPackageDevDependencies = []
+            , uvlockPackageOptionalDependencies = mempty
+            }
+        , UvLockPackage
+            { uvlockPackageName = "dep1"
+            , uvlockPackageVersion = Just "1.1.0"
+            , uvlockPackageSource = SourceRegistry "https://pypi.org/simple"
+            , uvlockPackageDependencies = []
+            , uvlockPackageDevDependencies = []
+            , uvlockPackageOptionalDependencies = mempty
+            }
+        , UvLockPackage
+            { uvlockPackageName = "local-lib"
+            , uvlockPackageVersion = Just "0.2.0"
+            , uvlockPackageSource = SourceDirectory "../local-lib"
+            , uvlockPackageDependencies = []
+            , uvlockPackageDevDependencies = []
+            , uvlockPackageOptionalDependencies = mempty
+            }
+        ]
+    }
+
 mkDep :: Text -> Text -> [DepEnvironment] -> Dependency
 mkDep name version envs =
   Dependency
@@ -202,6 +236,17 @@ dep5 = mkDep "dep5" "3.0.1" [EnvProduction, EnvDevelopment]
 
 dep6 :: Dependency
 dep6 = mkDep "dep6" "1.1.1" [EnvDevelopment]
+
+localLib :: Dependency
+localLib =
+  Dependency
+    { dependencyType = UnresolvedPathType
+    , dependencyName = "../local-lib"
+    , dependencyVersion = Just (CEq "0.2.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = Set.fromList [EnvProduction]
+    , dependencyTags = mempty
+    }
 
 anyio :: Dependency
 anyio = mkDep "anyio" "4.11.0" [EnvProduction, EnvDevelopment]
@@ -251,6 +296,13 @@ spec = do
       expectDeps [dep1, dep3, dep6] result
       expectEdges [(dep3, dep6)] result
 
+    it "should handle directory source dependencies" $ do
+      let result = buildGraph lockWithDirectory
+
+      expectDirect [dep1, localLib] result
+      expectDeps [dep1, localLib] result
+      expectEdges [] result
+
   describe "parse uv.lock" $ do
     it' "correctly parse and interpret uv.lock" $ do
       path <- makeAbsolute [relfile|test/Python/testdata/uv.lock|]
@@ -293,5 +345,23 @@ spec = do
         , (httpx, idna')
         , (anyio', idna')
         , (anyio', sniffio)
+        ]
+        result
+
+    it' "correctly parse uv.lock with directory source dependency" $ do
+      path <- makeAbsolute [relfile|test/Python/testdata/uv-directory.lock|]
+      uvlock <- readContentsToml path
+      let result = buildGraph uvlock
+      let anyio' = mkDep "anyio" "4.11.0" [EnvProduction]
+      let idna' = mkDep "idna" "3.11" [EnvProduction]
+      let sniffio' = mkDep "sniffio" "1.3.1" [EnvProduction]
+
+      expectDirect' [anyio', localLib] result
+      expectDeps'
+        [anyio', idna', localLib, sniffio']
+        result
+      expectEdges'
+        [ (anyio', idna')
+        , (anyio', sniffio')
         ]
         result

--- a/test/Python/testdata/uv-directory.lock
+++ b/test/Python/testdata/uv-directory.lock
@@ -1,0 +1,54 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "anyio"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/78/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/b3/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097 },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008 },
+]
+
+[[package]]
+name = "local-lib"
+version = "0.2.0"
+source = { directory = "../local-lib" }
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "uv-dir-test"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "anyio" },
+    { name = "local-lib" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=4.11.0" },
+    { name = "local-lib", directory = "../local-lib" },
+]


### PR DESCRIPTION
# Overview

The uv.lock parser handles `editable`, `virtual`, `registry`, `git`, `url`, and `path` source types but missed `directory`. uv represents local directory dependencies with `source = { directory = "..." }`, so `fossa analyze` fails on projects that have them. PR #1682 (ANE-2886) added the other source types — `directory` was omitted.

This PR adds `SourceDirectory` to `UvLockPackageSource` and parses the `"directory"` key, resolving it as `UnresolvedPathType` (same behavior as `path` dependencies).

## Acceptance criteria

When users run `fossa analyze` on a uv project that has local directory dependencies (`source = { directory = "..." }` in `uv.lock`), analysis completes instead of failing with a parse error.

## Testing plan

1. Build succeeds: `cabal build`
2. New unit tests in `test/Python/UvSpec.hs`:
   - `buildGraph` test with a `SourceDirectory` dependency verifies it resolves as `UnresolvedPathType`
   - TOML parsing test with `test/Python/testdata/uv-directory.lock` verifies the `directory` key is parsed correctly
3. Unit tests could not be run locally due to a pre-existing git-lfs issue with `test/Container/testdata/emptypath.tar` (LFS pointer not resolved). CI should run them successfully.

## Risks

None — additive change. The `pickKey` parser is order-independent, and existing source types are unaffected.

## Metrics

N/A

## References

- [ANE-2901](https://fossa.atlassian.net/browse/ANE-2901): Add directory source type to uv.lock parser
- [ANE-2886 / PR #1682](https://github.com/fossas/fossa-cli/pull/1682): Original PR that added other source types
- [uv dependency docs](https://docs.astral.sh/uv/concepts/projects/dependencies/): confirms `directory` is a valid source representation

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.

[ANE-2901]: https://fossa.atlassian.net/browse/ANE-2901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ