### PR TITLE
[Container Scanning] Support scanning `/var/lib/dpkg/status.d` directory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # FOSSA CLI Changelog
 
+## 3.17.11
+
+- Conan: Handle list-valued license in make_fossa_deps_conan ([#1719](https://github.com/fossas/fossa-cli/pull/1719)).
+- Strip non printable characters from locators ([#1720](https://github.com/fossas/fossa-cli/pull/1720)).
+- Container scanning: Support scanning /var/lib/dpkg/status.d directory ([#1721](https://github.com/fossas/fossa-cli/pull/1721)).
+
 ## 3.17.10
 
 - Licensing: Fix bad SPL matches ([#1717](https://github.com/fossas/fossa-cli/pull/1717)).

--- a/src/Strategy/Dpkg.hs
+++ b/src/Strategy/Dpkg.hs
@@ -12,13 +12,14 @@ import Data.Aeson (ToJSON)
 import Data.String.Conversion (toText)
 import Data.Text qualified as Text
 import Discovery.Filters (AllFilters)
+import Data.Foldable (find)
 import Discovery.Simple (simpleDiscover)
 import Discovery.Walk (
   WalkStep (WalkContinue),
   findFileNamed,
   walkWithFilters',
  )
-import Effect.ReadFS (Has, ReadFS)
+import Effect.ReadFS (Has, ReadFS, listDir)
 import GHC.Generics (Generic)
 import Path (Abs, Dir, File, Path, toFilePath)
 import Strategy.Dpkg.Database (analyze)
@@ -27,7 +28,6 @@ import Types (
   DiscoveredProject (..),
   DiscoveredProjectType (DpkgDatabaseProjectType),
  )
-
 data DpkgDatabase = DpkgDatabase
   { dbDir :: Path Abs Dir
   , dbFile :: Path Abs File
@@ -59,13 +59,19 @@ findProjects ::
   OsInfo ->
   Path Abs Dir ->
   m [DpkgDatabase]
-findProjects osInfo = walkWithFilters' $ \dir _ files -> do
-  case findFileNamed "status" files of
-    Nothing -> pure ([], WalkContinue)
-    Just file -> do
-      if (Text.isInfixOf "var/lib/dpkg/" $ toText . toFilePath $ file)
-        then pure ([DpkgDatabase dir file osInfo], WalkContinue)
-        else pure ([], WalkContinue)
+findProjects osInfo = walkWithFilters' $ \dir dirs files -> do
+  let standardDBs = case findFileNamed "status" files of
+        Just file -> 
+          if Text.isInfixOf "var/lib/dpkg/" (toText . toFilePath $ file)
+            then [DpkgDatabase dir file osInfo]
+            else []
+        Nothing -> []
+  statusD_DBs <- case find (\f -> toFilePath f == "var/lib/dpkg/status.d/") dirs of
+      Just dir' -> do
+        (_, filesInDir) <- listDir dir'
+        pure $ map (\file -> DpkgDatabase dir' file osInfo) (filter (not . Text.isSuffixOf ".md5sums" . toText) filesInDir)
+      Nothing -> pure []
+  pure (standardDBs ++ statusD_DBs, WalkContinue)
 
 mkProject :: DpkgDatabase -> DiscoveredProject DpkgDatabase
 mkProject project =

--- a/src/Strategy/Dpkg.hs
+++ b/src/Strategy/Dpkg.hs
@@ -9,10 +9,10 @@ import Container.OsRelease (OsInfo)
 import Control.Effect.Diagnostics (Diagnostics)
 import Control.Effect.Reader (Reader)
 import Data.Aeson (ToJSON)
+import Data.Foldable (find)
 import Data.String.Conversion (toText)
 import Data.Text qualified as Text
 import Discovery.Filters (AllFilters)
-import Data.Foldable (find)
 import Discovery.Simple (simpleDiscover)
 import Discovery.Walk (
   WalkStep (WalkContinue),
@@ -28,6 +28,7 @@ import Types (
   DiscoveredProject (..),
   DiscoveredProjectType (DpkgDatabaseProjectType),
  )
+
 data DpkgDatabase = DpkgDatabase
   { dbDir :: Path Abs Dir
   , dbFile :: Path Abs File
@@ -61,16 +62,16 @@ findProjects ::
   m [DpkgDatabase]
 findProjects osInfo = walkWithFilters' $ \dir dirs files -> do
   let standardDBs = case findFileNamed "status" files of
-        Just file -> 
+        Just file ->
           if Text.isInfixOf "var/lib/dpkg/" (toText . toFilePath $ file)
             then [DpkgDatabase dir file osInfo]
             else []
         Nothing -> []
   statusD_DBs <- case find (\f -> toFilePath f == "var/lib/dpkg/status.d/") dirs of
-      Just dir' -> do
-        (_, filesInDir) <- listDir dir'
-        pure $ map (\file -> DpkgDatabase dir' file osInfo) (filter (not . Text.isSuffixOf ".md5sums" . toText) filesInDir)
-      Nothing -> pure []
+    Just dir' -> do
+      (_, filesInDir) <- listDir dir'
+      pure $ map (\file -> DpkgDatabase dir' file osInfo) (filter (not . Text.isSuffixOf ".md5sums" . toText) filesInDir)
+    Nothing -> pure []
   pure (standardDBs ++ statusD_DBs, WalkContinue)
 
 mkProject :: DpkgDatabase -> DiscoveredProject DpkgDatabase


### PR DESCRIPTION
# Overview

`fossa container analyze` supports reading package lists from a /var/lib/dpkg/status file. The code for that is here: https://github.com/fossas/fossa-cli/blob/master/src/Strategy/Dpkg.hs#L63 

Some container types split the contents of that status file into multiple files, all contained in a `/var/lib/dpkg/status.d` directory. The format of those files is the same as the `/var/lib/dpkg/status` file.

This PR updates container scanning to discover files in the `/var/lib/dpkg/status.d` directory and parse them.

## Acceptance criteria

- [x] We parse files in `/var/lib/dpkg/status.d` and find dependencies in them.

## Testing plan

Run `fossa container analyze gcr.io/distroless/base-debian12:debug --output | jq` before and after the changes in the branch. Before, it'll show no dependencies and after it will show all the expected dependencies.

## Risks

None

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
