### PR TITLE
Release groups: resolve add-projects target via server-side lookup (CORE-7241)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Release groups: `fossa release-group add-projects` resolves its target release with a single server-side lookup when the FOSSA instance supports it, avoiding timeouts for organizations with large numbers of release groups or releases. ([#1728](https://github.com/fossas/fossa-cli/pull/1728))
+
 ## 3.17.12
 
 - Licensing: Add FSL 1.1 license variants. ([#1727](https://github.com/fossas/fossa-cli/pull/1727))

--- a/src/App/Fossa/ReleaseGroup/AddProjects.hs
+++ b/src/App/Fossa/ReleaseGroup/AddProjects.hs
@@ -10,13 +10,13 @@ import App.Fossa.ReleaseGroup.Common (retrieveReleaseGroupId, retrieveReleaseGro
 import App.Types (ReleaseGroupProjectRevision (..), ReleaseGroupReleaseRevision (..))
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, context, fatalText)
-import Control.Effect.FossaApiClient (FossaApiClient, getReleaseGroupReleases, getReleaseGroups, updateReleaseGroupRelease)
+import Control.Effect.FossaApiClient (FossaApiClient, getOrganization, getReleaseGroupReleases, getReleaseGroups, resolveReleaseGroupRelease, updateReleaseGroupRelease)
 import Control.Effect.Lift (Lift)
-import Data.Set qualified as Set
 import Data.String.Conversion (ToText (..))
 import Data.Text (Text)
 import Effect.Logger (Logger, logDebug, logInfo, logStdout, pretty)
-import Fossa.API.CoreTypes (ReleaseGroupRelease (..), ReleaseProject (..), UpdateReleaseProjectRequest (..), UpdateReleaseRequest (..))
+import Fossa.API.CoreTypes (ReleaseGroupRelease (..), ReleaseGroupReleaseLookup (..), UpdateReleaseProjectRequest (..), UpdateReleaseRequest (..))
+import Fossa.API.Types (Organization (..))
 import Text.Pretty.Simple (pShow)
 
 addProjectsMain ::
@@ -30,42 +30,46 @@ addProjectsMain ::
 addProjectsMain AddProjectsConfig{..} = do
   logInfo "Running FOSSA release-group add-projects"
 
-  releaseGroups <- getReleaseGroups
-  maybeReleaseGroupId <- context "Retrieving release group ID" $ retrieveReleaseGroupId title releaseGroups
-  case maybeReleaseGroupId of
-    Nothing -> fatalText $ "Release group `" <> title <> "` not found"
-    Just releaseGroupId -> do
-      releases <- getReleaseGroupReleases releaseGroupId
-      release <- context "Retrieving release group release" $ retrieveReleaseGroupRelease (releaseTitle releaseGroupReleaseRevision) releases
-      let releaseId = releaseGroupReleaseId release
+  org <- getOrganization
+  (releaseGroupId, releaseId) <-
+    if orgSupportsFasterReleaseGroupAddProjects org
+      then do
+        -- Core resolves both ids in a single request and filters in the database,
+        -- avoiding an unpaginated fetch of every release group and release.
+        lookupRes <-
+          context "Resolving release group release" $
+            resolveReleaseGroupRelease title (releaseTitle releaseGroupReleaseRevision)
+        pure (lookupReleaseGroupId lookupRes, lookupReleaseId lookupRes)
+      else do
+        -- Fallback for Core instances without the lookup endpoint: list every
+        -- release group and release and match by title client-side.
+        releaseGroups <- getReleaseGroups
+        maybeReleaseGroupId <- context "Retrieving release group ID" $ retrieveReleaseGroupId title releaseGroups
+        case maybeReleaseGroupId of
+          Nothing -> fatalText $ "Release group `" <> title <> "` not found"
+          Just releaseGroupId -> do
+            releases <- getReleaseGroupReleases releaseGroupId
+            release <- context "Retrieving release group release" $ retrieveReleaseGroupRelease (releaseTitle releaseGroupReleaseRevision) releases
+            pure (releaseGroupId, releaseGroupReleaseId release)
 
-      let updateReleaseRequest = constructUpdateRequest release releaseGroupReleaseRevision
-      res <- updateReleaseGroupRelease releaseGroupId releaseId updateReleaseRequest
-      logStdout $ "Projects were added to release group release id: " <> toText (releaseGroupReleaseId res) <> "\n"
-      logStdout $ "View the updated release at: " <> updatedReleaseLink releaseGroupId (releaseGroupReleaseId res) <> "\n"
-      logDebug $ "Projects added to release: " <> pretty (pShow $ releaseGroupReleaseProjects res)
+  let updateReleaseRequest = constructUpdateRequest releaseGroupReleaseRevision
+  res <- updateReleaseGroupRelease releaseGroupId releaseId updateReleaseRequest
+  logStdout $ "Projects were added to release group release id: " <> toText (releaseGroupReleaseId res) <> "\n"
+  logStdout $ "View the updated release at: " <> updatedReleaseLink releaseGroupId (releaseGroupReleaseId res) <> "\n"
+  logDebug $ "Projects added to release: " <> pretty (pShow $ releaseGroupReleaseProjects res)
   where
     updatedReleaseLink :: Int -> Int -> Text
     updatedReleaseLink releaseGroupId releaseId = "https://app.fossa.com/projects/group/" <> toText releaseGroupId <> "/releases/" <> toText releaseId
 
-constructUpdateRequest :: ReleaseGroupRelease -> ReleaseGroupReleaseRevision -> UpdateReleaseRequest
-constructUpdateRequest targetRelease releaseRevision = UpdateReleaseRequest (releaseTitle releaseRevision) projectsReq
+constructUpdateRequest :: ReleaseGroupReleaseRevision -> UpdateReleaseRequest
+constructUpdateRequest releaseRevision = UpdateReleaseRequest (releaseTitle releaseRevision) projectsReq
   where
     projectsReq :: [UpdateReleaseProjectRequest]
-    projectsReq = map (constructUpdateProjectRequest currentProjectLocators) $ releaseProjects releaseRevision
+    projectsReq = map constructUpdateProjectRequest $ releaseProjects releaseRevision
 
-    currentProjectLocators :: Set.Set Text
-    currentProjectLocators = projectLocatorSet targetRelease
-
-    -- Given the release you want to modify, construct a set of the current projects in the release
-    projectLocatorSet :: ReleaseGroupRelease -> Set.Set Text
-    projectLocatorSet ReleaseGroupRelease{releaseGroupReleaseProjects} = Set.fromList $ map releaseProjectLocator releaseGroupReleaseProjects
-
-    -- `maybeReleaseGroupId` in UpdateReleaseProjectRequest is used by CORE to identify if the project is a new project or if it needs an update.
-    -- If the value Nothing then it means that it is a new project, otherwise it is an existing project that will be updated.
-    -- TODO: An update means that the project will be queued for scanning. With the current logic, even if the revisionId and branch remain the same,
-    --       we are still re-scanning the project. We can introduce a stricter filtering mechanism to only update the project if the revisionId / branch differ from the existing values.
-    constructUpdateProjectRequest :: Set.Set Text -> ReleaseGroupProjectRevision -> UpdateReleaseProjectRequest
-    constructUpdateProjectRequest locatorSet ReleaseGroupProjectRevision{..} = do
-      let maybeReleaseGroupId = if Set.member releaseGroupProjectLocator locatorSet then Just (releaseGroupReleaseId targetRelease) else Nothing
-      UpdateReleaseProjectRequest releaseGroupProjectLocator releaseGroupProjectRevision releaseGroupProjectBranch maybeReleaseGroupId
+    -- Core determines whether each project is new or an existing project to update by
+    -- comparing against the release's current projects server-side, so the CLI only
+    -- sends the desired locator, revision, and branch for each project.
+    constructUpdateProjectRequest :: ReleaseGroupProjectRevision -> UpdateReleaseProjectRequest
+    constructUpdateProjectRequest ReleaseGroupProjectRevision{..} =
+      UpdateReleaseProjectRequest releaseGroupProjectLocator releaseGroupProjectRevision releaseGroupProjectBranch

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -106,6 +106,7 @@ runFossaApiClient apiOpts action = do
             UpdateReleaseGroupRelease releaseGroupId releaseId updateReq -> Core.updateReleaseGroupRelease releaseGroupId releaseId updateReq
             GetReleaseGroups -> Core.getReleaseGroups
             GetReleaseGroupReleases releaseGroupId -> Core.getReleaseGroupReleases releaseGroupId
+            ResolveReleaseGroupRelease releaseGroupTitle releaseTitle -> Core.resolveReleaseGroupRelease releaseGroupTitle releaseTitle
             CreateReleaseGroup req -> Core.createReleaseGroup req
             -- Project
             GetProjectV2 locator -> Core.getProjectV2 locator

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -29,6 +29,7 @@ module Control.Carrier.FossaApiClient.Internal.Core (
   createReleaseGroupRelease,
   getReleaseGroups,
   getReleaseGroupReleases,
+  resolveReleaseGroupRelease,
   updateReleaseGroupRelease,
   getProjectV2,
   updateProject,
@@ -396,6 +397,17 @@ getReleaseGroupReleases ::
 getReleaseGroupReleases releaseGroupId = do
   apiOpts <- ask
   API.getReleaseGroupReleases apiOpts releaseGroupId
+
+resolveReleaseGroupRelease ::
+  ( API.APIClientEffs sig m
+  , Has (Reader ApiOpts) sig m
+  ) =>
+  Text ->
+  Text ->
+  m CoreTypes.ReleaseGroupReleaseLookup
+resolveReleaseGroupRelease releaseGroupTitle releaseTitle = do
+  apiOpts <- ask
+  API.resolveReleaseGroupRelease apiOpts releaseGroupTitle releaseTitle
 
 getProjectV2 ::
   ( API.APIClientEffs sig m

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -57,6 +57,7 @@ module Control.Carrier.FossaApiClient.Internal.FossaAPIV1 (
   deleteReleaseGroupRelease,
   getReleaseGroups,
   getReleaseGroupReleases,
+  resolveReleaseGroupRelease,
   updateReleaseGroupRelease,
   createReleaseGroup,
   createReleaseGroupRelease,
@@ -1848,6 +1849,30 @@ createReleaseGroupRelease apiOpts releaseGroupId createReleaseReq = fossaReq $ d
   resp <-
     context "Creating release group release" $
       req POST (releaseGroupReleaseURLEndpoint baseUrl $ toText releaseGroupId) (ReqBodyJson createReleaseReq) jsonResponse baseOpts
+  pure (responseBody resp)
+
+releaseGroupReleaseLookupURLEndpoint :: Url 'Https -> Url 'Https
+releaseGroupReleaseLookupURLEndpoint baseUrl = baseUrl /: "api" /: "cli" /: "project_group" /: "release_lookup"
+
+-- | Resolve a release group title + release title to their numeric ids in a
+-- single request. Core filters in the database and returns only the ids, so the
+-- CLI avoids fetching and client-side filtering every release group and release.
+resolveReleaseGroupRelease ::
+  APIClientEffs sig m =>
+  ApiOpts ->
+  Text ->
+  Text ->
+  m CoreTypes.ReleaseGroupReleaseLookup
+resolveReleaseGroupRelease apiOpts releaseGroupTitle releaseTitle = fossaReq $ do
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+  let opts =
+        "releaseGroupTitle"
+          =: releaseGroupTitle
+          <> "releaseTitle"
+            =: releaseTitle
+  resp <-
+    context "Resolving release group release" $
+      req GET (releaseGroupReleaseLookupURLEndpoint baseUrl) NoReqBody jsonResponse (baseOpts <> opts)
   pure (responseBody resp)
 
 updateProjectURLEndpoint :: Url 'Https -> Text -> Url 'Https

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -51,6 +51,7 @@ module Control.Effect.FossaApiClient (
   createReleaseGroupRelease,
   getReleaseGroups,
   getReleaseGroupReleases,
+  resolveReleaseGroupRelease,
   updateReleaseGroupRelease,
   getProjectV2,
   updateProject,
@@ -177,6 +178,7 @@ data FossaApiClientF a where
   UpdateReleaseGroupRelease :: Int -> Int -> CoreTypes.UpdateReleaseRequest -> FossaApiClientF CoreTypes.ReleaseGroupRelease
   GetReleaseGroups :: FossaApiClientF [CoreTypes.ReleaseGroup]
   GetReleaseGroupReleases :: Int -> FossaApiClientF [CoreTypes.ReleaseGroupRelease]
+  ResolveReleaseGroupRelease :: Text -> Text -> FossaApiClientF CoreTypes.ReleaseGroupReleaseLookup
   GetProjectV2 :: Text -> FossaApiClientF CoreTypes.Project
   UpdateProject :: Text -> CoreTypes.UpdateProjectRequest -> FossaApiClientF CoreTypes.Project
   UpdateRevision :: Text -> CoreTypes.UpdateRevisionRequest -> FossaApiClientF CoreTypes.Revision
@@ -339,6 +341,9 @@ getReleaseGroups = sendSimple GetReleaseGroups
 
 getReleaseGroupReleases :: Has FossaApiClient sig m => Int -> m [CoreTypes.ReleaseGroupRelease]
 getReleaseGroupReleases releaseGroupId = sendSimple $ GetReleaseGroupReleases releaseGroupId
+
+resolveReleaseGroupRelease :: Has FossaApiClient sig m => Text -> Text -> m CoreTypes.ReleaseGroupReleaseLookup
+resolveReleaseGroupRelease releaseGroupTitle releaseTitle = sendSimple $ ResolveReleaseGroupRelease releaseGroupTitle releaseTitle
 
 getProjectV2 :: Has FossaApiClient sig m => Text -> m CoreTypes.Project
 getProjectV2 locator = sendSimple $ GetProjectV2 locator

--- a/src/Fossa/API/CoreTypes.hs
+++ b/src/Fossa/API/CoreTypes.hs
@@ -10,6 +10,7 @@ module Fossa.API.CoreTypes (
   ReleaseProject (..),
   UpdateReleaseProjectRequest (..),
   UpdateReleaseRequest (..),
+  ReleaseGroupReleaseLookup (..),
   CreateReleaseGroupRequest (..),
   CreateReleaseGroupResponse (..),
   UpdateProjectRequest (..),
@@ -167,9 +168,6 @@ data UpdateReleaseProjectRequest = UpdateReleaseProjectRequest
   { updateReleaseProjectLocator :: Text
   , updateReleaseProjectRevisionId :: Text
   , updateReleaseProjectBranch :: Text
-  , -- Existence of this field signifies to core that the project exists and the release project just needs to be updated.
-    -- If this field is empty it means that we are adding a new project to the release.
-    targetReleaseGroupId :: Maybe Int
   }
   deriving (Eq, Ord, Show)
 
@@ -179,8 +177,23 @@ instance ToJSON UpdateReleaseProjectRequest where
       [ "projectId" .= updateReleaseProjectLocator
       , "revisionId" .= updateReleaseProjectRevisionId
       , "branch" .= updateReleaseProjectBranch
-      , "projectGroupReleaseId" .= maybe Null toJSON targetReleaseGroupId
       ]
+
+-- | Response from the CLI-specific release-group release lookup endpoint
+-- (@GET \/api\/cli\/project_group\/release_lookup@). Core resolves a release
+-- group title + release title to their numeric ids server-side so the CLI does
+-- not have to fetch and filter every group/release.
+data ReleaseGroupReleaseLookup = ReleaseGroupReleaseLookup
+  { lookupReleaseGroupId :: Int
+  , lookupReleaseId :: Int
+  }
+  deriving (Eq, Ord, Show)
+
+instance FromJSON ReleaseGroupReleaseLookup where
+  parseJSON = withObject "ReleaseGroupReleaseLookup" $ \obj ->
+    ReleaseGroupReleaseLookup
+      <$> obj .: "releaseGroupId"
+      <*> obj .: "releaseId"
 
 data CreateReleaseGroupRequest = CreateReleaseGroupRequest
   { title :: Text

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -511,6 +511,10 @@ data Organization = Organization
   , orgSupportsGitBackedCargoLocators :: Bool
   , orgSubscription :: Subscription
   , orgSnippetScanSourceCodeRetentionDays :: Maybe Int
+  , orgSupportsFasterReleaseGroupAddProjects :: Bool
+  -- ^ True if Core exposes the faster CLI release-group lookup endpoint
+  -- (@GET \/api\/cli\/project_group\/release_lookup@). When false, the CLI
+  -- falls back to listing all groups/releases and filtering client-side.
   }
   deriving (Eq, Ord, Show)
 
@@ -539,6 +543,7 @@ blankOrganization =
     , orgSupportsGitBackedCargoLocators = False
     , orgSubscription = Free
     , orgSnippetScanSourceCodeRetentionDays = Nothing
+    , orgSupportsFasterReleaseGroupAddProjects = False
     }
 
 instance FromJSON Organization where
@@ -562,6 +567,7 @@ instance FromJSON Organization where
       <*> obj .:? "supportsGitBackedCargoLocators" .!= False
       <*> obj .:? "subscription" .!= Free
       <*> obj .:? "snippetScanSourceCodeRetentionDays" .!= Nothing
+      <*> obj .:? "supportsFasterRGAddProject" .!= False
 
 data TokenType
   = Push

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -42,7 +42,7 @@ spec = do
     describe "SAML URL builder" $ do
       it' "should render simple locators" $ do
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
-            org = Just $ Organization (OrgId 1) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing
+            org = Just $ Organization (OrgId 1) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing False
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -50,7 +50,7 @@ spec = do
 
       it' "should render git@ locators" $ do
         let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
-            org = Just $ Organization (OrgId 103) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing
+            org = Just $ Organization (OrgId 103) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing False
             revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -58,7 +58,7 @@ spec = do
 
       it' "should render full url correctly" $ do
         let locator = Locator "a" "b" $ Just "c"
-            org = Just $ Organization (OrgId 33) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing
+            org = Just $ Organization (OrgId 33) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing False
             revision = ProjectRevision "" "not this revision" $ Just "master"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -75,7 +75,7 @@ spec = do
     describe "Fossa URL Builder" $
       it' "should render from API info" $ do
         GetApiOpts `returnsOnce` Fixtures.apiOpts
-        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing
+        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing False
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getFossaBuildUrl revision locator

--- a/test/App/Fossa/API/BuildLinkSpec.hs
+++ b/test/App/Fossa/API/BuildLinkSpec.hs
@@ -10,7 +10,7 @@ import Control.Effect.FossaApiClient (
 import Data.Text (Text)
 import Fossa.API.Types (
   OrgId (OrgId),
-  Organization (Organization),
+  Organization (..),
  )
 import Fossa.API.Types qualified as API
 import Srclib.Types (Locator (Locator))
@@ -36,13 +36,39 @@ fullSamlURL = "https://app.fossa.com/account/saml/33?next=/projects/a%252bb/refs
 simpleStandardURL :: Text
 simpleStandardURL = "https://app.fossa.com/projects/haskell%2b89%2fspectrometer/refs/branch/master/revision123"
 
+-- | Build an Organization for these tests, varying only the id. Uses record
+-- syntax so that new fields on Organization don't silently break these fixtures.
+mkOrg :: OrgId -> Organization
+mkOrg oid =
+  Organization
+    { organizationId = oid
+    , orgUsesSAML = True
+    , orgCoreSupportsLocalLicenseScan = False
+    , orgSupportsAnalyzedRevisionsQuery = True
+    , orgDefaultVendoredDependencyScanType = CLILicenseScan
+    , orgSupportsIssueDiffs = True
+    , orgSupportsNativeContainerScan = True
+    , orgSupportsDependenciesCachePolling = True
+    , orgRequiresFullFileUploads = False
+    , orgDefaultsToFirstPartyScans = False
+    , orgSupportsPathDependencyScans = False
+    , orgSupportsFirstPartyScans = False
+    , orgCustomLicenseScanConfigs = []
+    , orgSupportsReachability = False
+    , orgSupportsPreflightChecks = False
+    , orgSupportsGitBackedCargoLocators = False
+    , orgSubscription = API.Free
+    , orgSnippetScanSourceCodeRetentionDays = Nothing
+    , orgSupportsFasterReleaseGroupAddProjects = False
+    }
+
 spec :: Spec
 spec = do
   describe "BuildLink" $ do
     describe "SAML URL builder" $ do
       it' "should render simple locators" $ do
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
-            org = Just $ Organization (OrgId 1) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing False
+            org = Just $ mkOrg (OrgId 1)
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -50,7 +76,7 @@ spec = do
 
       it' "should render git@ locators" $ do
         let locator = Locator "fetcher@123/abc" "git@github.com/user/repo" $ Just "revision@123/abc"
-            org = Just $ Organization (OrgId 103) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing False
+            org = Just $ mkOrg (OrgId 103)
             revision = ProjectRevision "not this project name" "not this revision" $ Just "weird--branch"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -58,7 +84,7 @@ spec = do
 
       it' "should render full url correctly" $ do
         let locator = Locator "a" "b" $ Just "c"
-            org = Just $ Organization (OrgId 33) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing False
+            org = Just $ mkOrg (OrgId 33)
             revision = ProjectRevision "" "not this revision" $ Just "master"
         actual <- getBuildURLWithOrg org revision Fixtures.apiOpts locator
 
@@ -75,7 +101,7 @@ spec = do
     describe "Fossa URL Builder" $
       it' "should render from API info" $ do
         GetApiOpts `returnsOnce` Fixtures.apiOpts
-        GetOrganization `returnsOnce` Organization (OrgId 1) True False True CLILicenseScan True True True False False False False [] False False False API.Free Nothing False
+        GetOrganization `returnsOnce` mkOrg (OrgId 1)
         let locator = Locator "fetcher123" "project123" $ Just "revision123"
             revision = ProjectRevision "" "not this revision" $ Just "master123"
         actual <- getFossaBuildUrl revision locator

--- a/test/App/Fossa/ReleaseGroup/AddProjectsSpec.hs
+++ b/test/App/Fossa/ReleaseGroup/AddProjectsSpec.hs
@@ -11,6 +11,7 @@ import Control.Carrier.Debug (ignoreDebug)
 import Control.Effect.FossaApiClient (FossaApiClientF (..))
 import Fossa.API.CoreTypes (UpdateReleaseProjectRequest (..), UpdateReleaseRequest (..))
 import Fossa.API.CoreTypes qualified as Types
+import Fossa.API.Types (Organization (..))
 import Test.Effect (expectFatal', it', shouldBe')
 import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec, describe, it, shouldBe)
@@ -24,6 +25,10 @@ addProjectsConfig =
     , releaseGroupReleaseRevision = expectedReleaseGroupReleaseRevisionFromConfig
     }
 
+-- | An organization that advertises the faster release-group lookup endpoint.
+orgWithFasterLookup :: Organization
+orgWithFasterLookup = Fixtures.organization{orgSupportsFasterReleaseGroupAddProjects = True}
+
 updateReleaseRequest :: UpdateReleaseRequest
 updateReleaseRequest = do
   let expectedUpdateProjectReq =
@@ -31,7 +36,6 @@ updateReleaseRequest = do
           { updateReleaseProjectLocator = "custom+1/git@github.com/fossa-cli"
           , updateReleaseProjectRevisionId = "custom+1/git@github.com/fossa-cli$12345"
           , updateReleaseProjectBranch = "main"
-          , targetReleaseGroupId = Nothing
           }
   UpdateReleaseRequest
     { updatedReleaseTitle = "example-release-title"
@@ -58,20 +62,33 @@ spec :: Spec
 spec = do
   constructUpdateRequestSpec
 
-  describe "Add Release Group Projects" $ do
+  describe "Add Release Group Projects (client-side fallback)" $ do
     it' "should fail if release group does not exist when updating a release" $ do
+      GetOrganization `returnsOnce` Fixtures.organization
       GetReleaseGroups `returnsOnce` [Fixtures.releaseGroup{Types.releaseGroupTitle = "example-title-2"}]
       expectFatal' $ ignoreDebug $ addProjectsMain addProjectsConfig
 
     it' "should fail to update the release" $ do
+      GetOrganization `returnsOnce` Fixtures.organization
       GetReleaseGroups `returnsOnce` [Fixtures.releaseGroup]
       GetReleaseGroupReleases 1 `returnsOnce` [Fixtures.release]
       expectReleaseGroupAddProjectsToFail
       expectFatal' $ ignoreDebug $ addProjectsMain addProjectsConfig
 
-    it' "should successfully to update the release" $ do
+    it' "should successfully update the release" $ do
+      GetOrganization `returnsOnce` Fixtures.organization
       GetReleaseGroups `returnsOnce` [Fixtures.releaseGroup]
       GetReleaseGroupReleases 1 `returnsOnce` [Fixtures.release]
+      expectReleaseGroupAddProjectsSuccess
+      res <- ignoreDebug $ addProjectsMain addProjectsConfig
+      res `shouldBe'` ()
+
+  describe "Add Release Group Projects (server-side lookup)" $ do
+    -- No GetReleaseGroups / GetReleaseGroupReleases expectations are registered, so
+    -- this also verifies the fast path does NOT fall back to listing them.
+    it' "should resolve ids via the lookup endpoint when the org supports it" $ do
+      GetOrganization `returnsOnce` orgWithFasterLookup
+      ResolveReleaseGroupRelease "example-title" "example-release-title" `returnsOnce` Fixtures.releaseGroupReleaseLookup
       expectReleaseGroupAddProjectsSuccess
       res <- ignoreDebug $ addProjectsMain addProjectsConfig
       res `shouldBe'` ()
@@ -80,7 +97,6 @@ constructUpdateRequestSpec :: Spec
 constructUpdateRequestSpec = do
   describe "constructUpdateRequest" $ do
     it "should successfully create an UpdateReleaseRequest" $ do
-      let release = Fixtures.release
-          releaseRevision = expectedReleaseGroupReleaseRevisionFromConfig
-          res = constructUpdateRequest release releaseRevision
+      let releaseRevision = expectedReleaseGroupReleaseRevisionFromConfig
+          res = constructUpdateRequest releaseRevision
       res `shouldBe` updateReleaseRequest

--- a/test/App/Fossa/ReleaseGroup/AddProjectsSpec.hs
+++ b/test/App/Fossa/ReleaseGroup/AddProjectsSpec.hs
@@ -93,6 +93,11 @@ spec = do
       res <- ignoreDebug $ addProjectsMain addProjectsConfig
       res `shouldBe'` ()
 
+    it' "should fail when the lookup endpoint cannot resolve the release" $ do
+      GetOrganization `returnsOnce` orgWithFasterLookup
+      fails (ResolveReleaseGroupRelease "example-title" "example-release-title") "not found"
+      expectFatal' $ ignoreDebug $ addProjectsMain addProjectsConfig
+
 constructUpdateRequestSpec :: Spec
 constructUpdateRequestSpec = do
   describe "constructUpdateRequest" $ do

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -56,6 +56,7 @@ module Test.Fixtures (
   releaseGroup,
   release,
   releaseProject,
+  releaseGroupReleaseLookup,
   policy,
   team,
   excludePath,
@@ -146,6 +147,7 @@ organization =
     , orgSupportsGitBackedCargoLocators = False
     , orgSubscription = Free
     , orgSnippetScanSourceCodeRetentionDays = Nothing
+    , orgSupportsFasterReleaseGroupAddProjects = False
     }
 
 organizationWithPreflightChecks :: API.Organization
@@ -169,6 +171,7 @@ organizationWithPreflightChecks =
     , orgSupportsGitBackedCargoLocators = False
     , orgSubscription = Free
     , orgSnippetScanSourceCodeRetentionDays = Nothing
+    , orgSupportsFasterReleaseGroupAddProjects = False
     }
 
 organizationWithPremiumSubscription :: API.Organization
@@ -192,6 +195,7 @@ organizationWithPremiumSubscription =
     , orgSupportsGitBackedCargoLocators = False
     , orgSubscription = Premium
     , orgSnippetScanSourceCodeRetentionDays = Nothing
+    , orgSupportsFasterReleaseGroupAddProjects = False
     }
 
 organizationWithGitBackedCargoLocators :: API.Organization
@@ -215,6 +219,7 @@ organizationWithGitBackedCargoLocators =
     , orgSupportsGitBackedCargoLocators = True
     , orgSubscription = Free
     , orgSnippetScanSourceCodeRetentionDays = Nothing
+    , orgSupportsFasterReleaseGroupAddProjects = False
     }
 
 pushToken :: API.TokenTypeResponse
@@ -269,6 +274,13 @@ releaseProject =
     { CoreAPI.releaseProjectLocator = "custom+1/example"
     , CoreAPI.releaseProjectRevisionId = "custom+1/example$123"
     , CoreAPI.releaseProjectBranch = "main"
+    }
+
+releaseGroupReleaseLookup :: CoreAPI.ReleaseGroupReleaseLookup
+releaseGroupReleaseLookup =
+  CoreAPI.ReleaseGroupReleaseLookup
+    { CoreAPI.lookupReleaseGroupId = 1
+    , CoreAPI.lookupReleaseId = 2
     }
 
 policy :: CoreAPI.Policy

--- a/test/Test/MockApi.hs
+++ b/test/Test/MockApi.hs
@@ -244,6 +244,7 @@ matchExpectation a@(CreateReleaseGroup{}) (ApiExpectation _ requestExpectation b
 matchExpectation a@(CreateReleaseGroupRelease{}) (ApiExpectation _ requestExpectation b@(CreateReleaseGroupRelease{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetReleaseGroups{}) (ApiExpectation _ requestExpectation b@(GetReleaseGroups{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetReleaseGroupReleases{}) (ApiExpectation _ requestExpectation b@(GetReleaseGroupReleases{}) resp) = checkResult requestExpectation a b resp
+matchExpectation a@(ResolveReleaseGroupRelease{}) (ApiExpectation _ requestExpectation b@(ResolveReleaseGroupRelease{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetPolicies{}) (ApiExpectation _ requestExpectation b@(GetPolicies{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetTeams{}) (ApiExpectation _ requestExpectation b@(GetTeams{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetProjectV2{}) (ApiExpectation _ requestExpectation b@(GetProjectV2{}) resp) = checkResult requestExpectation a b resp


### PR DESCRIPTION
# Overview

`fossa release-group add-projects` resolves its target release by first listing
**every** release group (`GET /api/project_group`) and then **every** release in
the matched group with all of their projects (`GET /api/project_group/:id/release`),
filtering by title client-side. For organizations with large numbers of release groups
and releases, those responses are large enough to time out.

This change makes the CLI resolve the release group + release titles to their numeric
ids in a single request against a new endpoint, `GET /api/cli/project_group/release_lookup`,
which filters in the database and returns only the ids. The CLI gates on a new
`supportsFasterRGAddProject` capability flag from `GET /api/cli/organization`: when the
connected FOSSA instance advertises it, the CLI uses the lookup; otherwise it falls back
to the existing list-and-filter behavior, so older FOSSA instances are unaffected.

It also drops the now-unused `projectGroupReleaseId` field from the release update
request. Core determines whether each project is new or an update from its own database,
so the CLI no longer needs to fetch the release's current projects to compute it.

## Acceptance criteria

- Against a FOSSA instance that advertises `supportsFasterRGAddProject`,
  `fossa release-group add-projects` resolves its target with one lookup request instead
  of listing all release groups and releases, so it no longer times out for large orgs.
- Against instances that do not advertise it, behavior is unchanged.

## Testing plan

1. Fast path — against a FOSSA instance running the paired Core change
   ([fossas/FOSSA#18308](https://github.com/fossas/FOSSA/pull/18308), which returns
   `supportsFasterRGAddProject: true`), using a **full-access** API token:
   ```
   fossa release-group add-projects --debug \
     --endpoint <core-url> --fossa-api-key <FULL_ACCESS_TOKEN> \
     --title '<release group>' --release '<release>' \
     --project-locator '<locator>' --project-revision '<rev>' --project-branch '<branch>'
   ```
   Confirm from `--debug`, and by watching the Core server logs, that it calls
   `GET /api/cli/project_group/release_lookup` rather than the full `GET /api/project_group`
   list, and that the projects are added.
2. Fallback path — set `supportsFasterRGAddProject: false` in `routes/cli/v0.ts` (and restart
   Core), then run the same command; confirm from `--debug` and the server logs that it uses
   `GET /api/project_group` + `GET /api/project_group/:id/release`, and the result is unchanged.

## Risks

- The CLI now always omits `projectGroupReleaseId` from the update body (it previously sent
  the release id for already-present projects). This is safe because Core computes
  add-vs-update from its own database and never read the field; the paired Core PR removes it
  from the request schema. Worth a reviewer sanity check that the update body is accepted.
- The new path is gated behind the org capability flag; instances without it use the
  unchanged fallback, so there is no behavior change for older FOSSA deployments.

## Metrics

Not tracked by the CLI. The change reduces API payload size and request count for
`add-projects` (two list calls -> one id lookup), which is what eliminates the timeouts.

## References

- [CORE-7241](https://fossa.atlassian.net/browse/CORE-7241): Faster release-group add-projects.
- Paired Core PR (endpoint + `supportsFasterRGAddProject` flag): fossas/FOSSA#18308.

## Checklist

- [x] I added tests for this PR's change. (`AddProjectsSpec` covers both the lookup and fallback paths.)
- [ ] User-visible docs: no interface change — same command and flags, just faster — so no `docs/` change.
- [ ] Docs ToC: n/a (no docs added).
- [x] Externally visible -> `Changelog.md`: added an `## Unreleased` entry.
- [ ] `.fossa.yml` / `fossa-deps`: not changed.
- [ ] Subcommand options: `release-group add-projects` flags are unchanged, so no `docs/references/subcommands` update.


[CORE-7241]: https://fossa.atlassian.net/browse/CORE-7241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ