### PR TITLE
[ANE-2523] NuGet: analyze every .csproj in a directory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 - Config: `paths.only` and `paths.exclude` in `.fossa.yml` now accept glob patterns. ([#1703](https://github.com/fossas/fossa-cli/pull/1703))
 - Licensing - Fix two bad GPL matches [No PR]
-- NuGet: PackageReference discovery now analyzes every `.csproj`/`.xproj`/`.vbproj`/`.dbproj`/`.fsproj` in a directory. Previously only the first match returned by the directory listing was analyzed, so sibling project files were silently dropped.
+- NuGet: PackageReference discovery now analyzes every `.csproj`/`.xproj`/`.vbproj`/`.dbproj`/`.fsproj` in a directory. Previously only the first match returned by the directory listing was analyzed, so sibling project files were silently dropped. ([#1712](https://github.com/fossas/fossa-cli/pull/1712))
 
 
 ## 3.17.5

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Config: `paths.only` and `paths.exclude` in `.fossa.yml` now accept glob patterns. ([#1703](https://github.com/fossas/fossa-cli/pull/1703))
 - Licensing - Fix two bad GPL matches [No PR]
+- NuGet: PackageReference discovery now analyzes every `.csproj`/`.xproj`/`.vbproj`/`.dbproj`/`.fsproj` in a directory. Previously only the first match returned by the directory listing was analyzed, so sibling project files were silently dropped.
 
 
 ## 3.17.5

--- a/integration-test/Analysis/NugetSpec.hs
+++ b/integration-test/Analysis/NugetSpec.hs
@@ -45,8 +45,17 @@ testServiceStackForPkgReferences :: Spec
 testServiceStackForPkgReferences =
   aroundAll (withAnalysisOf NonStrict $ serviceStack NuGet.discover) $ do
     describe "ServiceStack" $ do
+      -- 92 = every project file under v5.13.2 (91 .csproj + 1
+      -- .fsproj). The pre-ANE-2523 expectation was 64; that count
+      -- was masking the bug — 19 directories hold 2-3 sibling csproj
+      -- files (e.g. src/ServiceStack/{ServiceStack, ServiceStack.Core,
+      -- ServiceStack.Source}.csproj for the .NET-Framework /
+      -- .NET-Core / source-distribution variants), and the old
+      -- `find isPackageRefFile` was picking only one alphabetically
+      -- and silently dropping the rest. Discovery now emits one
+      -- NuGetProject per project file.
       it "should find targets" $ \(result, _) -> do
-        length result `shouldBe` 64
+        length result `shouldBe` 92
 
 testServiceStackForPkgConfig :: Spec
 testServiceStackForPkgConfig =

--- a/integration-test/Analysis/NugetSpec.hs
+++ b/integration-test/Analysis/NugetSpec.hs
@@ -45,15 +45,6 @@ testServiceStackForPkgReferences :: Spec
 testServiceStackForPkgReferences =
   aroundAll (withAnalysisOf NonStrict $ serviceStack NuGet.discover) $ do
     describe "ServiceStack" $ do
-      -- 92 = every project file under v5.13.2 (91 .csproj + 1
-      -- .fsproj). The pre-ANE-2523 expectation was 64; that count
-      -- was masking the bug — 19 directories hold 2-3 sibling csproj
-      -- files (e.g. src/ServiceStack/{ServiceStack, ServiceStack.Core,
-      -- ServiceStack.Source}.csproj for the .NET-Framework /
-      -- .NET-Core / source-distribution variants), and the old
-      -- `find isPackageRefFile` was picking only one alphabetically
-      -- and silently dropping the rest. Discovery now emits one
-      -- NuGetProject per project file.
       it "should find targets" $ \(result, _) -> do
         length result `shouldBe` 92
 

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -692,6 +692,7 @@ test-suite unit-tests
     Node.PackageLockSpec
     Node.PackageLockV3Spec
     NuGet.DirectoryPackagesPropsSpec
+    NuGet.NuGetSpec
     NuGet.NuspecSpec
     NuGet.PackageReferenceSpec
     NuGet.PackagesConfigSpec

--- a/src/Strategy/NuGet.hs
+++ b/src/Strategy/NuGet.hs
@@ -16,7 +16,6 @@ import Control.Effect.Reader (Reader)
 import Data.Aeson (
   ToJSON,
  )
-import Data.Foldable (find)
 import Data.List qualified as L
 import Discovery.Filters (AllFilters)
 import Discovery.Simple (simpleDiscover)
@@ -51,9 +50,7 @@ findProjects :: (Has ReadFS sig m, Has Diagnostics sig m, Has (Reader AllFilters
 findProjects = walkWithFilters' $ \_ _ files -> do
   case findProjectAssetsJsonFile files of
     Just file -> pure ([NuGetProject file], WalkContinue)
-    Nothing -> case find isPackageRefFile files of
-      Just file -> pure ([NuGetProject file], WalkContinue)
-      Nothing -> pure ([], WalkContinue)
+    Nothing -> pure (map NuGetProject (filter isPackageRefFile files), WalkContinue)
   where
     findProjectAssetsJsonFile :: [Path Abs File] -> Maybe (Path Abs File)
     findProjectAssetsJsonFile = findFileNamed "project.assets.json"

--- a/test/NuGet/NuGetSpec.hs
+++ b/test/NuGet/NuGetSpec.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module NuGet.NuGetSpec (
+  spec,
+) where
+
+import Path (mkRelDir, mkRelFile, (</>))
+import Path.IO (getCurrentDir)
+import Strategy.NuGet (NuGetProject (..))
+import Strategy.NuGet qualified as NuGet
+import Test.Effect (it', shouldMatchList')
+import Test.Hspec (Spec, describe, runIO)
+import Types (DiscoveredProject (projectData))
+
+spec :: Spec
+spec = do
+  currDir <- runIO getCurrentDir
+  let projectDir = currDir </> $(mkRelDir "test/NuGet/testdata/multi-csproj")
+      appCore = projectDir </> $(mkRelFile "App.Core.csproj")
+      ingageWeb = projectDir </> $(mkRelFile "IngageWeb.csproj")
+  describe "NuGet discovery" $
+    it' "discovers every .csproj sibling in a directory (ANE-2523)" $ do
+      projects <- NuGet.discover projectDir
+      let files = map (nugetProjectFile . projectData) projects
+      files `shouldMatchList'` [appCore, ingageWeb]

--- a/test/NuGet/testdata/multi-csproj/App.Core.csproj
+++ b/test/NuGet/testdata/multi-csproj/App.Core.csproj
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
+  </ItemGroup>
+</Project>

--- a/test/NuGet/testdata/multi-csproj/IngageWeb.csproj
+++ b/test/NuGet/testdata/multi-csproj/IngageWeb.csproj
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Overview

Discovery in `src/Strategy/NuGet.hs` used `find isPackageRefFile files`, which returned only the first matching project file per directory. Any directory containing multiple `.csproj`/`.xproj`/`.vbproj`/`.dbproj`/`.fsproj` files would silently drop all siblings — and if the surviving file had no dependencies, the directory looked empty in the FOSSA report. This PR switches to `filter`, mapping `NuGetProject` over every match.

## Acceptance criteria

A directory with multiple project files now produces one `NuGetProject` per file. Single-project directories and the `project.assets.json` short-circuit branch are unchanged.

## Testing plan

1. `cabal test unit-tests --test-options="--match=NuGet"` — 132 examples pass, including the new `NuGet.NuGet` discovery spec.
2. New unit fixture `test/NuGet/testdata/multi-csproj/` contains two `.csproj` files; the new spec asserts both are discovered.
3. Integration: `ServiceStack` expected target count goes from 64 → 92 (every project file under v5.13.2: 91 `.csproj` + 1 `.fsproj`). 19 directories hold 2–3 sibling `.csproj` files (e.g. `src/ServiceStack/{ServiceStack, ServiceStack.Core, ServiceStack.Source}.csproj` for the .NET-Framework / .NET-Core / source-distribution variants); the old `find isPackageRefFile` picked one alphabetically and silently dropped the rest. The new count is every project file the bug was masking.

## Risks

The integration tests in `integration-test/Analysis/NugetSpec.hs` (`ServiceStack`, `dotnet-core-2.0-example`, `DapperAOT-CPM`) assert literal target counts. If any of those fixtures contains a directory with multiple sibling `.csproj` files, the count goes up. Per the ticket: if those tests fail with higher counts, that's the bug being fixed — update the expected counts.

## Metrics

N/A.

## References

- [ANE-2523](https://fossa.atlassian.net/browse/ANE-2523) (support ticket TKT-12984)
- File changed: https://github.com/fossas/fossa-cli/blob/main/src/Strategy/NuGet.hs#L54

## Checklist

- [x] Tests added (`test/NuGet/NuGetSpec.hs`).
- [x] No docs changes — `docs/references/strategies/languages/dotnet/packagereference.md` already documents the fixed behavior ("all NuGet project files").
- [x] `Changelog.md` updated under 3.17.6.
- [x] No subcommand option or schema changes.

[ANE-2523]: https://fossa.atlassian.net/browse/ANE-2523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
