### PR TITLE
Bump rustls-webpki to 0.103.13 to fix GHSA-82j2-j2ch-gfr8 and GHSA-965h-392x-2mh5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static 1.5.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -763,7 +763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1105,7 +1105,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.1",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1855,7 +1855,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1906,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2864,7 +2864,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
# Overview

Bumps the `rustls-webpki` Rust crate from 0.103.3 to 0.103.13 to resolve security vulnerabilities reported upstream by the rustls project.

Re-authors Dependabot PR #1702 so CI can run with repository secrets (the dependabot run failed `dependency-scan`, `Linux-arm-build`, and `integration-test` because Dependabot PRs are denied access to `FOSSA_API_KEY` and `GITHUB_TOKEN`).

## Acceptance criteria

`rustls-webpki` resolves to `0.103.13` in `Cargo.lock` and the Rust workspace continues to build.

## Testing plan

1. `cargo check --release` passes with the updated dependency (verified locally).
2. CI build and dependency-scan jobs pass.

## Risks

Minimal — patch version bump of an indirect dependency with no API changes on our side. `Cargo.toml` is unchanged; only `Cargo.lock` moves. The change also re-resolves five unrelated `windows-sys` transitive entries from `0.52.0` to `0.59.0` as a side-effect of running `cargo update`.

## Metrics

N/A

## References

- [Dependabot PR #1702](https://github.com/fossas/fossa-cli/pull/1702) (being replaced)
- [GHSA-82j2-j2ch-gfr8](https://github.com/rustls/webpki/security/advisories/GHSA-82j2-j2ch-gfr8) — reachable panic in CRL parsing (fixed in 0.103.13)
- [GHSA-965h-392x-2mh5](https://github.com/advisories/GHSA-965h-392x-2mh5) — URI name constraints (fixed in 0.103.12)
- [GHSA-xgp8-3hg3-c2mh](https://github.com/advisories/GHSA-xgp8-3hg3-c2mh) — DNS wildcard name constraint (fixed in 0.103.12)
- [GHSA-pwjx-qhcg-rvj4](https://github.com/rustls/webpki/security/advisories/GHSA-pwjx-qhcg-rvj4) — CRL Distribution Point selection (fixed in 0.103.10)
- [rustls-webpki 0.103.3 → 0.103.13 changelog](https://github.com/rustls/webpki/compare/v/0.103.3...v/0.103.13)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
  - No tests needed — this is a dependency version bump with no code changes.
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
  - N/A — no user-visible change.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
  - N/A
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
  - N/A — internal dependency update only.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json,yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command.
  - N/A
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
  - N/A
