### PR TITLE
Bump version for themis v1.0.58

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.17.13
+
+- Licensing: Detect the Lucky Penny Software RPL-1.5 dual-license notice (AutoMapper, MediatR), resolving it to `rpl-1.5 OR proprietary-license` instead of `unknown`. ([#1729](https://github.com/fossas/fossa-cli/pull/1729))
+
 ## 3.17.12
 
 - Licensing: Add FSL 1.1 license variants. ([#1727](https://github.com/fossas/fossa-cli/pull/1727))


### PR DESCRIPTION
Prep new release to incorporate https://github.com/fossas/themis/releases/tag/v1.0.58.