### PR TITLE
[ANE-2908] Swift Package.swift parser improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Swift: Fix a bug in the `Package.swift` parser which would cause it to error on valid syntax.
+
 ## 3.17.2
 
 - Poetry: Support PEP 621 `[project].dependencies` for Poetry 2.x projects. Production dependencies declared in the standard `[project]` section are now correctly detected alongside legacy `[tool.poetry.dependencies]`. ([#1683](https://github.com/fossas/fossa-cli/pull/1683))

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -16,6 +16,7 @@ import Control.Applicative (Alternative ((<|>)), optional)
 import Control.Effect.Diagnostics (Diagnostics, context, errCtx, errDoc, errHelp, fatalText, recover, warnOnErr)
 import Control.Monad (void)
 import Data.Foldable (asum)
+import Data.Functor (($>))
 import Data.Map.Strict qualified as Map
 import Data.Set (Set, fromList, member)
 import Data.Text (Text)
@@ -200,16 +201,22 @@ parsePackageDependencies :: Parser [SwiftPackageDep]
 parsePackageDependencies = do
   _ <- lexeme $ skipManyTill anySingle $ symbol "let package = Package("
 
-  -- This order is important. We consume `products` first, because it can contain `targets` fields which we want to ignore.
-  -- Next we consume `targets` because it can contain `dependencies` fields we want to ignore.
-  -- What's left should now be the actual project dependencies.
-  _ <- try $ parseNonDepSection "products"
-  _ <- try $ parseNonDepSection "targets"
-  try parseDeps <|> pure []
+  concat
+    <$> sepEndBy
+      ( do
+          key <- parseKey
+          _ <- symbol ":"
+          case key of
+            "dependencies" -> parseDeps
+            _ -> parseNonDepArray <|> (parseQuotedText $> []) <|> parseIdentifier
+      )
+      (symbol ",")
   where
-    parseNonDepSection name = skipManyTill anySingle (symbol (name <> ":")) *> nestedBrackets
-    parseDeps = skipManyTill anySingle (symbol "dependencies:") *> betweenSquareBrackets (sepEndBy (lexeme parsePackageDep) $ symbol ",")
+    parseKey = try (lexeme $ takeWhile1P (Just "package key") (/= ':'))
+    parseDeps = betweenSquareBrackets (sepEndBy (lexeme parsePackageDep) $ symbol ",")
+    parseIdentifier = takeWhile1P (Just "parse identifier") (/= ',') $> []
     nestedBrackets = void $ betweenSquareBrackets $ many (nestedBrackets <|> void (noneOf ("[]" :: [Char])))
+    parseNonDepArray = nestedBrackets $> []
 
 parseSwiftToolVersion :: Parser Text
 parseSwiftToolVersion =

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -214,8 +214,8 @@ parsePackageDependencies = do
   where
     parseKey = try $ lexeme $ takeWhile1P (Just "package key") (/= ':') <* symbol ":"
     parseDeps = betweenSquareBrackets (sepEndBy (lexeme parsePackageDep) $ symbol ",")
-    parseIdentifier = takeWhile1P (Just "parse identifier") (/= ',') $> []
-    nestedBrackets = void $ betweenSquareBrackets $ many (nestedBrackets <|> void (noneOf ("[]" :: [Char])))
+    parseIdentifier = takeWhile1P (Just "parse identifier") (`notElem` (",()[]" :: String)) $> []
+    nestedBrackets = void $ betweenSquareBrackets $ many (nestedBrackets <|> void (noneOf ("[]" :: String)))
     parseNonDepArray = nestedBrackets $> []
 
 parseSwiftToolVersion :: Parser Text

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -16,7 +16,6 @@ import Control.Applicative (Alternative ((<|>)), optional)
 import Control.Effect.Diagnostics (Diagnostics, context, errCtx, errDoc, errHelp, fatalText, recover, warnOnErr)
 import Control.Monad (void)
 import Data.Foldable (asum)
-import Data.Functor (($>))
 import Data.Map.Strict qualified as Map
 import Data.Set (Set, fromList, member)
 import Data.Text (Text)
@@ -28,7 +27,17 @@ import Graphing (Graphing, deeps, directs, induceJust, promoteToDirect)
 import Path
 import Strategy.Swift.Errors (MissingPackageResolvedFile (..), MissingPackageResolvedFileHelp (..), swiftFossaDocUrl, swiftPackageResolvedRef, xcodeCoordinatePkgVersion)
 import Strategy.Swift.PackageResolved (SwiftPackageResolvedFile, resolvedDependenciesOf)
-import Text.Megaparsec (MonadParsec (takeWhile1P, try), Parsec, anySingle, anySingleBut, between, empty, many, manyTill, noneOf, sepEndBy, skipManyTill)
+import Text.Megaparsec (
+  MonadParsec (takeWhile1P, try),
+  Parsec,
+  anySingle,
+  between,
+  empty,
+  many,
+  noneOf,
+  sepEndBy,
+  skipManyTill,
+ )
 import Text.Megaparsec.Char (space1)
 import Text.Megaparsec.Char.Lexer qualified as Lexer
 
@@ -196,13 +205,11 @@ parsePackageDependencies = do
   -- What's left should now be the actual project dependencies.
   _ <- try $ parseNonDepSection "products"
   _ <- try $ parseNonDepSection "targets"
-  parseDeps
+  try parseDeps <|> pure []
   where
     parseNonDepSection name = skipManyTill anySingle (symbol (name <> ":")) *> nestedBrackets
     parseDeps = skipManyTill anySingle (symbol "dependencies:") *> betweenSquareBrackets (sepEndBy (lexeme parsePackageDep) $ symbol ",")
     nestedBrackets = void $ betweenSquareBrackets $ many (nestedBrackets <|> void (noneOf ("[]" :: [Char])))
-
--- nestedBrackets = void $ betweenSquareBrackets $ many (nestedBrackets <|> void (anySingleBut '['))
 
 parseSwiftToolVersion :: Parser Text
 parseSwiftToolVersion =

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -205,14 +205,13 @@ parsePackageDependencies = do
     <$> sepEndBy
       ( do
           key <- parseKey
-          _ <- symbol ":"
           case key of
             "dependencies" -> parseDeps
             _ -> parseNonDepArray <|> (parseQuotedText $> []) <|> parseIdentifier
       )
       (symbol ",")
   where
-    parseKey = try (lexeme $ takeWhile1P (Just "package key") (/= ':'))
+    parseKey = try (lexeme $ takeWhile1P (Just "package key") (/= ':')) <* symbol ":"
     parseDeps = betweenSquareBrackets (sepEndBy (lexeme parsePackageDep) $ symbol ",")
     parseIdentifier = takeWhile1P (Just "parse identifier") (/= ',') $> []
     nestedBrackets = void $ betweenSquareBrackets $ many (nestedBrackets <|> void (noneOf ("[]" :: [Char])))

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -199,19 +199,20 @@ parsePackageDep = try parsePathDep <|> parseGitDep
 
 parsePackageDependencies :: Parser [SwiftPackageDep]
 parsePackageDependencies = do
-  _ <- lexeme $ skipManyTill anySingle $ symbol "let package = Package("
+  _ <- lexeme $ skipManyTill anySingle $ symbol "let package = Package"
 
-  concat
-    <$> sepEndBy
-      ( do
-          key <- parseKey
-          case key of
-            "dependencies" -> parseDeps
-            _ -> parseNonDepArray <|> (parseQuotedText $> []) <|> parseIdentifier
-      )
-      (symbol ",")
+  betweenBrackets $
+    concat
+      <$> sepEndBy
+        ( do
+            key <- parseKey
+            case key of
+              "dependencies" -> parseDeps
+              _ -> parseNonDepArray <|> (parseQuotedText $> []) <|> parseIdentifier
+        )
+        (symbol ",")
   where
-    parseKey = try (lexeme $ takeWhile1P (Just "package key") (/= ':')) <* symbol ":"
+    parseKey = try $ lexeme $ takeWhile1P (Just "package key") (/= ':') <* symbol ":"
     parseDeps = betweenSquareBrackets (sepEndBy (lexeme parsePackageDep) $ symbol ",")
     parseIdentifier = takeWhile1P (Just "parse identifier") (/= ',') $> []
     nestedBrackets = void $ betweenSquareBrackets $ many (nestedBrackets <|> void (noneOf ("[]" :: [Char])))

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -16,6 +16,7 @@ import Control.Applicative (Alternative ((<|>)), optional)
 import Control.Effect.Diagnostics (Diagnostics, context, errCtx, errDoc, errHelp, fatalText, recover, warnOnErr)
 import Control.Monad (void)
 import Data.Foldable (asum)
+import Data.Functor (($>))
 import Data.Map.Strict qualified as Map
 import Data.Set (Set, fromList, member)
 import Data.Text (Text)
@@ -27,15 +28,7 @@ import Graphing (Graphing, deeps, directs, induceJust, promoteToDirect)
 import Path
 import Strategy.Swift.Errors (MissingPackageResolvedFile (..), MissingPackageResolvedFileHelp (..), swiftFossaDocUrl, swiftPackageResolvedRef, xcodeCoordinatePkgVersion)
 import Strategy.Swift.PackageResolved (SwiftPackageResolvedFile, resolvedDependenciesOf)
-import Text.Megaparsec (
-  MonadParsec (takeWhile1P, try),
-  Parsec,
-  anySingle,
-  between,
-  empty,
-  sepEndBy,
-  skipManyTill,
- )
+import Text.Megaparsec (MonadParsec (takeWhile1P, try), Parsec, anySingle, anySingleBut, between, empty, many, manyTill, noneOf, sepEndBy, skipManyTill)
 import Text.Megaparsec.Char (space1)
 import Text.Megaparsec.Char.Lexer qualified as Lexer
 
@@ -197,7 +190,19 @@ parsePackageDep = try parsePathDep <|> parseGitDep
 parsePackageDependencies :: Parser [SwiftPackageDep]
 parsePackageDependencies = do
   _ <- lexeme $ skipManyTill anySingle $ symbol "let package = Package("
-  skipManyTill anySingle (symbol "dependencies:") *> betweenSquareBrackets (sepEndBy (lexeme parsePackageDep) $ symbol ",")
+
+  -- This order is important. We consume `products` first, because it can contain `targets` fields which we want to ignore.
+  -- Next we consume `targets` because it can contain `dependencies` fields we want to ignore.
+  -- What's left should now be the actual project dependencies.
+  _ <- try $ parseNonDepSection "products"
+  _ <- try $ parseNonDepSection "targets"
+  parseDeps
+  where
+    parseNonDepSection name = skipManyTill anySingle (symbol (name <> ":")) *> nestedBrackets
+    parseDeps = skipManyTill anySingle (symbol "dependencies:") *> betweenSquareBrackets (sepEndBy (lexeme parsePackageDep) $ symbol ",")
+    nestedBrackets = void $ betweenSquareBrackets $ many (nestedBrackets <|> void (noneOf ("[]" :: [Char])))
+
+-- nestedBrackets = void $ betweenSquareBrackets $ many (nestedBrackets <|> void (anySingleBut '['))
 
 parseSwiftToolVersion :: Parser Text
 parseSwiftToolVersion =

--- a/test/Swift/PackageSwiftSpec.hs
+++ b/test/Swift/PackageSwiftSpec.hs
@@ -80,16 +80,23 @@ expectedSwiftPackageNoDeps = SwiftPackage "6.0" []
 spec :: Spec
 spec = do
   packageDotSwiftFile <- runIO (TIO.readFile "test/Swift/testdata/Package.swift")
+  packageDotSwiftFullFile <- runIO (TIO.readFile "test/Swift/testdata/Package.full.swift")
   packageDotSwiftNoDepsFile <- runIO (TIO.readFile "test/Swift/testdata/Package.no-deps.swift")
 
   describe "Parses Package.swift file" $ do
-    it "should parse swift-tools-version" $ do
+    it "should parse swift-tools-version and dependencies" $ do
       case runParser parsePackageSwiftFile "" packageDotSwiftFile of
         Left failCode -> expectationFailure $ show failCode
         Right result -> result `shouldBe` expectedSwiftPackage
 
+  describe "Parses Package.full.swift file" $ do
+    it "should parse swift-tools-version and dependencies" $ do
+      case runParser parsePackageSwiftFile "" packageDotSwiftFullFile of
+        Left failCode -> expectationFailure $ show failCode
+        Right result -> result `shouldBe` expectedSwiftPackage
+
   describe "Parses Package.no-deps.swift file" $ do
-    it "should parse swift-tools-version" $ do
+    it "should parse swift-tools-version and dependencies" $ do
       case runParser parsePackageSwiftFile "" packageDotSwiftNoDepsFile of
         Left failCode -> expectationFailure $ show failCode
         Right result -> result `shouldBe` expectedSwiftPackageNoDeps

--- a/test/Swift/PackageSwiftSpec.hs
+++ b/test/Swift/PackageSwiftSpec.hs
@@ -74,15 +74,25 @@ expectedSwiftPackage =
       ]
       ++ [PathSource "../..", PathSource "../.."]
 
+expectedSwiftPackageNoDeps :: SwiftPackage
+expectedSwiftPackageNoDeps = SwiftPackage "6.0" []
+
 spec :: Spec
 spec = do
   packageDotSwiftFile <- runIO (TIO.readFile "test/Swift/testdata/Package.swift")
+  packageDotSwiftNoDepsFile <- runIO (TIO.readFile "test/Swift/testdata/Package.no-deps.swift")
 
   describe "Parses Package.swift file" $ do
     it "should parse swift-tools-version" $ do
       case runParser parsePackageSwiftFile "" packageDotSwiftFile of
         Left failCode -> expectationFailure $ show failCode
         Right result -> result `shouldBe` expectedSwiftPackage
+
+  describe "Parses Package.no-deps.swift file" $ do
+    it "should parse swift-tools-version" $ do
+      case runParser parsePackageSwiftFile "" packageDotSwiftNoDepsFile of
+        Left failCode -> expectationFailure $ show failCode
+        Right result -> result `shouldBe` expectedSwiftPackageNoDeps
 
   describe "buildGraph, when no resolved content is discovered" $ do
     it "should use git dependency type, when constraint is of branch, revision, or exact type" $ do

--- a/test/Swift/testdata/Package.full.swift
+++ b/test/Swift/testdata/Package.full.swift
@@ -81,5 +81,5 @@ let package = Package(
     providers: [
         .brew(["example-lib"]),
         .apt(["libexample-dev"])
-    ]
+    ], // Trailing comma!
 )

--- a/test/Swift/testdata/Package.full.swift
+++ b/test/Swift/testdata/Package.full.swift
@@ -1,8 +1,7 @@
 // swift-tools-version:5.3
 
-// A typical Package.swift. The `targets` section is intentionally before the `dependencies` section to test
-// that our parser doesn't get confused by the target dependencies (which we should ignore) coming before
-// the actual dependencies
+// This Package.swift has values set for all valid options. This is to test that our parser is able to handle
+// all fields in a Package.swift
 
 import PackageDescription
 
@@ -18,18 +17,7 @@ let package = Package(
         .library(name: "PaperStatic", type: .static, targets: ["Paper"]),
         .library(name: "PaperDynamic", type: .dynamic, targets: ["Paper"]),
     ],
-    targets: [
-        .target(
-            name: "DeckOfPlayingCards",
-            dependencies: [
-                .byName(name: "PlayingCard")
-            ]),
-        .testTarget(
-            name: "DeckOfPlayingCardsTests",
-            dependencies: [
-                .target(name: "DeckOfPlayingCards")
-            ]),
-    ],
+    // Random comment
     dependencies: [
 
         // without any contsraint
@@ -68,5 +56,30 @@ let package = Package(
         // path
         .package(path: "../.."),
         .package(name: "package-with-name", path: "../.."),
+    ],
+    targets: [
+        .target(
+            name: "DeckOfPlayingCards",
+            dependencies: [
+                .byName(name: "PlayingCard")
+            ]),
+        .testTarget(
+            name: "DeckOfPlayingCardsTests",
+            dependencies: [
+                .target(name: "DeckOfPlayingCards")
+            ]),
+    ],
+    swiftLanguageModes: [.v5, .v6],
+
+    /*
+     * Another comment
+     */
+
+    cLanguageStandard: .c11,
+    cxxLanguageStandard: .cxx17, // Specifies the C++17 standard
+    pkgConfig: "example-lib", // Searches for example-lib.pc
+    providers: [
+        .brew(["example-lib"]),
+        .apt(["libexample-dev"])
     ]
 )

--- a/test/Swift/testdata/Package.no-deps.swift
+++ b/test/Swift/testdata/Package.no-deps.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MyPackage",
+    platforms: [.iOS(.v15), .macOS(.v12)], // Minimum deployment targets
+    products: [
+        .library(name: "MyLibrary", targets: ["MyLibrary"]) // Publicly accessible modules
+    ],
+    targets: [
+        .target(name: "MyLibrary", dependencies: ["OtherPackage"]),
+        .testTarget(name: "MyLibraryTests", dependencies: ["MyLibrary"])
+    ]
+)

--- a/test/Swift/testdata/Package.no-deps.swift
+++ b/test/Swift/testdata/Package.no-deps.swift
@@ -1,4 +1,8 @@
 // swift-tools-version: 6.0
+
+// This Package.swift has no dependencies. This Package.swift ensures the parser doesn't get confused
+// by the dependencies listed within `targets`
+
 import PackageDescription
 
 let package = Package(

--- a/test/Swift/testdata/Package.swift
+++ b/test/Swift/testdata/Package.swift
@@ -14,6 +14,18 @@ let package = Package(
         .library(name: "PaperStatic", type: .static, targets: ["Paper"]),
         .library(name: "PaperDynamic", type: .dynamic, targets: ["Paper"]),
     ],
+    targets: [
+        .target(
+            name: "DeckOfPlayingCards",
+            dependencies: [
+                .byName(name: "PlayingCard")
+            ]),
+        .testTarget(
+            name: "DeckOfPlayingCardsTests",
+            dependencies: [
+                .target(name: "DeckOfPlayingCards")
+            ]),
+    ],
     dependencies: [
 
         // without any contsraint
@@ -52,17 +64,5 @@ let package = Package(
         // path
         .package(path: "../.."),
         .package(name: "package-with-name", path: "../.."),
-    ],
-    targets: [
-        .target(
-            name: "DeckOfPlayingCards",
-            dependencies: [
-                .byName(name: "PlayingCard")
-            ]),
-        .testTarget(
-            name: "DeckOfPlayingCardsTests",
-            dependencies: [
-                .target(name: "DeckOfPlayingCards")
-            ]),
     ]
 )


### PR DESCRIPTION
# Overview
Updates the parser for `Package.swift` files to handle a few more cases:
- Updates the parser to not get confused by `dependencies` arguments within `targets`. If these came before the dependencies section, we'd end up parsing these dependencies instead of the actual package dependencies, and fail because they use different syntax.
- Handle no `dependencies` argument. The previous parser didn't handle this section missing completely. Now it does, and works even when there are dependencies listed within `targets` (which we correctly ignore).

## Acceptance criteria
We correctly handle `Package.swift` files that fall into either of the two cases outlined in the Overview section.

## Testing plan
- New unit test added, and updated the existing test to trip the bug from the first bullet point in the overview.
- Run `cabal run fossa -- . --output` on a directory containing either of the `Package.swift` files in test/Swift/testdata/
- Confirmed the `Package.swift` files in ANE-2910 are analyzed successfully.

## References
[ANE-2908](https://fossa.atlassian.net/browse/ANE-2908)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2908]: https://fossa.atlassian.net/browse/ANE-2908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ