### PR TITLE
Strategy/Scala: route sbt 1.4+ with explicit DependencyTreePlugin to built-in command (TKT-15490)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Scala/sbt: Fix silently dropped deep dependencies on sbt 1.4+ with explicit `addDependencyTreePlugin`. ([#1711](https://github.com/fossas/fossa-cli/pull/1711))
+- Scala/sbt: Route projects using `addDependencyTreePlugin` (sbt 1.4+) to the correct `dependencyBrowseTreeHTML` task, restoring deep dependencies. ([#1711](https://github.com/fossas/fossa-cli/pull/1711))
 
 ## 3.17.6
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Scala/sbt: Run the uppercase `dependencyBrowseTreeHTML` task when the project explicitly enables `addDependencyTreePlugin` on sbt 1.4+. Previously the lowercase `dependencyBrowseTreeHtml` was used unconditionally for the explicit-plugin path, which sbt 1.4+ rejects, causing deep dependencies to be silently dropped. ([TKT-15490](https://fossa.atlassian.net/browse/ANE-2718))
+
 ## 3.17.5
 
 - Vendetta: Debug bundles now include per-file component match data from Vendetta scans, making it easier to diagnose why a vendored dependency was or wasn't detected. ([#1706](https://github.com/fossas/fossa-cli/pull/1706))

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Scala/sbt: Run the uppercase `dependencyBrowseTreeHTML` task when the project explicitly enables `addDependencyTreePlugin` on sbt 1.4+. Previously the lowercase `dependencyBrowseTreeHtml` was used unconditionally for the explicit-plugin path, which sbt 1.4+ rejects, causing deep dependencies to be silently dropped. ([TKT-15490](https://fossa.atlassian.net/browse/ANE-2718))
+- Scala/sbt: Fix silently dropped deep dependencies on sbt 1.4+ with explicit `addDependencyTreePlugin`. ([#1711](https://github.com/fossas/fossa-cli/pull/1711))
 
 ## 3.17.6
 

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -203,13 +203,13 @@ analyzeWithPoms (ScalaProject _ _ closure) = context "Analyzing sbt dependencies
       }
 
 analyzeWithDepTreeJson :: (Has ReadFS sig m, Has Diagnostics sig m) => ScalaProject -> m DependencyResults
-analyzeWithDepTreeJson (ScalaProject _ treeJson closure) = context "Analyzing sbt dependencies using dependencyBrowseTreeHTML" $ do
+analyzeWithDepTreeJson (ScalaProject _ treeJson closure) = context "Analyzing sbt dependencies using dependency tree JSON" $ do
   treeJson' <-
     errCtx MissingFullDependencyPluginCtx $
       errHelp MissingFullDependencyPluginHelp $
         errDoc sbtDepsGraphPluginUrl $
           errDoc scalaFossaDocUrl $
-            fromMaybeText "Could not retrieve output from sbt dependencyBrowseTreeHTML" treeJson
+            fromMaybeText "Could not retrieve dependency tree JSON output from sbt" treeJson
   projectGraph <- TreeJson.analyze treeJson'
   pure $
     DependencyResults

--- a/src/Strategy/Scala.hs
+++ b/src/Strategy/Scala.hs
@@ -60,7 +60,7 @@ import Strategy.Maven.Pom.PomFile (RawPom (rawPomArtifact, rawPomGroup, rawPomVe
 import Strategy.Maven.Pom.Resolver (buildGlobalClosure)
 import Strategy.Scala.Common (mkSbtCommand)
 import Strategy.Scala.Errors (FailedToListProjects (FailedToListProjects), MaybeWithoutDependencyTreeTask (..), MissingFullDependencyPlugin (..), sbtDepsGraphPluginUrl, scalaFossaDocUrl)
-import Strategy.Scala.Plugin (genTreeJson, hasDependencyPlugins)
+import Strategy.Scala.Plugin (DependencyPluginsDetected (..), genTreeJson, hasDependencyPlugins)
 import Strategy.Scala.SbtDependencyTree (SbtArtifact (SbtArtifact), analyze, sbtDepTreeCmd)
 import Strategy.Scala.SbtDependencyTreeJson qualified as TreeJson
 import Types (
@@ -161,10 +161,10 @@ findProjects = walkWithFilters' $ \dir _ files -> do
           . context ("Listing sbt projects at " <> pathToText dir)
           $ genPoms dir
 
-      (miniDepPlugin, depPlugin) <- hasDependencyPlugins dir
-      case (projectsRes, miniDepPlugin, depPlugin) of
+      DependencyPluginsDetected{hasMiniDependencyTreePlugin, dependencyTreePlugin} <- hasDependencyPlugins dir
+      case (projectsRes, hasMiniDependencyTreePlugin, dependencyTreePlugin) of
         (Nothing, _, _) -> pure ([], WalkSkipAll)
-        (Just projects, False, False) -> pure ([SbtTargets Nothing [] projects], WalkSkipAll)
+        (Just projects, False, Nothing) -> pure ([SbtTargets Nothing [] projects], WalkSkipAll)
         (Just projects, True, _) -> do
           -- project is using miniature dependency tree plugin,
           -- which is included by default with sbt 1.4+
@@ -184,9 +184,13 @@ findProjects = walkWithFilters' $ \dir _ files -> do
             (True, _) -> pure ([SbtTargets Nothing [] projects], WalkSkipAll)
             (_, Just _) -> pure ([SbtTargets depTreeStdOut [] projects], WalkSkipAll)
             (_, _) -> pure ([], WalkSkipAll)
-        (Just projects, False, True) -> do
-          -- project is explicitly configured to use dependency-tree-plugin
-          treeJSONs <- recover $ genTreeJson dir
+        (Just projects, False, Just pluginKind) -> do
+          -- project is explicitly configured to use dependency-tree-plugin.
+          -- The casing of the dependencyBrowseTree task differs between the
+          -- modern (sbt 1.4+) DependencyTreePlugin and the legacy
+          -- net.virtualvoid sbt-dependency-graph plugin; pluginKind selects
+          -- the right one. See TKT-15490 / ANE-2718.
+          treeJSONs <- recover $ genTreeJson pluginKind dir
           pure ([SbtTargets Nothing (fromMaybe [] treeJSONs) projects], WalkSkipAll)
 
 analyzeWithPoms :: (Has Diagnostics sig m) => ScalaProject -> m DependencyResults

--- a/src/Strategy/Scala/Plugin.hs
+++ b/src/Strategy/Scala/Plugin.hs
@@ -70,18 +70,24 @@ hasDependencyPlugins projectDir = do
 --      used on sbt < 1.4. Provides the lowercase @dependencyBrowseTreeHtml@
 --      task.
 --
+-- Detection anchors on the @\<FQCN\>: enabled in@ suffix rather than the bare
+-- FQCN. @sbt plugins@ lists plugins the user has explicitly disabled (via
+-- @disablePlugins(...)@) with @: disabled in \<scope\>@ — those still
+-- contain the FQCN as a substring, so an unanchored match would wrongly
+-- route to a task that doesn't exist on the active plugin set.
+--
 -- When both modern and legacy non-mini plugins are present we prefer the
 -- modern one (sbt 1.4+ wins) since legacy plugin presence on a modern sbt
 -- typically means the user has both kinds of declarations in their build.
 detectDependencyPlugins :: Text -> DependencyPluginsDetected
 detectDependencyPlugins stdoutText =
   DependencyPluginsDetected
-    { hasMiniDependencyTreePlugin = Text.count ".MiniDependencyTreePlugin" stdoutText > 0
+    { hasMiniDependencyTreePlugin = "sbt.plugins.MiniDependencyTreePlugin: enabled in" `Text.isInfixOf` stdoutText
     , dependencyTreePlugin =
-        if Text.count "sbt.plugins.DependencyTreePlugin" stdoutText > 0
+        if "sbt.plugins.DependencyTreePlugin: enabled in" `Text.isInfixOf` stdoutText
           then Just ModernDependencyTreePlugin
           else
-            if Text.count "net.virtualvoid.sbt.graph.DependencyGraphPlugin" stdoutText > 0
+            if "net.virtualvoid.sbt.graph.DependencyGraphPlugin: enabled in" `Text.isInfixOf` stdoutText
               then Just LegacyDependencyGraphPlugin
               else Nothing
     }

--- a/src/Strategy/Scala/Plugin.hs
+++ b/src/Strategy/Scala/Plugin.hs
@@ -4,6 +4,8 @@ module Strategy.Scala.Plugin (
   hasDependencyPlugins,
   detectDependencyPlugins,
   genTreeJson,
+  DependencyTreePluginKind (..),
+  DependencyPluginsDetected (..),
 ) where
 
 import Control.Effect.Diagnostics (Diagnostics, fatalText)
@@ -22,45 +24,96 @@ import Effect.Exec (
 import Path (Abs, Dir, File, Path, mkRelFile, parent, parseAbsFile, (</>))
 import Strategy.Scala.Common (mkSbtCommand)
 
+-- | Which non-mini dependency-tree plugin (if any) the project has installed.
+--
+-- The two plugins differ in the casing of their @dependencyBrowseTree@ task.
+-- See 'mkDependencyBrowseTreeCmd' for the command names.
+data DependencyTreePluginKind
+  = -- | @sbt.plugins.DependencyTreePlugin@. Built into sbt 1.4+ and enabled
+    -- explicitly via @addDependencyTreePlugin@ in @plugins.sbt@. Provides the
+    -- uppercase @dependencyBrowseTreeHTML@ task.
+    ModernDependencyTreePlugin
+  | -- | @net.virtualvoid.sbt.graph.DependencyGraphPlugin@. The third-party
+    -- @sbt-dependency-graph@ plugin used on sbt < 1.4. Provides the lowercase
+    -- @dependencyBrowseTreeHtml@ task.
+    LegacyDependencyGraphPlugin
+  deriving (Eq, Ord, Show)
+
+-- | What the @sbt plugins@ output told us about dependency-tree plugins.
+data DependencyPluginsDetected = DependencyPluginsDetected
+  { hasMiniDependencyTreePlugin :: Bool
+  , dependencyTreePlugin :: Maybe DependencyTreePluginKind
+  }
+  deriving (Eq, Ord, Show)
+
 -- | Returns list of plugins used by sbt.
 -- Ref: https://www.scala-sbt.org/1.x/docs/Plugins.html
 getPlugins :: Command
 getPlugins = mkSbtCommand "plugins"
 
--- | Returns (hasMiniDependencyTreePlugin, hasDependencyTreePlugin) by running sbt plugins.
-hasDependencyPlugins :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m (Bool, Bool)
+-- | Detect which dependency-tree plugins are loaded by running @sbt plugins@.
+hasDependencyPlugins :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m DependencyPluginsDetected
 hasDependencyPlugins projectDir = do
   stdoutText <- (TextLazy.toStrict . decodeUtf8) <$> context "Identifying plugins" (execThrow projectDir getPlugins)
   pure $ detectDependencyPlugins stdoutText
 
--- | Detect dependency plugins from sbt plugins output.
--- Returns (hasMiniDependencyTreePlugin, hasDependencyTreePlugin).
-detectDependencyPlugins :: Text -> (Bool, Bool)
+-- | Classify dependency-tree plugins from the @sbt plugins@ output.
+--
+-- The plugin names mapped here:
+--
+--    * @sbt.plugins.MiniDependencyTreePlugin@ — bundled with sbt 1.4+, gives
+--      us the @dependencyTree@ task used by 'Strategy.Scala.SbtDependencyTree'.
+--    * @sbt.plugins.DependencyTreePlugin@ — opt-in on sbt 1.4+ via
+--      @addDependencyTreePlugin@. Provides the uppercase
+--      @dependencyBrowseTreeHTML@ task.
+--    * @net.virtualvoid.sbt.graph.DependencyGraphPlugin@ — third-party plugin
+--      used on sbt < 1.4. Provides the lowercase @dependencyBrowseTreeHtml@
+--      task.
+--
+-- When both modern and legacy non-mini plugins are present we prefer the
+-- modern one (sbt 1.4+ wins) since legacy plugin presence on a modern sbt
+-- typically means the user has both kinds of declarations in their build.
+detectDependencyPlugins :: Text -> DependencyPluginsDetected
 detectDependencyPlugins stdoutText =
-  ( Text.count ".MiniDependencyTreePlugin" stdoutText > 0
-  , Text.count ".DependencyTreePlugin" stdoutText > 0
-      || Text.count "net.virtualvoid.sbt.graph.DependencyGraphPlugin" stdoutText > 0 -- sbt < 1.4
-  )
+  DependencyPluginsDetected
+    { hasMiniDependencyTreePlugin = Text.count ".MiniDependencyTreePlugin" stdoutText > 0
+    , dependencyTreePlugin =
+        if Text.count "sbt.plugins.DependencyTreePlugin" stdoutText > 0
+          then Just ModernDependencyTreePlugin
+          else
+            if Text.count "net.virtualvoid.sbt.graph.DependencyGraphPlugin" stdoutText > 0
+              then Just LegacyDependencyGraphPlugin
+              else Nothing
+    }
 
--- | Generates Dependency Trees.
--- Ref: https://github.com/sbt/sbt/blob/master/main/src/main/scala/sbt/plugins/DependencyTreeSettings.scala#L101
+-- | The sbt task that writes @tree.html@/@tree.json@ alongside its dependency
+-- output. Plugin name vs task casing:
 --
--- This command unlike 'dependencyBrowseTree', does not open
--- the browser when executed.
+--    * 'ModernDependencyTreePlugin' (sbt 1.4+, @addDependencyTreePlugin@) →
+--      @dependencyBrowseTreeHTML@.
+--    * 'LegacyDependencyGraphPlugin' (sbt < 1.4, @sbt-dependency-graph@) →
+--      @dependencyBrowseTreeHtml@.
 --
--- It writes following files in target directory:
---  ./tree.json
---  ./tree.html
---  ./tree.data.js
---
--- This command is only used when the plugin is installed explicitly, i.e. sbt < 1.4.
--- Newer versions of sbt will use the built-in dependency graph plugin.
-mkDependencyBrowseTreeHTMLCmd :: Command
-mkDependencyBrowseTreeHTMLCmd = mkSbtCommand "dependencyBrowseTreeHtml"
+-- Picking the wrong casing produces an sbt error like
+-- @[error] Not a valid command: dependencyBrowseTreeHTML@ which surfaces to
+-- the user as "Could not retrieve output from sbt dependencyBrowseTreeHTML".
+-- That regression (CLI 3.8.30) is tracked under TKT-15490 / ANE-2718.
+mkDependencyBrowseTreeCmd :: DependencyTreePluginKind -> Command
+mkDependencyBrowseTreeCmd ModernDependencyTreePlugin = mkSbtCommand "dependencyBrowseTreeHTML"
+mkDependencyBrowseTreeCmd LegacyDependencyGraphPlugin = mkSbtCommand "dependencyBrowseTreeHtml"
 
-genTreeJson :: (Has Exec sig m, Has Diagnostics sig m) => Path Abs Dir -> m [Path Abs File]
-genTreeJson projectDir = do
-  stdoutBL <- context "Generating dependency tree html" $ execThrow projectDir mkDependencyBrowseTreeHTMLCmd
+-- | Generates dependency trees by invoking the appropriate
+-- @dependencyBrowseTree*@ task. Unlike @dependencyBrowseTree@, this does not
+-- open a browser when executed.
+--
+-- It writes the following files in the target directory:
+--
+--    * @./tree.json@
+--    * @./tree.html@
+--    * @./tree.data.js@
+genTreeJson :: (Has Exec sig m, Has Diagnostics sig m) => DependencyTreePluginKind -> Path Abs Dir -> m [Path Abs File]
+genTreeJson pluginKind projectDir = do
+  stdoutBL <- context "Generating dependency tree html" $ execThrow projectDir (mkDependencyBrowseTreeCmd pluginKind)
 
   -- stdout for "sbt dependencyBrowseTreeHTML" looks like:
   -- -

--- a/src/Strategy/Scala/Plugin.hs
+++ b/src/Strategy/Scala/Plugin.hs
@@ -71,11 +71,19 @@ hasDependencyPlugins projectDir = do
 --      used on sbt < 1.4. Provides the lowercase @dependencyBrowseTreeHtml@
 --      task.
 --
--- Detection anchors on the @\<FQCN\>: enabled in@ suffix rather than the bare
--- FQCN. @sbt plugins@ lists plugins the user has explicitly disabled (via
--- @disablePlugins(...)@) with @: disabled in \<scope\>@ — those still
--- contain the FQCN as a substring, so an unanchored match would wrongly
--- route to a task that doesn't exist on the active plugin set.
+-- @sbt plugins@ groups its output into per-project @Enabled plugins in
+-- \<project\>:@ sections, listing one bare plugin FQCN per indented line,
+-- followed by a trailing @Plugins that are loaded to the build but not enabled
+-- in any subprojects:@ section. A plugin the user disabled via
+-- @disablePlugins(...)@ moves into that trailing section. We therefore search
+-- only the text *before* that marker, so a disabled (loaded-but-not-enabled)
+-- plugin is not mistaken for an active one.
+--
+-- The plugin FQCN appears on its own line with no @: enabled in@ suffix. An
+-- earlier attempt to anchor detection on such a suffix matched nothing in real
+-- sbt output, which silently dropped deep dependencies and fell back to poms
+-- (regressed TKT-15490). See @test/Scala/PluginSpec.hs@ for fixtures captured
+-- from actual @sbt -batch -no-colors plugins@ runs.
 --
 -- When both modern and legacy non-mini plugins are present we prefer the
 -- modern one (sbt 1.4+ wins) since legacy plugin presence on a modern sbt
@@ -87,7 +95,9 @@ detectDependencyPlugins stdoutText =
     , dependencyTreePlugin = snd <$> find (enabled . fst) treePlugins
     }
   where
-    enabled name = (name <> ": enabled in") `Text.isInfixOf` stdoutText
+    enabledSection = fst $ Text.breakOn notEnabledMarker stdoutText
+    notEnabledMarker = "Plugins that are loaded to the build but not enabled"
+    enabled name = name `Text.isInfixOf` enabledSection
     treePlugins =
       [ ("sbt.plugins.DependencyTreePlugin", ModernDependencyTreePlugin)
       , ("net.virtualvoid.sbt.graph.DependencyGraphPlugin", LegacyDependencyGraphPlugin)

--- a/src/Strategy/Scala/Plugin.hs
+++ b/src/Strategy/Scala/Plugin.hs
@@ -10,6 +10,7 @@ module Strategy.Scala.Plugin (
 
 import Control.Effect.Diagnostics (Diagnostics, fatalText)
 import Control.Effect.Stack (context)
+import Data.List (find)
 import Data.Maybe (mapMaybe)
 import Data.String.Conversion (ConvertUtf8 (decodeUtf8), toString)
 import Data.Text (Text)
@@ -82,15 +83,15 @@ hasDependencyPlugins projectDir = do
 detectDependencyPlugins :: Text -> DependencyPluginsDetected
 detectDependencyPlugins stdoutText =
   DependencyPluginsDetected
-    { hasMiniDependencyTreePlugin = "sbt.plugins.MiniDependencyTreePlugin: enabled in" `Text.isInfixOf` stdoutText
-    , dependencyTreePlugin =
-        if "sbt.plugins.DependencyTreePlugin: enabled in" `Text.isInfixOf` stdoutText
-          then Just ModernDependencyTreePlugin
-          else
-            if "net.virtualvoid.sbt.graph.DependencyGraphPlugin: enabled in" `Text.isInfixOf` stdoutText
-              then Just LegacyDependencyGraphPlugin
-              else Nothing
+    { hasMiniDependencyTreePlugin = enabled "sbt.plugins.MiniDependencyTreePlugin"
+    , dependencyTreePlugin = snd <$> find (enabled . fst) treePlugins
     }
+  where
+    enabled name = (name <> ": enabled in") `Text.isInfixOf` stdoutText
+    treePlugins =
+      [ ("sbt.plugins.DependencyTreePlugin", ModernDependencyTreePlugin)
+      , ("net.virtualvoid.sbt.graph.DependencyGraphPlugin", LegacyDependencyGraphPlugin)
+      ]
 
 -- | The sbt task that writes @tree.html@/@tree.json@ alongside its dependency
 -- output. Plugin name vs task casing:

--- a/test/Scala/PluginSpec.hs
+++ b/test/Scala/PluginSpec.hs
@@ -59,6 +59,18 @@ spec = do
       detectDependencyPlugins sbtNoPlugins
         `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Nothing}
 
+    -- `sbt plugins` lists user-disabled plugins (`disablePlugins(...)`) with a
+    -- ": disabled in <scope>" suffix. The FQCN still appears on those lines,
+    -- so detection must anchor on ": enabled in" to avoid routing to a task
+    -- the active plugin set doesn't provide.
+    it "should not treat MiniDependencyTreePlugin as present when listed as disabled" $ do
+      detectDependencyPlugins sbtDisabledMiniPlugin
+        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Nothing}
+
+    it "should not treat modern DependencyTreePlugin as present when listed as disabled" $ do
+      detectDependencyPlugins sbtDisabledModernPlugin
+        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Nothing}
+
 -- sbt 1.4+ with only built-in plugin
 sbt14BuiltinOnly :: Text
 sbt14BuiltinOnly =
@@ -164,4 +176,29 @@ sbtNoPlugins =
 [info]   sbt.plugins.CorePlugin: enabled in root
 [info]   sbt.plugins.IvyPlugin: enabled in root
 [info]   sbt.plugins.JvmPlugin: enabled in root
+|]
+
+-- User-disabled MiniDependencyTreePlugin (e.g. `disablePlugins(MiniDependencyTreePlugin)`
+-- in build.sbt). The FQCN appears on a ": disabled in" line — detection
+-- must reject it.
+sbtDisabledMiniPlugin :: Text
+sbtDisabledMiniPlugin =
+  [r|[info] welcome to sbt 1.9.7 (Eclipse Adoptium Java 11.0.21)
+[info] In file:/Users/test/project/
+[info]   sbt.plugins.CorePlugin: enabled in root
+[info]   sbt.plugins.IvyPlugin: enabled in root
+[info]   sbt.plugins.JvmPlugin: enabled in root
+[info]   sbt.plugins.MiniDependencyTreePlugin: disabled in root
+|]
+
+-- User-disabled modern DependencyTreePlugin. Routing to the uppercase task
+-- would fail because the plugin isn't active.
+sbtDisabledModernPlugin :: Text
+sbtDisabledModernPlugin =
+  [r|[info] welcome to sbt 1.11.5 (Eclipse Adoptium Java 17.0.10)
+[info] In file:/Users/test/project/
+[info]   sbt.plugins.CorePlugin: enabled in root
+[info]   sbt.plugins.IvyPlugin: enabled in root
+[info]   sbt.plugins.JvmPlugin: enabled in root
+[info]   sbt.plugins.DependencyTreePlugin: disabled in root
 |]

--- a/test/Scala/PluginSpec.hs
+++ b/test/Scala/PluginSpec.hs
@@ -5,7 +5,11 @@ module Scala.PluginSpec (
 ) where
 
 import Data.Text (Text)
-import Strategy.Scala.Plugin (detectDependencyPlugins)
+import Strategy.Scala.Plugin (
+  DependencyPluginsDetected (..),
+  DependencyTreePluginKind (..),
+  detectDependencyPlugins,
+ )
 import Test.Hspec (
   Spec,
   describe,
@@ -18,20 +22,42 @@ spec :: Spec
 spec = do
   describe "detectDependencyPlugins" $ do
     it "should detect MiniDependencyTreePlugin (sbt 1.4+ built-in)" $ do
-      detectDependencyPlugins sbt14BuiltinOnly `shouldBe` (True, False)
+      detectDependencyPlugins sbt14BuiltinOnly
+        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = True, dependencyTreePlugin = Nothing}
 
-    it "should detect explicit DependencyTreePlugin" $ do
-      detectDependencyPlugins sbtExplicitPluginOnly `shouldBe` (False, True)
+    it "should detect explicit modern DependencyTreePlugin (sbt 1.4+ addDependencyTreePlugin)" $ do
+      detectDependencyPlugins sbtModernExplicitPluginOnly
+        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Just ModernDependencyTreePlugin}
 
-    it "should detect legacy net.virtualvoid plugin" $ do
-      detectDependencyPlugins sbtLegacyVirtualvoidPlugin `shouldBe` (False, True)
+    it "should detect legacy net.virtualvoid plugin (sbt < 1.4 sbt-dependency-graph)" $ do
+      detectDependencyPlugins sbtLegacyVirtualvoidPlugin
+        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Just LegacyDependencyGraphPlugin}
 
     -- TKT-14742: When both plugins present, findProjects should prefer MiniDependencyTreePlugin
-    it "should detect both plugins when MiniDependencyTreePlugin AND explicit plugin present" $ do
-      detectDependencyPlugins sbt14WithExplicitPlugin `shouldBe` (True, True)
+    it "should detect both plugins when MiniDependencyTreePlugin AND modern explicit plugin present" $ do
+      detectDependencyPlugins sbt14WithExplicitPlugin
+        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = True, dependencyTreePlugin = Just ModernDependencyTreePlugin}
+
+    -- TKT-15490: sbt 1.11.5 with addDependencyTreePlugin and no auto-loaded
+    -- MiniDependencyTreePlugin must be classified as ModernDependencyTreePlugin
+    -- so the analyzer runs the uppercase `dependencyBrowseTreeHTML` task. The
+    -- pre-fix code returned (False, True) and the routing dispatched to the
+    -- legacy lowercase `dependencyBrowseTreeHtml`, which sbt 1.4+ rejects.
+    it "should classify modern DependencyTreePlugin alone as Modern (TKT-15490 routing guard)" $ do
+      let detected = detectDependencyPlugins sbt111ExplicitPluginOnly
+      hasMiniDependencyTreePlugin detected `shouldBe` False
+      dependencyTreePlugin detected `shouldBe` Just ModernDependencyTreePlugin
+
+    -- If a project somehow lists both the modern and legacy plugin, prefer
+    -- the modern one — sbt 1.4+ wins, since the legacy plugin will not
+    -- function on a sbt that also surfaces sbt.plugins.DependencyTreePlugin.
+    it "should prefer modern DependencyTreePlugin when both modern and legacy are present" $ do
+      detectDependencyPlugins sbtBothModernAndLegacy
+        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Just ModernDependencyTreePlugin}
 
     it "should detect no plugins when neither is present" $ do
-      detectDependencyPlugins sbtNoPlugins `shouldBe` (False, False)
+      detectDependencyPlugins sbtNoPlugins
+        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Nothing}
 
 -- sbt 1.4+ with only built-in plugin
 sbt14BuiltinOnly :: Text
@@ -49,10 +75,29 @@ sbt14BuiltinOnly =
 [info]   sbt.plugins.SemanticdbPlugin: enabled in root
 |]
 
--- sbt < 1.4 with explicit addDependencyTreePlugin
-sbtExplicitPluginOnly :: Text
-sbtExplicitPluginOnly =
+-- sbt 1.4+ with explicit addDependencyTreePlugin and no MiniDependencyTreePlugin
+-- listed (the case the customer in TKT-15490 hit on sbt 1.11.5).
+sbtModernExplicitPluginOnly :: Text
+sbtModernExplicitPluginOnly =
   [r|[info] welcome to sbt 1.3.13 (Eclipse Adoptium Java 11.0.21)
+[info] loading global plugins from /Users/test/.sbt/1.0/plugins
+[info] loading project definition from /Users/test/project/project
+[info] loading settings for project root from build.sbt ...
+[info] set current project to test-project (in build file:/Users/test/project/)
+[info] In file:/Users/test/project/
+[info]   sbt.plugins.CorePlugin: enabled in root
+[info]   sbt.plugins.IvyPlugin: enabled in root
+[info]   sbt.plugins.JvmPlugin: enabled in root
+[info]   sbt.plugins.DependencyTreePlugin: enabled in root
+|]
+
+-- sbt 1.11.5 with addDependencyTreePlugin in plugins.sbt — mirrors the
+-- customer environment from TKT-15490. The customer reported that the
+-- pre-fix CLI invoked the lowercase `dependencyBrowseTreeHtml`, which sbt
+-- 1.4+ rejects.
+sbt111ExplicitPluginOnly :: Text
+sbt111ExplicitPluginOnly =
+  [r|[info] welcome to sbt 1.11.5 (Eclipse Adoptium Java 17.0.10)
 [info] loading global plugins from /Users/test/.sbt/1.0/plugins
 [info] loading project definition from /Users/test/project/project
 [info] loading settings for project root from build.sbt ...
@@ -94,6 +139,18 @@ sbt14WithExplicitPlugin =
 [info]   sbt.plugins.MiniDependencyTreePlugin: enabled in root
 [info]   sbt.plugins.DependencyTreePlugin: enabled in root
 [info]   sbt.plugins.SemanticdbPlugin: enabled in root
+|]
+
+-- A pathological setup that lists both modern and legacy plugins.
+sbtBothModernAndLegacy :: Text
+sbtBothModernAndLegacy =
+  [r|[info] welcome to sbt 1.9.7 (Eclipse Adoptium Java 11.0.21)
+[info] In file:/Users/test/project/
+[info]   sbt.plugins.CorePlugin: enabled in root
+[info]   sbt.plugins.IvyPlugin: enabled in root
+[info]   sbt.plugins.JvmPlugin: enabled in root
+[info]   sbt.plugins.DependencyTreePlugin: enabled in root
+[info]   net.virtualvoid.sbt.graph.DependencyGraphPlugin: enabled in root
 |]
 
 sbtNoPlugins :: Text

--- a/test/Scala/PluginSpec.hs
+++ b/test/Scala/PluginSpec.hs
@@ -18,187 +18,210 @@ import Test.Hspec (
  )
 import Text.RawString.QQ (r)
 
+-- The fixtures below mirror the real layout of @sbt -batch -no-colors plugins@:
+-- per-project "Enabled plugins in <project>:" sections list one bare plugin
+-- FQCN per indented line, and a trailing "Plugins that are loaded to the build
+-- but not enabled in any subprojects:" section lists the rest. There is no
+-- "<FQCN>: enabled in <scope>" suffix in real output. The sbt 1.9.8 fixtures
+-- (default, addDependencyTreePlugin, disabled-mini) are verbatim captures from
+-- fossas/scala3-example-project; the remainder follow the same layout.
 spec :: Spec
 spec = do
   describe "detectDependencyPlugins" $ do
-    it "should detect MiniDependencyTreePlugin (sbt 1.4+ built-in)" $ do
-      detectDependencyPlugins sbt14BuiltinOnly
+    -- Regression guard for TKT-15490: this is the verbatim `sbt plugins`
+    -- output for fossas/scala3-example-project (sbt 1.9.8, no plugins.sbt).
+    -- The built-in MiniDependencyTreePlugin must be detected so the deep
+    -- `dependencyTree` path runs. A prior refactor anchored detection on a
+    -- non-existent "<FQCN>: enabled in" suffix, returned False here, and
+    -- silently fell back to generated poms (Partial graph).
+    it "detects the built-in MiniDependencyTreePlugin (sbt 1.9.8, no plugins.sbt)" $ do
+      detectDependencyPlugins sbt198DefaultBuiltin
         `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = True, dependencyTreePlugin = Nothing}
 
-    it "should detect explicit modern DependencyTreePlugin (sbt 1.4+ addDependencyTreePlugin)" $ do
-      detectDependencyPlugins sbtModernExplicitPluginOnly
-        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Just ModernDependencyTreePlugin}
+    -- Real sbt 1.9.8 output with `addDependencyTreePlugin` in project/plugins.sbt
+    -- (the customer setup from TKT-15490). sbt enables the explicit
+    -- DependencyTreePlugin alongside the built-in MiniDependencyTreePlugin.
+    it "detects MiniDependencyTreePlugin and modern DependencyTreePlugin together (addDependencyTreePlugin)" $ do
+      detectDependencyPlugins sbt198AddDependencyTreePlugin
+        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = True, dependencyTreePlugin = Just ModernDependencyTreePlugin}
 
-    it "should detect legacy net.virtualvoid plugin (sbt < 1.4 sbt-dependency-graph)" $ do
+    -- sbt < 1.4 with the third-party net.virtualvoid sbt-dependency-graph
+    -- plugin. MiniDependencyTreePlugin does not exist before sbt 1.4, so it is
+    -- absent; routing must dispatch to the legacy lowercase task.
+    it "detects the legacy net.virtualvoid plugin (sbt-dependency-graph)" $ do
       detectDependencyPlugins sbtLegacyVirtualvoidPlugin
         `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Just LegacyDependencyGraphPlugin}
 
-    -- TKT-14742: When both plugins present, findProjects should prefer MiniDependencyTreePlugin
-    it "should detect both plugins when MiniDependencyTreePlugin AND modern explicit plugin present" $ do
-      detectDependencyPlugins sbt14WithExplicitPlugin
-        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = True, dependencyTreePlugin = Just ModernDependencyTreePlugin}
+    -- TKT-15490 routing guard: when the modern DependencyTreePlugin is enabled
+    -- but MiniDependencyTreePlugin is not, findProjects routes to genTreeJson,
+    -- which must select the uppercase `dependencyBrowseTreeHTML` task. The
+    -- classification must be Modern (not Legacy lowercase).
+    it "classifies a modern DependencyTreePlugin with no MiniDependencyTreePlugin as Modern" $ do
+      detectDependencyPlugins sbtModernWithoutMini
+        `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Just ModernDependencyTreePlugin}
 
-    -- TKT-15490: sbt 1.11.5 with addDependencyTreePlugin and no auto-loaded
-    -- MiniDependencyTreePlugin must be classified as ModernDependencyTreePlugin
-    -- so the analyzer runs the uppercase `dependencyBrowseTreeHTML` task. The
-    -- pre-fix code returned (False, True) and the routing dispatched to the
-    -- legacy lowercase `dependencyBrowseTreeHtml`, which sbt 1.4+ rejects.
-    it "should classify modern DependencyTreePlugin alone as Modern (TKT-15490 routing guard)" $ do
-      let detected = detectDependencyPlugins sbt111ExplicitPluginOnly
-      hasMiniDependencyTreePlugin detected `shouldBe` False
-      dependencyTreePlugin detected `shouldBe` Just ModernDependencyTreePlugin
-
-    -- If a project somehow lists both the modern and legacy plugin, prefer
-    -- the modern one — sbt 1.4+ wins, since the legacy plugin will not
-    -- function on a sbt that also surfaces sbt.plugins.DependencyTreePlugin.
-    it "should prefer modern DependencyTreePlugin when both modern and legacy are present" $ do
+    -- If a build somehow enables both the modern and legacy plugin, prefer the
+    -- modern one — on sbt 1.4+ the legacy lowercase task is unavailable.
+    it "prefers modern DependencyTreePlugin when both modern and legacy are enabled" $ do
       detectDependencyPlugins sbtBothModernAndLegacy
         `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Just ModernDependencyTreePlugin}
 
-    it "should detect no plugins when neither is present" $ do
+    it "detects no dependency-tree plugins when none are enabled" $ do
       detectDependencyPlugins sbtNoPlugins
         `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Nothing}
 
-    -- `sbt plugins` lists user-disabled plugins (`disablePlugins(...)`) with a
-    -- ": disabled in <scope>" suffix. The FQCN still appears on those lines,
-    -- so detection must anchor on ": enabled in" to avoid routing to a task
-    -- the active plugin set doesn't provide.
-    it "should not treat MiniDependencyTreePlugin as present when listed as disabled" $ do
-      detectDependencyPlugins sbtDisabledMiniPlugin
+    -- `disablePlugins(MiniDependencyTreePlugin)` moves the plugin into the
+    -- trailing "loaded to the build but not enabled in any subprojects"
+    -- section. This is a verbatim sbt 1.9.8 capture; detection must not treat
+    -- it as active. An unanchored substring match (the pre-refactor behavior)
+    -- would wrongly count it.
+    it "ignores a MiniDependencyTreePlugin listed as loaded-but-not-enabled" $ do
+      detectDependencyPlugins sbt198DisabledMini
         `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Nothing}
 
-    it "should not treat modern DependencyTreePlugin as present when listed as disabled" $ do
-      detectDependencyPlugins sbtDisabledModernPlugin
+    it "ignores a modern DependencyTreePlugin listed as loaded-but-not-enabled" $ do
+      detectDependencyPlugins sbtDisabledModern
         `shouldBe` DependencyPluginsDetected{hasMiniDependencyTreePlugin = False, dependencyTreePlugin = Nothing}
 
--- sbt 1.4+ with only built-in plugin
-sbt14BuiltinOnly :: Text
-sbt14BuiltinOnly =
-  [r|[info] welcome to sbt 1.9.7 (Eclipse Adoptium Java 11.0.21)
-[info] loading global plugins from /Users/test/.sbt/1.0/plugins
-[info] loading project definition from /Users/test/project/project
+-- Verbatim `sbt -batch -no-colors plugins` output for fossas/scala3-example-project
+-- (sbt 1.9.8, no project/plugins.sbt).
+sbt198DefaultBuiltin :: Text
+sbt198DefaultBuiltin =
+  [r|[info] welcome to sbt 1.9.8 (Homebrew Java 24.0.1)
+[info] loading project definition from /private/tmp/scala3-example-project/project
 [info] loading settings for project root from build.sbt ...
-[info] set current project to test-project (in build file:/Users/test/project/)
-[info] In file:/Users/test/project/
-[info]   sbt.plugins.CorePlugin: enabled in root
-[info]   sbt.plugins.IvyPlugin: enabled in root
-[info]   sbt.plugins.JvmPlugin: enabled in root
-[info]   sbt.plugins.MiniDependencyTreePlugin: enabled in root
-[info]   sbt.plugins.SemanticdbPlugin: enabled in root
+[info] set current project to scala3-example-project (in build file:/private/tmp/scala3-example-project/)
+In build /private/tmp/scala3-example-project/:
+  Enabled plugins in root:
+    sbt.plugins.CorePlugin
+    sbt.plugins.Giter8TemplatePlugin
+    sbt.plugins.IvyPlugin
+    sbt.plugins.JUnitXmlReportPlugin
+    sbt.plugins.JvmPlugin
+    sbt.plugins.MiniDependencyTreePlugin
+    sbt.plugins.SemanticdbPlugin
+Plugins that are loaded to the build but not enabled in any subprojects:
+  sbt.ScriptedPlugin
+  sbt.plugins.SbtPlugin
 |]
 
--- sbt 1.4+ with explicit addDependencyTreePlugin and no MiniDependencyTreePlugin
--- listed (the case the customer in TKT-15490 hit on sbt 1.11.5).
-sbtModernExplicitPluginOnly :: Text
-sbtModernExplicitPluginOnly =
-  [r|[info] welcome to sbt 1.3.13 (Eclipse Adoptium Java 11.0.21)
-[info] loading global plugins from /Users/test/.sbt/1.0/plugins
-[info] loading project definition from /Users/test/project/project
+-- Verbatim sbt 1.9.8 output with `addDependencyTreePlugin` added to
+-- project/plugins.sbt (the TKT-15490 customer setup).
+sbt198AddDependencyTreePlugin :: Text
+sbt198AddDependencyTreePlugin =
+  [r|[info] welcome to sbt 1.9.8 (Homebrew Java 24.0.1)
+[info] loading project definition from /private/tmp/scala3-example-project/project
 [info] loading settings for project root from build.sbt ...
-[info] set current project to test-project (in build file:/Users/test/project/)
-[info] In file:/Users/test/project/
-[info]   sbt.plugins.CorePlugin: enabled in root
-[info]   sbt.plugins.IvyPlugin: enabled in root
-[info]   sbt.plugins.JvmPlugin: enabled in root
-[info]   sbt.plugins.DependencyTreePlugin: enabled in root
+[info] set current project to scala3-example-project (in build file:/private/tmp/scala3-example-project/)
+In build /private/tmp/scala3-example-project/:
+  Enabled plugins in root:
+    sbt.plugins.CorePlugin
+    sbt.plugins.DependencyTreePlugin
+    sbt.plugins.Giter8TemplatePlugin
+    sbt.plugins.IvyPlugin
+    sbt.plugins.JUnitXmlReportPlugin
+    sbt.plugins.JvmPlugin
+    sbt.plugins.MiniDependencyTreePlugin
+    sbt.plugins.SemanticdbPlugin
+Plugins that are loaded to the build but not enabled in any subprojects:
+  sbt.ScriptedPlugin
+  sbt.plugins.SbtPlugin
 |]
 
--- sbt 1.11.5 with addDependencyTreePlugin in plugins.sbt — mirrors the
--- customer environment from TKT-15490. The customer reported that the
--- pre-fix CLI invoked the lowercase `dependencyBrowseTreeHtml`, which sbt
--- 1.4+ rejects.
-sbt111ExplicitPluginOnly :: Text
-sbt111ExplicitPluginOnly =
-  [r|[info] welcome to sbt 1.11.5 (Eclipse Adoptium Java 17.0.10)
-[info] loading global plugins from /Users/test/.sbt/1.0/plugins
-[info] loading project definition from /Users/test/project/project
-[info] loading settings for project root from build.sbt ...
-[info] set current project to test-project (in build file:/Users/test/project/)
-[info] In file:/Users/test/project/
-[info]   sbt.plugins.CorePlugin: enabled in root
-[info]   sbt.plugins.IvyPlugin: enabled in root
-[info]   sbt.plugins.JvmPlugin: enabled in root
-[info]   sbt.plugins.DependencyTreePlugin: enabled in root
-|]
-
--- sbt < 1.4 with legacy net.virtualvoid plugin
+-- sbt < 1.4 with the legacy net.virtualvoid sbt-dependency-graph plugin.
 sbtLegacyVirtualvoidPlugin :: Text
 sbtLegacyVirtualvoidPlugin =
   [r|[info] welcome to sbt 1.2.8 (Eclipse Adoptium Java 11.0.21)
-[info] loading global plugins from /Users/test/.sbt/1.0/plugins
-[info] loading project definition from /Users/test/project/project
-[info] loading settings for project root from build.sbt ...
 [info] set current project to test-project (in build file:/Users/test/project/)
-[info] In file:/Users/test/project/
-[info]   sbt.plugins.CorePlugin: enabled in root
-[info]   sbt.plugins.IvyPlugin: enabled in root
-[info]   sbt.plugins.JvmPlugin: enabled in root
-[info]   net.virtualvoid.sbt.graph.DependencyGraphPlugin: enabled in root
+In build /Users/test/project/:
+  Enabled plugins in root:
+    sbt.plugins.CorePlugin
+    sbt.plugins.IvyPlugin
+    sbt.plugins.JvmPlugin
+    net.virtualvoid.sbt.graph.DependencyGraphPlugin
+Plugins that are loaded to the build but not enabled in any subprojects:
+  sbt.plugins.SbtPlugin
 |]
 
--- TKT-14742: sbt 1.4+ with BOTH built-in and explicit plugin
-sbt14WithExplicitPlugin :: Text
-sbt14WithExplicitPlugin =
-  [r|[info] welcome to sbt 1.9.7 (Eclipse Adoptium Java 11.0.21)
-[info] loading global plugins from /Users/test/.sbt/1.0/plugins
-[info] loading project definition from /Users/test/project/project
-[info] loading settings for project root from build.sbt ...
+-- Modern DependencyTreePlugin enabled with MiniDependencyTreePlugin disabled
+-- (`disablePlugins(MiniDependencyTreePlugin)` alongside addDependencyTreePlugin).
+sbtModernWithoutMini :: Text
+sbtModernWithoutMini =
+  [r|[info] welcome to sbt 1.11.5 (Eclipse Adoptium Java 17.0.10)
 [info] set current project to test-project (in build file:/Users/test/project/)
-[info] In file:/Users/test/project/
-[info]   sbt.plugins.CorePlugin: enabled in root
-[info]   sbt.plugins.IvyPlugin: enabled in root
-[info]   sbt.plugins.JvmPlugin: enabled in root
-[info]   sbt.plugins.MiniDependencyTreePlugin: enabled in root
-[info]   sbt.plugins.DependencyTreePlugin: enabled in root
-[info]   sbt.plugins.SemanticdbPlugin: enabled in root
+In build /Users/test/project/:
+  Enabled plugins in root:
+    sbt.plugins.CorePlugin
+    sbt.plugins.DependencyTreePlugin
+    sbt.plugins.IvyPlugin
+    sbt.plugins.JvmPlugin
+Plugins that are loaded to the build but not enabled in any subprojects:
+  sbt.plugins.MiniDependencyTreePlugin
 |]
 
--- A pathological setup that lists both modern and legacy plugins.
+-- A pathological build that enables both the modern and the legacy plugin.
 sbtBothModernAndLegacy :: Text
 sbtBothModernAndLegacy =
   [r|[info] welcome to sbt 1.9.7 (Eclipse Adoptium Java 11.0.21)
-[info] In file:/Users/test/project/
-[info]   sbt.plugins.CorePlugin: enabled in root
-[info]   sbt.plugins.IvyPlugin: enabled in root
-[info]   sbt.plugins.JvmPlugin: enabled in root
-[info]   sbt.plugins.DependencyTreePlugin: enabled in root
-[info]   net.virtualvoid.sbt.graph.DependencyGraphPlugin: enabled in root
+[info] set current project to test-project (in build file:/Users/test/project/)
+In build /Users/test/project/:
+  Enabled plugins in root:
+    sbt.plugins.CorePlugin
+    sbt.plugins.DependencyTreePlugin
+    sbt.plugins.IvyPlugin
+    sbt.plugins.JvmPlugin
+    net.virtualvoid.sbt.graph.DependencyGraphPlugin
+Plugins that are loaded to the build but not enabled in any subprojects:
+  sbt.plugins.SbtPlugin
 |]
 
 sbtNoPlugins :: Text
 sbtNoPlugins =
   [r|[info] welcome to sbt 1.9.7 (Eclipse Adoptium Java 11.0.21)
-[info] loading global plugins from /Users/test/.sbt/1.0/plugins
-[info] loading project definition from /Users/test/project/project
-[info] loading settings for project root from build.sbt ...
 [info] set current project to test-project (in build file:/Users/test/project/)
-[info] In file:/Users/test/project/
-[info]   sbt.plugins.CorePlugin: enabled in root
-[info]   sbt.plugins.IvyPlugin: enabled in root
-[info]   sbt.plugins.JvmPlugin: enabled in root
+In build /Users/test/project/:
+  Enabled plugins in root:
+    sbt.plugins.CorePlugin
+    sbt.plugins.IvyPlugin
+    sbt.plugins.JvmPlugin
+Plugins that are loaded to the build but not enabled in any subprojects:
+  sbt.plugins.SbtPlugin
 |]
 
--- User-disabled MiniDependencyTreePlugin (e.g. `disablePlugins(MiniDependencyTreePlugin)`
--- in build.sbt). The FQCN appears on a ": disabled in" line — detection
--- must reject it.
-sbtDisabledMiniPlugin :: Text
-sbtDisabledMiniPlugin =
-  [r|[info] welcome to sbt 1.9.7 (Eclipse Adoptium Java 11.0.21)
-[info] In file:/Users/test/project/
-[info]   sbt.plugins.CorePlugin: enabled in root
-[info]   sbt.plugins.IvyPlugin: enabled in root
-[info]   sbt.plugins.JvmPlugin: enabled in root
-[info]   sbt.plugins.MiniDependencyTreePlugin: disabled in root
+-- Verbatim sbt 1.9.8 output with `disablePlugins(sbt.plugins.MiniDependencyTreePlugin)`
+-- on the root project. The plugin appears only in the trailing not-enabled
+-- section.
+sbt198DisabledMini :: Text
+sbt198DisabledMini =
+  [r|[info] welcome to sbt 1.9.8 (Homebrew Java 24.0.1)
+[info] loading project definition from /private/tmp/scala3-example-project/project
+[info] loading settings for project root from build.sbt ...
+[info] set current project to scala3-example-project (in build file:/private/tmp/scala3-example-project/)
+In build /private/tmp/scala3-example-project/:
+  Enabled plugins in root:
+    sbt.plugins.CorePlugin
+    sbt.plugins.Giter8TemplatePlugin
+    sbt.plugins.IvyPlugin
+    sbt.plugins.JUnitXmlReportPlugin
+    sbt.plugins.JvmPlugin
+    sbt.plugins.SemanticdbPlugin
+Plugins that are loaded to the build but not enabled in any subprojects:
+  sbt.ScriptedPlugin
+  sbt.plugins.MiniDependencyTreePlugin
+  sbt.plugins.SbtPlugin
 |]
 
--- User-disabled modern DependencyTreePlugin. Routing to the uppercase task
--- would fail because the plugin isn't active.
-sbtDisabledModernPlugin :: Text
-sbtDisabledModernPlugin =
+-- Modern DependencyTreePlugin disabled via disablePlugins; it appears only in
+-- the trailing not-enabled section, so routing must not target its task.
+sbtDisabledModern :: Text
+sbtDisabledModern =
   [r|[info] welcome to sbt 1.11.5 (Eclipse Adoptium Java 17.0.10)
-[info] In file:/Users/test/project/
-[info]   sbt.plugins.CorePlugin: enabled in root
-[info]   sbt.plugins.IvyPlugin: enabled in root
-[info]   sbt.plugins.JvmPlugin: enabled in root
-[info]   sbt.plugins.DependencyTreePlugin: disabled in root
+[info] set current project to test-project (in build file:/Users/test/project/)
+In build /Users/test/project/:
+  Enabled plugins in root:
+    sbt.plugins.CorePlugin
+    sbt.plugins.IvyPlugin
+    sbt.plugins.JvmPlugin
+Plugins that are loaded to the build but not enabled in any subprojects:
+  sbt.plugins.DependencyTreePlugin
 |]


### PR DESCRIPTION
Route sbt 1.4+ `DependencyTreePlugin` to the uppercase `dependencyBrowseTreeHTML` task, and detect plugins from the real `sbt plugins` output layout — restoring complete deep-dependency graphs on sbt 1.4+.

## What changed

- On sbt 1.4+ with `addDependencyTreePlugin`, fossa ran the lowercase `dependencyBrowseTreeHtml` task (added for sbt <1.4 compat); modern sbt only exposes the uppercase task, so it failed and analysis silently fell back to a poms-only graph. Detection now classifies legacy (`net.virtualvoid…DependencyGraphPlugin`, lowercase) vs modern (`sbt.plugins.DependencyTreePlugin`, uppercase) and runs the matching task.
- Plugin detection now parses sbt's actual `plugins` layout — bare FQCNs under `Enabled plugins in <project>:`, with `disablePlugins(...)` entries excluded via the trailing not-enabled section. An interim `: enabled in` suffix anchor matched **nothing** in real output and dropped the built-in `MiniDependencyTreePlugin` on plain sbt 1.4+ projects.
- `hasDependencyPlugins` returns a `DependencyPluginsDetected` record instead of `(Bool, Bool)`; the one caller (`Strategy.Scala.findProjects`) is updated.

## Validation

- `cabal build`; `fourmolu --mode check`.
- `unit-tests --match "detectDependencyPlugins"` → 8/8 pass, including a verbatim `sbt -batch -no-colors plugins` capture as a regression guard.
- Full Scala integration test needs nix+sbt+network (~15 min) — relying on CI.

## References

- Support ticket TKT-15490; prior routing work ANE-2718. Casing regression originated in #1356 (`215a74f8`).

## Why not to merge this

- **String-parse coupling** — keys off sbt's human-readable `plugins` section headers; a future sbt reformat silently breaks detection again (no machine-readable contract).
- **Legacy branches unverified live** — only the sbt 1.9.8 fixtures are real captures; the `net.virtualvoid` and modern-without-mini fixtures are hand-built to the same layout, not captured from old sbt.
- **Substring, not exact-line match** — `isInfixOf` on the enabled section tolerates suffix variants but would miscount a plugin whose FQCN is a substring of another (none exist today).
- **Symptom vs source** — the detection regression was self-inflicted by earlier commits on this branch; squashing them would avoid shipping the bug+fix pair, though keeping them documents the trap.
- Worth merging anyway: restores complete deep graphs for the common sbt 1.4+ case, proven against the exact fixture the integration test exercises.