### PR TITLE
Replace broken eastwood Clojure fixture with clj-http

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.17.6
+
+- Licensing - Fix two bad GPL matches [No PR]
+
 ## 3.17.5
 
 - Vendetta: Debug bundles now include per-file component match data from Vendetta scans, making it easier to diagnose why a vendored dependency was or wasn't detected. ([#1706](https://github.com/fossas/fossa-cli/pull/1706))

--- a/integration-test/Analysis/ClojureSpec.hs
+++ b/integration-test/Analysis/ClojureSpec.hs
@@ -14,17 +14,17 @@ import Types (DiscoveredProjectType (..), GraphBreadth (Complete))
 clojureEnv :: FixtureEnvironment
 clojureEnv = NixEnv ["openjdk11", "clojure", "leiningen"]
 
-eastwood :: AnalysisTestFixture (Leiningen.LeiningenProject)
-eastwood =
+cljHttp :: AnalysisTestFixture (Leiningen.LeiningenProject)
+cljHttp =
   AnalysisTestFixture
-    "eastwood"
+    "clj-http"
     Leiningen.discover
     clojureEnv
     Nothing
     $ FixtureArtifact
-      "https://github.com/jonase/eastwood/archive/refs/tags/Release-1.0.0.tar.gz"
-      [reldir|clojure/eastwood/|]
-      [reldir|eastwood-Release-1.0.0/|]
+      "https://github.com/dakrone/clj-http/archive/refs/tags/3.13.1.tar.gz"
+      [reldir|clojure/clj-http/|]
+      [reldir|clj-http-3.13.1/|]
 
 ring :: AnalysisTestFixture (Leiningen.LeiningenProject)
 ring =
@@ -40,5 +40,6 @@ ring =
 
 spec :: Spec
 spec = do
-  testSuiteDepResultSummary NonStrict eastwood LeiningenProjectType (DependencyResultsSummary 10 7 3 1 Complete)
+  -- Placeholder counts; will be replaced once CI reports the actual values.
+  testSuiteDepResultSummary NonStrict cljHttp LeiningenProjectType (DependencyResultsSummary 999 999 999 1 Complete)
   testSuiteDepResultSummary NonStrict ring LeiningenProjectType (DependencyResultsSummary 23 6 17 1 Complete)

--- a/integration-test/Analysis/ClojureSpec.hs
+++ b/integration-test/Analysis/ClojureSpec.hs
@@ -40,6 +40,5 @@ ring =
 
 spec :: Spec
 spec = do
-  -- Placeholder counts; will be replaced once CI reports the actual values.
-  testSuiteDepResultSummary NonStrict cljHttp LeiningenProjectType (DependencyResultsSummary 999 999 999 1 Complete)
+  testSuiteDepResultSummary NonStrict cljHttp LeiningenProjectType (DependencyResultsSummary 71 27 44 1 Complete)
   testSuiteDepResultSummary NonStrict ring LeiningenProjectType (DependencyResultsSummary 23 6 17 1 Complete)


### PR DESCRIPTION
# Overview

`Analysis.Clojure.eastwood` has been failing on master because the pinned eastwood `Release-1.0.0` tarball ships a secondary `project.clj` under `.circleci/nvd/` whose OWASP `dependency-check` transitive deps are no longer resolvable from Maven Central / Clojars. Newer eastwood tags ship even more nested example projects, so bumping the tag doesn't help.

This PR replaces the eastwood fixture with `clj-http 3.13.1`, which has a single `project.clj` at the root and depends only on widely-mirrored Apache HttpComponents and commons artifacts.

## Acceptance criteria

`Analysis.Clojure.clj-http` and `Analysis.Clojure.ring` pass in the Integration Tests workflow.

## Testing plan

CI integration-tests run on this branch goes green for the Clojure tests.

## Risks

The dependency-count assertion (`DependencyResultsSummary`) is currently a placeholder; needs to be updated with the real numbers reported by CI before this is ready to merge.

## References

Supersedes #1709.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense). _This is a test-fixture replacement; the integration test it repairs is the test._
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`. _Not user-visible._
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. _Not externally visible._
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command.
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.