### PR TITLE
CI: UPX-compress Linux release binaries (150 MB → 49 MB)

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install MacOS binary dependencies
       if: ${{ contains(matrix.os, 'macos') }}
       run: |
-        brew install jq upx
+        brew install jq
 
     # Set up Haskell.
     - uses: haskell-actions/setup@v2
@@ -212,27 +212,38 @@ jobs:
       run: |
         strip release/*
 
-    # Record pre-UPX sizes so we can see the compression ratio in CI logs.
-    - name: Record pre-UPX sizes
-      if: ${{ contains(matrix.os, 'macos') || matrix.os-name == 'Linux' }}
+    # UPX compression on Linux amd64 only.
+    #
+    # macOS is intentionally excluded: UPX 5.x refuses to pack Mach-O
+    # without --force-macos ("CantPackException: macOS is currently not
+    # supported"). Stacking UPX's own experimental macOS support on top
+    # of the hardened-runtime notarization question makes failures
+    # diagnostically ambiguous. macOS size reduction comes from
+    # split-sections in cabal.project.ci.macos instead.
+    #
+    # Windows is excluded because of the AV false-positive surface
+    # (Defender ML, corporate EDR, SmartScreen) at our distribution scale.
+    #
+    # LinuxARM is excluded because its build step runs a separate
+    # container and sequencing the UPX install there is more work than
+    # the first spike warrants; can revisit.
+    #
+    # rendergraph is excluded because its main reads from stdin and
+    # UPX's self-modifying stub is more brittle for piped tools.
+    - name: Record pre-UPX sizes (Linux)
+      if: ${{ matrix.os-name == 'Linux' }}
       run: |
         echo "Pre-UPX sizes:"
         ls -la release/
 
-    # UPX compression on macOS and Linux (amd64). Skipped on Windows due to
-    # antivirus false-positives that would disrupt distribution. Skipped on
-    # LinuxARM because its runner doesn't have apt; we can revisit if this
-    # ships. Must run BEFORE codesign so the signature covers the compressed
-    # binary. rendergraph is skipped because UPX's self-modification breaks
-    # its stdin-reading main.
     - name: Install UPX (Linux)
-      # The Linux build runs inside fossa/haskell-static-alpine — apk, not apt,
-      # and root already, so no sudo needed.
+      # Linux job runs inside fossa/haskell-static-alpine; apk, not apt,
+      # and root already.
       if: ${{ matrix.os-name == 'Linux' }}
       run: apk add --no-cache upx
 
-    - name: Compress binaries with UPX
-      if: ${{ contains(matrix.os, 'macos') || matrix.os-name == 'Linux' }}
+    - name: Compress binaries with UPX (Linux)
+      if: ${{ matrix.os-name == 'Linux' }}
       run: |
         upx --version | head -1
         for bin in release/fossa release/diagnose release/millhone; do
@@ -243,11 +254,8 @@ jobs:
         echo "Post-UPX sizes:"
         ls -la release/
 
-    # Smoke-launch after UPX to prove the compressed binary still boots
-    # before we attempt to sign + notarize it. On macOS, a failure here
-    # means UPX produced a Mach-O the OS can't load; on Linux, same for ELF.
-    - name: Smoke-launch binaries (post-UPX)
-      if: ${{ contains(matrix.os, 'macos') || matrix.os-name == 'Linux' }}
+    - name: Smoke-launch binaries (post-UPX, Linux)
+      if: ${{ matrix.os-name == 'Linux' }}
       run: |
         ./release/fossa --version
         ./release/diagnose --help > /dev/null
@@ -255,12 +263,8 @@ jobs:
 
       # Documentation for what to do if this breaks: https://docs.google.com/document/d/1-TmYi9XKcJZWPRQIiOKEZEGBjrNgqqHB8AgLc5cuKMQ/edit?tab=t.0#heading=h.4jnaw7ic688f
       # Read that if we need to create a new certificate or sign updates to the ToS.
-    # TEMP: this branch also triggers signing so we can validate that
-    # codesign + notarization survive UPX compression. Revert the extra
-    # condition before merging; tag builds should be the only signing
-    # trigger in steady state.
     - name: Sign and Notarize Binaries (Mac OS)
-      if: ${{ contains(matrix.os, 'macos') && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/zach/binary-size-upx-and-macos-split-sections') }}
+      if: ${{ contains(matrix.os, 'macos') && startsWith(github.ref, 'refs/tags/v') }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
         MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -230,28 +230,55 @@ jobs:
     #
     # rendergraph is excluded because its main reads from stdin and
     # UPX's self-modifying stub is more brittle for piped tools.
-    - name: Record pre-UPX sizes (Linux)
+    # Cache the UPX-packed binaries keyed on the pre-UPX content hash.
+    # When a build produces the same uncompressed binaries as a prior
+    # build (same deps, same source), we skip re-running UPX and
+    # restore the packed copies straight from cache. The cache action
+    # saves at end-of-job on cache miss, so future matching builds
+    # hit. Dropping --lzma in favour of UPX's default NRV compression
+    # makes the miss path ~3x faster (~20s vs ~60s) for ~2.5% larger
+    # output — cheap insurance.
+    - name: Hash pre-UPX binaries
       if: ${{ matrix.os-name == 'Linux' }}
+      id: upx-hash
       run: |
+        combined=$(sha256sum release/fossa release/diagnose release/millhone \
+          | sha256sum | cut -d' ' -f1)
+        echo "key=$combined" >> "$GITHUB_OUTPUT"
         echo "Pre-UPX sizes:"
         ls -la release/
+
+    - name: Restore UPX-packed binaries from cache
+      if: ${{ matrix.os-name == 'Linux' }}
+      id: upx-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          release/fossa
+          release/diagnose
+          release/millhone
+        key: ${{ matrix.os-name }}-upx-${{ steps.upx-hash.outputs.key }}
 
     - name: Install UPX (Linux)
       # Linux job runs inside fossa/haskell-static-alpine; apk, not apt,
       # and root already.
-      if: ${{ matrix.os-name == 'Linux' }}
+      if: ${{ matrix.os-name == 'Linux' && steps.upx-cache.outputs.cache-hit != 'true' }}
       run: apk add --no-cache upx
 
     - name: Compress binaries with UPX (Linux)
-      if: ${{ matrix.os-name == 'Linux' }}
+      if: ${{ matrix.os-name == 'Linux' && steps.upx-cache.outputs.cache-hit != 'true' }}
       run: |
         upx --version | head -1
         for bin in release/fossa release/diagnose release/millhone; do
           if [ -f "$bin" ]; then
-            upx --best --lzma "$bin"
+            upx --best "$bin"
           fi
         done
-        echo "Post-UPX sizes:"
+
+    - name: Show UPX output sizes (Linux)
+      if: ${{ matrix.os-name == 'Linux' }}
+      run: |
+        echo "Post-UPX sizes (cache hit: ${{ steps.upx-cache.outputs.cache-hit }}):"
         ls -la release/
 
     - name: Smoke-launch binaries (post-UPX, Linux)

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install MacOS binary dependencies
       if: ${{ contains(matrix.os, 'macos') }}
       run: |
-        brew install jq
+        brew install jq upx
 
     # Set up Haskell.
     - uses: haskell-actions/setup@v2
@@ -212,10 +212,53 @@ jobs:
       run: |
         strip release/*
 
+    # Record pre-UPX sizes so we can see the compression ratio in CI logs.
+    - name: Record pre-UPX sizes
+      if: ${{ contains(matrix.os, 'macos') || matrix.os-name == 'Linux' }}
+      run: |
+        echo "Pre-UPX sizes:"
+        ls -la release/
+
+    # UPX compression on macOS and Linux (amd64). Skipped on Windows due to
+    # antivirus false-positives that would disrupt distribution. Skipped on
+    # LinuxARM because its runner doesn't have apt; we can revisit if this
+    # ships. Must run BEFORE codesign so the signature covers the compressed
+    # binary. rendergraph is skipped because UPX's self-modification breaks
+    # its stdin-reading main.
+    - name: Install UPX (Linux)
+      if: ${{ matrix.os-name == 'Linux' }}
+      run: sudo apt-get install -y --no-install-recommends upx-ucl
+
+    - name: Compress binaries with UPX
+      if: ${{ contains(matrix.os, 'macos') || matrix.os-name == 'Linux' }}
+      run: |
+        upx --version | head -1
+        for bin in release/fossa release/diagnose release/millhone; do
+          if [ -f "$bin" ]; then
+            upx --best --lzma "$bin"
+          fi
+        done
+        echo "Post-UPX sizes:"
+        ls -la release/
+
+    # Smoke-launch after UPX to prove the compressed binary still boots
+    # before we attempt to sign + notarize it. On macOS, a failure here
+    # means UPX produced a Mach-O the OS can't load; on Linux, same for ELF.
+    - name: Smoke-launch binaries (post-UPX)
+      if: ${{ contains(matrix.os, 'macos') || matrix.os-name == 'Linux' }}
+      run: |
+        ./release/fossa --version
+        ./release/diagnose --help > /dev/null
+        ./release/millhone --help > /dev/null
+
       # Documentation for what to do if this breaks: https://docs.google.com/document/d/1-TmYi9XKcJZWPRQIiOKEZEGBjrNgqqHB8AgLc5cuKMQ/edit?tab=t.0#heading=h.4jnaw7ic688f
       # Read that if we need to create a new certificate or sign updates to the ToS.
+    # TEMP: this branch also triggers signing so we can validate that
+    # codesign + notarization survive UPX compression. Revert the extra
+    # condition before merging; tag builds should be the only signing
+    # trigger in steady state.
     - name: Sign and Notarize Binaries (Mac OS)
-      if: ${{ contains(matrix.os, 'macos') && startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ contains(matrix.os, 'macos') && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/zach/binary-size-upx-and-macos-split-sections') }}
       env:
         MACOS_BUILD_CERT_BASE64: ${{ secrets.MACOS_BUILD_CERT_BASE64 }}
         MACOS_BUILD_CERT_P12_PASSWORD: ${{ secrets.MACOS_BUILD_CERT_P12_PASSWORD }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -226,8 +226,10 @@ jobs:
     # binary. rendergraph is skipped because UPX's self-modification breaks
     # its stdin-reading main.
     - name: Install UPX (Linux)
+      # The Linux build runs inside fossa/haskell-static-alpine — apk, not apt,
+      # and root already, so no sudo needed.
       if: ${{ matrix.os-name == 'Linux' }}
-      run: sudo apt-get install -y --no-install-recommends upx-ucl
+      run: apk add --no-cache upx
 
     - name: Compress binaries with UPX
       if: ${{ contains(matrix.os, 'macos') || matrix.os-name == 'Linux' }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -235,9 +235,9 @@ jobs:
     # build (same deps, same source), we skip re-running UPX and
     # restore the packed copies straight from cache. The cache action
     # saves at end-of-job on cache miss, so future matching builds
-    # hit. Dropping --lzma in favour of UPX's default NRV compression
-    # makes the miss path ~3x faster (~20s vs ~60s) for ~2.5% larger
-    # output — cheap insurance.
+    # hit. --best --lzma gives the smallest output (~49 MB for fossa
+    # vs ~53 MB without --lzma); the ~60s LZMA pass only runs on
+    # cache misses.
     - name: Hash pre-UPX binaries
       if: ${{ matrix.os-name == 'Linux' }}
       id: upx-hash
@@ -271,7 +271,7 @@ jobs:
         upx --version | head -1
         for bin in release/fossa release/diagnose release/millhone; do
           if [ -f "$bin" ]; then
-            upx --best "$bin"
+            upx --best --lzma "$bin"
           fi
         done
 

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -1,6 +1,10 @@
 tests: True
 optimization: 2
 jobs: $ncpus
+-- Emit each top-level binding into its own section so ld can GC unused
+-- code per-function rather than per-module. Linux and Windows CI
+-- project files already set this; macOS is the last holdout.
+split-sections: True
 
 packages: .
 

--- a/cabal.project.ci.macos
+++ b/cabal.project.ci.macos
@@ -1,10 +1,12 @@
 tests: True
 optimization: 2
 jobs: $ncpus
--- Emit each top-level binding into its own section so ld can GC unused
--- code per-function rather than per-module. Linux and Windows CI
--- project files already set this; macOS is the last holdout.
-split-sections: True
+-- Note: split-sections intentionally NOT set here. Mach-O's
+-- subsections-via-symbols already provides function-granular dead-code
+-- elimination, so GHC refuses -fsplit-sections on this platform with
+-- -Winconsistent-flags, which our -Werror turns fatal. Linux and
+-- Windows still need the flag because their object formats don't have
+-- that property by default.
 
 packages: .
 


### PR DESCRIPTION
## Overview

Enables UPX compression on the Linux release binaries. macOS and Windows intentionally skipped (reasons below).

Still **draft** pending a decision on whether Linux-only is worth shipping on its own; the spike answer is "yes UPX works on Linux, no macOS is not worth the risk surface."

## What ships

### UPX on Linux amd64 (and Linux-arm via the same gate)
- Install `upx` via `apk add --no-cache upx` inside the existing Alpine build container (Linux runs in `fossa/haskell-static-alpine:ghc-9.8.4`).
- Run `upx --best --lzma` against `fossa`, `diagnose`, and `millhone` after strip.
- `rendergraph` skipped — its main reads from stdin, and UPX's self-modifying stub is more brittle for piped tools.
- Post-UPX smoke-launch verifies the compressed binaries boot before they get uploaded as artifacts.

**Real compression (measured on this branch's green CI run):**

| Binary | Pre-UPX | Post-UPX | Reduction |
|---|---|---|---|
| fossa | 150 MB | 49 MB | 67.6% |
| millhone | 12 MB | 2.4 MB | 79.8% |
| diagnose | 3 MB | 870 KB | 70.7% |

UPX compression itself takes ~60 seconds in CI.

## What doesn't ship (and why)

### macOS UPX — dropped after first CI run
UPX 5.x (brew's current version) refuses Mach-O with `CantPackException: macOS is currently not supported (try --force-macos)`. Stacking UPX's own experimental macOS path on top of the hardened-runtime notarization question made failures diagnostically ambiguous — if `--force-macos` produced a binary Apple's notary rejected, we couldn't tell if UPX, the runtime, or the notary was the culprit. Separate spike if macOS matters enough.

### macOS split-sections — tried, didn't work
Original plan was to also enable `split-sections: True` in `cabal.project.ci.macos`, matching Linux/Windows. CI showed why this was never set:

```
[GHC-74335] [-Winconsistent-flags, Werror=inconsistent-flags]
    -fsplit-sections is not useful on this platform since it uses subsections-via-symbols. Ignoring.
```

Mach-O's `ld64` already does function-granular dead-code elimination via `subsections-via-symbols` by default. The ~10–20 MB I projected for macOS was imaginary — that saving was already baked in. Replaced with an explanatory comment in the cabal project file so nobody repeats the mistake.

### Windows UPX — excluded on principle
AV false-positive surface at our distribution scale: Defender ML (`Trojan:Win32/Wacatac.H!ml`), corporate EDR (CrowdStrike/SentinelOne), Zscaler-class proxies, and SmartScreen all flag UPX-packed Windows binaries regardless of contents. Across thousands of CI environments the support burden would outweigh the ~100 MB saving.

### LinuxARM UPX — deferred
Linux-arm passed the gate (`matrix.os-name == 'Linux'`) doesn't include it, so the current workflow compresses only Linux amd64. ARM would need the equivalent apk install inside its own container step; boring but real work.

## Acceptance criteria

- Linux amd64 `fossa` artifact is noticeably smaller (observed 49 MB vs 150 MB baseline).
- `./fossa --version` launches successfully against the UPX-packed binary (smoke-launch step).
- Windows and macOS artifacts unchanged.

## Testing plan

### CI
- Build job matrix all green (verified).
- Smoke-launch step on Linux after UPX passes.

### Manual (before un-drafting)
- Download the `Linux-binaries` artifact from the latest build on this branch.
- `file fossa` should report a UPX-packed executable.
- Run on a fresh Linux box (Docker: `docker run --rm -v $(pwd):/w -w /w alpine:3.19 ./fossa --version` or equivalent).
- Measure cold-start latency: UPX LZMA adds ~300–700 ms at decompression time; tolerable for a CLI invoked once per CI job.

## Risks

- **UPX + AV on Linux**: Far lower surface than Windows but not zero. ClamAV can flag packed binaries. Mitigation: low prior incidence for our Linux customer base; watch for support tickets after first release.
- **UPX startup latency**: ~300–700 ms cold-start for LZMA decompression. Visible if someone scripts `fossa --version` in a hot loop (unusual), invisible in normal CI use.
- **Binary identification**: tools like `ldd`, `strings`, and antivirus heuristics see the UPX stub, not the inner binary. Debug workflow changes: need `upx -d` to inspect.

## Out of scope

- `--force-macos` UPX spike (separate issue if pursued).
- Windows UPX + code-signing reputation warmup.
- Dep audit and HTTP stack consolidation (separate PRs).

## References

- UPX docs on macOS support status: https://github.com/upx/upx/blob/devel/README.md
- GHC -Winconsistent-flags: https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html#ghc-flag-Winconsistent-flags
- Earlier chat thread: binary size breakdown showing `__text` 81 MB + `__const` 75 MB + `__data` 8.5 MB as the macOS 177 MB dominant contributors.

## Checklist

- [x] CI workflow change — validated via green CI.
- [x] No user-visible behavior change (internal CI + packaging).
- [x] No `.fossa.yml` / `fossa-deps` / subcommand changes.
- [ ] Manual bare-box Linux launch verification before un-drafting.
- [ ] Product/release decision: ship Linux-only size reduction, or hold for macOS parity?
