### PR TITLE
Remove hlint ignore now fix has merged

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -3,13 +3,6 @@
 - ignore: {name: "Redundant bracket"}
 - ignore: {name: "Use list comprehension"}
 
-# Hlint 3.6.1 has a bug where typed TH splices are not recognized so it reports
-# TemplateHaskell as an unused pragma: https://github.com/ndmitchell/hlint/issues/1531
-# A fix is merged, but has not yet been released.
-# Remove the ignore directive when this commit makes it into a release and is part of haskell-dev-tools.
-# https://github.com/ndmitchell/hlint/commit/505a4d57b972f3ba605ad7a59721cef1f3d98a84
-- ignore: {name: "Unused LANGUAGE pragma", within: [App.Version.TH, App.Version]}
-
 # Import Preferences
 - modules:
   - {name: Data.Set, as: Set, message: "Use complete name for qualified import of Set"}


### PR DESCRIPTION
# Overview

In `.hlint.yaml` I saw the comment, checked the versions of HLint used by `.github/workflows/lint.yml` and by `make lint-haskell` (`make lint` requires `lint-haskell`). I checked the fix commit, https://github.com/ndmitchell/hlint/commit/505a4d57b972f3ba605ad7a59721cef1f3d98a84, and this has tags for `3.8` and `3.10`.

```
$ make lint-haskell
Running hlint
HLint v3.10, (C) Neil Mitchell 2006-2025
...
```

## Acceptance criteria

HLint doesn't suggest "Unused LANGUAGE pragma".

## Testing plan

Run `make lint` or `make lint-haskell` locally. Also `hlint -j .` will do too. This latter check is quicker and runs in 8s rather than the 38s of `make lint-haskell`.

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
