### PR TITLE
Remove hlint ignore now fix has merged

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -3,13 +3,6 @@
 - ignore: {name: "Redundant bracket"}
 - ignore: {name: "Use list comprehension"}
 
-# Hlint 3.6.1 has a bug where typed TH splices are not recognized so it reports
-# TemplateHaskell as an unused pragma: https://github.com/ndmitchell/hlint/issues/1531
-# A fix is merged, but has not yet been released.
-# Remove the ignore directive when this commit makes it into a release and is part of haskell-dev-tools.
-# https://github.com/ndmitchell/hlint/commit/505a4d57b972f3ba605ad7a59721cef1f3d98a84
-- ignore: {name: "Unused LANGUAGE pragma", within: [App.Version.TH, App.Version]}
-
 # Import Preferences
 - modules:
   - {name: Data.Set, as: Set, message: "Use complete name for qualified import of Set"}


### PR DESCRIPTION
# Overview

Re-opens #1723 from @philderbeast so CI runs (the original is from a fork). The commit is cherry-picked here unchanged.

The change removes a stale `.hlint.yaml` ignore directive that suppressed a false-positive "Unused LANGUAGE pragma" hint on `App.Version` and `App.Version.TH`. That hint came from an HLint bug with typed TH splices ([hlint#1531](https://github.com/ndmitchell/hlint/issues/1531)). The [fix](https://github.com/ndmitchell/hlint/commit/505a4d57b972f3ba605ad7a59721cef1f3d98a84) shipped in HLint 3.8 and 3.10, and the directive's own comment said to remove it once that landed in haskell-dev-tools.

## Acceptance criteria

HLint no longer reports "Unused LANGUAGE pragma", and `make lint` / `make lint-haskell` pass with the directive gone.

## Testing plan

1. From the repo root, run `make lint-haskell` (or the quicker `hlint -j .`).
2. Confirm it passes with no "Unused LANGUAGE pragma" hints for `App.Version` or `App.Version.TH`.

Verified locally with HLint 3.8: running hlint on `src/App/Version.hs` and `src/App/Version/TH.hs` with the directive removed produces no "Unused LANGUAGE pragma" (only globally-ignored "Redundant bracket" hints). The authoritative check is the linter CI job, which runs in the `haskell-dev-tools:9.8.4` container.

## Risks

None worth calling out. Config-only change, and the linter CI job is the gate.

## Metrics

N/A.

## References

- Original fork PR: #1723
- [hlint#1531](https://github.com/ndmitchell/hlint/issues/1531) and the [fix commit](https://github.com/ndmitchell/hlint/commit/505a4d57b972f3ba605ad7a59721cef1f3d98a84).

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense). _Lint-config removal; the linter itself is the check._
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.