### PR TITLE
Cut release for 3.17.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # FOSSA CLI Changelog
 
-## Unreleased
+## 3.17.3
 
 - pnpm: Support `catalog:` and `catalog:<name>` version specifiers. Versions are resolved from the `catalogs` section in `pnpm-lock.yaml`. ([#1696](https://github.com/fossas/fossa-cli/pull/1696))
 - pnpm: Remove stray `traceShow` debug output that dumped the parsed `pnpm-workspace.yaml` to stderr. ([#1696](https://github.com/fossas/fossa-cli/pull/1696))


### PR DESCRIPTION
# Overview

Update the changelog for 3.17.3

## Acceptance criteria

_If this PR is successful, what impact does it have on the user experience?_

_Example: When users do X, Y should now happen._

## Testing plan

_How did you validate that this PR works? What literal steps did you take when manually checking that your code works?_

_Example:_

1. _Set up test case X._
2. _Run command Y. Make sure Z happens._

_This section should list concrete steps that a reviewer can sanity check and repeat on their own machine (and provide any needed test cases)._

## Risks

_Highlight any areas that you're unsure of, want feedback on, or want reviewers to pay particular attention to._

_Example: I'm not sure I did X correctly, can reviewers please double-check that for me?_

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

_Example:_

- _[ANE-123](https://fossa.atlassian.net/browse/ANE-123): Implement X._

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
