### PR TITLE
[ANE-2911] Swift Version syntax

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - pnpm: Support `catalog:` and `catalog:<name>` version specifiers. Versions are resolved from the `catalogs` section in `pnpm-lock.yaml`. ([#1696](https://github.com/fossas/fossa-cli/pull/1696))
 - pnpm: Remove stray `traceShow` debug output that dumped the parsed `pnpm-workspace.yaml` to stderr. ([#1696](https://github.com/fossas/fossa-cli/pull/1696))
+- Swift: Add support for versions specified using the `Version()` syntax
 
 ## 3.17.2
 

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -124,7 +124,8 @@ parseVersionConstructor = (symbol "Version") >> assembleParts <$> parseParts
         Nothing -> (Just . Component) . toText <$> some digitChar
         Just ("prereleaseIdentifiers") -> (Just . PrereleaseIdentifiers) <$> parseStringArray
         Just ("buildMetadataIdentifiers") -> (Just . BuildMetadataIdentifiers) <$> parseStringArray
-        _ -> pure Nothing
+        -- Unknown key -- Not reachable in practice, but consume the value of any unknown keys so the parser continues
+        _ -> Nothing <$ (void parseStringArray <|> void parseQuotedText <|> void (some digitChar))
 
     parseStringArray :: Parser [Text]
     parseStringArray = betweenSquareBrackets (sepEndBy parseQuotedText (symbol ","))
@@ -218,9 +219,9 @@ parsePackageDep = try parsePathDep <|> parseGitDep
 
     parseRange :: Text -> Parser (Text, Text)
     parseRange rangeOperator = do
-      lhs <- parseQuotedText
+      lhs <- parseVersion
       _ <- symbol rangeOperator
-      rhs <- parseQuotedText
+      rhs <- parseVersion
       pure (lhs, rhs)
 
     optionallyTry :: Parser a -> Parser (Maybe a)

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -112,9 +112,7 @@ instance ToText SwiftVersion where
 data SwiftVersionPart = Component Text | PrereleaseIdentifiers [Text] | BuildMetadataIdentifiers [Text]
 
 parseVersionConstructor :: Parser SwiftVersion
-parseVersionConstructor = do
-  _ <- symbol "Version"
-  assembleParts <$> parseParts
+parseVersionConstructor = (symbol "Version") >> assembleParts <$> parseParts
   where
     parseParts :: Parser [SwiftVersionPart]
     parseParts = betweenBrackets $ catMaybes <$> sepEndBy1 parseVersionArgument (symbol ",")

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module Strategy.Swift.PackageSwift (
   analyzePackageSwift,
   SwiftPackageGitDep (..),
@@ -17,9 +19,11 @@ import Control.Effect.Diagnostics (Diagnostics, context, errCtx, errDoc, errHelp
 import Control.Monad (void)
 import Data.Foldable (asum)
 import Data.Functor (($>))
+import Data.List (foldl')
 import Data.Map.Strict qualified as Map
+import Data.Maybe (catMaybes)
 import Data.Set (Set, fromList, member)
-import Data.String.Conversion (toText)
+import Data.String.Conversion (ToText, toText)
 import Data.Text (Text, intercalate)
 import Data.Void (Void)
 import DepTypes (DepType (GitType, SwiftType), Dependency (..), VerConstraint (CEq))
@@ -90,6 +94,52 @@ isEndLine :: Char -> Bool
 isEndLine '\n' = True
 isEndLine '\r' = True
 isEndLine _ = False
+
+-- | Represents https://developer.apple.com/documentation/packagedescription/version
+data SwiftVersion = SwiftVersion
+  { parts :: [Text]
+  , prereleaseIdentifiers :: [Text]
+  , buildMetadataIdentifiers :: [Text]
+  }
+
+instance ToText SwiftVersion where
+  toText SwiftVersion{..} = version <> prerelease <> build
+    where
+      version = (intercalate "." parts)
+      prerelease = if not $ null prereleaseIdentifiers then "-" <> (intercalate "." prereleaseIdentifiers) else ""
+      build = if not $ null buildMetadataIdentifiers then "+" <> (intercalate "." buildMetadataIdentifiers) else ""
+
+data SwiftVersionPart = Component Text | PrereleaseIdentifiers [Text] | BuildMetadataIdentifiers [Text]
+
+parseVersionConstructor :: Parser SwiftVersion
+parseVersionConstructor = do
+  _ <- symbol "Version"
+  assembleParts <$> parseParts
+  where
+    parseParts :: Parser [SwiftVersionPart]
+    parseParts = betweenBrackets $ catMaybes <$> sepEndBy1 parseVersionArgument (symbol ",")
+
+    parseVersionArgument :: Parser (Maybe SwiftVersionPart)
+    parseVersionArgument = do
+      key <- (optional . try) (lexeme $ takeWhile1P (Just "package key") (`notElem` (":," :: String)) <* symbol ":")
+      case key of
+        Nothing -> (Just . Component) . toText <$> some digitChar
+        Just ("prereleaseIdentifiers") -> (Just . PrereleaseIdentifiers) <$> parseStringArray
+        Just ("buildMetadataIdentifiers") -> (Just . BuildMetadataIdentifiers) <$> parseStringArray
+        _ -> pure Nothing
+
+    parseStringArray :: Parser [Text]
+    parseStringArray = betweenSquareBrackets (sepEndBy parseQuotedText (symbol ","))
+
+    assembleParts :: [SwiftVersionPart] -> SwiftVersion
+    assembleParts =
+      foldl'
+        ( \version part -> case part of
+            Component p -> version{parts = (parts version) ++ [p]}
+            PrereleaseIdentifiers p -> version{prereleaseIdentifiers = p}
+            BuildMetadataIdentifiers p -> version{buildMetadataIdentifiers = p}
+        )
+        (SwiftVersion{parts = [], prereleaseIdentifiers = [], buildMetadataIdentifiers = []})
 
 -- | Represents https://github.com/apple/swift-package-manager/blob/main/Documentation/PackageDescription.md#methods.
 data SwiftPackage = SwiftPackage
@@ -163,12 +213,7 @@ parsePackageDep = try parsePathDep <|> parseGitDep
         <|> parseKeyValue t parseVersion
 
     parseVersion :: Parser Text
-    parseVersion = try parseQuotedText <|> parseVersionConstructor
-
-    parseVersionConstructor :: Parser Text
-    parseVersionConstructor = do
-      _ <- symbol "Version"
-      betweenBrackets $ (intercalate ".") <$> sepEndBy1 (toText <$> some digitChar) (symbol ",")
+    parseVersion = try parseQuotedText <|> (toText <$> parseVersionConstructor)
 
     parseUpToOperator :: Text -> Parser Text
     parseUpToOperator t = symbol ("." <> t) *> betweenBrackets (parseRequirement "from")

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -19,7 +19,8 @@ import Data.Foldable (asum)
 import Data.Functor (($>))
 import Data.Map.Strict qualified as Map
 import Data.Set (Set, fromList, member)
-import Data.Text (Text)
+import Data.String.Conversion (toText)
+import Data.Text (Text, intercalate)
 import Data.Void (Void)
 import DepTypes (DepType (GitType, SwiftType), Dependency (..), VerConstraint (CEq))
 import Diag.Common (MissingDeepDeps (MissingDeepDeps))
@@ -37,9 +38,11 @@ import Text.Megaparsec (
   many,
   noneOf,
   sepEndBy,
+  sepEndBy1,
   skipManyTill,
+  some,
  )
-import Text.Megaparsec.Char (space1)
+import Text.Megaparsec.Char (digitChar, space1)
 import Text.Megaparsec.Char.Lexer qualified as Lexer
 
 -- | Parsing
@@ -156,8 +159,16 @@ parsePackageDep = try parsePathDep <|> parseGitDep
 
     parseRequirement :: Text -> Parser Text
     parseRequirement t =
-      try (symbol ("." <> t) *> betweenBrackets parseQuotedText)
-        <|> parseKeyValue t parseQuotedText
+      try (symbol ("." <> t) *> betweenBrackets parseVersion)
+        <|> parseKeyValue t parseVersion
+
+    parseVersion :: Parser Text
+    parseVersion = try parseQuotedText <|> parseVersionConstructor
+
+    parseVersionConstructor :: Parser Text
+    parseVersionConstructor = do
+      _ <- symbol "Version"
+      betweenBrackets $ (intercalate ".") <$> sepEndBy1 (toText <$> some digitChar) (symbol ",")
 
     parseUpToOperator :: Text -> Parser Text
     parseUpToOperator t = symbol ("." <> t) *> betweenBrackets (parseRequirement "from")

--- a/test/Swift/PackageSwiftSpec.hs
+++ b/test/Swift/PackageSwiftSpec.hs
@@ -76,6 +76,7 @@ expectedSwiftPackage =
       , gitDepUpToNextMinor "https://github.com/example/example2.git" "13.99.123+abcd"
       , gitDepExactly "https://github.com/example/example3.git" "0.0.3-build.1"
       , gitDepExactly "https://github.com/example/example4.git" "1.0.14"
+      , gitDepWithRhsHalfOpenInterval "https://github.com/example/example5.git" "1.0.14" "1.0.20"
       ]
       ++ [PathSource "../..", PathSource "../.."]
 

--- a/test/Swift/PackageSwiftSpec.hs
+++ b/test/Swift/PackageSwiftSpec.hs
@@ -71,6 +71,10 @@ expectedSwiftPackage =
       , -- range
         gitDepWithRhsHalfOpenInterval "https://github.com/LeoNatan/LNPopupController.git" "2.5.0" "2.5.6"
       , gitDepWithClosedRange "https://github.com/Polidea/RxBluetoothKit.git" "3.0.5" "3.0.7"
+      , -- version constructor
+        gitDepFrom "https://github.com/example/example.git" "1.7.0-a.b+x.banana"
+      , gitDepUpToNextMinor "https://github.com/example/example2.git" "13.99.123+abcd"
+      , gitDepExactly "https://github.com/example/example3.git" "0.0.3-build.1"
       ]
       ++ [PathSource "../..", PathSource "../.."]
 

--- a/test/Swift/PackageSwiftSpec.hs
+++ b/test/Swift/PackageSwiftSpec.hs
@@ -75,6 +75,7 @@ expectedSwiftPackage =
         gitDepFrom "https://github.com/example/example.git" "1.7.0-a.b+x.banana"
       , gitDepUpToNextMinor "https://github.com/example/example2.git" "13.99.123+abcd"
       , gitDepExactly "https://github.com/example/example3.git" "0.0.3-build.1"
+      , gitDepExactly "https://github.com/example/example4.git" "1.0.14"
       ]
       ++ [PathSource "../..", PathSource "../.."]
 

--- a/test/Swift/testdata/Package.full.swift
+++ b/test/Swift/testdata/Package.full.swift
@@ -57,6 +57,7 @@ let package = Package(
         .package(url: "https://github.com/example/example.git", .from(Version(1, 7, 0, prereleaseIdentifiers: ["a", "b"], buildMetadataIdentifiers: ["x", "banana"]))),
         .package(url: "https://github.com/example/example2.git", .upToNextMinor(from: Version(13, 99, 123, buildMetadataIdentifiers: ["abcd"]))),
         .package(url: "https://github.com/example/example3.git", .exact(Version(0, 0, 3, prereleaseIdentifiers: ["build", "1"]))),
+        .package(url: "https://github.com/example/example4.git", .exact(Version(1, 0, 14))),
 
         // path
         .package(path: "../.."),

--- a/test/Swift/testdata/Package.full.swift
+++ b/test/Swift/testdata/Package.full.swift
@@ -58,6 +58,7 @@ let package = Package(
         .package(url: "https://github.com/example/example2.git", .upToNextMinor(from: Version(13, 99, 123, buildMetadataIdentifiers: ["abcd"]))),
         .package(url: "https://github.com/example/example3.git", .exact(Version(0, 0, 3, prereleaseIdentifiers: ["build", "1"]))),
         .package(url: "https://github.com/example/example4.git", .exact(Version(1, 0, 14))),
+        .package(url: "https://github.com/example/example5.git", Version(1, 0, 14)..<Version(1, 0, 20)),
 
         // path
         .package(path: "../.."),

--- a/test/Swift/testdata/Package.full.swift
+++ b/test/Swift/testdata/Package.full.swift
@@ -53,6 +53,11 @@ let package = Package(
         .package(url: "https://github.com/LeoNatan/LNPopupController.git", "2.5.0"..<"2.5.6"),
         .package(url: "https://github.com/Polidea/RxBluetoothKit.git", "3.0.5"..."3.0.7"),
 
+        // version constructor
+        .package(url: "https://github.com/example/example.git", .from(Version(1, 7, 0, prereleaseIdentifiers: ["a", "b"], buildMetadataIdentifiers: ["x", "banana"]))),
+        .package(url: "https://github.com/example/example2.git", .upToNextMinor(from: Version(13, 99, 123, buildMetadataIdentifiers: ["abcd"]))),
+        .package(url: "https://github.com/example/example3.git", .exact(Version(0, 0, 3, prereleaseIdentifiers: ["build", "1"]))),
+
         // path
         .package(path: "../.."),
         .package(name: "package-with-name", path: "../.."),

--- a/test/Swift/testdata/Package.swift
+++ b/test/Swift/testdata/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/shogo4405/HaishinKit.swift", exact: "1.1.6"),
 
         // upToNextMajor
-        .package(url: "https://github.com/dankogai/swift-sion", .upToNextMajor(from: "0.0.1")),
+       .package(url: "https://github.com/dankogai/swift-sion", .upToNextMajor(from: "0.0.1")),
 
         // upToNextMinor
         .package(url: "git@github.com:behrang/YamlSwift.git", .upToNextMinor(from: "3.4.0")),
@@ -64,6 +64,11 @@ let package = Package(
         // range
         .package(url: "https://github.com/LeoNatan/LNPopupController.git", "2.5.0"..<"2.5.6"),
         .package(url: "https://github.com/Polidea/RxBluetoothKit.git", "3.0.5"..."3.0.7"),
+ 
+        // version constructor
+        .package(url: "https://github.com/example/example.git", .from(Version(1, 7, 0, prereleaseIdentifiers: ["a", "b"], buildMetadataIdentifiers: ["x", "banana"]))),
+        .package(url: "https://github.com/example/example2.git", .upToNextMinor(from: Version(13, 99, 123, buildMetadataIdentifiers: ["abcd"]))),
+        .package(url: "https://github.com/example/example3.git", .exact(Version(0, 0, 3, prereleaseIdentifiers: ["build", "1"]))),
 
         // path
         .package(path: "../.."),

--- a/test/Swift/testdata/Package.swift
+++ b/test/Swift/testdata/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/shogo4405/HaishinKit.swift", exact: "1.1.6"),
 
         // upToNextMajor
-       .package(url: "https://github.com/dankogai/swift-sion", .upToNextMajor(from: "0.0.1")),
+        .package(url: "https://github.com/dankogai/swift-sion", .upToNextMajor(from: "0.0.1")),
 
         // upToNextMinor
         .package(url: "git@github.com:behrang/YamlSwift.git", .upToNextMinor(from: "3.4.0")),
@@ -70,6 +70,7 @@ let package = Package(
         .package(url: "https://github.com/example/example2.git", .upToNextMinor(from: Version(13, 99, 123, buildMetadataIdentifiers: ["abcd"]))),
         .package(url: "https://github.com/example/example3.git", .exact(Version(0, 0, 3, prereleaseIdentifiers: ["build", "1"]))),
         .package(url: "https://github.com/example/example4.git", .exact(Version(1, 0, 14))),
+        .package(url: "https://github.com/example/example5.git", Version(1, 0, 14)..<Version(1, 0, 20)),
 
         // path
         .package(path: "../.."),

--- a/test/Swift/testdata/Package.swift
+++ b/test/Swift/testdata/Package.swift
@@ -69,6 +69,7 @@ let package = Package(
         .package(url: "https://github.com/example/example.git", .from(Version(1, 7, 0, prereleaseIdentifiers: ["a", "b"], buildMetadataIdentifiers: ["x", "banana"]))),
         .package(url: "https://github.com/example/example2.git", .upToNextMinor(from: Version(13, 99, 123, buildMetadataIdentifiers: ["abcd"]))),
         .package(url: "https://github.com/example/example3.git", .exact(Version(0, 0, 3, prereleaseIdentifiers: ["build", "1"]))),
+        .package(url: "https://github.com/example/example4.git", .exact(Version(1, 0, 14))),
 
         // path
         .package(path: "../.."),


### PR DESCRIPTION
# Overview
Swift lets a version string be defined as either a string, or as an instance of `Version` ([docs](https://developer.apple.com/documentation/packagedescription/version)). The parser did not previously support this version syntax, and this PR adds support for it.

Note: Package.swift files are just Swift files, supporting the full Swift grammar. Since we're not going to write a full Swift interpreter, we're just choosing to support a reasonable subset of the Swift grammar in a limited context in order to parse most Package.swift files. For complicated Package.swift files, other strategies will be more suitable, such as parsing the JSON Package.resolved.

## Acceptance criteria
Package.swift files using the `Version(...)` syntax for versions can be parsed.

## Testing plan
- Package.swift files linked in the ticket can now be analyzed
- New tests added with the new syntax.

## Risks

## Metrics

## References

- [ANE-2911](https://fossa.atlassian.net/browse/ANE-2911): Handle Swift Version(...) syntax

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2911]: https://fossa.atlassian.net/browse/ANE-2911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ