### PR TITLE
fix(pnpm): merge colliding peer-suffixed v9 snapshot keys

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- pnpm: Fix v9 dev-dependency filtering when peer-suffixed lockfile keys collide ([#1724](https://github.com/fossas/fossa-cli/pull/1724)).
+
 ## 3.17.11
 
 - Conan: Handle list-valued license in make_fossa_deps_conan ([#1719](https://github.com/fossas/fossa-cli/pull/1719)).

--- a/src/Strategy/Node/Pnpm/PnpmLock.hs
+++ b/src/Strategy/Node/Pnpm/PnpmLock.hs
@@ -202,7 +202,20 @@ instance FromJSON PnpmLockFileSnapshots where
 
       -- Remove the peer dependency suffix. It's present in the snapshot entry, but it's not present in packages
       -- section which is where we look the dependency up.
-      let snapshots' = (HashMap.mapKeys withoutPeerDepSuffix) . toHashMapText $ snapshots
+      --
+      -- A single package can have several peer-suffixed snapshot keys (e.g.
+      -- @core@1.0.0(peerx@1.0.0)@ and @core@1.0.0(peery@1.0.0)@) that all
+      -- collapse to the same de-suffixed key. Merge (union) their dependency
+      -- lists instead of letting one variant overwrite the others, otherwise
+      -- edges that live only on a dropped variant are lost and their dev/prod
+      -- environment fails to propagate. (ANE-2852)
+      let snapshots' =
+            HashMap.fromListWith
+              (<>)
+              . map (\(k, v) -> (withoutPeerDepSuffix k, v))
+              . HashMap.toList
+              . toHashMapText
+              $ snapshots
       pure $
         PnpmLockFileSnapshots{snapshots = snapshots'}
 

--- a/test/Pnpm/PnpmLockSpec.hs
+++ b/test/Pnpm/PnpmLockSpec.hs
@@ -128,6 +128,7 @@ spec = do
   let pnpmLockV9LocalDep = currentDir </> $(mkRelFile "test/Pnpm/testdata/pnpm-9-local-dep/pnpm-lock.yaml")
   let pnpmLockV9MultiVersion = currentDir </> $(mkRelFile "test/Pnpm/testdata/pnpm-9-multi-version/pnpm-lock.yaml")
   let pnpmLockV9Catalogs = currentDir </> $(mkRelFile "test/Pnpm/testdata/pnpm-9-catalogs/pnpm-lock.yaml")
+  let pnpmLockV9PeerCollision = currentDir </> $(mkRelFile "test/Pnpm/testdata/pnpm-9-peer-collision/pnpm-lock.yaml")
 
   describe "works with v9 format" $ do
     checkGraph pnpmLockV9 pnpmLockV9GraphSpec
@@ -136,6 +137,7 @@ spec = do
     describe "local dep env propagation" $ checkGraph pnpmLockV9LocalDep pnpmLockV9LocalDepSpec
     describe "multi-version env labeling" $ checkGraph pnpmLockV9MultiVersion pnpmLockV9MultiVersionSpec
     describe "catalogs" $ checkGraph pnpmLockV9Catalogs pnpmLockV9CatalogsSpec
+    describe "colliding peer-suffixed snapshot keys" $ checkGraph pnpmLockV9PeerCollision pnpmLockV9PeerCollisionSpec
 
 pnpmLockGraphSpec :: Graphing Dependency -> Spec
 pnpmLockGraphSpec graph = do
@@ -489,6 +491,30 @@ pnpmLockV9MultiVersionSpec graph = do
       expectDep (mkProdDep "sax@1.2.1") graph
       -- sax@1.4.4 is dev-only (from app-b)
       expectDep (mkDevDep "sax@1.4.4") graph
+
+-- ANE-2852 regression: a dev-only package (`core`) appears in `snapshots:`
+-- under several peer-suffixed keys that all collapse to the same de-suffixed
+-- key. The collapse must merge (not overwrite) the colliding dependency lists,
+-- otherwise a child reachable only through a dropped variant (`plugin-a` /
+-- `plugin-b`) loses its dev path and leaks as production.
+pnpmLockV9PeerCollisionSpec :: Graphing Dependency -> Spec
+pnpmLockV9PeerCollisionSpec graph = do
+  let hasEdge :: Dependency -> Dependency -> Expectation
+      hasEdge = expectEdge graph
+
+  describe "buildGraph with colliding peer-suffixed snapshot keys" $ do
+    it "should mark the direct dev dependency as dev" $
+      expectDirect [mkDevDep "core@1.0.0"] graph
+
+    it "should keep edges from every colliding peer variant" $ do
+      hasEdge (mkDevDep "core@1.0.0") (mkDevDep "plugin-a@1.0.0")
+      hasEdge (mkDevDep "core@1.0.0") (mkDevDep "plugin-b@1.0.0")
+
+    it "should propagate dev to children of all merged variants" $ do
+      -- Without the merge, last-wins drops one variant and its child leaks
+      -- with an empty environment (reported as production).
+      expectDep (mkDevDep "plugin-a@1.0.0") graph
+      expectDep (mkDevDep "plugin-b@1.0.0") graph
 
 pnpmLockV9CatalogsSpec :: Graphing Dependency -> Spec
 pnpmLockV9CatalogsSpec graph = do

--- a/test/Pnpm/testdata/pnpm-9-peer-collision/pnpm-lock.yaml
+++ b/test/Pnpm/testdata/pnpm-9-peer-collision/pnpm-lock.yaml
@@ -1,0 +1,55 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+# ANE-2852 regression: a dev-only package (`core`) is installed under multiple
+# peer-suffixed snapshot keys.  Those keys all collapse to the same de-suffixed
+# key (`core@1.0.0`).  A last-wins collapse keeps only one variant's dependency
+# list, so a transitive child reachable only through a dropped variant loses its
+# dev path and leaks as production.  Here `plugin-a` lives only on the
+# `(peerx@1.0.0)` variant and `plugin-b` only on the `(peery@1.0.0)` variant, so
+# last-wins always drops one of them.  Merging the colliding entries keeps both
+# edges and lets the dev environment propagate to both children.
+importers:
+  .:
+    devDependencies:
+      core:
+        specifier: ^1.0.0
+        version: 1.0.0(peerx@1.0.0)
+
+packages:
+  core@1.0.0:
+    resolution: {integrity: sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==}
+
+  peerx@1.0.0:
+    resolution: {integrity: sha512-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb==}
+
+  peery@1.0.0:
+    resolution: {integrity: sha512-cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc==}
+
+  plugin-a@1.0.0:
+    resolution: {integrity: sha512-dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd==}
+
+  plugin-b@1.0.0:
+    resolution: {integrity: sha512-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee==}
+
+snapshots:
+  core@1.0.0(peerx@1.0.0):
+    dependencies:
+      peerx: 1.0.0
+      plugin-a: 1.0.0
+
+  core@1.0.0(peery@1.0.0):
+    dependencies:
+      peery: 1.0.0
+      plugin-b: 1.0.0
+
+  peerx@1.0.0: {}
+
+  peery@1.0.0: {}
+
+  plugin-a@1.0.0: {}
+
+  plugin-b@1.0.0: {}


### PR DESCRIPTION
Merge (instead of last-wins overwrite) pnpm v9 snapshot entries whose peer-suffixed keys collapse to the same key, so dev-only transitives stop leaking as production.

## Overview
- In pnpm v9, snapshot keys carry a peer-dep suffix that's stripped for lookup against the (unsuffixed) `packages` section.
- A package installed under multiple peer variants produces several snapshot keys that collapse to the same stripped key. The old `HashMap.mapKeys withoutPeerDepSuffix` collapse was **last-wins**, silently dropping all but one variant's dependency list.
- Edges living only on a dropped variant vanished, so dev-only transitives got no dev path → empty env → reported as **production**. Densely-shared "core" packages collide (leak); single-variant leaf plugins don't (filter correctly) — matching the 10-leak/9-filter asymmetry in the ticket.
- Fix: collapse with `HashMap.fromListWith (<>)`, unioning colliding entries' dependency lists. Only the v9 snapshots decoder changes; v5/v6/v7 paths untouched.

## Acceptance criteria
- A `devDependency` reachable only via a dropped peer variant (and its transitives) is classified `EnvDevelopment` / filtered, not production.

## Testing plan
- New fixture `test/Pnpm/testdata/pnpm-9-peer-collision/pnpm-lock.yaml`: a dev dep under two peer-suffixed snapshot keys with distinct children.
- `cabal test unit-tests --match "Pnpm.PnpmLock"` → 26/26 pass.
- Confirmed the new spec **fails without the fix** (child leaks with empty env, edge missing) and passes with it. v6 transitive-peer spec still green.

## Confidence / for reviewer
- **Medium (~60%).** Root cause inferred from code, **not yet reproduced against the affected project's real `pnpm-lock.yaml`**. Reviewer should confirm against the actual lockfile (the leaking edge could be a genuine prod path rather than a collision) and watch for v6/v7 regressions.

## Why not to merge this
- **Symptom vs source** — merge restores edges, but if a package legitimately appears under a prod path anywhere in the monorepo, prod-wins would still (correctly) mark it prod; this PR can't distinguish that without the real lockfile.
- **Unreproduced** — no repro against the affected project's actual lockfile; the exact dropped edge is inferred, so the fix may be necessary-but-insufficient (prior fix #1668 also looked complete and wasn't).
- **List union, not set** — `(<>)` concatenates dep-pair lists, so duplicate `(name, rev)` pairs across variants are kept; harmless (edges are idempotent) but slightly larger intermediate lists.
- **Secondary factor untouched** — the investigation flagged v9 `peerDependencies` ranges in `deepDependencies` as a possible spurious prod→dev bridge; deliberately left out to keep this surgical.
- Counterweight: low blast radius, sits squarely on the most likely root cause, and ships with a regression test that demonstrably fails without the change.

## References
- ANE-2852: pnpm v9 devDependencies not filtered.
- Prior art (landed, partial): [#1668](https://github.com/fossas/fossa-cli/pull/1668).
- Affected project: [github.com/collibra/frontend](https://github.com/collibra/frontend).
