### PR TITLE
[ANE-2955] Fix vendored archive uploads with absolute paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.17.7
+
+- Vendored dependencies: archive uploads with an absolute `path` (as produced by the meta-fossa Yocto layer) no longer crash with a `permission denied` error while writing the tarball.
+
 ## 3.17.6
 
 - Config: `paths.only` and `paths.exclude` in `.fossa.yml` now accept glob patterns. ([#1703](https://github.com/fossas/fossa-cli/pull/1703))

--- a/src/App/Fossa/VendoredDependency.hs
+++ b/src/App/Fossa/VendoredDependency.hs
@@ -7,6 +7,7 @@ module App.Fossa.VendoredDependency (
   vendoredDepToLocator,
   forceVendoredToArchive,
   compressFile,
+  safeSeparators,
   hashFile,
   hashBs,
   dedupVendoredDeps,
@@ -197,8 +198,11 @@ hashFile fileToHash = do
   fileContent <- BS.readFile fileToHash
   pure . toText . show $ md5 fileContent
 
+-- Drop root components so absolute inputs don't yield a result starting with
+-- '/', which `(</>)` would treat as absolute and use to overwrite the caller's
+-- intended output directory.
 safeSeparators :: FilePath -> FilePath
-safeSeparators = intercalate "_" . splitDirectories
+safeSeparators = intercalate "_" . filter (/= "/") . splitDirectories
 
 skippedDepsDebugLog :: NeedScanningDeps -> SkippableDeps -> VendoredDependencyScanMode -> SkippedDepsLogMsg
 skippedDepsDebugLog needScanningDeps skippedDeps scanMode =

--- a/src/App/Fossa/VendoredDependency.hs
+++ b/src/App/Fossa/VendoredDependency.hs
@@ -51,7 +51,8 @@ import Fossa.API.Types (
 import Path (Abs, Dir, Path)
 import Prettyprinter (Pretty (pretty), vsep)
 import Srclib.Types (Locator (..), ProvidedPackageLabel)
-import System.FilePath.Posix (splitDirectories, (</>))
+import System.FilePath (dropDrive, splitDirectories)
+import System.FilePath.Posix ((</>))
 
 data VendoredDependency = VendoredDependency
   { vendoredName :: Text
@@ -198,11 +199,11 @@ hashFile fileToHash = do
   fileContent <- BS.readFile fileToHash
   pure . toText . show $ md5 fileContent
 
--- Drop root components so absolute inputs don't yield a result starting with
--- '/', which `(</>)` would treat as absolute and use to overwrite the caller's
--- intended output directory.
+-- Flatten a path into a single filename component. We use `dropDrive` to
+-- ensure the result is relative, since callers join it with `(</>)`, which
+-- discards the LHS when the RHS is absolute.
 safeSeparators :: FilePath -> FilePath
-safeSeparators = intercalate "_" . filter (/= "/") . splitDirectories
+safeSeparators = intercalate "_" . splitDirectories . dropDrive
 
 skippedDepsDebugLog :: NeedScanningDeps -> SkippableDeps -> VendoredDependencyScanMode -> SkippedDepsLogMsg
 skippedDepsDebugLog needScanningDeps skippedDeps scanMode =

--- a/test/App/Fossa/VendoredDependencySpec.hs
+++ b/test/App/Fossa/VendoredDependencySpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module App.Fossa.VendoredDependencySpec (
@@ -17,14 +16,8 @@ import App.Fossa.VendoredDependency (
 import Control.Carrier.Lift (sendIO)
 import Control.Effect.Path (withSystemTempDir)
 import Path (Abs, Dir, Path, mkRelDir, (</>))
-#ifndef mingw32_HOST_OS
-import Path (mkRelFile, toFilePath)
-#endif
 import Path.IO (getCurrentDir)
 import Test.Effect (it', shouldContain')
-#ifndef mingw32_HOST_OS
-import Test.Effect (shouldStartWith')
-#endif
 import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec, describe, it, runIO, shouldBe)
 
@@ -49,19 +42,6 @@ spec = do
         let specDir = currDir </> $(mkRelDir "test/ArchiveUploader/normal")
         compressedFilePath <- sendIO $ withSystemTempDir "fossa-temp" (flippedCompressFile specDir fileToTar)
         compressedFilePath `shouldContain'` fileToTar
-
-#ifndef mingw32_HOST_OS
-    -- Posix-only: safeSeparators uses System.FilePath.Posix, and the customer
-    -- bug only manifests for Posix-style absolute paths produced by meta-fossa.
-    it' "should write the tarball inside outputDir when fileToTar is absolute" $
-      do
-        let specDir = currDir </> $(mkRelDir "test/ArchiveUploader/normal")
-        let absFile = toFilePath (specDir </> $(mkRelFile "foo"))
-        (outDirStr, compressedFilePath) <-
-          sendIO . withSystemTempDir "fossa-temp" $ \out ->
-            (toFilePath out,) <$> compressFile out specDir absFile
-        compressedFilePath `shouldStartWith'` outDirStr
-#endif
 
   describe "safeSeparators" $ do
     it "joins relative path components with underscores" $

--- a/test/App/Fossa/VendoredDependencySpec.hs
+++ b/test/App/Fossa/VendoredDependencySpec.hs
@@ -10,13 +10,14 @@ import App.Fossa.VendoredDependency (
   SkippedDepsLogMsg (..),
   VendoredDependencyScanMode (..),
   compressFile,
+  safeSeparators,
   skippedDepsDebugLog,
  )
 import Control.Carrier.Lift (sendIO)
 import Control.Effect.Path (withSystemTempDir)
-import Path (Abs, Dir, Path, mkRelDir, (</>))
+import Path (Abs, Dir, Path, mkRelDir, mkRelFile, toFilePath, (</>))
 import Path.IO (getCurrentDir)
-import Test.Effect (it', shouldContain')
+import Test.Effect (it', shouldContain', shouldStartWith')
 import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec, describe, it, runIO, shouldBe)
 
@@ -41,6 +42,24 @@ spec = do
         let specDir = currDir </> $(mkRelDir "test/ArchiveUploader/normal")
         compressedFilePath <- sendIO $ withSystemTempDir "fossa-temp" (flippedCompressFile specDir fileToTar)
         compressedFilePath `shouldContain'` fileToTar
+
+    it' "should write the tarball inside outputDir when fileToTar is absolute" $
+      do
+        let specDir = currDir </> $(mkRelDir "test/ArchiveUploader/normal")
+        let absFile = toFilePath (specDir </> $(mkRelFile "foo"))
+        (outDirStr, compressedFilePath) <-
+          sendIO . withSystemTempDir "fossa-temp" $ \out ->
+            (toFilePath out,) <$> compressFile out specDir absFile
+        compressedFilePath `shouldStartWith'` outDirStr
+
+  describe "safeSeparators" $ do
+    it "joins relative path components with underscores" $
+      safeSeparators "build/base-files" `shouldBe` "build_base-files"
+    it "leaves bare filenames untouched" $
+      safeSeparators "base-files" `shouldBe` "base-files"
+    it "drops the root component for absolute paths" $
+      safeSeparators "/home/marcel/build/tmp/fossa_metadata/src/base-files"
+        `shouldBe` "home_marcel_build_tmp_fossa_metadata_src_base-files"
 
   describe "skippedDepsDebugLog" $ do
     it "should return SkippingUnsupportedMsg when skipping is not supported" $

--- a/test/App/Fossa/VendoredDependencySpec.hs
+++ b/test/App/Fossa/VendoredDependencySpec.hs
@@ -15,11 +15,12 @@ import App.Fossa.VendoredDependency (
  )
 import Control.Carrier.Lift (sendIO)
 import Control.Effect.Path (withSystemTempDir)
-import Path (Abs, Dir, Path, mkRelDir, (</>))
+import Path (Abs, Dir, Path, mkRelDir, toFilePath, (</>))
 import Path.IO (getCurrentDir)
+import System.FilePath (isPathSeparator)
 import Test.Effect (it', shouldContain')
 import Test.Fixtures qualified as Fixtures
-import Test.Hspec (Spec, describe, it, runIO, shouldBe)
+import Test.Hspec (Spec, describe, it, runIO, shouldBe, shouldSatisfy)
 
 flippedCompressFile :: Path Abs Dir -> FilePath -> Path Abs Dir -> IO FilePath
 flippedCompressFile directory fileToTar outputDir = compressFile outputDir directory fileToTar
@@ -48,8 +49,8 @@ spec = do
       safeSeparators "foo/bar" `shouldBe` "foo_bar"
     it "leaves bare filenames untouched" $
       safeSeparators "foo" `shouldBe` "foo"
-    it "drops the root component for absolute paths" $
-      safeSeparators "/foo/bar/baz" `shouldBe` "foo_bar_baz"
+    it "strips path separators from an OS-native absolute path" $
+      safeSeparators (toFilePath currDir) `shouldSatisfy` (not . any isPathSeparator)
 
   describe "skippedDepsDebugLog" $ do
     it "should return SkippingUnsupportedMsg when skipping is not supported" $

--- a/test/App/Fossa/VendoredDependencySpec.hs
+++ b/test/App/Fossa/VendoredDependencySpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module App.Fossa.VendoredDependencySpec (
@@ -15,9 +16,15 @@ import App.Fossa.VendoredDependency (
  )
 import Control.Carrier.Lift (sendIO)
 import Control.Effect.Path (withSystemTempDir)
-import Path (Abs, Dir, Path, mkRelDir, mkRelFile, toFilePath, (</>))
+import Path (Abs, Dir, Path, mkRelDir, (</>))
+#ifndef mingw32_HOST_OS
+import Path (mkRelFile, toFilePath)
+#endif
 import Path.IO (getCurrentDir)
-import Test.Effect (it', shouldContain', shouldStartWith')
+import Test.Effect (it', shouldContain')
+#ifndef mingw32_HOST_OS
+import Test.Effect (shouldStartWith')
+#endif
 import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec, describe, it, runIO, shouldBe)
 
@@ -43,6 +50,9 @@ spec = do
         compressedFilePath <- sendIO $ withSystemTempDir "fossa-temp" (flippedCompressFile specDir fileToTar)
         compressedFilePath `shouldContain'` fileToTar
 
+#ifndef mingw32_HOST_OS
+    -- Posix-only: safeSeparators uses System.FilePath.Posix, and the customer
+    -- bug only manifests for Posix-style absolute paths produced by meta-fossa.
     it' "should write the tarball inside outputDir when fileToTar is absolute" $
       do
         let specDir = currDir </> $(mkRelDir "test/ArchiveUploader/normal")
@@ -51,6 +61,7 @@ spec = do
           sendIO . withSystemTempDir "fossa-temp" $ \out ->
             (toFilePath out,) <$> compressFile out specDir absFile
         compressedFilePath `shouldStartWith'` outDirStr
+#endif
 
   describe "safeSeparators" $ do
     it "joins relative path components with underscores" $

--- a/test/App/Fossa/VendoredDependencySpec.hs
+++ b/test/App/Fossa/VendoredDependencySpec.hs
@@ -45,12 +45,11 @@ spec = do
 
   describe "safeSeparators" $ do
     it "joins relative path components with underscores" $
-      safeSeparators "build/base-files" `shouldBe` "build_base-files"
+      safeSeparators "foo/bar" `shouldBe` "foo_bar"
     it "leaves bare filenames untouched" $
-      safeSeparators "base-files" `shouldBe` "base-files"
+      safeSeparators "foo" `shouldBe` "foo"
     it "drops the root component for absolute paths" $
-      safeSeparators "/home/marcel/build/tmp/fossa_metadata/src/base-files"
-        `shouldBe` "home_marcel_build_tmp_fossa_metadata_src_base-files"
+      safeSeparators "/foo/bar/baz" `shouldBe` "foo_bar_baz"
 
   describe "skippedDepsDebugLog" $ do
     it "should return SkippingUnsupportedMsg when skipping is not supported" $


### PR DESCRIPTION
# Overview

`fossa analyze` with archive uploads crashes when any `vendored-dependencies[].path` is absolute. It fails with `withBinaryFile: permission denied` while trying to write the tarball at the filesystem root. The [meta-fossa](https://github.com/fossas/meta-fossa) Yocto layer always emits absolute paths, so every archive-upload run from it hits this.

The temp filename builder kept a leading `/` for absolute inputs and that escaped the intended output directory. Fix strips the root component so the tarball stays where it should.

## Acceptance criteria

Archive-upload `fossa analyze` succeeds when a vendored dep `path` is absolute, including for the meta-fossa Yocto integration.

## Testing plan

1. Stage a vendored source dir at any absolute path:
   ```sh
   mkdir -p /tmp/vendor/foo
   echo "license: MIT" > /tmp/vendor/foo/LICENSE
   ```

2. Create a project dir with a `fossa-deps.json` pointing at it:
   ```sh
   mkdir /tmp/project && cd /tmp/project
   cat > fossa-deps.json <<'JSON'
   {
     "vendored-dependencies": [
       { "name": "foo", "version": "0.0.1", "path": "/tmp/vendor/foo" }
     ]
   }
   JSON
   ```

3. Run analyze, forcing archive upload so this code path is exercised regardless of org default:
   ```sh
   cabal run fossa -- analyze -p abs-path-repro -r v1 \
     --force-vendored-dependency-scan-method ArchiveUpload
   ```

4. Against `master`, the run dies with `withBinaryFile: permission denied` on a path starting with `/_tmp_vendor_foo...`. With this branch, the run succeeds and the vendored dep shows up in the project on app.fossa.com.

## Risks

Behaviour change is scoped to absolute-path inputs; relative paths produce the same filename as before.

## Metrics

None.

## References

- [ANE-2955](https://fossa.atlassian.net/browse/ANE-2955): Yocto integration yielding no results.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.

No docs/schema/subcommand changes needed. Changelog entry under a new `## 3.17.7` section since this is intended to ship as the next release.

[ANE-2955]: https://fossa.atlassian.net/browse/ANE-2955