### PR TITLE
[ANE-2458] Enable path dependency analysis by default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## 3.17.2
 
 - Path dependencies: License scanning of path dependencies is now enabled by default. The `--experimental-analyze-path-dependencies` flag is deprecated and has no effect; use `--disable-path-dependency-scans` to opt out.
+- Ruby: Gems declared in `Gemfile.lock` `PATH` sections are now reported as path dependencies (previously they were emitted as regular gem deps with the local path only in `locations`). This lets them flow through path-dependency license scanning and upload.
 - Poetry: Support PEP 621 `[project].dependencies` for Poetry 2.x projects. Production dependencies declared in the standard `[project]` section are now correctly detected alongside legacy `[tool.poetry.dependencies]`. ([#1683](https://github.com/fossas/fossa-cli/pull/1683))
 
 ## 3.17.1

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 3.17.2
 
+- Path dependencies: License scanning of path dependencies is now enabled by default. The `--experimental-analyze-path-dependencies` flag is deprecated and has no effect; use `--disable-path-dependency-scans` to opt out.
 - Poetry: Support PEP 621 `[project].dependencies` for Poetry 2.x projects. Production dependencies declared in the standard `[project]` section are now correctly detected alongside legacy `[tool.poetry.dependencies]`. ([#1683](https://github.com/fossas/fossa-cli/pull/1683))
 
 ## 3.17.1

--- a/docs/references/experimental/path-dependency.md
+++ b/docs/references/experimental/path-dependency.md
@@ -5,7 +5,7 @@
 Path dependency is a dependency, which is sourced from filesystem, as opposed to a package manager registry or URL. A path dependency may or may not have transitive dependencies. 
 Path dependency is also referred to as `local` or `vendor` dependency by some package managers.
 
-For example, in the following `go.mod` file, with `gomod` analysis and the `--experimental-analyze-path-dependencies` flag, `fossa-cli` would consider `../vendor/squirrel`, to be a path dependency. If path dependency analysis is disabled, `fossa-cli` would ignore this dependency completely and only show transitive dependencies originating from `../vendor/squirrel`. In such a case, license and copyright obligations originating from `../vendor/squirrel` will not be captured in FOSSA's findings, and subsequent software bill of materials generated.
+For example, in the following `go.mod` file, with `gomod` analysis, `fossa-cli` would consider `../vendor/squirrel`, to be a path dependency. If path dependency analysis is disabled (via the `--disable-path-dependency-scans` flag), `fossa-cli` would ignore this dependency completely and only show transitive dependencies originating from `../vendor/squirrel`. In such a case, license and copyright obligations originating from `../vendor/squirrel` will not be captured in FOSSA's findings, and subsequent software bill of materials generated.
 
 ```go
 // Example go.mod file
@@ -41,11 +41,13 @@ In the event that caching is causing problems, FOSSA can be made to rescan this 
 
 ### How do I enable path dependency in FOSSA analysis?
 
-Run `fossa analyze` with the `--experimental-analyze-path-dependencies` flag.
+Path dependency analysis is enabled by default. No flag is required.
+
+The legacy `--experimental-analyze-path-dependencies` flag is now a deprecated no-op and will be removed in a future release.
 
 ### How do I disable path dependency in FOSSA analysis?
 
-By default, path dependency analysis is disabled. Note that, in the future, `fossa-cli` will enable path dependency analysis by default.
+Run `fossa analyze` with the `--disable-path-dependency-scans` flag.
 
 ### Is `fossa-cli` uploading the content of my path dependency to the server?
 

--- a/docs/references/strategies/languages/golang/gomodules.md
+++ b/docs/references/strategies/languages/golang/gomodules.md
@@ -55,10 +55,9 @@ Currently, this strategy does not yet include path dependencies or their transit
 
 This strategy is the default Go analysis method. For historical context about this strategy's development, please see this [document](./v3-go-resolver-transition-qa.md).
 
-### Experimental: Path dependencies
+### Path dependencies
 
-`golist` strategy, supports experimental [path dependencies](./../../../experimental/path-dependency.md). It is not, 
-enabled by default, and has to be explicitly enabled by using `--experimental-analyze-path-dependencies` flag with `fossa analyze` command.
+`golist` strategy supports [path dependencies](./../../../experimental/path-dependency.md). Path dependency analysis is enabled by default. To opt out, use the `--disable-path-dependency-scans` flag with the `fossa analyze` command.
 
 In your project, you may have path dependencies, which are sourced from file system. For example, 
 consider `go.mod` file, which looks something like:
@@ -72,12 +71,12 @@ require github.com/Masterminds/squirrel v1.4.0
 replace github.com/Masterminds/squirrel => ../vendor/squirrel
 ```
 
-With this `go.mod` file and with [experimental path dependencies functionality](./../../../experimental/path-dependency.md) enabled, `fossa-cli` will
+With this `go.mod` file and with [path dependencies functionality](./../../../experimental/path-dependency.md) enabled, `fossa-cli` will
 correctly, include `../vendor/squirrel` in the dependency findings. It will identify transitive dependencies
 originating from package at `../vendor/squirrel`. It will also perform license scan in the directory to identify
 any license and copyright obligations. 
 
-Without [experimental path dependencies functionality](./../../../experimental/path-dependency.md) enabled, `fossa-cli` will not include `../vendor/squirrel` 
+Without [path dependencies functionality](./../../../experimental/path-dependency.md) enabled, `fossa-cli` will not include `../vendor/squirrel` 
 in the dependency graph. Further, it will not show [path](https://docs.fossa.com/docs/dependencies-browser#transitive-dependencies) in FOSSA UI 
 for any of it's transitive dependencies.
 

--- a/docs/references/strategies/languages/python/pdm.md
+++ b/docs/references/strategies/languages/python/pdm.md
@@ -81,7 +81,7 @@ whereas white signifies unknown environment. If a dependency shared parent who h
 
 ### Limitations
 
-- Any [local dependencies](https://pdm.fming.dev/latest/usage/dependency/#local-dependencies) will not be reported, by default. To enable, local dependencies in analysis, enable experimental path dependencies. Learn more about [path dependencies and how to enable them](./../../../experimental/path-dependency.md).
+- Any [local dependencies](https://pdm.fming.dev/latest/usage/dependency/#local-dependencies) are reported via path dependency analysis, which is enabled by default. Learn more about [path dependencies](./../../../experimental/path-dependency.md).
 - Any dependency using: `hg` (mercurial), `svn` (subversion), `bzr` (bazaar) source, will not be reported.
 
 ## Example

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -188,7 +188,7 @@ In addition to the [standard flags](#specifying-fossa-project-details), the anal
 | [`--experimental-enable-binary-discovery`](../experimental/binary-discovery/README.md)   | Enable reporting binary files as unlicensed dependencies. For more information, see the [binary discovery overview](../experimental/binary-discovery/README.md).                               |
 | `--experimental-force-first-party-scans`                                                 | Force [first party scans](../../features/first-party-license-scans.md) to run                                                                                                                  |
 | `--experimental-block-first-party-scans`                                                 | Force [first party scans](../../features/first-party-license-scans.md) to not run. This can be used to forcibly turn off first-party scans if your organization defaults to first-party scans. |
-| `--experimental-analyze-path-dependencies`                                               | License scan path dependencies, and include them in the final analysis. For more information, see the [path dependency overview](../experimental/path-dependency.md).                          |
+| `--disable-path-dependency-scans`                                                        | Disable license scanning of path dependencies. Path dependency analysis is enabled by default. For more information, see the [path dependency overview](../experimental/path-dependency.md). |
 
 
 ### F.A.Q.

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -76,7 +76,7 @@ import App.Fossa.ManualDeps (
   ManualDepsResult (..),
   analyzeFossaDepsFile,
  )
-import App.Fossa.PathDependency (enrichPathDependencies, enrichPathDependencies', withPathDependencyNudge)
+import App.Fossa.PathDependency (enrichPathDependencies, enrichPathDependencies')
 import App.Fossa.PreflightChecks (PreflightCommandChecks (AnalyzeChecks), preflightChecks)
 import App.Fossa.Reachability.Upload (analyzeForReachability, onlyFoundUnits)
 import App.Fossa.Subcommand (SubCommand)
@@ -481,7 +481,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
         $ runStickyLogger SevInfo
         $ traverse (enrichPathDependencies includeAll vendoredDepsOptions revision) filteredProjects
     (True, _) -> pure $ map enrichPathDependencies' filteredProjects
-    (False, _) -> traverse (withPathDependencyNudge includeAll) filteredProjects
+    (False, _) -> pure filteredProjects
   logDebug $ "Filtered projects with path dependencies: " <> pretty (show filteredProjects')
 
   reachabilityUnitsResult <-

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -139,6 +139,8 @@ import Types (ArchiveUploadType (..), DiscoveredProjectType, LicenseScanPathFilt
 -- CLI flags, for use with 'Data.Flag'
 data DeprecatedAllowNativeLicenseScan = DeprecatedAllowNativeLicenseScan deriving (Generic)
 data DeprecatedUseV3GoResolver = DeprecatedUseV3GoResolver deriving (Generic)
+data DeprecatedExperimentalAnalyzePathDependencies = DeprecatedExperimentalAnalyzePathDependencies deriving (Generic)
+data DisablePathDependencyScans = DisablePathDependencyScans deriving (Generic)
 data ForceVendoredDependencyRescans = ForceVendoredDependencyRescans deriving (Generic)
 data ForceFirstPartyScans = ForceFirstPartyScans deriving (Generic)
 data ForceNoFirstPartyScans = ForceNoFirstPartyScans deriving (Generic)
@@ -242,7 +244,8 @@ data AnalyzeCliOpts = AnalyzeCliOpts
   , analyzeSkipVSIGraphResolution :: [VSI.Locator]
   , analyzeBaseDir :: FilePath
   , analyzeDeprecatedUseV3GoResolver :: Flag DeprecatedUseV3GoResolver
-  , analyzePathDependencies :: Bool
+  , analyzeDeprecatedExperimentalAnalyzePathDependencies :: Flag DeprecatedExperimentalAnalyzePathDependencies
+  , analyzeDisablePathDependencyScans :: Flag DisablePathDependencyScans
   , analyzeForceFirstPartyScans :: Flag ForceFirstPartyScans
   , analyzeForceNoFirstPartyScans :: Flag ForceNoFirstPartyScans
   , analyzeIgnoreOrgWideCustomLicenseScanConfigs :: Flag IgnoreOrgWideCustomLicenseScanConfigs
@@ -364,6 +367,7 @@ cliParser =
     <*> baseDirArg
     <*> experimentalUseV3GoResolver
     <*> experimentalAnalyzePathDependencies
+    <*> disablePathDependencyScans
     <*> flagOpt ForceFirstPartyScans (applyFossaStyle <> long "experimental-force-first-party-scans" <> stringToHelpDoc "Force first party scans")
     <*> flagOpt ForceNoFirstPartyScans (applyFossaStyle <> long "experimental-block-first-party-scans" <> stringToHelpDoc "Block first party scans. This can be used to forcibly turn off first-party scans if your organization defaults to first-party scans.")
     <*> flagOpt IgnoreOrgWideCustomLicenseScanConfigs (applyFossaStyle <> long "ignore-org-wide-custom-license-scan-configs" <> stringToHelpDoc "Ignore custom-license scan configurations for your organization. These configurations are defined in the `Integrations` section of the Admin settings in the FOSSA web app")
@@ -405,12 +409,16 @@ withoutDefaultFilterParser docsUrl = flagOpt WithoutDefaultFilters (applyFossaSt
 experimentalUseV3GoResolver :: Parser (Flag DeprecatedUseV3GoResolver)
 experimentalUseV3GoResolver = flagOpt DeprecatedUseV3GoResolver (applyFossaStyle <> long "experimental-use-v3-go-resolver" <> hidden)
 
-experimentalAnalyzePathDependencies :: Parser Bool
+experimentalAnalyzePathDependencies :: Parser (Flag DeprecatedExperimentalAnalyzePathDependencies)
 experimentalAnalyzePathDependencies =
-  switch $
-    long "experimental-analyze-path-dependencies"
-      <> applyFossaStyle
-      <> stringToHelpDoc "License scan dependencies sourced from file system, as indicated in manifest files. This will be enabled by default in the future."
+  flagOpt DeprecatedExperimentalAnalyzePathDependencies (applyFossaStyle <> long "experimental-analyze-path-dependencies" <> hidden)
+
+disablePathDependencyScans :: Parser (Flag DisablePathDependencyScans)
+disablePathDependencyScans =
+  flagOpt DisablePathDependencyScans $
+    applyFossaStyle
+      <> long "disable-path-dependency-scans"
+      <> stringToHelpDoc "Disable license scanning of path dependencies. Path dependency analysis is enabled by default."
 
 vendoredDependencyModeOpt :: Parser ArchiveUploadType
 vendoredDependencyModeOpt = option (eitherReader parseType) (applyFossaStyle <> long "force-vendored-dependency-scan-method" <> metavar "METHOD" <> helpDoc vendoredDependencyScanMethodHelp)
@@ -506,6 +514,19 @@ mergeOpts maybeDebugDir cfg env cliOpts = do
         , "The --experimental-use-v3-go-resolver flag is deprecated and no longer has any effect."
         , ""
         , "The v3 Go resolver (package-based analysis) is now the default behavior."
+        , ""
+        , "Please remove this flag from your commands."
+        ]
+
+  let experimentalAnalyzePathDependenciesFlagUsed = fromFlag DeprecatedExperimentalAnalyzePathDependencies $ analyzeDeprecatedExperimentalAnalyzePathDependencies cliOpts
+  when experimentalAnalyzePathDependenciesFlagUsed $ do
+    logWarn $
+      vsep
+        [ "DEPRECATION NOTICE"
+        , "========================"
+        , "The --experimental-analyze-path-dependencies flag is deprecated and no longer has any effect."
+        , ""
+        , "Path dependency analysis is now enabled by default. Use --disable-path-dependency-scans to opt out."
         , ""
         , "Please remove this flag from your commands."
         ]
@@ -684,13 +705,13 @@ collectCLIFilters AnalyzeCliOpts{..} =
     (comboExclude analyzeExcludeTargets analyzeExcludePaths)
 
 collectStrategyConfig :: Maybe ConfigFile -> AnalyzeCliOpts -> StrategyConfig
-collectStrategyConfig maybeCfg AnalyzeCliOpts{analyzePathDependencies = shouldAnalyzePathDependencies} =
+collectStrategyConfig maybeCfg AnalyzeCliOpts{analyzeDisablePathDependencyScans} =
   StrategyConfig
     ( fmap
         gradleConfigsOnly
         (maybeCfg >>= configExperimental >>= gradle)
     )
-    shouldAnalyzePathDependencies
+    (not $ fromFlag DisablePathDependencyScans analyzeDisablePathDependencyScans)
     (UseGitBackedCargoLocators True)
 
 collectVendoredDeps ::

--- a/src/App/Fossa/PathDependency.hs
+++ b/src/App/Fossa/PathDependency.hs
@@ -1,15 +1,13 @@
 module App.Fossa.PathDependency (
   enrichPathDependencies,
   enrichPathDependencies',
-  withPathDependencyNudge,
 
   -- * for testing only,
   hashOf,
   absPathOf,
 ) where
 
-import App.Docs (pathDependencyDocsUrl)
-import App.Fossa.Analyze.Project (ProjectResult (projectResultGraph, projectResultPath, projectResultType))
+import App.Fossa.Analyze.Project (ProjectResult (projectResultGraph, projectResultPath))
 import App.Fossa.Config.Analyze (IncludeAll (..), VendoredDependencyOptions, forceRescans)
 import App.Fossa.LicenseScanner (scanDirectory)
 import App.Fossa.VendoredDependency (hashBs, hashFile)
@@ -37,7 +35,7 @@ import Control.Effect.FossaApiClient (
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Path ()
 import Control.Effect.StickyLogger (StickyLogger)
-import Control.Monad (unless, when)
+import Control.Monad (unless)
 import Data.Flag (Flag, fromFlag)
 import Data.List (find, partition)
 import Data.List.NonEmpty qualified as NE
@@ -46,7 +44,6 @@ import Data.String.Conversion (toText)
 import Data.Text (Text)
 import DepTypes (DepType (..), Dependency (..), VerConstraint (CEq))
 import Effect.Exec (Exec)
-import Effect.Logger (Logger, logInfo, pretty, redText)
 import Effect.ReadFS (
   Has,
   ReadFS,
@@ -97,24 +94,6 @@ enrichPathDependencies' pr = do
   let graph = projectResultGraph pr
   let graph' = gmap (\d -> if dependencyType d == UnresolvedPathType then d{dependencyType = PathType} else d) graph
   pr{projectResultGraph = graph'}
-
-withPathDependencyNudge :: Has Logger sig m => Flag IncludeAll -> ProjectResult -> m ProjectResult
-withPathDependencyNudge includeAll pr = do
-  let includeAll' = (fromFlag IncludeAll includeAll)
-  let maybePathDeps = NE.nonEmpty $ filter (isValidPathDep includeAll') $ vertexList $ projectResultGraph pr
-
-  -- Only nudge users, if they have any path dependencies!
-  when (isJust maybePathDeps) $ do
-    logInfo $
-      redText "NOTE: "
-        <> "path dependency detected in project: "
-        <> pretty projectLabel
-        <> "! To enable path dependency analysis, use: --experimental-analyze-path-dependencies flag."
-        <> pretty (" See " <> pathDependencyDocsUrl <> " for more information.")
-  pure pr
-  where
-    projectLabel :: Text
-    projectLabel = toText (projectResultType pr) <> " at: " <> toText (projectResultPath pr)
 
 -- | Scan and Uploads path dependency from a graph
 resolvePaths ::

--- a/src/Strategy/Ruby/GemfileLock.hs
+++ b/src/Strategy/Ruby/GemfileLock.hs
@@ -72,6 +72,8 @@ data GemfileLabel
   = GemfileVersion Text
   | -- | repo url, revision
     GitRemote Text (Maybe Text)
+  | -- | local filesystem path to a gem source (from a Gemfile.lock PATH section)
+    PathRemote Text
   | -- | url
     OtherRemote Text
   deriving (Eq, Ord, Show)
@@ -94,6 +96,8 @@ toDependency pkg = foldr applyLabel start
     applyLabel (GemfileVersion ver) dep = dep{dependencyVersion = dependencyVersion dep <|> (Just . CEq) ver}
     applyLabel (GitRemote repo maybeRevision) dep =
       dep{dependencyType = GitType, dependencyName = repo, dependencyVersion = (Just . CEq) =<< maybeRevision, dependencyLocations = maybe repo (\revision -> repo <> "@" <> revision) maybeRevision : dependencyLocations dep}
+    applyLabel (PathRemote path) dep =
+      dep{dependencyType = UnresolvedPathType, dependencyName = path}
     applyLabel (OtherRemote loc) dep =
       dep{dependencyLocations = loc : dependencyLocations dep}
 
@@ -107,7 +111,7 @@ buildGraph sections =
     addSection (GitSection remote revision branch specs) =
       traverse_ (addSpec (GitRemote remote (revision <|> branch))) specs
     addSection (PathSection remote specs) =
-      traverse_ (addSpec (OtherRemote remote)) specs
+      traverse_ (addSpec (PathRemote remote)) specs
     addSection (GemSection remote specs) =
       traverse_ (addSpec (OtherRemote remote)) specs
     addSection UnknownSection{} = pure ()

--- a/test/Ruby/GemfileLockSpec.hs
+++ b/test/Ruby/GemfileLockSpec.hs
@@ -43,6 +43,17 @@ dependencyThree =
     , dependencyTags = Map.empty
     }
 
+dependencyPath :: Dependency
+dependencyPath =
+  Dependency
+    { dependencyType = UnresolvedPathType
+    , dependencyName = "../local-gem"
+    , dependencyVersion = Just (CEq "0.1.0")
+    , dependencyLocations = []
+    , dependencyEnvironments = mempty
+    , dependencyTags = Map.empty
+    }
+
 gitSection :: Section
 gitSection =
   GitSection
@@ -82,6 +93,17 @@ dependencySection =
     , DirectDep{directName = "dep-two"}
     ]
 
+pathSection :: Section
+pathSection =
+  PathSection
+    "../local-gem"
+    [ Spec
+        { specVersion = "0.1.0"
+        , specName = "local-gem"
+        , specDeps = []
+        }
+    ]
+
 gemfileLockSection :: [Section]
 gemfileLockSection = [gitSection, gemSection, dependencySection]
 
@@ -89,7 +111,7 @@ spec :: T.Spec
 spec = do
   gemfileLock <- T.runIO (TIO.readFile "test/Ruby/testdata/gemfileLock")
 
-  T.describe "gemfile lock analyzer" $
+  T.describe "gemfile lock analyzer" $ do
     T.it "produces the expected output" $ do
       let graph = buildGraph gemfileLockSection
 
@@ -101,6 +123,11 @@ spec = do
         , (dependencyTwo, dependencyThree)
         ]
         graph
+
+    T.it "emits PATH section gems as UnresolvedPathType with the local path as the name" $ do
+      let graph = buildGraph [pathSection, DependencySection [DirectDep{directName = "local-gem"}]]
+      expectDeps [dependencyPath] graph
+      expectDirect [dependencyPath] graph
 
   T.describe "gemfile lock parser" $ do
     T.it "parses error messages into an empty list" $ do

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -640,7 +640,7 @@ fixtureStrategyConfig :: StrategyConfig
 fixtureStrategyConfig =
   StrategyConfig
     { allowedGradleConfigs = Nothing
-    , resolvePathDependencies = False
+    , resolvePathDependencies = True
     , useGitBackedCargoLocators = ANZ.UseGitBackedCargoLocators True
     }
 


### PR DESCRIPTION
# Overview

Flips the default for path dependency license scanning from off to on. The legacy `--experimental-analyze-path-dependencies` flag is kept as a hidden no-op that emits a deprecation warning. A new `--disable-path-dependency-scans` flag is introduced for opt-out.

## Acceptance criteria

- Running `fossa analyze` on a project containing path dependencies in a supported ecosystem (Go `replace` directives, PDM `path = ...`, Cargo `path = ...`) now triggers a CLI license scan and upload without any extra flag.
- Running `fossa analyze --disable-path-dependency-scans` restores the previous default behavior (skip license scanning of path deps).
- Running `fossa analyze --experimental-analyze-path-dependencies` prints a deprecation notice but does not change behavior (path deps are scanned either way).
- The previous "NOTE: path dependency detected..." nudge is no longer emitted, since the feature is on by default.

## Testing plan

1. Build with `cabal build spectrometer` — succeeds.
2. Build the test suite with `cabal build unit-tests` — succeeds.
3. Manually inspect `fossa analyze --help` to confirm `--disable-path-dependency-scans` is listed and `--experimental-analyze-path-dependencies` is hidden.
4. Run `fossa analyze` on a Go project with a `replace` directive pointing at a local path and confirm the path dep is license-scanned without passing any flag.
5. Run `fossa analyze --disable-path-dependency-scans` on the same project and confirm no path dep scan occurs.
6. Run `fossa analyze --experimental-analyze-path-dependencies` on the same project and confirm a deprecation warning is printed.

## Risks

- This is a user-visible default change. Organizations whose FOSSA endpoint has `orgSupportsPathDependencyScans` enabled will start uploading path dependency license data without explicitly opting in. The code path already gates on `orgSupportsPathDependencyScans`, so orgs without the feature are unaffected.
- Users who relied on the "nudge" log line to discover the feature will no longer see it. Docs have been updated to reflect the new default.

## Metrics

- N/A — this is a default-flip for an existing feature. Observed usage of `--disable-path-dependency-scans` post-release would indicate friction; if we see widespread opt-out, we should revisit.

## References

- [ANE-2458](https://fossa.atlassian.net/browse/ANE-2458): Enable path dependency support by default.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
  - Existing `App.Fossa.PathDependencySpec` continues to cover the core enrichment logic. The CLI-flag flip is exercised indirectly via `fixtureStrategyConfig.resolvePathDependencies = True`, which now matches the new default.
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
  - No new docs pages added; existing pages updated in place.
- [x] If this change is externally visible, I updated `Changelog.md`.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json`...
  - Not applicable; no config file schema changes.
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.

[ANE-2458]: https://fossa.atlassian.net/browse/ANE-2458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ