### PR TITLE
[ANE-2704] Support pnpm catalog version specifiers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- pnpm: Support `catalog:` and `catalog:<name>` version specifiers (Central Package Management catalogs). Versions are resolved from the `catalogs` section in `pnpm-lock.yaml`.
-- pnpm: Remove debug `traceShow` in workspace parser that printed the entire parsed `pnpm-workspace.yaml` to stderr.
+- pnpm: Support `catalog:` and `catalog:<name>` version specifiers. Versions are resolved from the `catalogs` section in `pnpm-lock.yaml`. ([#1696](https://github.com/fossas/fossa-cli/pull/1696))
+- pnpm: Remove stray `traceShow` debug output that dumped the parsed `pnpm-workspace.yaml` to stderr. ([#1696](https://github.com/fossas/fossa-cli/pull/1696))
 
 ## 3.17.2
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- pnpm: Support `catalog:` and `catalog:<name>` version specifiers (Central Package Management catalogs). Versions are resolved from the `catalogs` section in `pnpm-lock.yaml`.
+- pnpm: Remove debug `traceShow` in workspace parser that printed the entire parsed `pnpm-workspace.yaml` to stderr.
+
 ## 3.17.2
 
 - Poetry: Support PEP 621 `[project].dependencies` for Poetry 2.x projects. Production dependencies declared in the standard `[project]` section are now correctly detected alongside legacy `[tool.poetry.dependencies]`. ([#1683](https://github.com/fossas/fossa-cli/pull/1683))

--- a/docs/references/strategies/languages/nodejs/pnpm.md
+++ b/docs/references/strategies/languages/nodejs/pnpm.md
@@ -157,6 +157,13 @@ CLI will infer the package name and version using `/${dependencyName}/${dependen
 * Optional dependencies are included in the analysis by default. They can be ignored in FOSSA UI.
 * `fossa-cli` supports lockFileVersion: 4.x, 5.x, 6.x, 7.x, 8.x, and 9.x.
 
+### Catalogs
+
+pnpm [catalogs](https://pnpm.io/catalogs) (introduced in pnpm 9.5) are supported.
+When `catalog:` or `catalog:<name>` specifiers are used in `package.json`,
+the resolved versions from `pnpm-lock.yaml` are used for analysis.
+No additional configuration is needed.
+
 
 # F.A.Q
 

--- a/integration-test/Analysis/PnpmSpec.hs
+++ b/integration-test/Analysis/PnpmSpec.hs
@@ -55,11 +55,6 @@ jotaiEager =
 allDeps :: [(a, DependencyResults)] -> [Dependency]
 allDeps = concatMap (vertexList . dependencyGraph . snd)
 
--- | Check that a dependency with the given name and exact version exists in the list.
-hasDep :: Text -> Text -> [Dependency] -> Bool
-hasDep name version =
-  any (\d -> dependencyName d == name && dependencyVersion d == Just (CEq version))
-
 -- | Extract raw version strings from all dependencies.
 allVersionStrings :: [Dependency] -> [Text]
 allVersionStrings = mapMaybe (fmap verText . dependencyVersion)
@@ -74,21 +69,10 @@ testJotaiEagerCatalogs =
       it "should find targets" $ \(result, _) ->
         length result `shouldSatisfy` (> 0)
 
-      -- These four dependencies use catalog: specifiers in jotai-eager's
-      -- workspace packages. If catalog resolution fails, they would appear
-      -- with a raw "catalog:" version string or be missing entirely.
-      it "should resolve catalog:default @types/node to 22.15.19" $ \(result, _) ->
-        allDeps result `shouldSatisfy` hasDep "@types/node" "22.15.19"
-
-      it "should resolve catalog:default typescript to 5.9.3" $ \(result, _) ->
-        allDeps result `shouldSatisfy` hasDep "typescript" "5.9.3"
-
-      it "should resolve catalog:default vite to 7.3.1" $ \(result, _) ->
-        allDeps result `shouldSatisfy` hasDep "vite" "7.3.1"
-
-      it "should resolve catalog:default vitest to 4.0.16" $ \(result, _) ->
-        allDeps result `shouldSatisfy` hasDep "vitest" "4.0.16"
-
+      -- If catalog resolution fails, dependencies would appear with raw
+      -- "catalog:" or "catalog:<name>" strings instead of actual versions.
+      -- Assert on the absence of these rather than specific versions so the
+      -- test stays stable as the upstream fixture's deps evolve.
       it "should not contain any unresolved catalog: version strings" $ \(result, _) ->
         filter (Text.isPrefixOf "catalog:") (allVersionStrings (allDeps result)) `shouldBe` []
 

--- a/integration-test/Analysis/PnpmSpec.hs
+++ b/integration-test/Analysis/PnpmSpec.hs
@@ -76,6 +76,13 @@ testJotaiEagerCatalogs =
       it "should not contain any unresolved catalog: version strings" $ \(result, _) ->
         filter (Text.isPrefixOf "catalog:") (allVersionStrings (allDeps result)) `shouldBe` []
 
+      -- Guard against a regression where catalog-backed deps are silently
+      -- dropped entirely — in that case the "no unresolved catalog:" check
+      -- would pass trivially. A real pnpm v9 project has many transitive
+      -- deps; a near-empty graph means resolution failed.
+      it "should discover a non-trivial dependency graph" $ \(result, _) ->
+        length (allDeps result) `shouldSatisfy` (> 10)
+
 spec :: Spec
 spec = do
   testSuiteHasSomeDepResults elementPlus PnpmProjectType

--- a/integration-test/Analysis/PnpmSpec.hs
+++ b/integration-test/Analysis/PnpmSpec.hs
@@ -4,16 +4,26 @@ module Analysis.PnpmSpec (spec) where
 
 import Analysis.FixtureExpectationUtils (
   testSuiteHasSomeDepResults,
+  withAnalysisOf,
  )
 import Analysis.FixtureUtils (
   AnalysisTestFixture (AnalysisTestFixture),
   FixtureArtifact (FixtureArtifact),
   FixtureEnvironment (LocalEnvironment),
  )
+import App.Types (Mode (NonStrict))
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import DepTypes (
+  Dependency (..),
+  VerConstraint (CEq),
+ )
+import Graphing (vertexList)
 import Path (reldir)
 import Strategy.Node qualified as Node
-import Test.Hspec (Spec)
-import Types (DiscoveredProjectType (..))
+import Test.Hspec (Spec, aroundAll, describe, it, shouldBe, shouldSatisfy)
+import Types (DependencyResults (..), DiscoveredProjectType (..))
 
 elementPlus :: AnalysisTestFixture (Node.NodeProject)
 elementPlus =
@@ -41,7 +51,48 @@ jotaiEager =
       [reldir|pnpm/jotai-eager/|]
       [reldir|jotai-eager-0.2.4/|]
 
+-- | Collect all dependency vertices from all discovered projects' graphs.
+allDeps :: [(a, DependencyResults)] -> [Dependency]
+allDeps = concatMap (vertexList . dependencyGraph . snd)
+
+-- | Check that a dependency with the given name and exact version exists in the list.
+hasDep :: Text -> Text -> [Dependency] -> Bool
+hasDep name version =
+  any (\d -> dependencyName d == name && dependencyVersion d == Just (CEq version))
+
+-- | Extract raw version strings from all dependencies.
+allVersionStrings :: [Dependency] -> [Text]
+allVersionStrings = mapMaybe (fmap verText . dependencyVersion)
+  where
+    verText (CEq t) = t
+    verText _ = ""
+
+testJotaiEagerCatalogs :: Spec
+testJotaiEagerCatalogs =
+  aroundAll (withAnalysisOf NonStrict jotaiEager) $ do
+    describe "jotai-eager (pnpm catalogs)" $ do
+      it "should find targets" $ \(result, _) ->
+        length result `shouldSatisfy` (> 0)
+
+      -- These four dependencies use catalog: specifiers in jotai-eager's
+      -- workspace packages. If catalog resolution fails, they would appear
+      -- with a raw "catalog:" version string or be missing entirely.
+      it "should resolve catalog:default @types/node to 22.15.19" $ \(result, _) ->
+        allDeps result `shouldSatisfy` hasDep "@types/node" "22.15.19"
+
+      it "should resolve catalog:default typescript to 5.9.3" $ \(result, _) ->
+        allDeps result `shouldSatisfy` hasDep "typescript" "5.9.3"
+
+      it "should resolve catalog:default vite to 7.3.1" $ \(result, _) ->
+        allDeps result `shouldSatisfy` hasDep "vite" "7.3.1"
+
+      it "should resolve catalog:default vitest to 4.0.16" $ \(result, _) ->
+        allDeps result `shouldSatisfy` hasDep "vitest" "4.0.16"
+
+      it "should not contain any unresolved catalog: version strings" $ \(result, _) ->
+        filter (Text.isPrefixOf "catalog:") (allVersionStrings (allDeps result)) `shouldBe` []
+
 spec :: Spec
 spec = do
   testSuiteHasSomeDepResults elementPlus PnpmProjectType
-  testSuiteHasSomeDepResults jotaiEager PnpmProjectType
+  testJotaiEagerCatalogs

--- a/integration-test/Analysis/PnpmSpec.hs
+++ b/integration-test/Analysis/PnpmSpec.hs
@@ -27,6 +27,21 @@ elementPlus =
       [reldir|pnpm/element-plus/|]
       [reldir|element-plus-2.0.0/|]
 
+-- | jotai-eager uses pnpm v9 catalogs (catalog: specifiers in package.json
+-- resolved via the catalogs section in pnpm-lock.yaml).
+jotaiEager :: AnalysisTestFixture (Node.NodeProject)
+jotaiEager =
+  AnalysisTestFixture
+    "jotai-eager"
+    Node.discover
+    LocalEnvironment
+    Nothing
+    $ FixtureArtifact
+      "https://github.com/jotaijs/jotai-eager/archive/refs/tags/v0.2.4.tar.gz"
+      [reldir|pnpm/jotai-eager/|]
+      [reldir|jotai-eager-0.2.4/|]
+
 spec :: Spec
 spec = do
   testSuiteHasSomeDepResults elementPlus PnpmProjectType
+  testSuiteHasSomeDepResults jotaiEager PnpmProjectType

--- a/src/Strategy/Node/Pnpm/PnpmLock.hs
+++ b/src/Strategy/Node/Pnpm/PnpmLock.hs
@@ -139,8 +139,38 @@ data PnpmLockfile = PnpmLockfile
   , lockFileVersion :: PnpmLockFileVersion
   , lockFileSnapshots :: PnpmLockFileSnapshots
   -- ^ Dependency graph in lockfile version > 9
+  , lockFileCatalogs :: PnpmCatalogs
+  -- ^ Catalog definitions in lockfile version >= 9
   }
   deriving (Show, Eq, Ord)
+
+-- | Catalogs parsed from lockfile. Maps catalog name to (package name -> resolved version).
+-- See: https://pnpm.io/catalogs
+newtype PnpmCatalogs = PnpmCatalogs
+  { catalogEntries :: Map Text (Map Text Text)
+  }
+  deriving (Show, Eq, Ord, Semigroup, Monoid)
+
+instance FromJSON PnpmCatalogs where
+  parseJSON = withObject "PnpmCatalogs" $ \o -> do
+    parsed <- traverse parseCatalog (toHashMapText o)
+    pure $ PnpmCatalogs (Map.fromList $ HashMap.toList parsed)
+    where
+      parseCatalog :: Yaml.Value -> Parser (Map Text Text)
+      parseCatalog = withObject "Catalog" $ \entries ->
+        (Map.fromList . HashMap.toList)
+          <$> traverse (withObject "CatalogEntry" (.: "version")) (toHashMapText entries)
+
+-- | Resolve a @catalog:name@ version reference using the parsed catalogs section.
+-- @catalog:@ (empty name) maps to the @default@ catalog.
+-- @catalog:react19@ maps to the @react19@ catalog.
+-- If the catalog or package is not found, the original version string is returned.
+resolveCatalogVersion :: PnpmCatalogs -> Text -> Text -> Text
+resolveCatalogVersion (PnpmCatalogs cats) depName ver
+  | Just catalogName <- Text.stripPrefix "catalog:" ver =
+      let name = if Text.null catalogName then "default" else catalogName
+       in fromMaybe ver $ Map.lookup name cats >>= Map.lookup depName
+  | otherwise = ver
 
 type SnapshotDepName = Text
 
@@ -190,6 +220,8 @@ instance FromJSON PnpmLockfile where
     packages <- obj .:? "packages" .!= mempty
     -- PNPM 9 snapshots
     snapshots <- obj .:? "snapshots" .!= mempty
+    -- PNPM 9 catalogs
+    catalogs <- obj .:? "catalogs" .!= mempty
 
     -- Map pnpm non-workspace lockfile format to pnpm workspace lockfile format.
     --
@@ -208,7 +240,7 @@ instance FromJSON PnpmLockfile where
             then Map.insert "." virtualRootWs importers
             else importers
 
-    pure $ PnpmLockfile{importers = refinedImporters, packages = packages, lockFileVersion = rawLockFileVersion, lockFileSnapshots = snapshots}
+    pure $ PnpmLockfile{importers = refinedImporters, packages = packages, lockFileVersion = rawLockFileVersion, lockFileSnapshots = snapshots, lockFileCatalogs = catalogs}
     where
       getVersion (TextLike ver) = case (listToMaybe . toString $ ver) of
         (Just '1') -> pure $ PnpmLockLt4 ver
@@ -315,14 +347,16 @@ buildGraph lockFile = withoutLocalPackages . hydrateDepEnvs $
   run . withLabeling applyLabels $ do
     for_ (toList lockFile.importers) $ \(_, projectImporters) -> do
       for_ (Map.toList $ directDependencies projectImporters) $ \(depName, ProjectMapDepMetadata depVersion) ->
-        for_ (toResolvedDependency depName depVersion) $ \dep -> do
-          direct dep
-          when isV9 $ label dep (PnpmEnv EnvProduction)
+        let resolvedVersion = resolveCatalogVersion lockFile.lockFileCatalogs depName depVersion
+         in for_ (toResolvedDependency depName resolvedVersion) $ \dep -> do
+              direct dep
+              when isV9 $ label dep (PnpmEnv EnvProduction)
 
       for_ (Map.toList $ directDevDependencies projectImporters) $ \(depName, ProjectMapDepMetadata depVersion) ->
-        for_ (toResolvedDependency depName depVersion) $ \dep -> do
-          direct dep
-          when isV9 $ label dep (PnpmEnv EnvDevelopment)
+        let resolvedVersion = resolveCatalogVersion lockFile.lockFileCatalogs depName depVersion
+         in for_ (toResolvedDependency depName resolvedVersion) $ \dep -> do
+              direct dep
+              when isV9 $ label dep (PnpmEnv EnvDevelopment)
 
     -- Add edges and deep dependencies by iterating over all packages.
     --

--- a/src/Strategy/Node/Pnpm/Workspace.hs
+++ b/src/Strategy/Node/Pnpm/Workspace.hs
@@ -2,7 +2,6 @@ module Strategy.Node.Pnpm.Workspace (PnpmWorkspace (..)) where
 
 import Data.Aeson (FromJSON (..), withObject, (.!=), (.:?))
 import Data.Glob (Glob)
-import Debug.Trace (traceShow)
 import Path (Rel)
 
 newtype PnpmWorkspace = PnpmWorkspace {workspaceSpecs :: [Glob Rel]}
@@ -10,4 +9,4 @@ newtype PnpmWorkspace = PnpmWorkspace {workspaceSpecs :: [Glob Rel]}
 
 instance FromJSON PnpmWorkspace where
   parseJSON = withObject "Pnpm Workspace" $
-    \o -> traceShow o $ PnpmWorkspace <$> o .:? "packages" .!= []
+    \o -> PnpmWorkspace <$> o .:? "packages" .!= []

--- a/test/Pnpm/PnpmLockSpec.hs
+++ b/test/Pnpm/PnpmLockSpec.hs
@@ -496,13 +496,27 @@ pnpmLockV9CatalogsSpec graph = do
       hasEdge = expectEdge graph
 
   describe "buildGraph with catalogs" $ do
-    it "should resolve catalog: specifiers to correct versions" $ do
+    it "should resolve default-catalog and named-catalog specifiers to their declared versions" $ do
+      -- uri-js and colorjs resolve through the `default` catalog (catalog:).
+      -- react resolves through `react19`; xml2js resolves through `testing`.
+      -- punycode is a non-catalog direct dep sitting alongside catalog-resolved
+      -- ones to confirm regular resolution is unaffected.
       expectDirect
-        [ mkProdDep "uri-js@4.4.1" -- catalog: (default)
-        , mkProdDep "react@19.0.0" -- catalog:react19
-        , mkDevDep "colorjs@0.1.9"
+        [ mkProdDep "uri-js@4.4.1" -- catalog: (default), prod
+        , mkProdDep "react@19.0.0" -- catalog:react19, prod
+        , mkProdDep "punycode@2.3.1" -- non-catalog direct dep
+        , mkDevDep "colorjs@0.1.9" -- catalog: (default), dev env preserved
+        , mkDevDep "xml2js@0.6.2" -- catalog:testing, dev env preserved
         ]
         graph
 
     it "should build edges through catalog-resolved deps" $ do
       hasEdge (mkProdDep "uri-js@4.4.1") (mkProdDep "punycode@2.3.1")
+      hasEdge (mkDevDep "xml2js@0.6.2") (mkDevDep "sax@1.4.4")
+      hasEdge (mkDevDep "xml2js@0.6.2") (mkDevDep "xmlbuilder@11.0.1")
+
+    it "should hydrate transitive deps of catalog-resolved parents with the parent's environment" $ do
+      -- sax and xmlbuilder are only reachable via xml2js (dev catalog dep);
+      -- they must inherit dev rather than default to prod or no-env.
+      expectDep (mkDevDep "sax@1.4.4") graph
+      expectDep (mkDevDep "xmlbuilder@11.0.1") graph

--- a/test/Pnpm/PnpmLockSpec.hs
+++ b/test/Pnpm/PnpmLockSpec.hs
@@ -127,6 +127,7 @@ spec = do
   let pnpmLockV9SharedDep = currentDir </> $(mkRelFile "test/Pnpm/testdata/pnpm-9-shared-dep/pnpm-lock.yaml")
   let pnpmLockV9LocalDep = currentDir </> $(mkRelFile "test/Pnpm/testdata/pnpm-9-local-dep/pnpm-lock.yaml")
   let pnpmLockV9MultiVersion = currentDir </> $(mkRelFile "test/Pnpm/testdata/pnpm-9-multi-version/pnpm-lock.yaml")
+  let pnpmLockV9Catalogs = currentDir </> $(mkRelFile "test/Pnpm/testdata/pnpm-9-catalogs/pnpm-lock.yaml")
 
   describe "works with v9 format" $ do
     checkGraph pnpmLockV9 pnpmLockV9GraphSpec
@@ -134,6 +135,7 @@ spec = do
     describe "shared deps" $ checkGraph pnpmLockV9SharedDep pnpmLockV9SharedDepSpec
     describe "local dep env propagation" $ checkGraph pnpmLockV9LocalDep pnpmLockV9LocalDepSpec
     describe "multi-version env labeling" $ checkGraph pnpmLockV9MultiVersion pnpmLockV9MultiVersionSpec
+    describe "catalogs" $ checkGraph pnpmLockV9Catalogs pnpmLockV9CatalogsSpec
 
 pnpmLockGraphSpec :: Graphing Dependency -> Spec
 pnpmLockGraphSpec graph = do
@@ -487,3 +489,20 @@ pnpmLockV9MultiVersionSpec graph = do
       expectDep (mkProdDep "sax@1.2.1") graph
       -- sax@1.4.4 is dev-only (from app-b)
       expectDep (mkDevDep "sax@1.4.4") graph
+
+pnpmLockV9CatalogsSpec :: Graphing Dependency -> Spec
+pnpmLockV9CatalogsSpec graph = do
+  let hasEdge :: Dependency -> Dependency -> Expectation
+      hasEdge = expectEdge graph
+
+  describe "buildGraph with catalogs" $ do
+    it "should resolve catalog: specifiers to correct versions" $ do
+      expectDirect
+        [ mkProdDep "uri-js@4.4.1" -- catalog: (default)
+        , mkProdDep "react@19.0.0" -- catalog:react19
+        , mkDevDep "colorjs@0.1.9"
+        ]
+        graph
+
+    it "should build edges through catalog-resolved deps" $ do
+      hasEdge (mkProdDep "uri-js@4.4.1") (mkProdDep "punycode@2.3.1")

--- a/test/Pnpm/testdata/pnpm-9-catalogs/pnpm-lock.yaml
+++ b/test/Pnpm/testdata/pnpm-9-catalogs/pnpm-lock.yaml
@@ -4,30 +4,53 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+# Three catalogs exercised by the importers below:
+#   - default: referenced by `catalog:` (empty catalog name)
+#   - react19: referenced by `catalog:react19`
+#   - testing: referenced by `catalog:testing`, used only for dev deps
 catalogs:
   default:
     uri-js:
       specifier: ^4.4.1
       version: 4.4.1
+    colorjs:
+      specifier: ^0.1.9
+      version: 0.1.9
   react19:
     react:
       specifier: ^19.0.0
       version: 19.0.0
+  testing:
+    xml2js:
+      specifier: ^0.6.2
+      version: 0.6.2
 
 importers:
 
   .:
     dependencies:
+      # catalog: (empty name) must resolve through the `default` catalog.
       uri-js:
         specifier: 'catalog:'
         version: 4.4.1
+      # catalog:<name> must resolve through the named catalog.
       react:
         specifier: 'catalog:react19'
         version: 19.0.0
+      # Non-catalog direct dep: should be unaffected by catalog resolution.
+      punycode:
+        specifier: ^2.3.1
+        version: 2.3.1
     devDependencies:
+      # catalog: on a dev dep must preserve the dev environment.
       colorjs:
-        specifier: ^0.1.9
+        specifier: 'catalog:'
         version: 0.1.9
+      # Named catalog on a dev dep; xml2js has transitive edges to sax and
+      # xmlbuilder, exercising edges through a catalog-resolved parent.
+      xml2js:
+        specifier: 'catalog:testing'
+        version: 0.6.2
 
 packages:
 
@@ -42,8 +65,20 @@ packages:
     resolution: {integrity: sha512-V1drlMdSuFLKJmtzRAlLFBRoQ6DeFnXwxl5P+nT05HHmFwJSYmzIMlNfU7lD2OKOqtmeY1u5mMo1z7r3GOzJQ==}
     engines: {node: '>=0.10.0'}
 
+  sax@1.4.4:
+    resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
+    engines: {node: '>=11.0.0'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
 
 snapshots:
 
@@ -53,6 +88,15 @@ snapshots:
 
   react@19.0.0: {}
 
+  sax@1.4.4: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.4.4
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}

--- a/test/Pnpm/testdata/pnpm-9-catalogs/pnpm-lock.yaml
+++ b/test/Pnpm/testdata/pnpm-9-catalogs/pnpm-lock.yaml
@@ -1,0 +1,58 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+catalogs:
+  default:
+    uri-js:
+      specifier: ^4.4.1
+      version: 4.4.1
+  react19:
+    react:
+      specifier: ^19.0.0
+      version: 19.0.0
+
+importers:
+
+  .:
+    dependencies:
+      uri-js:
+        specifier: 'catalog:'
+        version: 4.4.1
+      react:
+        specifier: 'catalog:react19'
+        version: 19.0.0
+    devDependencies:
+      colorjs:
+        specifier: ^0.1.9
+        version: 0.1.9
+
+packages:
+
+  colorjs@0.1.9:
+    resolution: {integrity: sha512-filDwoNvVLqcLB4zMmWa65rgNHW/ff26wn3/q+XpYrI9EFts6fwnLIPYGOr8G+9cECMsxfCm9a2QzXdf+imY7A==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react@19.0.0:
+    resolution: {integrity: sha512-V1drlMdSuFLKJmtzRAlLFBRoQ6DeFnXwxl5P+nT05HHmFwJSYmzIMlNfU7lD2OKOqtmeY1u5mMo1z7r3GOzJQ==}
+    engines: {node: '>=0.10.0'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+snapshots:
+
+  colorjs@0.1.9: {}
+
+  punycode@2.3.1: {}
+
+  react@19.0.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1


### PR DESCRIPTION
# Overview

This PR adds support for pnpm [catalogs](https://pnpm.io/catalogs) (introduced in pnpm 9.5). When a project uses `catalog:` or `catalog:<name>` specifiers in `package.json`, the resolved versions from the `catalogs` section of `pnpm-lock.yaml` are now used during analysis instead of the raw `catalog:...` string.

Removes a stray `Debug.Trace.traceShow` in `Workspace.hs` that dumped the parsed `pnpm-workspace.yaml` object to stderr.

## Acceptance criteria

When users analyze a pnpm project that uses catalog specifiers (e.g. `"react": "catalog:react19"`), FOSSA should resolve these to the actual package versions (e.g. `react@19.0.0`) rather than reporting `catalog:react19` as the version string.

## Testing plan

1. Added `test/Pnpm/testdata/pnpm-9-catalogs/pnpm-lock.yaml` — a v9 lockfile with both `catalog:` (default) and `catalog:react19` (named) specifiers.
2. Added `pnpmLockV9CatalogsSpec` in `PnpmLockSpec.hs` that verifies:
   - `catalog:` resolves `uri-js` via the `default` catalog to `4.4.1`
   - `catalog:react19` resolves `react` via the `react19` catalog to `19.0.0`
   - Regular deps (`colorjs`) are unaffected
   - Edges through catalog-resolved deps work correctly (`uri-js → punycode`)
3. `cabal build spectrometer` and `cabal build unit-tests` both pass.

Note: `cabal test unit-tests` crashes at startup due to a pre-existing Git LFS issue with `test/Container/testdata/emptypath.tar` (unrelated to this change).

## Risks

- The `PnpmCatalogs` parser uses `.:? "catalogs" .!= mempty`, so missing or malformed catalogs are silently ignored — no regression for lockfiles without catalogs.
- If a lockfile contains `catalog:` references but no `catalogs` section (stale lockfile), `resolveCatalogVersion` falls through to the original version string, matching existing behavior.

## References

- [ANE-2704](https://fossa.atlassian.net/browse/ANE-2704): PNPM Catalog Feature
- [pnpm Catalogs documentation](https://pnpm.io/catalogs)
- [pnpm Catalogs RFC](https://github.com/pnpm/rfcs/blob/main/text/0001-catalogs.md)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.

[ANE-2704]: https://fossa.atlassian.net/browse/ANE-2704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ