### PR TITLE
[ANE-1624] Preserve gem name and version for GIT deps in Gemfile.lock

### DIFF
--- a/src/Strategy/Ruby/GemfileLock.hs
+++ b/src/Strategy/Ruby/GemfileLock.hs
@@ -93,7 +93,10 @@ toDependency pkg = foldr applyLabel start
     applyLabel :: GemfileLabel -> Dependency -> Dependency
     applyLabel (GemfileVersion ver) dep = dep{dependencyVersion = dependencyVersion dep <|> (Just . CEq) ver}
     applyLabel (GitRemote repo maybeRevision) dep =
-      dep{dependencyType = GitType, dependencyName = repo, dependencyVersion = (Just . CEq) =<< maybeRevision, dependencyLocations = maybe repo (\revision -> repo <> "@" <> revision) maybeRevision : dependencyLocations dep}
+      dep
+        { dependencyType = GitType
+        , dependencyLocations = maybe repo (\revision -> repo <> "@" <> revision) maybeRevision : dependencyLocations dep
+        }
     applyLabel (OtherRemote loc) dep =
       dep{dependencyLocations = loc : dependencyLocations dep}
 

--- a/test/Ruby/GemfileLockSpec.hs
+++ b/test/Ruby/GemfileLockSpec.hs
@@ -14,8 +14,8 @@ dependencyOne :: Dependency
 dependencyOne =
   Dependency
     { dependencyType = GitType
-    , dependencyName = "url-for-dep-one"
-    , dependencyVersion = Just (CEq "12345")
+    , dependencyName = "dep-one"
+    , dependencyVersion = Just (CEq "1.0.0")
     , dependencyLocations = ["url-for-dep-one@12345"]
     , dependencyEnvironments = mempty
     , dependencyTags = Map.empty


### PR DESCRIPTION
# Overview

GIT dependencies in Gemfile.lock were being misidentified. The `applyLabel` function for `GitRemote` labels was overwriting `dependencyName` with the git URL and `dependencyVersion` with the revision hash, discarding the actual gem name and spec version.

For example, a gem like `clickhouse-activerecord` sourced from `https://github.com/KamiHQ/clickhouse-activerecord` would appear with the URL as its name and the commit SHA as its version, instead of the real gem name and version from the lockfile's `specs:` block.

This PR removes the `dependencyName` and `dependencyVersion` overrides from the `GitRemote` label handler, so that:
- `dependencyName` = gem name from specs (e.g. `"clickhouse-activerecord"`)
- `dependencyVersion` = gem version from specs (e.g. `"0.6.4"`)
- `dependencyType` = `GitType` (unchanged — still indicates git source)
- `dependencyLocations` = git URL with revision (unchanged)

## Acceptance criteria

When a Gemfile.lock contains GIT-sourced gems, `fossa analyze` should report them with their actual gem name and version, not the git URL and revision hash.

## Testing plan

1. Verified the `spectrometer` library builds cleanly with `cabal build spectrometer`.
2. Updated the existing unit test in `GemfileLockSpec.hs` to expect the corrected dependency name (`"dep-one"` instead of `"url-for-dep-one"`) and version (`"1.0.0"` instead of `"12345"`).
3. Unit test suite has a pre-existing crash on LFS-dependent test data (`emptypath.tar`) that prevents running locally without Git LFS; CI should handle this.

## Risks

This changes the output for any project with GIT-sourced gems in Gemfile.lock. Dependencies that were previously reported as `GitType` with URL-as-name will now be reported with the gem name. Downstream systems that keyed on the old `dependencyName` format may need adjustment.

## Metrics

N/A

## References

- [ANE-1624](https://fossa.atlassian.net/browse/ANE-1624): Git dependencies not being analyzed correctly in Gemfile.lock Strategy

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ANE-1624]: https://fossa.atlassian.net/browse/ANE-1624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ