### PR TITLE
[ANE-2724] Pass --debug to Ficus when CLI is in debug mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 ## 3.17.4
 - Conan: Update the conan script (docs/walkthroughs/make_fossa_deps_conan.py) to work with modern conan versions ([#1629](https://github.com/fossas/fossa-cli/pull/1629) and [#1698](https://github.com/fossas/fossa-cli/pull/1698))
 
+## Unreleased
+
+- Vendetta: Debug bundles now include per-file component match data from Vendetta scans, making it easier to diagnose why a vendored dependency was or wasn't detected. ([#1706](https://github.com/fossas/fossa-cli/pull/1706))
+
 ## 3.17.3
 
 - pnpm: Support `catalog:` and `catalog:<name>` version specifiers. Versions are resolved from the `catalogs` section in `pnpm-lock.yaml`. ([#1696](https://github.com/fossas/fossa-cli/pull/1696))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,11 @@
 # FOSSA CLI Changelog
-## 3.17.4
-- Conan: Update the conan script (docs/walkthroughs/make_fossa_deps_conan.py) to work with modern conan versions ([#1629](https://github.com/fossas/fossa-cli/pull/1629) and [#1698](https://github.com/fossas/fossa-cli/pull/1698))
 
-## 3.17.4
+## 3.17.5
 
 - Vendetta: Debug bundles now include per-file component match data from Vendetta scans, making it easier to diagnose why a vendored dependency was or wasn't detected. ([#1706](https://github.com/fossas/fossa-cli/pull/1706))
+
+## 3.17.4
+- Conan: Update the conan script (docs/walkthroughs/make_fossa_deps_conan.py) to work with modern conan versions ([#1629](https://github.com/fossas/fossa-cli/pull/1629) and [#1698](https://github.com/fossas/fossa-cli/pull/1698))
 
 ## 3.17.3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 ## 3.17.4
 - Conan: Update the conan script (docs/walkthroughs/make_fossa_deps_conan.py) to work with modern conan versions ([#1629](https://github.com/fossas/fossa-cli/pull/1629) and [#1698](https://github.com/fossas/fossa-cli/pull/1698))
 
-## Unreleased
+## 3.17.4
 
 - Vendetta: Debug bundles now include per-file component match data from Vendetta scans, making it easier to diagnose why a vendored dependency was or wasn't detected. ([#1706](https://github.com/fossas/fossa-cli/pull/1706))
 

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -254,11 +254,16 @@ runFicus maybeDebugDir ficusConfig = do
     logDebug $ "Working directory: " <> pretty (toFilePath $ ficusConfigRootDir ficusConfig)
 
     logDebugWithTime "Creating process configuration..."
-    let processConfig =
+    -- When running in debug mode, pass --debug to Ficus too.
+    let debugArgs = case maybeDebugDir of
+          Just _ -> ["--debug"]
+          Nothing -> []
+        allArgs = map toString $ cmdArgs cmd
+        processConfig =
           setWorkingDir (toFilePath $ ficusConfigRootDir ficusConfig) $
             setStdout createPipe $
               setStderr createPipe $
-                proc (toString $ cmdName cmd) (map toString $ cmdArgs cmd)
+                proc (toString $ cmdName cmd) (debugArgs ++ allArgs)
 
     logInfo $ "Running Ficus analysis on " <> pretty (toFilePath $ ficusConfigRootDir ficusConfig)
     logDebugWithTime "Starting Ficus process..."

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -258,12 +258,11 @@ runFicus maybeDebugDir ficusConfig = do
     let debugArgs = case maybeDebugDir of
           Just _ -> ["--debug"]
           Nothing -> []
-        allArgs = map toString $ cmdArgs cmd
         processConfig =
           setWorkingDir (toFilePath $ ficusConfigRootDir ficusConfig) $
             setStdout createPipe $
               setStderr createPipe $
-                proc (toString $ cmdName cmd) (debugArgs ++ allArgs)
+                proc (toString $ cmdName cmd) (debugArgs ++ map toString (cmdArgs cmd))
 
     logInfo $ "Running Ficus analysis on " <> pretty (toFilePath $ ficusConfigRootDir ficusConfig)
     logDebugWithTime "Starting Ficus process..."

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -249,20 +249,16 @@ runFicus maybeDebugDir ficusConfig = do
   logDebugWithTime "About to extract Ficus binary..."
   withFicusBinary $ \bin -> do
     logDebugWithTime "Ficus binary extracted, building command..."
-    cmd <- ficusCommand ficusConfig bin
+    cmd <- ficusCommand ficusConfig bin (isJust maybeDebugDir)
     logDebugWithTime "Executing ficus (streaming)"
     logDebug $ "Working directory: " <> pretty (toFilePath $ ficusConfigRootDir ficusConfig)
 
     logDebugWithTime "Creating process configuration..."
-    -- When running in debug mode, pass --debug to Ficus too.
-    let debugArgs = case maybeDebugDir of
-          Just _ -> ["--debug"]
-          Nothing -> []
-        processConfig =
+    let processConfig =
           setWorkingDir (toFilePath $ ficusConfigRootDir ficusConfig) $
             setStdout createPipe $
               setStderr createPipe $
-                proc (toString $ cmdName cmd) (debugArgs ++ map toString (cmdArgs cmd))
+                proc (toString $ cmdName cmd) (map toString $ cmdArgs cmd)
 
     logInfo $ "Running Ficus analysis on " <> pretty (toFilePath $ ficusConfigRootDir ficusConfig)
     logDebugWithTime "Starting Ficus process..."
@@ -397,8 +393,8 @@ runFicus maybeDebugDir ficusConfig = do
 
 -- Run Ficus, passing config-based args as configuration.
 -- Caveat! This hard-codes some flags currently which may later need to be set on a strategy-by-strategy basis.
-ficusCommand :: (Has Diagnostics sig m, Has Logger sig m) => FicusConfig -> BinaryPaths -> m Command
-ficusCommand ficusConfig bin = do
+ficusCommand :: (Has Diagnostics sig m, Has Logger sig m) => FicusConfig -> BinaryPaths -> Bool -> m Command
+ficusCommand ficusConfig bin debugMode = do
   endpoint <- case ficusConfigEndpoint ficusConfig of
     Just baseUri -> do
       proxyUri <- setPath [PathComponent "api", PathComponent "proxy", PathComponent "analysis"] (TrailingSlash False) baseUri
@@ -415,7 +411,8 @@ ficusCommand ficusConfig bin = do
   pure cmd
   where
     snippetScanRetentionDays = ficusConfigSnippetScanRetentionDays ficusConfig
-    configArgs endpoint = ["analyze", "--secret", secret, "--endpoint", endpoint, "--locator", locator, "--set", "all:skip-hidden-files", "--set", "all:gitignore", "--exclude", ".git", "--exclude", ".git/**"] ++ configExcludes ++ configStrategies ++ maybe [] (\days -> ["--snippet-scan-retention-days", toText days]) snippetScanRetentionDays ++ [targetDir]
+    debugArgs = ["--debug" | debugMode]
+    configArgs endpoint = debugArgs ++ ["analyze", "--secret", secret, "--endpoint", endpoint, "--locator", locator, "--set", "all:skip-hidden-files", "--set", "all:gitignore", "--exclude", ".git", "--exclude", ".git/**"] ++ configExcludes ++ configStrategies ++ maybe [] (\days -> ["--snippet-scan-retention-days", toText days]) snippetScanRetentionDays ++ [targetDir]
     targetDir = toText $ toFilePath $ ficusConfigRootDir ficusConfig
     secret = maybe "" (toText . unApiKey) $ ficusConfigSecret ficusConfig
     locator = renderLocator $ Locator "custom" (projectName $ ficusConfigRevision ficusConfig) (Just $ projectRevision $ ficusConfigRevision ficusConfig)


### PR DESCRIPTION
# Overview

> [!IMPORTANT]
> This PR depends on fossas/ficus#170 being released first. Current Ficus will reject the `--debug` flag, so this must not be merged until a Ficus release containing that change is vendored in.

When the CLI runs with `--debug`, Ficus was still running at its default `info` log level. This meant debug-level observations (like per-file Vendetta match data from fossas/ficus#170) were filtered out and never made it into the debug bundle.

This passes `--debug` to Ficus when the CLI is in debug mode, so that Ficus's debug observations show up in `fossa.ficus-stdout.log`.

We use a CLI flag rather than setting `FICUS_LOG=debug` via the process environment because it's simpler (no need to inherit and merge the parent environment) and it keeps Ficus's debug mode explicitly visible in the command invocation.

## Acceptance criteria

- When the CLI runs with `--debug`, Ficus receives `--debug` and emits debug-level observations
- When the CLI runs without `--debug`, Ficus behavior is unchanged

## Testing plan

Requires fossas/ficus#170 to be released and vendored first.

1. Run a vendetta scan with `--debug`:
```sh
fossa analyze --x-vendetta --debug
```

2. Inspect `fossa.ficus-stdout.log` in the debug bundle:
```sh
unzip -p fossa.debug.zip fossa.ficus-stdout.log | jq 'select(.level == "DEBUG") | .observation.payload | fromjson?'
```
You should see structured file match observations like:
```json
{"file":"vendor/sqlite/sqlite3.c","component":"sqlite","purl":"pkg:github/nicowilliams/sqlite@version-3.32.1","corrected":false,"single_file_lib":false}
```

3. Run without `--debug` and confirm `fossa.ficus-stdout.log` does NOT contain debug observations (only `finding` and `error` level).

### Debug bundle size impact

Tested on the fossa-cli repo itself (~22k files walked by Vendetta):

| | Zip size | stdout (raw) | stderr (raw) |
|---|---|---|---|
| Without `--debug` to Ficus | 885 KB | 7 KB | 8 KB |
| With `--debug` to Ficus | 1,024 KB | 4,075 KB | 4,682 KB |

The zip grows by ~140 KB (16%) thanks to ~95% compression on the repetitive debug output.

## Risks

This PR **must** be released after fossas/ficus#170. Current Ficus rejects unknown flags, so merging this before the Ficus update would break Ficus invocation when `--debug` is used.

## References

- [ANE-2724](https://fossa.atlassian.net/browse/ANE-2724)
- fossas/ficus#170: Ficus-side changes (debug observations + `--debug` flag)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`

No tests needed for this change. It's passing a flag through to a subprocess.

[ANE-2724]: https://fossa.atlassian.net/browse/ANE-2724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ