### PR TITLE
Add workflow to close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,11 +5,16 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    concurrency:
+      group: stale-issues-workflow
+      cancel-in-progress: false
 
     steps:
     - uses: actions/stale@v10

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+    - uses: actions/stale@v10
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 21
+        days-before-issue-close: 7
+        stale-issue-message: "This issue has been marked stale because it has had no activity for 21 days. It will be closed in 7 days if no further activity occurs."
+        close-issue-message: "This issue has been automatically closed because it has had no activity for 7 days since being marked stale."
+        stale-issue-label: "stale"
+
+        # Don't auto-close PRs
+        days-before-pr-stale: -1
+        days-before-pr-close: -1


### PR DESCRIPTION
# Overview
Add a workflow to manage stale GitHub issues. Comment and label issues as stale if they have no activity for 3 weeks, and close them if they don't see any action for another week.

## Acceptance criteria

_If this PR is successful, what impact does it have on the user experience?_

_Example: When users do X, Y should now happen._

## Testing plan

_How did you validate that this PR works? What literal steps did you take when manually checking that your code works?_

_Example:_

1. _Set up test case X._
2. _Run command Y. Make sure Z happens._

_This section should list concrete steps that a reviewer can sanity check and repeat on their own machine (and provide any needed test cases)._

## Risks

_Highlight any areas that you're unsure of, want feedback on, or want reviewers to pay particular attention to._

_Example: I'm not sure I did X correctly, can reviewers please double-check that for me?_

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

_Add links to any referenced GitHub issues, Zendesk tickets, Jira tickets, Slack threads, etc._

_Example:_

- _[ANE-123](https://fossa.atlassian.net/browse/ANE-123): Implement X._

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
