### PR TITLE
Cargo: Fix transitive dev-dependency classification

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,11 +2,8 @@
 
 ## 3.17.2
 
+- Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production ([#1692](https://github.com/fossas/fossa-cli/pull/1692)).
 - Poetry: Support PEP 621 `[project].dependencies` for Poetry 2.x projects. Production dependencies declared in the standard `[project]` section are now correctly detected alongside legacy `[tool.poetry.dependencies]`. ([#1683](https://github.com/fossas/fossa-cli/pull/1683))
-
-## 3.17.1
-
-- Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production. Projects with non-trivial dev-dep trees may see their Production dependency set shrink and their Development set grow ([#1692](https://github.com/fossas/fossa-cli/pull/1692)).
 
 ## 3.17.1
 - Node.js: Yarn and npm workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`. ([#1643](https://github.com/fossas/fossa-cli/pull/1643))

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 
 ## 3.17.1
 
+- Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production. Projects with non-trivial dev-dep trees may see their Production dependency set shrink and their Development set grow.
 - Node.js: Yarn and npm workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`.
 - Project edit: Fix 500 error when running `fossa project edit --policy` on existing projects ([#1688](https://github.com/fossas/fossa-cli/pull/1688))
 - UV: Add `directory` source type to uv.lock parser, fixing parse failures on projects with local directory dependencies ([#1690](https://github.com/fossas/fossa-cli/pull/1690))

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,9 @@
 ## 3.17.1
 
 - Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production. Projects with non-trivial dev-dep trees may see their Production dependency set shrink and their Development set grow ([#1692](https://github.com/fossas/fossa-cli/pull/1692)).
-- Node.js: Yarn and npm workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`.
+
+## 3.17.1
+- Node.js: Yarn and npm workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`. ([#1643](https://github.com/fossas/fossa-cli/pull/1643))
 - Project edit: Fix 500 error when running `fossa project edit --policy` on existing projects ([#1688](https://github.com/fossas/fossa-cli/pull/1688))
 - UV: Add `directory` source type to uv.lock parser, fixing parse failures on projects with local directory dependencies ([#1690](https://github.com/fossas/fossa-cli/pull/1690))
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@
 
 ## 3.17.1
 
-- Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production. Projects with non-trivial dev-dep trees may see their Production dependency set shrink and their Development set grow.
+- Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production. Projects with non-trivial dev-dep trees may see their Production dependency set shrink and their Development set grow ([#1692](https://github.com/fossas/fossa-cli/pull/1692)).
 - Node.js: Yarn and npm workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`.
 - Project edit: Fix 500 error when running `fossa project edit --policy` on existing projects ([#1688](https://github.com/fossas/fossa-cli/pull/1688))
 - UV: Add `directory` source type to uv.lock parser, fixing parse failures on projects with local directory dependencies ([#1690](https://github.com/fossas/fossa-cli/pull/1690))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.17.9
+
+- Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production ([#1692](https://github.com/fossas/fossa-cli/pull/1692)).
+
 ## 3.17.8
 
 - Vendored dependencies: archive uploads with an absolute `path` (as produced by the meta-fossa Yocto layer) no longer crash with a `permission denied` error while writing the tarball. ([#1713](https://github.com/fossas/fossa-cli/pull/1713))
@@ -31,10 +35,6 @@
 - Swift: Fix a bug in the `Package.swift` parser which would cause it to error on valid syntax.
 - NuGet: Add Central Package Management (CPM) support — versions defined in `Directory.Packages.props` are now resolved for `PackageReference` entries that omit a `Version` attribute. ([#1694](https://github.com/fossas/fossa-cli/pull/1694))
 - Poetry: Support PEP 621 `[project].dependencies` for Poetry 2.x projects. Production dependencies declared in the standard `[project]` section are now correctly detected alongside legacy `[tool.poetry.dependencies]`. ([#1683](https://github.com/fossas/fossa-cli/pull/1683))
-
-## 3.17.1
-
-- Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production. Projects with non-trivial dev-dep trees may see their Production dependency set shrink and their Development set grow ([#1692](https://github.com/fossas/fossa-cli/pull/1692)).
 
 ## 3.17.1
 - Node.js: Yarn and npm workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`. ([#1643](https://github.com/fossas/fossa-cli/pull/1643))

--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,7 @@
 
 ## 3.17.1
 
+- Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production. Projects with non-trivial dev-dep trees may see their Production dependency set shrink and their Development set grow.
 - Node.js: Yarn and npm workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`.
 - Project edit: Fix 500 error when running `fossa project edit --policy` on existing projects ([#1688](https://github.com/fossas/fossa-cli/pull/1688))
 - UV: Add `directory` source type to uv.lock parser, fixing parse failures on projects with local directory dependencies ([#1690](https://github.com/fossas/fossa-cli/pull/1690))

--- a/Changelog.md
+++ b/Changelog.md
@@ -34,7 +34,7 @@
 
 ## 3.17.1
 
-- Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production. Projects with non-trivial dev-dep trees may see their Production dependency set shrink and their Development set grow.
+- Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production. Projects with non-trivial dev-dep trees may see their Production dependency set shrink and their Development set grow ([#1692](https://github.com/fossas/fossa-cli/pull/1692)).
 - Node.js: Yarn and npm workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`.
 - Project edit: Fix 500 error when running `fossa project edit --policy` on existing projects ([#1688](https://github.com/fossas/fossa-cli/pull/1688))
 - UV: Add `directory` source type to uv.lock parser, fixing parse failures on projects with local directory dependencies ([#1690](https://github.com/fossas/fossa-cli/pull/1690))

--- a/Changelog.md
+++ b/Changelog.md
@@ -35,7 +35,9 @@
 ## 3.17.1
 
 - Cargo: Fix transitive dev-dependency classification. Dependencies reachable only through dev-dep or build-dep roots are now correctly labeled as Development instead of Production. Projects with non-trivial dev-dep trees may see their Production dependency set shrink and their Development set grow ([#1692](https://github.com/fossas/fossa-cli/pull/1692)).
-- Node.js: Yarn and npm workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`.
+
+## 3.17.1
+- Node.js: Yarn and npm workspace packages now appear as individual build targets (e.g. `yarn@./:my-package`, `npm@./:my-package`), enabling per-package dependency scoping via `.fossa.yml`. ([#1643](https://github.com/fossas/fossa-cli/pull/1643))
 - Project edit: Fix 500 error when running `fossa project edit --policy` on existing projects ([#1688](https://github.com/fossas/fossa-cli/pull/1688))
 - UV: Add `directory` source type to uv.lock parser, fixing parse failures on projects with local directory dependencies ([#1690](https://github.com/fossas/fossa-cli/pull/1690))
 

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -39,7 +39,7 @@ import Control.Effect.Diagnostics (
   warn,
  )
 import Control.Effect.Reader (Reader, ask)
-import Control.Monad (guard, unless)
+import Control.Monad (guard, unless, when)
 import Data.Aeson.Types (
   FromJSON (parseJSON),
   ToJSON,
@@ -52,13 +52,13 @@ import Data.Foldable (for_, traverse_)
 import Data.Functor (void)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing)
+import Data.Maybe (catMaybes, fromMaybe, isJust)
 import Data.Set (Set)
-import Data.Set qualified as Set
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text, breakOn)
 import Data.Text qualified as Text
 import Data.Void (Void)
+import DepTypes (hydrateDepEnvs)
 import Diag.Diagnostic (renderDiagnostic)
 import Discovery.Filters (AllFilters)
 import Discovery.Simple (simpleDiscover)
@@ -485,66 +485,28 @@ toDependency emitGitBackedLocators sourceMap pkg =
         extractGitCommitHash sourceUrl
       _ -> Nothing
 
+-- An edge's kind reflects the parent's manifest declaration, not the path taken
+-- to reach the parent — so we can only trust kinds on the workspace members'
+-- direct edges. Label those, then let 'hydrateDepEnvs' propagate environments
+-- to every transitive descendant.
+kindToLabel :: Maybe Text.Text -> CargoLabel
+kindToLabel (Just _) = CargoDepKind EnvDevelopment
+kindToLabel Nothing = CargoDepKind EnvProduction
+
 buildGraph :: Bool -> CargoMetadata -> Graphing Dependency
-buildGraph emitGitBackedLocators meta = shrinkRoots $
+buildGraph emitGitBackedLocators meta = shrinkRoots . hydrateDepEnvs $
   run . withLabeling (toDependency emitGitBackedLocators sourceMap) $ do
-    traverse_ direct $ metadataWorkspaceMembers meta
-    for_ (resolvedNodes (metadataResolve meta)) $ \node ->
-      for_ (resolveNodeDeps node) $ \dep ->
-        edge (resolveNodeId node) (nodePkg dep)
-    let (prodRoots, devRoots) = classifyRoots meta
-        adj = buildAdjacency meta
-        prodReachable = reachable adj prodRoots
-        devReachable = reachable adj devRoots
-    for_ (Set.toList prodReachable) $ \pkg ->
-      label pkg (CargoDepKind EnvProduction)
-    for_ (Set.toList devReachable) $ \pkg ->
-      label pkg (CargoDepKind EnvDevelopment)
+    traverse_ direct workspaceMembers
+    for_ (resolvedNodes (metadataResolve meta)) $ \node -> do
+      let parentId = resolveNodeId node
+          fromWorkspace = parentId `elem` workspaceMembers
+      for_ (resolveNodeDeps node) $ \dep -> do
+        edge parentId (nodePkg dep)
+        when fromWorkspace $
+          traverse_ (label (nodePkg dep) . kindToLabel . nodeDepKind) (nodeDepKinds dep)
   where
     sourceMap = buildPackageSourceMap $ metadataPackages meta
-
-classifyRoots :: CargoMetadata -> (Set PackageId, Set PackageId)
-classifyRoots meta = foldMap classifyMember (metadataWorkspaceMembers meta)
-  where
-    nodeMap :: Map.Map PackageId [NodeDependency]
-    nodeMap =
-      Map.fromList
-        [ (resolveNodeId node, resolveNodeDeps node)
-        | node <- resolvedNodes (metadataResolve meta)
-        ]
-
-    classifyMember :: PackageId -> (Set PackageId, Set PackageId)
-    classifyMember wm =
-      let deps = fromMaybe [] (Map.lookup wm nodeMap)
-       in foldMap classifyDep deps
-
-    classifyDep :: NodeDependency -> (Set PackageId, Set PackageId)
-    classifyDep dep =
-      let pkg = nodePkg dep
-          kinds = nodeDepKinds dep
-          hasNormal = any (isNothing . nodeDepKind) kinds
-          allDev = all (isJust . nodeDepKind) kinds
-       in case (hasNormal, allDev) of
-            (True, _) -> (Set.singleton pkg, mempty)
-            (_, True) -> (mempty, Set.singleton pkg)
-            _ -> mempty
-
-buildAdjacency :: CargoMetadata -> Map.Map PackageId [PackageId]
-buildAdjacency meta =
-  Map.fromList
-    [ (resolveNodeId node, map nodePkg (resolveNodeDeps node))
-    | node <- resolvedNodes (metadataResolve meta)
-    ]
-
-reachable :: Map.Map PackageId [PackageId] -> Set PackageId -> Set PackageId
-reachable adj = go Set.empty . Set.toList
-  where
-    go visited [] = visited
-    go visited (x : xs)
-      | Set.member x visited = go visited xs
-      | otherwise =
-          let children = fromMaybe [] (Map.lookup x adj)
-           in go (Set.insert x visited) (children ++ xs)
+    workspaceMembers = metadataWorkspaceMembers meta
 
 -- | Custom Parsec type alias
 type PkgSpecParser a = Parsec Void Text a

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -54,6 +54,7 @@ import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, fromMaybe, isJust)
 import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text, breakOn)
 import Data.Text qualified as Text
@@ -503,14 +504,14 @@ buildGraph emitGitBackedLocators meta = shrinkRoots . hydrateDepEnvs $
     traverse_ direct workspaceMembers
     for_ (resolvedNodes (metadataResolve meta)) $ \node -> do
       let parentId = resolveNodeId node
-          fromWorkspace = parentId `elem` workspaceMembers
+          fromWorkspace = Set.member parentId workspaceMembers
       for_ (resolveNodeDeps node) $ \dep -> do
         edge parentId (nodePkg dep)
         when fromWorkspace $
           traverse_ (label (nodePkg dep) . kindToLabel . nodeDepKind) (nodeDepKinds dep)
   where
     sourceMap = buildPackageSourceMap $ metadataPackages meta
-    workspaceMembers = metadataWorkspaceMembers meta
+    workspaceMembers = Set.fromList (metadataWorkspaceMembers meta)
 
 -- | Custom Parsec type alias
 type PkgSpecParser a = Parsec Void Text a

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -503,6 +503,10 @@ toDependency emitGitBackedLocators sourceMap pkg =
 -- dev-dependencies for workspace members, so non-workspace edges with kind
 -- "dev" do not appear in 'cargo metadata' output. The only non-null kind we
 -- see on a non-workspace edge is "build".
+--
+-- Note: pnpm and yarn use 'hydrateDepEnvs' for this, but it has no notion of
+-- edge kinds and would tag packages reached only through a "dev"/"build" edge
+-- as Production. The edge-kind-filtered reachability below is why we diverge.
 buildGraph :: Bool -> CargoMetadata -> Graphing Dependency
 buildGraph emitGitBackedLocators meta = shrinkRoots $
   run . withLabeling (toDependency emitGitBackedLocators sourceMap) $ do

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -561,9 +561,10 @@ reachable :: Map.Map PackageId [PackageId] -> Set PackageId -> Set PackageId
 reachable adj = go Set.empty . Set.toList
   where
     go visited [] = visited
-    go visited (x : xs)
-      | Set.member x visited = go visited xs
-      | otherwise =
+    go visited (x : xs) =
+      if Set.member x visited
+        then go visited xs
+        else
           let children = fromMaybe [] (Map.lookup x adj)
            in go (Set.insert x visited) (children ++ xs)
 

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -526,6 +526,9 @@ buildGraph emitGitBackedLocators meta = shrinkRoots $
     nodes = resolvedNodes (metadataResolve meta)
     workspaceMembers = Set.fromList (metadataWorkspaceMembers meta)
 
+    -- These predicates are not mutually exclusive: a dep declared in both
+    -- [dependencies] and [dev-dependencies] on the same parent carries both
+    -- a null and a non-null kind, so the edge feeds prodAdj *and* devSeeds.
     isProdEdge dep = any (isNothing . nodeDepKind) (nodeDepKinds dep)
     isDevEdge dep = any (isJust . nodeDepKind) (nodeDepKinds dep)
 

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -52,8 +52,9 @@ import Data.Foldable (for_, traverse_)
 import Data.Functor (void)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes, fromMaybe, isJust)
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing)
 import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text, breakOn)
 import Data.Text qualified as Text
@@ -74,7 +75,6 @@ import Effect.Exec (
   execThrow,
  )
 import Effect.Grapher (
-  LabeledGrapher,
   direct,
   edge,
   label,
@@ -485,36 +485,66 @@ toDependency emitGitBackedLocators sourceMap pkg =
         extractGitCommitHash sourceUrl
       _ -> Nothing
 
--- Possible values here are "build", "dev", and null.
--- Null refers to productions, while dev and build refer to development-time dependencies
--- Cargo does not differentiate test dependencies and dev dependencies,
--- so we just simplify it to Development.
-kindToLabel :: Maybe Text.Text -> CargoLabel
-kindToLabel (Just _) = CargoDepKind EnvDevelopment
-kindToLabel Nothing = CargoDepKind EnvProduction
-
-addLabel :: Has (LabeledGrapher PackageId CargoLabel) sig m => NodeDependency -> m ()
-addLabel dep = do
-  let packageId = nodePkg dep
-  traverse_ (label packageId . kindToLabel . nodeDepKind) $ nodeDepKinds dep
-
-addEdge :: Has (LabeledGrapher PackageId CargoLabel) sig m => ResolveNode -> m ()
-addEdge node = do
-  let parentId = resolveNodeId node
-  for_ (resolveNodeDeps node) $ \dep -> do
-    addLabel dep
-    edge parentId $ nodePkg dep
-
 buildGraph :: Bool -> CargoMetadata -> Graphing Dependency
--- By construction, workspace members are the root nodes in the graph.
--- Use shrinkRoots to remove them and promote their direct dependencies to the
--- direct dependencies we report for the project.
 buildGraph emitGitBackedLocators meta = shrinkRoots $
   run . withLabeling (toDependency emitGitBackedLocators sourceMap) $ do
     traverse_ direct $ metadataWorkspaceMembers meta
-    traverse_ addEdge $ resolvedNodes $ metadataResolve meta
+    for_ (resolvedNodes (metadataResolve meta)) $ \node ->
+      for_ (resolveNodeDeps node) $ \dep ->
+        edge (resolveNodeId node) (nodePkg dep)
+    let (prodRoots, devRoots) = classifyRoots meta
+        adj = buildAdjacency meta
+        prodReachable = reachable adj prodRoots
+        devReachable = reachable adj devRoots
+    for_ (Set.toList prodReachable) $ \pkg ->
+      label pkg (CargoDepKind EnvProduction)
+    for_ (Set.toList devReachable) $ \pkg ->
+      label pkg (CargoDepKind EnvDevelopment)
   where
     sourceMap = buildPackageSourceMap $ metadataPackages meta
+
+classifyRoots :: CargoMetadata -> (Set PackageId, Set PackageId)
+classifyRoots meta = foldMap classifyMember (metadataWorkspaceMembers meta)
+  where
+    nodeMap :: Map.Map PackageId [NodeDependency]
+    nodeMap =
+      Map.fromList
+        [ (resolveNodeId node, resolveNodeDeps node)
+        | node <- resolvedNodes (metadataResolve meta)
+        ]
+
+    classifyMember :: PackageId -> (Set PackageId, Set PackageId)
+    classifyMember wm =
+      let deps = fromMaybe [] (Map.lookup wm nodeMap)
+       in foldMap classifyDep deps
+
+    classifyDep :: NodeDependency -> (Set PackageId, Set PackageId)
+    classifyDep dep =
+      let pkg = nodePkg dep
+          kinds = nodeDepKinds dep
+          hasNormal = any (isNothing . nodeDepKind) kinds
+          allDev = all (isJust . nodeDepKind) kinds
+       in case (hasNormal, allDev) of
+            (True, _) -> (Set.singleton pkg, mempty)
+            (_, True) -> (mempty, Set.singleton pkg)
+            _ -> mempty
+
+buildAdjacency :: CargoMetadata -> Map.Map PackageId [PackageId]
+buildAdjacency meta =
+  Map.fromList
+    [ (resolveNodeId node, map nodePkg (resolveNodeDeps node))
+    | node <- resolvedNodes (metadataResolve meta)
+    ]
+
+reachable :: Map.Map PackageId [PackageId] -> Set PackageId -> Set PackageId
+reachable adj = go Set.empty . Set.toList
+  where
+    go visited [] = visited
+    go visited (x : xs)
+      | Set.member x visited = go visited xs
+      | otherwise =
+          let children = fromMaybe [] (Map.lookup x adj)
+           in go (Set.insert x visited) (children ++ xs)
 
 -- | Custom Parsec type alias
 type PkgSpecParser a = Parsec Void Text a

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -489,6 +489,10 @@ toDependency emitGitBackedLocators sourceMap pkg =
 -- to reach the parent — so we can only trust kinds on the workspace members'
 -- direct edges. Label those, then let 'hydrateDepEnvs' propagate environments
 -- to every transitive descendant.
+--
+-- Possible values are "build", "dev", and null. Null means production; both
+-- "build" and "dev" map to Development (Cargo does not differentiate test
+-- dependencies from dev dependencies).
 kindToLabel :: Maybe Text.Text -> CargoLabel
 kindToLabel (Just _) = CargoDepKind EnvDevelopment
 kindToLabel Nothing = CargoDepKind EnvProduction

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -504,9 +504,12 @@ toDependency emitGitBackedLocators sourceMap pkg =
 -- "dev" do not appear in 'cargo metadata' output. The only non-null kind we
 -- see on a non-workspace edge is "build".
 --
--- Note: pnpm and yarn use 'hydrateDepEnvs' for this, but it has no notion of
--- edge kinds and would tag packages reached only through a "dev"/"build" edge
--- as Production. The edge-kind-filtered reachability below is why we diverge.
+-- Cargo is the only strategy with per-edge kinds; others (pnpm, yarn, poetry)
+-- label nodes and propagate with 'hydrateDepEnvs'. That helper walks from a
+-- labeled node to every dependency it declares, regardless of edge kind, so
+-- a Production label on a workspace member would flow through a "dev" or
+-- "build" edge and mislabel the dev/build subtree as Production. We roll our
+-- own edge-filtered reachability here rather than generalize the shared helper.
 buildGraph :: Bool -> CargoMetadata -> Graphing Dependency
 buildGraph emitGitBackedLocators meta = shrinkRoots $
   run . withLabeling (toDependency emitGitBackedLocators sourceMap) $ do

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -519,37 +519,31 @@ buildGraph emitGitBackedLocators meta = shrinkRoots $
     nodes = resolvedNodes (metadataResolve meta)
     workspaceMembers = Set.fromList (metadataWorkspaceMembers meta)
 
+    isProdEdge dep = any (isNothing . nodeDepKind) (nodeDepKinds dep)
+    isDevEdge dep = any (isJust . nodeDepKind) (nodeDepKinds dep)
+
     -- Adjacency containing only edges whose parent declares the child as a
     -- normal dependency (at least one kind is null). Production reachability
     -- must only traverse these — a build or dev edge breaks the release chain.
     prodAdj =
-      Map.fromList
-        [ ( resolveNodeId node
-          , [ nodePkg dep
-            | dep <- resolveNodeDeps node
-            , any (isNothing . nodeDepKind) (nodeDepKinds dep)
-            ]
-          )
-        | node <- nodes
-        ]
+      Map.fromList $
+        map
+          (\node -> (resolveNodeId node, map nodePkg (filter isProdEdge (resolveNodeDeps node))))
+          nodes
 
     -- Every edge in the metadata graph, for Development reachability.
     allAdj =
-      Map.fromList
-        [ (resolveNodeId node, map nodePkg (resolveNodeDeps node))
-        | node <- nodes
-        ]
+      Map.fromList $
+        map (\node -> (resolveNodeId node, map nodePkg (resolveNodeDeps node))) nodes
 
     -- Targets of any non-null-kind edge. Each seeds a Development subtree:
     -- the target and all its transitive descendants are never linked into
     -- a release build.
     devSeeds =
-      Set.fromList
-        [ nodePkg dep
-        | node <- nodes
-        , dep <- resolveNodeDeps node
-        , any (isJust . nodeDepKind) (nodeDepKinds dep)
-        ]
+      Set.fromList $
+        map nodePkg $
+          filter isDevEdge $
+            concatMap resolveNodeDeps nodes
 
     prodReachable = reachable prodAdj workspaceMembers
     devReachable = reachable allAdj devSeeds

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -39,7 +39,7 @@ import Control.Effect.Diagnostics (
   warn,
  )
 import Control.Effect.Reader (Reader, ask)
-import Control.Monad (guard, unless, when)
+import Control.Monad (guard, unless)
 import Data.Aeson.Types (
   FromJSON (parseJSON),
   ToJSON,
@@ -52,14 +52,13 @@ import Data.Foldable (for_, traverse_)
 import Data.Functor (void)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes, fromMaybe, isJust)
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String.Conversion (toString, toText)
 import Data.Text (Text, breakOn)
 import Data.Text qualified as Text
 import Data.Void (Void)
-import DepTypes (hydrateDepEnvs)
 import Diag.Diagnostic (renderDiagnostic)
 import Discovery.Filters (AllFilters)
 import Discovery.Simple (simpleDiscover)
@@ -486,32 +485,84 @@ toDependency emitGitBackedLocators sourceMap pkg =
         extractGitCommitHash sourceUrl
       _ -> Nothing
 
--- An edge's kind reflects the parent's manifest declaration, not the path taken
--- to reach the parent — so we can only trust kinds on the workspace members'
--- direct edges. Label those, then let 'hydrateDepEnvs' propagate environments
--- to every transitive descendant.
+-- A Cargo edge's kind ("build", "dev", or null) reflects the parent's manifest
+-- declaration, not the path taken to reach the parent. We classify each package
+-- by which workspace-rooted paths can reach it:
 --
--- Possible values are "build", "dev", and null. Null means production; both
--- "build" and "dev" map to Development (Cargo does not differentiate test
--- dependencies from dev dependencies).
-kindToLabel :: Maybe Text.Text -> CargoLabel
-kindToLabel (Just _) = CargoDepKind EnvDevelopment
-kindToLabel Nothing = CargoDepKind EnvProduction
-
+--   * Production: reachable from a workspace member via a path of null-kind
+--     edges only. These packages are linked into the release artifact.
+--
+--   * Development: any package reachable (via any edge) from the target of a
+--     non-null-kind edge. A "build" or "dev" edge marks the start of a subtree
+--     that never ships in the release binary, and every descendant of that
+--     subtree inherits Development.
+--
+-- A package can carry both labels when it's reachable by both kinds of paths.
+--
+-- We do not need a separate "dev-deps of prod-deps" case: Cargo only resolves
+-- dev-dependencies for workspace members, so non-workspace edges with kind
+-- "dev" do not appear in 'cargo metadata' output. The only non-null kind we
+-- see on a non-workspace edge is "build".
 buildGraph :: Bool -> CargoMetadata -> Graphing Dependency
-buildGraph emitGitBackedLocators meta = shrinkRoots . hydrateDepEnvs $
+buildGraph emitGitBackedLocators meta = shrinkRoots $
   run . withLabeling (toDependency emitGitBackedLocators sourceMap) $ do
-    traverse_ direct workspaceMembers
-    for_ (resolvedNodes (metadataResolve meta)) $ \node -> do
-      let parentId = resolveNodeId node
-          fromWorkspace = Set.member parentId workspaceMembers
-      for_ (resolveNodeDeps node) $ \dep -> do
-        edge parentId (nodePkg dep)
-        when fromWorkspace $
-          traverse_ (label (nodePkg dep) . kindToLabel . nodeDepKind) (nodeDepKinds dep)
+    traverse_ direct (metadataWorkspaceMembers meta)
+    for_ nodes $ \node ->
+      for_ (resolveNodeDeps node) $ \dep ->
+        edge (resolveNodeId node) (nodePkg dep)
+    for_ (Set.toList prodReachable) $ \pkg ->
+      label pkg (CargoDepKind EnvProduction)
+    for_ (Set.toList devReachable) $ \pkg ->
+      label pkg (CargoDepKind EnvDevelopment)
   where
     sourceMap = buildPackageSourceMap $ metadataPackages meta
+    nodes = resolvedNodes (metadataResolve meta)
     workspaceMembers = Set.fromList (metadataWorkspaceMembers meta)
+
+    -- Adjacency containing only edges whose parent declares the child as a
+    -- normal dependency (at least one kind is null). Production reachability
+    -- must only traverse these — a build or dev edge breaks the release chain.
+    prodAdj =
+      Map.fromList
+        [ ( resolveNodeId node
+          , [ nodePkg dep
+            | dep <- resolveNodeDeps node
+            , any (isNothing . nodeDepKind) (nodeDepKinds dep)
+            ]
+          )
+        | node <- nodes
+        ]
+
+    -- Every edge in the metadata graph, for Development reachability.
+    allAdj =
+      Map.fromList
+        [ (resolveNodeId node, map nodePkg (resolveNodeDeps node))
+        | node <- nodes
+        ]
+
+    -- Targets of any non-null-kind edge. Each seeds a Development subtree:
+    -- the target and all its transitive descendants are never linked into
+    -- a release build.
+    devSeeds =
+      Set.fromList
+        [ nodePkg dep
+        | node <- nodes
+        , dep <- resolveNodeDeps node
+        , any (isJust . nodeDepKind) (nodeDepKinds dep)
+        ]
+
+    prodReachable = reachable prodAdj workspaceMembers
+    devReachable = reachable allAdj devSeeds
+
+reachable :: Map.Map PackageId [PackageId] -> Set PackageId -> Set PackageId
+reachable adj = go Set.empty . Set.toList
+  where
+    go visited [] = visited
+    go visited (x : xs)
+      | Set.member x visited = go visited xs
+      | otherwise =
+          let children = fromMaybe [] (Map.lookup x adj)
+           in go (Set.insert x visited) (children ++ xs)
 
 -- | Custom Parsec type alias
 type PkgSpecParser a = Parsec Void Text a

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -552,8 +552,7 @@ buildGraph emitGitBackedLocators meta = shrinkRoots $
     devSeeds =
       Set.fromList $
         map nodePkg $
-          filter isDevEdge $
-            concatMap resolveNodeDeps nodes
+          concatMap (filter isDevEdge . resolveNodeDeps) nodes
 
     prodReachable = reachable prodAdj workspaceMembers
     devReachable = reachable allAdj devSeeds

--- a/src/Strategy/Cargo.hs
+++ b/src/Strategy/Cargo.hs
@@ -538,7 +538,7 @@ buildGraph emitGitBackedLocators meta = shrinkRoots $
     prodAdj =
       Map.fromList $
         map
-          (\node -> (resolveNodeId node, map nodePkg (filter isProdEdge (resolveNodeDeps node))))
+          (\node -> (resolveNodeId node, map nodePkg . filter isProdEdge . resolveNodeDeps $ node))
           nodes
 
     -- Every edge in the metadata graph, for Development reachability.

--- a/test/Cargo/MetadataSpec.hs
+++ b/test/Cargo/MetadataSpec.hs
@@ -75,6 +75,8 @@ spec = do
 
   post1_77MetadataParseSpec
 
+  devDepTransitiveLabelingSpec
+
   extractGitCommitHashSpec
 
   gitCommitHashVersionSpec
@@ -200,6 +202,67 @@ post1_77MetadataParseSpec =
       let graph = buildGraph False expectedMetadataPost1_77
       expectDeps [ansiTermDep, clapDep, fooDep, barDepFallback] graph
       dependencyName barDepFallback `shouldBe` "bar"
+
+devKind :: Text -> NodeDepKind
+devKind k = NodeDepKind (Just k) Nothing
+
+devDepTransitiveLabelingSpec :: Test.Spec
+devDepTransitiveLabelingSpec =
+  Test.describe "dev-dep transitive labeling" $ do
+    Test.it "transitive deps of dev-deps are labeled Development" $ do
+      let wsId = PackageId "myapp" "0.1.0" "path+file:///path/to/myapp"
+          itoaId = mkPkgId "itoa" "1.0.18"
+          approxId = mkPkgId "approx" "0.5.1"
+          numTraitsId = mkPkgId "num-traits" "0.2.19"
+          autocfgId = mkPkgId "autocfg" "1.4.0"
+
+          wsNode = ResolveNode wsId
+            [ NodeDependency itoaId [nullKind]
+            , NodeDependency approxId [devKind "dev"]
+            ]
+          approxNode = ResolveNode approxId
+            [ NodeDependency numTraitsId [nullKind]
+            ]
+          numTraitsNode = ResolveNode numTraitsId
+            [ NodeDependency autocfgId [devKind "build"]
+            ]
+          itoaNode = ResolveNode itoaId []
+          autocfgNode = ResolveNode autocfgId []
+
+          meta = CargoMetadata [] [wsId] $ Resolve [wsNode, approxNode, numTraitsNode, itoaNode, autocfgNode]
+          graph = buildGraph False meta
+
+          itoaDep = mkDep "itoa" "1.0.18" CargoType [EnvProduction]
+          approxDep = mkDep "approx" "0.5.1" CargoType [EnvDevelopment]
+          numTraitsDep = mkDep "num-traits" "0.2.19" CargoType [EnvDevelopment]
+          autocfgDep = mkDep "autocfg" "1.4.0" CargoType [EnvDevelopment]
+
+      expectDeps [itoaDep, approxDep, numTraitsDep, autocfgDep] graph
+      expectDirect [itoaDep, approxDep] graph
+
+    Test.it "dep reachable from both prod and dev roots gets both labels" $ do
+      let wsId = PackageId "myapp" "0.1.0" "path+file:///path/to/myapp"
+          aId = mkPkgId "A" "1.0.0"
+          bId = mkPkgId "B" "1.0.0"
+          cId = mkPkgId "C" "1.0.0"
+
+          wsNode = ResolveNode wsId
+            [ NodeDependency aId [nullKind]
+            , NodeDependency bId [devKind "dev"]
+            ]
+          aNode = ResolveNode aId [NodeDependency cId [nullKind]]
+          bNode = ResolveNode bId [NodeDependency cId [nullKind]]
+          cNode = ResolveNode cId []
+
+          meta = CargoMetadata [] [wsId] $ Resolve [wsNode, aNode, bNode, cNode]
+          graph = buildGraph False meta
+
+          aDep = mkDep "A" "1.0.0" CargoType [EnvProduction]
+          bDep = mkDep "B" "1.0.0" CargoType [EnvDevelopment]
+          cDep = mkDep "C" "1.0.0" CargoType [EnvProduction, EnvDevelopment]
+
+      expectDeps [aDep, bDep, cDep] graph
+      expectDirect [aDep, bDep] graph
 
 extractGitCommitHashSpec :: Test.Spec
 extractGitCommitHashSpec =

--- a/test/Cargo/MetadataSpec.hs
+++ b/test/Cargo/MetadataSpec.hs
@@ -216,16 +216,22 @@ devDepTransitiveLabelingSpec =
           numTraitsId = mkPkgId "num-traits" "0.2.19"
           autocfgId = mkPkgId "autocfg" "1.4.0"
 
-          wsNode = ResolveNode wsId
-            [ NodeDependency itoaId [nullKind]
-            , NodeDependency approxId [devKind "dev"]
-            ]
-          approxNode = ResolveNode approxId
-            [ NodeDependency numTraitsId [nullKind]
-            ]
-          numTraitsNode = ResolveNode numTraitsId
-            [ NodeDependency autocfgId [devKind "build"]
-            ]
+          wsNode =
+            ResolveNode
+              wsId
+              [ NodeDependency itoaId [nullKind]
+              , NodeDependency approxId [devKind "dev"]
+              ]
+          approxNode =
+            ResolveNode
+              approxId
+              [ NodeDependency numTraitsId [nullKind]
+              ]
+          numTraitsNode =
+            ResolveNode
+              numTraitsId
+              [ NodeDependency autocfgId [devKind "build"]
+              ]
           itoaNode = ResolveNode itoaId []
           autocfgNode = ResolveNode autocfgId []
 
@@ -246,10 +252,12 @@ devDepTransitiveLabelingSpec =
           bId = mkPkgId "B" "1.0.0"
           cId = mkPkgId "C" "1.0.0"
 
-          wsNode = ResolveNode wsId
-            [ NodeDependency aId [nullKind]
-            , NodeDependency bId [devKind "dev"]
-            ]
+          wsNode =
+            ResolveNode
+              wsId
+              [ NodeDependency aId [nullKind]
+              , NodeDependency bId [devKind "dev"]
+              ]
           aNode = ResolveNode aId [NodeDependency cId [nullKind]]
           bNode = ResolveNode bId [NodeDependency cId [nullKind]]
           cNode = ResolveNode cId []
@@ -263,6 +271,26 @@ devDepTransitiveLabelingSpec =
 
       expectDeps [aDep, bDep, cDep] graph
       expectDirect [aDep, bDep] graph
+
+    Test.it "direct dep declared as both normal and dev gets both labels" $ do
+      -- Cargo emits multiple NodeDepKinds when a dep is declared in both
+      -- [dependencies] and [dev-dependencies] on the same package.
+      let wsId = PackageId "myapp" "0.1.0" "path+file:///path/to/myapp"
+          dualId = mkPkgId "dual" "1.0.0"
+          transId = mkPkgId "trans" "1.0.0"
+
+          wsNode = ResolveNode wsId [NodeDependency dualId [nullKind, devKind "dev"]]
+          dualNode = ResolveNode dualId [NodeDependency transId [nullKind]]
+          transNode = ResolveNode transId []
+
+          meta = CargoMetadata [] [wsId] $ Resolve [wsNode, dualNode, transNode]
+          graph = buildGraph False meta
+
+          dualDep = mkDep "dual" "1.0.0" CargoType [EnvProduction, EnvDevelopment]
+          transDep = mkDep "trans" "1.0.0" CargoType [EnvProduction, EnvDevelopment]
+
+      expectDeps [dualDep, transDep] graph
+      expectDirect [dualDep] graph
 
 extractGitCommitHashSpec :: Test.Spec
 extractGitCommitHashSpec =

--- a/test/Cargo/MetadataSpec.hs
+++ b/test/Cargo/MetadataSpec.hs
@@ -292,6 +292,53 @@ devDepTransitiveLabelingSpec =
       expectDeps [dualDep, transDep] graph
       expectDirect [dualDep] graph
 
+    Test.it "build-deps of prod-deps and their transitives are Development" $ do
+      -- Regression guard: build-script utilities (autocfg, cc, version_check,
+      -- etc.) are declared as [build-dependencies] of normal deps. They are
+      -- compiled during the build but never linked into the release artifact,
+      -- so they should be labeled Development, not Production — even though
+      -- their parent is a production dep.
+      let wsId = PackageId "myapp" "0.1.0" "path+file:///path/to/myapp"
+          serdeId = mkPkgId "serde" "1.0.0"
+          autocfgId = mkPkgId "autocfg" "1.0.0"
+          autocfgChildId = mkPkgId "autocfg-child" "1.0.0"
+
+          wsNode = ResolveNode wsId [NodeDependency serdeId [nullKind]]
+          serdeNode = ResolveNode serdeId [NodeDependency autocfgId [devKind "build"]]
+          autocfgNode = ResolveNode autocfgId [NodeDependency autocfgChildId [nullKind]]
+          childNode = ResolveNode autocfgChildId []
+
+          meta = CargoMetadata [] [wsId] $ Resolve [wsNode, serdeNode, autocfgNode, childNode]
+          graph = buildGraph False meta
+
+          serdeDep = mkDep "serde" "1.0.0" CargoType [EnvProduction]
+          autocfgDep = mkDep "autocfg" "1.0.0" CargoType [EnvDevelopment]
+          childDep = mkDep "autocfg-child" "1.0.0" CargoType [EnvDevelopment]
+
+      expectDeps [serdeDep, autocfgDep, childDep] graph
+      expectDirect [serdeDep] graph
+
+    Test.it "dep reachable via a normal prod path and a build-edge gets both labels" $ do
+      -- X is a direct normal dep of the workspace (Production) AND a build-dep
+      -- of a prod dep (Development via the build-edge split). Both labels
+      -- should be applied.
+      let wsId = PackageId "myapp" "0.1.0" "path+file:///path/to/myapp"
+          aId = mkPkgId "A" "1.0.0"
+          xId = mkPkgId "X" "1.0.0"
+
+          wsNode = ResolveNode wsId [NodeDependency aId [nullKind], NodeDependency xId [nullKind]]
+          aNode = ResolveNode aId [NodeDependency xId [devKind "build"]]
+          xNode = ResolveNode xId []
+
+          meta = CargoMetadata [] [wsId] $ Resolve [wsNode, aNode, xNode]
+          graph = buildGraph False meta
+
+          aDep = mkDep "A" "1.0.0" CargoType [EnvProduction]
+          xDep = mkDep "X" "1.0.0" CargoType [EnvProduction, EnvDevelopment]
+
+      expectDeps [aDep, xDep] graph
+      expectDirect [aDep, xDep] graph
+
 extractGitCommitHashSpec :: Test.Spec
 extractGitCommitHashSpec =
   Test.describe "extractGitCommitHash" $ do


### PR DESCRIPTION
# Overview

The cargo strategy was labeling transitive dependencies by the kind of the single edge directly pointing at them. This caused deps reachable only via a dev-dep subtree to be reported as `Production` whenever the intermediate edges happened to be normal-kind — for example `workspace → approx (dev) → num-traits (normal)` leaked `num-traits` into Production.

The fix in `src/Strategy/Cargo.hs` replaces per-edge labeling with two edge-kind-aware reachability passes over the resolved graph:

- **Production:** reachable from workspace members through paths of null-kind edges only. A `"build"` or `"dev"` edge breaks the release chain, so its target (and everything transitively below) is not Production via that path.
- **Development:** reachable (via any edge) from the target of any non-null-kind edge. A build or dev edge marks the root of a subtree that is never linked into the release binary, and every descendant of that subtree inherits Development.

A package reachable by both kinds of paths carries both labels — `LabeledGrapher` already supports multi-labels, so no structural changes were needed.

### Why we don't need a separate rule for transitive dev-deps

Cargo only resolves `[dev-dependencies]` for workspace members. Dev-deps declared inside a non-workspace crate are not part of `cargo metadata`'s `resolve` graph, so the only non-null kind we ever see on a non-workspace edge is `"build"`. The reachability rule above handles it uniformly.

## Acceptance criteria

- Transitive deps reached only via dev-dep or build-dep roots are labeled `Development` (previously leaked to `Production` when intermediate edges were normal-kind).
- Build-dependencies of production deps (e.g. `autocfg`, `cc`, `version_check`) and their transitives are labeled `Development` — they're needed to compile the project but are never linked into the release artifact.
- A dep reachable from both a Production root and a Development root gets both labels (multi-label preserved).
- Projects with non-trivial dev-dep or build-dep trees will see their Production set shrink and their Development set grow. This is a correctness fix but is a visible behavior change, called out in the changelog.

## Testing plan

### Minimal reproduction

The `Cargo.toml` includes two dependencies. `itoa` has no transitive deps. It is included as a prod dependency, so it should be the only production dependency in the graph.

`approx` is being included as a dev dependency. It has two transitive dependencies: `approx` requires `num-traits` as a normal dependency, and `num-traits` requires `autocfg` as a build-script dependency.

Before this fix, `fossa analyze` reported both `itoa` and `num-traits` as production dependencies. After the fix, it correctly reports only `itoa` as a production dependency.

1. Create `/tmp/cargo-devdep-test/Cargo.toml`:

   ```toml
   [package]
   name = "cargo-devdep-test"
   version = "0.1.0"
   edition = "2021"

   [dependencies]
   itoa = "1"

   [dev-dependencies]
   approx = "0.5"
   ```

2. Create `/tmp/cargo-devdep-test/src/lib.rs`:

   ```rust
   pub fn add(a: u64, b: u64) -> u64 { a + b }
   ```

3. Generate the lockfile:

   ```bash
   cd /tmp/cargo-devdep-test && cargo generate-lockfile
   ```

4. Run fossa (released) and fossa-dev (this branch):

   ```bash
   cd /tmp/cargo-devdep-test
   fossa analyze --output | jq
   make install-dev
   fossa-dev analyze --output | jq
   ```

Compare the two outputs. The output from `fossa-dev` only includes `cargo+itoa`. The output from `fossa` includes both `cargo+itoa` and `cargo+num-traits`.

Run again with `--include-unused-deps`. All four deps appear in the graph; the difference is that `approx`, `num-traits`, and `autocfg` are now labeled Development instead of leaking into Production.

### Real-world verification: sparkle and ficus

This is where the build-dep correctness is visible — the minimal `num-traits`-style repro above doesn't differentiate the fix from released `fossa` (both classify `autocfg` as Development, just by different paths). The sparkle/ficus scans are the evidence that the fix handles the build-dep case at scale without regressing any Production deps.

I scanned both projects with released `fossa` (3.16.6) and `fossa-dev` from this branch, then diffed `sourceUnits.Build.Dependencies`:

| Project | Released | This PR | Delta |
|---|---|---|---|
| ficus | 370 | 355 | −15 |
| sparkle | 724 | 693 | −31 |

All movement is Production → Development — no deps incorrectly leaked the other direction. The reclassified deps are exactly the categories you'd expect:

- **Test frameworks:** `proptest`, `wiremock`, `tokio-test`, `axum-test`, `simple_test_case`, `test-log`, `tracing-test-macro`, `assert-json-diff`
- **Build-script utilities:** `autocfg`, `cc`, `cfg_aliases`, `pkg-config`, `rustc_version`, `vcpkg`, `version_check`, `jobserver`, `shlex`, `find-msvc-tools`
- **Dev utilities:** `xshell`, `xshell-macros`, `cargo_metadata`, `cargo-platform`, `env_logger`, `env_filter`, `tempfile`
- **Platform-specific deps of dev tooling:** `winapi-i686-pc-windows-gnu`, `winapi-x86_64-pc-windows-gnu`, `hermit-abi`

### Automated coverage

New `MetadataSpec` cases:

- Transitive deps of dev-deps labeled Development (the original bug).
- Dep reachable from both prod and dev roots gets both labels.
- Direct dep declared as both normal and dev gets both labels.
- **Build-deps of prod-deps and their transitives are Development** (catches the regression that a naïve propagation approach would reintroduce).
- **Dep reachable via a normal prod path and a build-edge gets both labels** (multi-label under the edge-kind-aware algorithm).

## Risks

Correctness fix with a visible behavior change: Production dep sets will shrink for any project that has dev-dep or build-dep trees with non-trivial transitive closures. This was the intent — previously those trees were partially leaking into Production. Flagged in the changelog. No deps move in the opposite direction (Dev → Prod), so there's no risk of over-reporting.

## Metrics

Not tracked.

## References

- Plan: `cargo-dev-prod-labeling-fix.md`

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.