### PR TITLE
Strip non printable characters from locators

### DIFF
--- a/src/Srclib/Types.hs
+++ b/src/Srclib/Types.hs
@@ -41,6 +41,7 @@ module Srclib.Types (
 ) where
 
 import Data.Aeson
+import Data.Char qualified as Char
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
@@ -497,7 +498,10 @@ instance ToText Locator where
 
 renderLocator :: Locator -> Text
 renderLocator Locator{..} =
-  locatorFetcher <> "+" <> locatorProject <> "$" <> fromMaybe "" locatorRevision
+  stripNonPrintable $
+    locatorFetcher <> "+" <> locatorProject <> "$" <> fromMaybe "" locatorRevision
+  where
+    stripNonPrintable = Text.filter Char.isPrint
 
 -- The projectId is the full locator of the project. E.g. custom+123/someProject (<fetcher>+<orgId>/<project-name>)
 projectId :: Locator -> Text

--- a/test/Srclib/TypesSpec.hs
+++ b/test/Srclib/TypesSpec.hs
@@ -7,6 +7,7 @@ import Srclib.Types (
   SourceUnit (..),
   SourceUnitBuild (..),
   SourceUnitDependency (..),
+  renderLocator,
   toProjectLocator,
   translateSourceUnitLocators,
  )
@@ -15,6 +16,11 @@ import Types (GraphBreadth (Complete))
 
 spec :: Spec
 spec = do
+  describe "renderLocator" $ do
+    it "should strip non-printable characters such as NUL bytes" $ do
+      let locator = Locator "go" "github.com/gin-gonic\NUL/gin" (Just "v1.\t9.1\DEL")
+      renderLocator locator `shouldBe` "go+github.com/gin-gonic/gin$v1.9.1"
+
   describe "translateSourceUnitLocators" $ do
     -- Helper to create a simple translation function from a map (for backward compatibility in tests)
     let simpleTranslate translationMap loc =


### PR DESCRIPTION
# Overview
Remove non-printable characters from locators in the `sourceUnits` section of the CLI output. The graphs in the "projects" section still include non-printable characters, as arguably leaving them in is more correct and we don't currently have issues with them being there (mostly because we don't read that output).

## Acceptance criteria
Locators in source units don't include non-printable characters.

## Testing plan
In a new directory, create a pyproject.toml with the following contents:
```
[tool.poetry]
name = "nonprint"
version = "0.1.0"
description = "Reproduction for null bytes in Build.Imports"
authors = []

[tool.poetry.dependencies]
python = "^3.9"
"flask\u0000\u0000" = "^1.1.4"
"requests\u0000\u0000" = ">=2.0"

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
```
Run `cabal run fossa -- analyze --output ./your-test-dir` and confirm that the locators in the source units don't contain null characters.

## Risks

_Highlight any areas that you're unsure of, want feedback on, or want reviewers to pay particular attention to._

_Example: I'm not sure I did X correctly, can reviewers please double-check that for me?_

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References
[CORE-7083](https://fossa.atlassian.net/browse/CORE-7083)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[CORE-7083]: https://fossa.atlassian.net/browse/CORE-7083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ