### PR TITLE
[CORE-6867] Smoke-test ficus binary after vendor download

### DIFF
--- a/vendor_download.sh
+++ b/vendor_download.sh
@@ -271,3 +271,12 @@ for binary in vendor-bins/*; do
     "$binary" --version || echo "failed to get version information"
   fi
 done
+
+# Strict smoke-test ficus: it is embedded via Template Haskell into the CLI
+# binary (and downstream consumers like Hubble), so a non-runnable ficus
+# (wrong glibc, wrong arch, corrupt download) ships silently otherwise and
+# only manifests at run time.
+./vendor-bins/ficus --version > /dev/null || {
+  echo "ERROR: vendor-bins/ficus does not run in this image"
+  exit 1
+}


### PR DESCRIPTION
See: https://github.com/fossas/ficus/pull/169

The pre-existing version-check loop runs `--version` on every binary but swallows failures via `|| echo "failed to get version information"`, so a non-runnable ficus (wrong glibc, wrong arch, corrupt download) prints a warning and the script continues. The binary then gets embedded into the CLI (and downstream consumers like Hubble) via Template Haskell and the failure only manifests at run time.

Add a strict smoke-execute of vendor-bins/ficus that fails the build if the binary cannot load in the build image's libc/arch.

# Overview

Ensure compatibility with downstream consumers by failing when ficus binary cannot be run.

## Acceptance criteria

Incompatible consumers _cannot_ build against in incompatible ficus. Specifically wrt to libc version.

## Testing plan

I think maybe if we accept this PR (without rebuilt ficus from https://github.com/fossas/ficus/pull/169), and then rebuild Hubble against this branch of ficus-cli, we should expect it to _fail_. If it fails then this change has succeeded in preventing a bad Hubble/ficus build.

## Risks

The previous logic was testing, but NOT failing. Maybe there is a use case where we don't want to fail if ficus is not runnable?

## Metrics


## References

_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

_Example:_

- _[ANE-123](https://fossa.atlassian.net/browse/ANE-123): Implement X._

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
