### PR TITLE
Fix broken Analysis.Clojure.eastwood integration test

### DIFF
--- a/integration-test/Analysis/CarthageSpec.hs
+++ b/integration-test/Analysis/CarthageSpec.hs
@@ -22,6 +22,7 @@ swiftQueue =
       "https://github.com/lucas34/SwiftQueue/archive/refs/tags/5.0.2.tar.gz"
       [reldir|carthage/SwiftQueue/|]
       [reldir|SwiftQueue-5.0.2/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/ClojureSpec.hs
+++ b/integration-test/Analysis/ClojureSpec.hs
@@ -6,38 +6,31 @@ module Analysis.ClojureSpec (spec) where
 import Analysis.FixtureExpectationUtils
 import Analysis.FixtureUtils
 import App.Types (Mode (NonStrict))
-import Data.List (isInfixOf)
 import Path
 import Strategy.Leiningen qualified as Leiningen
 import Test.Hspec
-import Types (DiscoveredProject (..), DiscoveredProjectType (..), GraphBreadth (Complete))
+import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 
 clojureEnv :: FixtureEnvironment
 clojureEnv = NixEnv ["openjdk11", "clojure", "leiningen"]
-
--- | Discover Leiningen projects but skip anything under a @.circleci@ directory.
---
--- The pinned eastwood Release-1.0.0 tarball ships a secondary @project.clj@ at
--- @.circleci/nvd/@ that pulls in OWASP dependency-check artifacts which are no
--- longer resolvable from Maven Central / Clojars. Without this filter, @lein
--- deps :tree-data@ fails on that subproject and breaks the integration test
--- even though the eastwood project itself is healthy.
-discoverSkippingCircleCI :: Path Abs Dir -> TestC IO [DiscoveredProject Leiningen.LeiningenProject]
-discoverSkippingCircleCI dir = filter notUnderCircleCI <$> Leiningen.discover dir
-  where
-    notUnderCircleCI dp = not (".circleci" `isInfixOf` toFilePath (projectPath dp))
 
 eastwood :: AnalysisTestFixture (Leiningen.LeiningenProject)
 eastwood =
   AnalysisTestFixture
     "eastwood"
-    discoverSkippingCircleCI
+    Leiningen.discover
     clojureEnv
     Nothing
     $ FixtureArtifact
       "https://github.com/jonase/eastwood/archive/refs/tags/Release-1.0.0.tar.gz"
       [reldir|clojure/eastwood/|]
       [reldir|eastwood-Release-1.0.0/|]
+      -- The .circleci/nvd subproject pulls in OWASP dependency-check artifacts
+      -- (e.g. dependency-check-core 6.2.2) that are no longer resolvable from
+      -- Maven Central / Clojars, which makes `lein deps :tree-data` fail on
+      -- that subproject. We don't care about it for this test; the real
+      -- eastwood project lives at the root of the tarball.
+      [[reldir|.circleci/|]]
 
 ring :: AnalysisTestFixture (Leiningen.LeiningenProject)
 ring =
@@ -50,6 +43,7 @@ ring =
       "https://github.com/ring-clojure/ring/archive/refs/tags/1.9.4.tar.gz"
       [reldir|clojure/ring/|]
       [reldir|ring-1.9.4/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/ClojureSpec.hs
+++ b/integration-test/Analysis/ClojureSpec.hs
@@ -6,19 +6,32 @@ module Analysis.ClojureSpec (spec) where
 import Analysis.FixtureExpectationUtils
 import Analysis.FixtureUtils
 import App.Types (Mode (NonStrict))
+import Data.List (isInfixOf)
 import Path
 import Strategy.Leiningen qualified as Leiningen
 import Test.Hspec
-import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
+import Types (DiscoveredProject (..), DiscoveredProjectType (..), GraphBreadth (Complete))
 
 clojureEnv :: FixtureEnvironment
 clojureEnv = NixEnv ["openjdk11", "clojure", "leiningen"]
+
+-- | Discover Leiningen projects but skip anything under a @.circleci@ directory.
+--
+-- The pinned eastwood Release-1.0.0 tarball ships a secondary @project.clj@ at
+-- @.circleci/nvd/@ that pulls in OWASP dependency-check artifacts which are no
+-- longer resolvable from Maven Central / Clojars. Without this filter, @lein
+-- deps :tree-data@ fails on that subproject and breaks the integration test
+-- even though the eastwood project itself is healthy.
+discoverSkippingCircleCI :: Path Abs Dir -> TestC IO [DiscoveredProject Leiningen.LeiningenProject]
+discoverSkippingCircleCI dir = filter notUnderCircleCI <$> Leiningen.discover dir
+  where
+    notUnderCircleCI dp = not (".circleci" `isInfixOf` toFilePath (projectPath dp))
 
 eastwood :: AnalysisTestFixture (Leiningen.LeiningenProject)
 eastwood =
   AnalysisTestFixture
     "eastwood"
-    Leiningen.discover
+    discoverSkippingCircleCI
     clojureEnv
     Nothing
     $ FixtureArtifact

--- a/integration-test/Analysis/CocoapodsSpec.hs
+++ b/integration-test/Analysis/CocoapodsSpec.hs
@@ -22,6 +22,7 @@ shadowsocksXNG =
       "https://github.com/shadowsocks/ShadowsocksX-NG/archive/refs/tags/v1.9.4.tar.gz"
       [reldir|cocoapods/ShadowsocksX-NG/|]
       [reldir|ShadowsocksX-NG-1.9.4/|]
+      []
 
 sDWebImage :: AnalysisTestFixture (Cocoapods.CocoapodsProject)
 sDWebImage =
@@ -34,6 +35,7 @@ sDWebImage =
       "https://github.com/SDWebImage/SDWebImage/archive/refs/tags/5.12.0.tar.gz"
       [reldir|cocoapods/ring/|]
       [reldir|SDWebImage-5.12.0/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/ElixirSpec.hs
+++ b/integration-test/Analysis/ElixirSpec.hs
@@ -47,6 +47,7 @@ absinthe =
       "https://github.com/absinthe-graphql/absinthe/archive/refs/tags/v1.6.6.tar.gz"
       [reldir|elixir/absinthe/|]
       [reldir|absinthe-1.6.6/|]
+      []
 
 -- | commanded v1.4.6: Tests the primary (MIX_ENV=prod) path.
 --
@@ -66,6 +67,7 @@ commanded =
       "https://github.com/commanded/commanded/archive/refs/tags/v1.4.6.tar.gz"
       [reldir|elixir/commanded/|]
       [reldir|commanded-1.4.6/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/ErlangSpec.hs
+++ b/integration-test/Analysis/ErlangSpec.hs
@@ -25,6 +25,7 @@ emqx =
       "https://github.com/emqx/emqx/archive/refs/tags/v4.3.10.tar.gz"
       [reldir|erlang/emqx/|]
       [reldir|emqx-4.3.10/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/FixtureUtils.hs
+++ b/integration-test/Analysis/FixtureUtils.hs
@@ -28,6 +28,7 @@ import Control.Carrier.Telemetry (
   IgnoreTelemetryC,
   withoutTelemetry,
  )
+import Control.Monad (when)
 import Data.Conduit (runConduitRes, (.|))
 import Data.Conduit.Binary qualified as CB
 import Data.Function ((&))
@@ -105,13 +106,13 @@ data FixtureArtifact = FixtureArtifact
   { tarGzFileUrl :: Text
   , extractAt :: Path Rel Dir
   , scopedDir :: Path Rel Dir
-  , -- | Subdirectories of 'scopedDir' to remove after extraction.
-    --
-    -- Use this when an upstream tarball contains a subproject that is no
-    -- longer buildable (e.g. transitive deps removed from a public registry).
-    -- The directory is deleted before discovery runs, so it won't be picked
-    -- up as a separate project to analyze.
-    excludePaths :: [Path Rel Dir]
+  , excludePaths :: [Path Rel Dir]
+  -- ^ Subdirectories of 'scopedDir' to remove after extraction.
+  --
+  -- Use this when an upstream tarball contains a subproject that is no
+  -- longer buildable (e.g. transitive deps removed from a public registry).
+  -- The directory is deleted before discovery runs, so it won't be picked
+  -- up as a separate project to analyze.
   }
   deriving (Show, Eq, Ord)
 
@@ -251,4 +252,4 @@ applyExcludePaths projectRoot = mapM_ removeIfExists
     removeIfExists rel = do
       let absPath = projectRoot </> rel
       exists <- PIO.doesDirExist absPath
-      if exists then PIO.removeDirRecur absPath else pure ()
+      when exists $ PIO.removeDirRecur absPath

--- a/integration-test/Analysis/FixtureUtils.hs
+++ b/integration-test/Analysis/FixtureUtils.hs
@@ -105,6 +105,13 @@ data FixtureArtifact = FixtureArtifact
   { tarGzFileUrl :: Text
   , extractAt :: Path Rel Dir
   , scopedDir :: Path Rel Dir
+  , -- | Subdirectories of 'scopedDir' to remove after extraction.
+    --
+    -- Use this when an upstream tarball contains a subproject that is no
+    -- longer buildable (e.g. transitive deps removed from a public registry).
+    -- The directory is deleted before discovery runs, so it won't be picked
+    -- up as a separate project to analyze.
+    excludePaths :: [Path Rel Dir]
   }
   deriving (Show, Eq, Ord)
 
@@ -230,4 +237,18 @@ getArtifact target = sendIO $ do
         Nothing -> pure . Left $ "Failed to extract file from " <> urlStr
         Just extractor -> do
           sendIO $ extractor archiveExtractFolder tempFile
+          sendIO $ applyExcludePaths (archiveExtractFolder </> scopedDir target) (excludePaths target)
           pure . Right $ archiveExtractFolder
+
+-- | Recursively remove each excluded path from the extracted project directory.
+--
+-- Silently skips paths that don't exist in the artifact, since a fixture
+-- declaring an exclude for a path the upstream tarball doesn't ship is not
+-- itself a test failure.
+applyExcludePaths :: Path Abs Dir -> [Path Rel Dir] -> IO ()
+applyExcludePaths projectRoot = mapM_ removeIfExists
+  where
+    removeIfExists rel = do
+      let absPath = projectRoot </> rel
+      exists <- PIO.doesDirExist absPath
+      if exists then PIO.removeDirRecur absPath else pure ()

--- a/integration-test/Analysis/GoSpec.hs
+++ b/integration-test/Analysis/GoSpec.hs
@@ -25,6 +25,7 @@ vault =
       "https://github.com/hashicorp/vault/archive/refs/tags/v1.9.1.tar.gz"
       [reldir|go/vault/|]
       [reldir|vault-1.9.1/|]
+      []
 
 testVault :: Spec
 testVault =

--- a/integration-test/Analysis/GradleSpec.hs
+++ b/integration-test/Analysis/GradleSpec.hs
@@ -32,6 +32,7 @@ springBoot =
       "https://github.com/spring-projects/spring-boot/archive/refs/tags/v4.0.0-RC2.tar.gz"
       [reldir|gradle/sample/|]
       [reldir|spring-boot-4.0.0-RC2|]
+      []
 
 gradleSettingsOnly :: AnalysisTestFixture (Gradle.GradleProject)
 gradleSettingsOnly =
@@ -44,6 +45,7 @@ gradleSettingsOnly =
       "https://docs.gradle.org/7.3.3/samples/zips/sample_building_java_applications-groovy-dsl.zip"
       [reldir|gradle/sample/|]
       [reldir|.|]
+      []
 
 testSpringBoot :: Spec
 testSpringBoot =

--- a/integration-test/Analysis/LicenseScannerSpec.hs
+++ b/integration-test/Analysis/LicenseScannerSpec.hs
@@ -39,6 +39,7 @@ recursiveArchive =
     "https://github.com/fossas/cli-license-scan-integration-test-fixtures/archive/refs/heads/main.zip"
     [reldir|manual-deps/license-scanner/|]
     [reldir|recursive-archive|]
+    []
 
 vendoredDep :: VendoredDependency
 vendoredDep =

--- a/integration-test/Analysis/MavenSpec.hs
+++ b/integration-test/Analysis/MavenSpec.hs
@@ -45,6 +45,7 @@ keycloak =
       "https://github.com/keycloak/keycloak/archive/refs/tags/15.1.0.tar.gz"
       [reldir|maven/keycloak/|]
       [reldir|keycloak-15.1.0//|]
+      []
 
 guava :: AnalysisTestFixture Maven.MavenProject
 guava =
@@ -57,6 +58,7 @@ guava =
       "https://github.com/google/guava/archive/refs/tags/v31.1.tar.gz"
       [reldir|maven/guava/|]
       [reldir|guava-31.1|]
+      []
 
 simplePomFile :: AnalysisTestFixture Maven.MavenProject
 simplePomFile =
@@ -69,6 +71,7 @@ simplePomFile =
       "https://github.com/fossas/example-pom-file/archive/refs/heads/main.tar.gz"
       [reldir|maven/simple_pom_file/|]
       [reldir|example-pom-file-main|]
+      []
 
 pomFileWithBuildDirOverride :: AnalysisTestFixture Maven.MavenProject
 pomFileWithBuildDirOverride =
@@ -81,6 +84,7 @@ pomFileWithBuildDirOverride =
       "https://github.com/fossas/example-pom-file/archive/refs/heads/override-build-directory.tar.gz"
       [reldir|maven/build_dir_override/|]
       [reldir|example-pom-file-override-build-directory|]
+      []
 
 testKeycloakNonStrict :: Spec
 testKeycloakNonStrict = do

--- a/integration-test/Analysis/NugetSpec.hs
+++ b/integration-test/Analysis/NugetSpec.hs
@@ -28,6 +28,7 @@ serviceStack discoveryFunc =
       "https://github.com/ServiceStack/ServiceStack/archive/refs/tags/v5.13.2.tar.gz"
       [reldir|nuget/ServiceStack/|]
       [reldir|servicestack-5.13.2//|]
+      []
 
 dotnetCoreTwoExample :: (Path Abs Dir -> TestC IO [DiscoveredProject a]) -> AnalysisTestFixture a
 dotnetCoreTwoExample discoveryFunc =
@@ -40,6 +41,7 @@ dotnetCoreTwoExample discoveryFunc =
       "https://github.com/james-fossa/dotnet-core-2.0-example/archive/refs/tags/0.0.1.tar.gz"
       [reldir|nuget/dotnet-core-2.0-example-0.0.1/|]
       [reldir|dotnet-core-2.0-example-0.0.1//|]
+      []
 
 testServiceStackForPkgReferences :: Spec
 testServiceStackForPkgReferences =
@@ -81,6 +83,7 @@ dapperAOT =
       "https://github.com/DapperLib/DapperAOT/archive/refs/tags/1.0.48.tar.gz"
       [reldir|nuget/DapperAOT/|]
       [reldir|DapperAOT-1.0.48//|]
+      []
 
 -- | Versions pinned in DapperAOT's Directory.Packages.props at tag 1.0.48.
 -- Used to verify that PackageReferences without inline versions are resolved

--- a/integration-test/Analysis/PnpmSpec.hs
+++ b/integration-test/Analysis/PnpmSpec.hs
@@ -36,6 +36,7 @@ elementPlus =
       "https://github.com/element-plus/element-plus/archive/refs/tags/2.0.0.tar.gz"
       [reldir|pnpm/element-plus/|]
       [reldir|element-plus-2.0.0/|]
+      []
 
 -- | jotai-eager uses pnpm v9 catalogs (catalog: specifiers in package.json
 -- resolved via the catalogs section in pnpm-lock.yaml).
@@ -50,6 +51,7 @@ jotaiEager =
       "https://github.com/jotaijs/jotai-eager/archive/refs/tags/v0.2.4.tar.gz"
       [reldir|pnpm/jotai-eager/|]
       [reldir|jotai-eager-0.2.4/|]
+      []
 
 -- | Collect all dependency vertices from all discovered projects' graphs.
 allDeps :: [(a, DependencyResults)] -> [Dependency]

--- a/integration-test/Analysis/Python/PipenvSpec.hs
+++ b/integration-test/Analysis/Python/PipenvSpec.hs
@@ -22,6 +22,7 @@ pipenv =
       "https://github.com/pypa/pipenv/archive/refs/tags/v2021.11.23.tar.gz"
       [reldir|python/pipenv/pipenv/|]
       [reldir|pipenv-2021.11.23/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/Python/PoetrySpec.hs
+++ b/integration-test/Analysis/Python/PoetrySpec.hs
@@ -22,6 +22,7 @@ poetry =
       "https://github.com/python-poetry/poetry/archive/72497bcb66b5a1cc20e3aa95973c523a22b05bfa.tar.gz"
       [reldir|python/poetry/poetry/|]
       [reldir|poetry-72497bcb66b5a1cc20e3aa95973c523a22b05bfa/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/Python/SetuptoolsSpec.hs
+++ b/integration-test/Analysis/Python/SetuptoolsSpec.hs
@@ -22,6 +22,7 @@ theFuck =
       "https://github.com/nvbn/thefuck/archive/refs/tags/3.31.tar.gz"
       [reldir|python/setuptools/thefuck/|]
       [reldir|thefuck-3.31/|]
+      []
 
 flask :: AnalysisTestFixture (Setuptools.SetuptoolsProject)
 flask =
@@ -34,6 +35,7 @@ flask =
       "https://github.com/pallets/flask/archive/refs/tags/2.0.2.tar.gz"
       [reldir|python/setuptools/flask/|]
       [reldir|flask-2.0.2/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/Python/UvSpec.hs
+++ b/integration-test/Analysis/Python/UvSpec.hs
@@ -22,6 +22,7 @@ uv =
       "https://github.com/fpgmaas/cookiecutter-uv/archive/refs/tags/0.0.11.tar.gz"
       [reldir|python/uv/cookiecutter-uv/|]
       [reldir|cookiecutter-uv-0.0.11/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/RubySpec.hs
+++ b/integration-test/Analysis/RubySpec.hs
@@ -22,6 +22,7 @@ rails =
       "https://github.com/rails/rails/archive/refs/tags/v6.1.4.tar.gz"
       [reldir|ruby/rails/|]
       [reldir|rails-6.1.4/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/RustSpec.hs
+++ b/integration-test/Analysis/RustSpec.hs
@@ -30,6 +30,7 @@ bat =
       "https://github.com/sharkdp/bat/archive/refs/tags/v0.18.3.tar.gz"
       [reldir|rust/bat/|]
       [reldir|bat-0.18.3//|]
+      []
 
 fd :: AnalysisTestFixture (Cargo.CargoProject)
 fd =
@@ -42,6 +43,7 @@ fd =
       "https://github.com/sharkdp/fd/archive/refs/tags/v8.3.0.tar.gz"
       [reldir|rust/fd/|]
       [reldir|fd-8.3.0/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/ScalaSpec.hs
+++ b/integration-test/Analysis/ScalaSpec.hs
@@ -32,6 +32,7 @@ scalaExampleProject =
       "https://github.com/fossas/scala3-example-project/archive/refs/heads/main.tar.gz"
       [reldir|scala/scala-3-ex-project/|]
       [reldir|scala3-example-project-main/target/scala-3.4.0/|]
+      []
 
 spec :: Spec
 spec = do

--- a/integration-test/Analysis/SwiftSpec.hs
+++ b/integration-test/Analysis/SwiftSpec.hs
@@ -22,6 +22,7 @@ exampleProject =
       "https://github.com/fossas/example-pbxproj-project/archive/refs/heads/main.tar.gz"
       [reldir|swift/example_project/|]
       [reldir|example-pbxproj-project-main/myproj/|]
+      []
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
# Overview

`Analysis.Clojure.eastwood` has been failing on master because the pinned eastwood `Release-1.0.0` tarball ships a secondary `project.clj` under `.circleci/nvd/` that pulls in OWASP `dependency-check-core 6.2.2` and friends, which are no longer resolvable from Maven Central / Clojars. Discovery picks up that subproject and `lein deps :tree-data` fails on it even though the real eastwood project at the root is healthy.

This PR adds an `excludePaths :: [Path Rel Dir]` field to `FixtureArtifact` — a list of subdirectories of `scopedDir` that `getArtifact` removes immediately after extraction, before discovery sees them. The eastwood fixture declares `[.circleci/]`; every other fixture passes `[]`. Future fixtures with similar upstream-broken subprojects can declare them the same way regardless of strategy.

I admit that this is a bit of a hacky fix, but I didn't want to spend the time to find a new test fixture that would just work without any fixes.

## Acceptance criteria

`Analysis.Clojure.eastwood` and `Analysis.Clojure.ring` pass in the Integration Tests workflow. No other tests change behavior.

## Testing plan

CI: Integration Tests run [25760240142](https://github.com/fossas/fossa-cli/actions/runs/25760240142) on this branch is green; both eastwood and ring Clojure tests pass.

## Risks

None expected — the new field defaults to `[]` everywhere it isn't explicitly set, so all other fixtures behave exactly as before.

## References

None.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense). _This is a test-infrastructure fix; the integration test it repairs is the test._
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`. _Not user-visible._
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. _Not externally visible._
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command.
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.