### PR TITLE
Npm: support target-level dependency scoping for v3 lockfiles

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Node: Workspaces declared with a leading `./` (for example `./packages/*`) are now matched, so their members are analyzed and their production dependencies are no longer dropped from the results. ([#1733](https://github.com/fossas/fossa-cli/pull/1733))
-- Npm: Support target-level dependency scoping for v3 lockfiles (npm v9+ workspaces). ([#NNNN](https://github.com/fossas/fossa-cli/pull/NNNN))
+- Npm: Support target-level dependency scoping for v3 lockfiles (npm v9+ workspaces). ([#1732](https://github.com/fossas/fossa-cli/pull/1732))
 
 ## 3.17.14
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Node: Workspaces declared with a leading `./` (for example `./packages/*`) are now matched, so their members are analyzed and their production dependencies are no longer dropped from the results. ([#1733](https://github.com/fossas/fossa-cli/pull/1733))
+- Npm: Support target-level dependency scoping for v3 lockfiles (npm v9+ workspaces). ([#NNNN](https://github.com/fossas/fossa-cli/pull/NNNN))
 
 ## 3.17.14
 

--- a/docs/references/strategies/languages/nodejs/npm-lockfile.md
+++ b/docs/references/strategies/languages/nodejs/npm-lockfile.md
@@ -36,10 +36,11 @@ included in the analysis.
 When no filtering is applied, all targets are selected and all dependencies
 from every workspace package are included in the analysis.
 
-> Note: Target-level dependency scoping is only supported for lockfile version 1
-> (npm v5–v6) and version 2 (npm v7–v8). Version 3 lockfiles (npm v9+) will
-> show workspace build targets, but filtering to specific targets does not yet
-> scope the dependency results.
+> Note: Target-level dependency scoping is supported for all lockfile versions:
+> version 1 (npm v5–v6), version 2 (npm v7–v8), and version 3 (npm v9+). For
+> version 3 lockfiles, selecting a workspace target scopes the results to that
+> workspace's dependencies, including dependencies of sibling workspaces it
+> links to and the external packages resolved from the shared root install.
 
 ## Analysis (for lockFile version 3)
 

--- a/integration-test/Analysis/NpmLockV3WorkspaceSpec.hs
+++ b/integration-test/Analysis/NpmLockV3WorkspaceSpec.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | End-to-end coverage for target-level dependency scoping of npm workspaces
+-- monorepos using a v3 root lockfile: discovery over a vendored monorepo
+-- fixture, then analysis per selected build target.
+module Analysis.NpmLockV3WorkspaceSpec (spec) where
+
+import Analysis.FixtureUtils (FixtureEnvironment (LocalEnvironment), testRunner, withResult)
+import App.Fossa.Analyze.Types (AnalyzeProject (analyzeProject))
+import App.Types (Mode (NonStrict))
+import Control.Carrier.Debug (ignoreDebug)
+import Control.Carrier.Reader (runReader)
+import Data.Maybe (isNothing)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Set.NonEmpty qualified as NonEmptySet
+import Data.Text (Text)
+import DepTypes (Dependency (dependencyName, dependencyVersion))
+import Graphing (Graphing)
+import Graphing qualified
+import Path (Dir, Path, Rel, mkRelDir, (</>))
+import Path.IO qualified as PIO
+import Test.Hspec (Spec, beforeAll, describe, it, shouldBe, shouldSatisfy)
+import Types (
+  BuildTarget (BuildTarget),
+  DependencyResults (dependencyGraph),
+  DiscoveredProject (projectBuildTargets, projectData, projectType),
+  DiscoveredProjectType (NpmProjectType),
+  FoundTargets (FoundTargets, ProjectWithoutTargets),
+ )
+
+import Strategy.Node qualified as Node
+
+fixtureDir :: Path Rel Dir
+fixtureDir = $(mkRelDir "test/Node/testdata/npm-lock-v3-workspaces/")
+
+allTargetNames :: [Text]
+allTargetNames =
+  [ "npm-monorepo-fossa-test"
+  , "@fossa-test/api-service"
+  , "@fossa-test/cli-tool"
+  , "@fossa-test/shared-utils"
+  , "@fossa-test/web-client"
+  ]
+
+data FixtureGraphs = FixtureGraphs
+  { discoveredTargets :: FoundTargets
+  , wholeGraph :: Graphing Dependency
+  , apiGraph :: Graphing Dependency
+  , cliGraph :: Graphing Dependency
+  , sharedGraph :: Graphing Dependency
+  , webGraph :: Graphing Dependency
+  }
+
+mkTargets :: [Text] -> FoundTargets
+mkTargets = maybe ProjectWithoutTargets FoundTargets . NonEmptySet.nonEmpty . Set.fromList . map BuildTarget
+
+depNames :: Graphing Dependency -> Set Text
+depNames = Set.fromList . map dependencyName . Graphing.vertexList
+
+analyzeFixture :: IO FixtureGraphs
+analyzeFixture = do
+  currentDir <- PIO.getCurrentDir
+  let scanDir = currentDir </> fixtureDir
+  discovered <- testRunner (Node.discover scanDir) LocalEnvironment
+  withResult discovered $ \_ projects -> case projects of
+    [project] -> do
+      projectType project `shouldBe` NpmProjectType
+      let analyzeWith targets = do
+            analyzed <- testRunner (ignoreDebug $ runReader NonStrict $ analyzeProject targets (projectData project)) LocalEnvironment
+            withResult analyzed $ \_ depResults -> pure (dependencyGraph depResults)
+      FixtureGraphs (projectBuildTargets project)
+        <$> analyzeWith (projectBuildTargets project)
+        <*> analyzeWith (mkTargets ["@fossa-test/api-service"])
+        <*> analyzeWith (mkTargets ["@fossa-test/cli-tool"])
+        <*> analyzeWith (mkTargets ["@fossa-test/shared-utils"])
+        <*> analyzeWith (mkTargets ["@fossa-test/web-client"])
+    projects' -> fail ("expected exactly one discovered project, got " <> show (length projects'))
+
+spec :: Spec
+spec = beforeAll analyzeFixture $
+  describe "npm workspaces monorepo with v3 lockfile" $ do
+    it "should expose the root and each workspace as build targets" $ \fixture ->
+      discoveredTargets fixture `shouldBe` mkTargets allTargetNames
+
+    it "should produce distinct dependency sets per selected workspace" $ \fixture -> do
+      let workspaceGraphs = [apiGraph fixture, cliGraph fixture, sharedGraph fixture, webGraph fixture]
+      length (Set.fromList (map depNames workspaceGraphs)) `shouldBe` length workspaceGraphs
+
+      depNames (apiGraph fixture) `shouldSatisfy` Set.isSubsetOf (Set.fromList ["cors", "uuid"])
+      depNames (apiGraph fixture) `shouldSatisfy` (\names -> not (any (`Set.member` names) ["lodash", "commander", "react", "typescript"]))
+
+      depNames (cliGraph fixture) `shouldSatisfy` Set.isSubsetOf (Set.fromList ["chalk", "commander"])
+      depNames (cliGraph fixture) `shouldSatisfy` (\names -> not (any (`Set.member` names) ["cors", "lodash", "react"]))
+
+      depNames (sharedGraph fixture) `shouldBe` Set.fromList ["lodash", "uuid"]
+
+    it "should attribute a linked sibling workspace's dependencies to the requesting workspace" $ \fixture -> do
+      -- web-client depends on the shared-utils workspace via a lockfile link
+      -- entry; its scoped result must include shared-utils' external deps
+      -- with real versions, and no entry for the workspace itself.
+      depNames (webGraph fixture) `shouldSatisfy` Set.isSubsetOf (Set.fromList ["react", "classnames", "lodash", "uuid"])
+      Set.member "@fossa-test/shared-utils" (depNames (webGraph fixture)) `shouldBe` False
+      filter (isNothing . dependencyVersion) (Graphing.vertexList (webGraph fixture)) `shouldBe` []
+
+    it "should analyze the whole repo when all targets are selected" $ \fixture -> do
+      let wholeNames = depNames (wholeGraph fixture)
+      -- root dev deps and every workspace's deps are present
+      ["prettier", "typescript", "cors", "chalk", "lodash", "react"] `shouldSatisfy` all (`Set.member` wholeNames)
+      [apiGraph fixture, cliGraph fixture, sharedGraph fixture, webGraph fixture]
+        `shouldSatisfy` all ((`Set.isSubsetOf` wholeNames) . depNames)

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -777,6 +777,7 @@ test-suite integration-tests
     Analysis.GradleSpec
     Analysis.LicenseScannerSpec
     Analysis.MavenSpec
+    Analysis.NpmLockV3WorkspaceSpec
     Analysis.NugetSpec
     Analysis.PnpmSpec
     Analysis.Python.PipenvSpec

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -218,7 +218,7 @@ analyzeBunLock (Manifest bunLockFile) = do
   result <- BunLock.analyze bunLockFile
   pure $ DependencyResults result Complete [bunLockFile]
 
-analyzeNpmLock :: (Has Diagnostics sig m, Has ReadFS sig m) => FoundTargets -> Manifest -> PkgJsonGraph -> m DependencyResults
+analyzeNpmLock :: (Has Diagnostics sig m, Has ReadFS sig m, Has Logger sig m) => FoundTargets -> Manifest -> PkgJsonGraph -> m DependencyResults
 analyzeNpmLock targets (Manifest npmLockFile) graph = do
   npmLockVersion <- detectNpmLockVersion npmLockFile
   result <- case npmLockVersion of

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -327,17 +327,17 @@ resolveNpmV3WorkspacePaths (FoundTargets targets) graph@PkgJsonGraph{..} =
         namePathPairs :: [(Text, Text)]
         namePathPairs =
           mapMaybe
-            (\(Manifest m, pj) -> fmap (,manifestToWorkspacePath m) (packageName pj))
+            (\(Manifest m, pj) -> (,) <$> packageName pj <*> manifestToWorkspacePath m)
             (Map.toList jsonLookup)
 
-        manifestToWorkspacePath :: Path Abs File -> Text
+        manifestToWorkspacePath :: Path Abs File -> Maybe Text
         manifestToWorkspacePath m =
           let manifestDir = parent m
            in if manifestDir == rootDir
-                then ""
+                then Just ""
                 else -- npm keys workspaces with forward slashes on every OS, so
                 -- normalize the platform separator before matching.
-                  maybe "" (Text.replace "\\" "/" . toText . FP.dropTrailingPathSeparator . toFilePath) (stripProperPrefix rootDir manifestDir)
+                  fmap (Text.replace "\\" "/" . toText . FP.dropTrailingPathSeparator . toFilePath) (stripProperPrefix rootDir manifestDir)
 
 extractDepLists :: PkgJsonGraph -> FlatDeps
 extractDepLists PkgJsonGraph{..} = foldMap extractSingle $ Map.elems jsonLookup

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -327,7 +327,7 @@ resolveNpmV3WorkspacePaths (FoundTargets targets) graph@PkgJsonGraph{..} =
         namePathPairs :: [(Text, Text)]
         namePathPairs =
           mapMaybe
-            (\(Manifest m, pj) -> fmap (\name -> (name, manifestToWorkspacePath m)) (packageName pj))
+            (\(Manifest m, pj) -> fmap (,manifestToWorkspacePath m) (packageName pj))
             (Map.toList jsonLookup)
 
         manifestToWorkspacePath :: Path Abs File -> Text

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -222,7 +222,7 @@ analyzeNpmLock :: (Has Diagnostics sig m, Has ReadFS sig m) => FoundTargets -> M
 analyzeNpmLock targets (Manifest npmLockFile) graph = do
   npmLockVersion <- detectNpmLockVersion npmLockFile
   result <- case npmLockVersion of
-    NpmLockV3Compatible -> PackageLockV3.analyze npmLockFile
+    NpmLockV3Compatible -> PackageLockV3.analyze npmLockFile targets
     NpmLockV1Compatible -> PackageLock.analyze npmLockFile (extractDepListsForTargets targets graph) (findWorkspaceNames graph)
   pure $ DependencyResults result Complete [npmLockFile]
 

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -9,6 +9,7 @@ module Strategy.Node (
   getDeps,
   findWorkspaceBuildTargets,
   extractDepListsForTargets,
+  resolveNpmV3WorkspacePaths,
 ) where
 
 import Algebra.Graph.AdjacencyMap qualified as AM
@@ -39,7 +40,7 @@ import Data.Maybe (catMaybes, isJust, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Set.NonEmpty qualified as NonEmptySet
-import Data.String.Conversion (decodeUtf8, toString)
+import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Tagged (applyTag)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -73,6 +74,7 @@ import Path (
   Rel,
   mkRelFile,
   parent,
+  stripProperPrefix,
   toFilePath,
   (</>),
  )
@@ -99,6 +101,7 @@ import Strategy.Node.Pnpm.PnpmLock qualified as PnpmLock
 import Strategy.Node.Pnpm.Workspace (PnpmWorkspace (workspaceSpecs))
 import Strategy.Node.YarnV1.YarnLock qualified as V1
 import Strategy.Node.YarnV2.YarnLock qualified as V2
+import System.FilePath qualified as FP
 import Types (
   BuildTarget (BuildTarget),
   DependencyResults (DependencyResults),
@@ -222,7 +225,7 @@ analyzeNpmLock :: (Has Diagnostics sig m, Has ReadFS sig m, Has Logger sig m) =>
 analyzeNpmLock targets (Manifest npmLockFile) graph = do
   npmLockVersion <- detectNpmLockVersion npmLockFile
   result <- case npmLockVersion of
-    NpmLockV3Compatible -> PackageLockV3.analyze npmLockFile targets
+    NpmLockV3Compatible -> PackageLockV3.analyze (resolveNpmV3WorkspacePaths targets graph) npmLockFile
     NpmLockV1Compatible -> PackageLock.analyze npmLockFile (extractDepListsForTargets targets graph) (findWorkspaceNames graph)
   pure $ DependencyResults result Complete [npmLockFile]
 
@@ -306,6 +309,35 @@ findWorkspaceNames PkgJsonGraph{..} =
 
     workspaceNames :: [Text]
     workspaceNames = mapMaybe (packageName <=< flip Map.lookup jsonLookup) childManifests
+
+-- | Map selected build targets (workspace package names) to the root-relative
+-- path keys npm v3 lockfiles use: @""@ for the root, @"packages/a"@ for a
+-- member. 'Nothing' means no target filter, so no scoping is applied.
+resolveNpmV3WorkspacePaths :: FoundTargets -> PkgJsonGraph -> Maybe (Set Text)
+resolveNpmV3WorkspacePaths ProjectWithoutTargets _ = Nothing
+resolveNpmV3WorkspacePaths (FoundTargets targets) graph@PkgJsonGraph{..} =
+  case findWorkspaceRootManifest graph of
+    Left _ -> Nothing
+    Right (Manifest rootManifest) ->
+      Just . Set.fromList . map snd $ filter ((`Set.member` targetNames) . fst) namePathPairs
+      where
+        rootDir = parent rootManifest
+        targetNames = Set.map unBuildTarget (NonEmptySet.toSet targets)
+
+        namePathPairs :: [(Text, Text)]
+        namePathPairs =
+          mapMaybe
+            (\(Manifest m, pj) -> fmap (\name -> (name, manifestToWorkspacePath m)) (packageName pj))
+            (Map.toList jsonLookup)
+
+        manifestToWorkspacePath :: Path Abs File -> Text
+        manifestToWorkspacePath m =
+          let manifestDir = parent m
+           in if manifestDir == rootDir
+                then ""
+                else -- npm keys workspaces with forward slashes on every OS, so
+                -- normalize the platform separator before matching.
+                  maybe "" (Text.replace "\\" "/" . toText . FP.dropTrailingPathSeparator . toFilePath) (stripProperPrefix rootDir manifestDir)
 
 extractDepLists :: PkgJsonGraph -> FlatDeps
 extractDepLists PkgJsonGraph{..} = foldMap extractSingle $ Map.elems jsonLookup

--- a/src/Strategy/Node/Npm/PackageLockV3.hs
+++ b/src/Strategy/Node/Npm/PackageLockV3.hs
@@ -421,7 +421,10 @@ buildGraph foundTargets pkgLockV3 = pruneIfScoped . run . evalGrapher $ do
     -- analysis reports them as-is to preserve pre-scoping output.
     resolveDirectDeps :: PackagePath -> [PackagePath] -> [Dependency]
     resolveDirectDeps selfPath depPaths
-      | isScoped = mapMaybe toDependency $ concatMap (expandLinks (Set.singleton selfPath)) depPaths
+      | isScoped =
+          concatMap
+            (mapMaybe toDependency . expandLinks (Set.singleton selfPath))
+            depPaths
       | otherwise = mapMaybe toDependency depPaths
 
     -- Expands a workspace link stub (e.g. "node_modules/some-ws-name" with
@@ -437,14 +440,13 @@ buildGraph foundTargets pkgLockV3 = pruneIfScoped . run . evalGrapher $ do
         | linkedPath `Set.member` visited -> []
         | otherwise -> case (linkedPath, Map.lookup linkedPath (packages pkgLockV3)) of
             (PackageLockV3WorkSpace workspacePath, Just workspaceMeta) ->
-              concatMap (expandLinks (Set.insert linkedPath visited)) $
-                map (vendoredPathElseTopLevelPath workspacePath) $
-                  concatMap
-                    Map.keys
-                    [ plV3PkgDependencies workspaceMeta
-                    , plV3PkgPeerDependencies workspaceMeta
-                    , plV3PkgOptionalDependencies workspaceMeta
-                    ]
+              concatMap (expandLinks (Set.insert linkedPath visited) . vendoredPathElseTopLevelPath workspacePath) $
+                concatMap
+                  Map.keys
+                  [ plV3PkgDependencies workspaceMeta
+                  , plV3PkgPeerDependencies workspaceMeta
+                  , plV3PkgOptionalDependencies workspaceMeta
+                  ]
             _ -> []
 
     -- Resolves a link stub to the entry it points at.

--- a/src/Strategy/Node/Npm/PackageLockV3.hs
+++ b/src/Strategy/Node/Npm/PackageLockV3.hs
@@ -15,7 +15,7 @@ module Strategy.Node.Npm.PackageLockV3 (
 
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, context)
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Data.Aeson (
   FromJSON (parseJSON),
   FromJSONKey (fromJSONKey),
@@ -30,8 +30,10 @@ import Data.Aeson (
 import Data.Foldable (find, for_, traverse_)
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (catMaybes, mapMaybe)
+import Data.Maybe (catMaybes, isJust, mapMaybe)
+import Data.Set (Set)
 import Data.Set qualified as Set
+import Data.Set.NonEmpty qualified as NonEmptySet
 import Data.Text (Text, breakOnEnd)
 import Data.Text qualified as Text
 import DepTypes (
@@ -43,11 +45,13 @@ import DepTypes (
 import Effect.Grapher (direct, edge, evalGrapher, run)
 import Effect.ReadFS (ReadFS, readContentsJson)
 import Graphing (Graphing)
+import Graphing qualified
 import Path (
   Abs,
   File,
   Path,
  )
+import Types (FoundTargets (..), unBuildTarget)
 
 data PackageLockV3 = PackageLockV3
   { rootPackage :: PackageLockV3Package
@@ -136,26 +140,30 @@ instance FromJSON PackageName where
 
 -- | Describes package and it's dependencies.
 data PackageLockV3Package = PackageLockV3Package
-  { plV3PkgVersion :: Maybe Text
+  { plV3PkgName :: Maybe Text
+  , plV3PkgVersion :: Maybe Text
   , plV3PkgResolved :: NpmLockV3Resolved
   , plV3PkgDependencies :: Map PackageName Text
   , plV3PkgDevDependencies :: Map PackageName Text
   , plV3PkgOptionalDependencies :: Map PackageName Text
   , plV3PkgPeerDependencies :: Map PackageName Text
   , plV3PkgDev :: Bool
+  , plV3PkgLink :: Bool
   }
   deriving (Show, Eq, Ord)
 
 instance FromJSON PackageLockV3Package where
   parseJSON = withObject "PackageLockV3Package" $ \obj ->
     PackageLockV3Package
-      <$> obj .:? "version"
+      <$> obj .:? "name"
+      <*> obj .:? "version"
       <*> obj .:? "resolved" .!= (NpmLockV3Resolved Nothing)
       <*> obj .:? "dependencies" .!= mempty
       <*> obj .:? "devDependencies" .!= mempty
       <*> obj .:? "optionalDependencies" .!= mempty
       <*> obj .:? "peerDependencies" .!= mempty
       <*> obj .:? "dev" .!= False -- if 'dev' key is not included, it is presumed to be prod dependency
+      <*> obj .:? "link" .!= False -- 'link' is only present (and true) for workspace link entries
 
 newtype NpmLockV3Resolved = NpmLockV3Resolved {unNpmLockV3Resolved :: Maybe Text}
   deriving (Eq, Ord, Show)
@@ -165,10 +173,10 @@ instance FromJSON NpmLockV3Resolved where
   parseJSON (Bool _) = pure $ NpmLockV3Resolved Nothing
   parseJSON _ = fail "Expected to contain string or boolean value for 'resolved' field!"
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
-analyze file = context "Analyzing Npm Lockfile (v3)" $ do
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> FoundTargets -> m (Graphing Dependency)
+analyze file targets = context "Analyzing Npm Lockfile (v3)" $ do
   packageLockJson <- context "Parsing v3 compatible package-lock.json" $ readContentsJson @PackageLockV3 file
-  context "Building dependency graph" $ pure $ buildGraph packageLockJson
+  context "Building dependency graph" $ pure $ buildGraph targets packageLockJson
 
 -- | Builds a graph for package lock v3.
 --
@@ -218,9 +226,19 @@ analyze file = context "Analyzing Npm Lockfile (v3)" $ do
 --    - https://docs.npmjs.com/cli/v8/using-npm/workspaces
 --    - http://npm.github.io/how-npm-works-docs/npm3/how-npm3-works.html
 --
+--  Target scoping:
+--
+--  When a proper subset of the project's build targets is selected (via
+--  --only-target / --exclude-target), only the selected root/workspace
+--  entries mark their dependencies as direct, and the graph is pruned to
+--  what is reachable from those directs. Selection matches build target
+--  names against the "name" field of root/workspace entries. When all
+--  targets are selected (the default), or no entry matches, the whole
+--  unscoped graph is produced, preserving pre-scoping output exactly.
+--
 --  --
-buildGraph :: PackageLockV3 -> Graphing Dependency
-buildGraph pkgLockV3 = run . evalGrapher $ do
+buildGraph :: FoundTargets -> PackageLockV3 -> Graphing Dependency
+buildGraph foundTargets pkgLockV3 = pruneIfScoped . run . evalGrapher $ do
   for_ (Map.toList $ packages pkgLockV3) $ \(pkgPathKey, pkgMetadata) -> do
     case pkgPathKey of
       -- For root package,
@@ -249,22 +267,23 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
       -- to version spec (e.g. ^1.0.0) provided in 'dependencies' field.
       --
       -- Root's direct dependencies are always resolved at top-path.
-      PackageLockV3Root -> do
-        let directDeps :: [PackagePath]
-            directDeps =
-              map toTopLevelPackage $
-                concatMap
-                  Map.keys
-                  [ plV3PkgDependencies pkgMetadata
-                  , plV3PkgDevDependencies pkgMetadata
-                  , plV3PkgPeerDependencies pkgMetadata
-                  , plV3PkgOptionalDependencies pkgMetadata
-                  ]
+      PackageLockV3Root ->
+        when (isSelected PackageLockV3Root) $ do
+          let directDeps :: [PackagePath]
+              directDeps =
+                map toTopLevelPackage $
+                  concatMap
+                    Map.keys
+                    [ plV3PkgDependencies pkgMetadata
+                    , plV3PkgDevDependencies pkgMetadata
+                    , plV3PkgPeerDependencies pkgMetadata
+                    , plV3PkgOptionalDependencies pkgMetadata
+                    ]
 
-        let resolvedDeps :: [Dependency]
-            resolvedDeps = mapMaybe toDependency directDeps
+          let resolvedDeps :: [Dependency]
+              resolvedDeps = resolveDirectDeps PackageLockV3Root directDeps
 
-        traverse_ direct resolvedDeps
+          traverse_ direct resolvedDeps
 
       -- For workspace packages, for instance:
       --
@@ -288,22 +307,23 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
       -- Direct Dependencies within workspace pkg are treated as direct.
       -- Direct Peer Dependencies within workspace pkg are treated as direct.
       -- Development Dependencies within workspace pkg are treated as direct development.
-      PackageLockV3WorkSpace workspaceRootPath -> do
-        let directDeps :: [PackagePath]
-            directDeps =
-              map (vendoredPathElseTopLevelPath workspaceRootPath) $
-                concatMap
-                  Map.keys
-                  [ plV3PkgDependencies pkgMetadata
-                  , plV3PkgDevDependencies pkgMetadata
-                  , plV3PkgPeerDependencies pkgMetadata
-                  , plV3PkgOptionalDependencies pkgMetadata
-                  ]
+      PackageLockV3WorkSpace workspaceRootPath ->
+        when (isSelected (PackageLockV3WorkSpace workspaceRootPath)) $ do
+          let directDeps :: [PackagePath]
+              directDeps =
+                map (vendoredPathElseTopLevelPath workspaceRootPath) $
+                  concatMap
+                    Map.keys
+                    [ plV3PkgDependencies pkgMetadata
+                    , plV3PkgDevDependencies pkgMetadata
+                    , plV3PkgPeerDependencies pkgMetadata
+                    , plV3PkgOptionalDependencies pkgMetadata
+                    ]
 
-        let resolvedDeps :: [Dependency]
-            resolvedDeps = mapMaybe toDependency directDeps
+          let resolvedDeps :: [Dependency]
+              resolvedDeps = resolveDirectDeps (PackageLockV3WorkSpace workspaceRootPath) directDeps
 
-        traverse_ direct resolvedDeps
+          traverse_ direct resolvedDeps
 
       -- For typical dependency packages, for instance:
       --
@@ -344,14 +364,98 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
                   , plV3PkgOptionalDependencies pkgMetadata
                   ]
 
+        -- When scoping, drop edges to workspace link stubs: they have no
+        -- version, and the linked workspace's deps are attributed via
+        -- 'resolveDirectDeps' when that workspace (or a consumer) is selected.
         let resolvedDeepDeps :: [Dependency]
-            resolvedDeepDeps = mapMaybe toDependency deepDeps
+            resolvedDeepDeps =
+              mapMaybe toDependency $
+                if isScoped
+                  then filter (not . isLinkEntry) deepDeps
+                  else deepDeps
 
         case currentDep of
           Nothing -> pure () -- This will never happen, given that we are iterating on same package path.
           Just parentDep -> do
             for_ resolvedDeepDeps $ edge parentDep
   where
+    -- Root/workspace entries selected for analysis. @Nothing@ means the
+    -- analysis is unscoped (all entries are selected), which must preserve
+    -- pre-scoping output exactly. Falls back to unscoped when no entry
+    -- matches any target (e.g. entries missing a "name" field), so a bad
+    -- selection never silently produces an empty graph.
+    scopedSelection :: Maybe (Set PackagePath)
+    scopedSelection = case foundTargets of
+      ProjectWithoutTargets -> Nothing
+      FoundTargets targets ->
+        let targetNames :: Set Text
+            targetNames = Set.map unBuildTarget $ NonEmptySet.toSet targets
+
+            topLevelEntries :: Map PackagePath PackageLockV3Package
+            topLevelEntries = Map.filterWithKey (\k _ -> isTopLevelEntry k) (packages pkgLockV3)
+
+            selected :: Set PackagePath
+            selected = Map.keysSet $ Map.filter (maybe False (`Set.member` targetNames) . plV3PkgName) topLevelEntries
+         in if Set.null selected || selected == Map.keysSet topLevelEntries
+              then Nothing
+              else Just selected
+
+    isTopLevelEntry :: PackagePath -> Bool
+    isTopLevelEntry = \case
+      PackageLockV3Root -> True
+      PackageLockV3WorkSpace _ -> True
+      PackageLockV3PathKey _ _ -> False
+
+    isScoped :: Bool
+    isScoped = isJust scopedSelection
+
+    isSelected :: PackagePath -> Bool
+    isSelected pkgPath = maybe True (Set.member pkgPath) scopedSelection
+
+    pruneIfScoped :: Graphing Dependency -> Graphing Dependency
+    pruneIfScoped = if isScoped then Graphing.pruneUnreachable else id
+
+    -- Converts the resolved direct dependency paths of a root/workspace entry
+    -- to dependencies. When scoping, workspace link stubs are expanded into
+    -- the linked workspace's own dependencies (see 'expandLinks'); unscoped
+    -- analysis reports them as-is to preserve pre-scoping output.
+    resolveDirectDeps :: PackagePath -> [PackagePath] -> [Dependency]
+    resolveDirectDeps selfPath depPaths
+      | isScoped = mapMaybe toDependency $ concatMap (expandLinks (Set.singleton selfPath)) depPaths
+      | otherwise = mapMaybe toDependency depPaths
+
+    -- Expands a workspace link stub (e.g. "node_modules/some-ws-name" with
+    -- "link": true and "resolved" pointing at the workspace's path) into the
+    -- linked workspace's own resolved prod/peer/optional dependencies, so a
+    -- selected workspace's dependency on a sibling workspace is attributed
+    -- to the sibling's real dependencies instead of a versionless link stub.
+    -- The visited set guards against mutually-dependent workspaces.
+    expandLinks :: Set PackagePath -> PackagePath -> [PackagePath]
+    expandLinks visited pkgPath = case linkTarget pkgPath of
+      Nothing -> [pkgPath]
+      Just linkedPath
+        | linkedPath `Set.member` visited -> []
+        | otherwise -> case (linkedPath, Map.lookup linkedPath (packages pkgLockV3)) of
+            (PackageLockV3WorkSpace workspacePath, Just workspaceMeta) ->
+              concatMap (expandLinks (Set.insert linkedPath visited)) $
+                map (vendoredPathElseTopLevelPath workspacePath) $
+                  concatMap
+                    Map.keys
+                    [ plV3PkgDependencies workspaceMeta
+                    , plV3PkgPeerDependencies workspaceMeta
+                    , plV3PkgOptionalDependencies workspaceMeta
+                    ]
+            _ -> []
+
+    -- Resolves a link stub to the entry it points at.
+    linkTarget :: PackagePath -> Maybe PackagePath
+    linkTarget pkgPath = case Map.lookup pkgPath (packages pkgLockV3) of
+      Just meta | plV3PkgLink meta -> parsePathKey <$> unNpmLockV3Resolved (plV3PkgResolved meta)
+      _ -> Nothing
+
+    isLinkEntry :: PackagePath -> Bool
+    isLinkEntry pkgPath = maybe False plV3PkgLink $ Map.lookup pkgPath $ packages pkgLockV3
+
     -- Prefer resolution path in following order of precedent:
     --
     --  1) {prefix}/node_modules/{pkgName}

--- a/src/Strategy/Node/Npm/PackageLockV3.hs
+++ b/src/Strategy/Node/Npm/PackageLockV3.hs
@@ -43,6 +43,7 @@ import DepTypes (
   VerConstraint (CEq),
  )
 import Effect.Grapher (direct, edge, evalGrapher, run)
+import Effect.Logger (Logger, logWarn, pretty)
 import Effect.ReadFS (ReadFS, readContentsJson)
 import Graphing (Graphing)
 import Graphing qualified
@@ -173,10 +174,48 @@ instance FromJSON NpmLockV3Resolved where
   parseJSON (Bool _) = pure $ NpmLockV3Resolved Nothing
   parseJSON _ = fail "Expected to contain string or boolean value for 'resolved' field!"
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> FoundTargets -> m (Graphing Dependency)
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => Path Abs File -> FoundTargets -> m (Graphing Dependency)
 analyze file targets = context "Analyzing Npm Lockfile (v3)" $ do
   packageLockJson <- context "Parsing v3 compatible package-lock.json" $ readContentsJson @PackageLockV3 file
+  case (targets, scopedSelection targets packageLockJson) of
+    (FoundTargets targetNames, Just selected) ->
+      when (Set.null selected) $
+        logWarn . pretty $
+          "Target filter ("
+            <> Text.intercalate ", " (map unBuildTarget (Set.toList (NonEmptySet.toSet targetNames)))
+            <> ") did not match any root or workspace entry in the v3 lockfile; reporting an empty dependency graph."
+    _ -> pure ()
   context "Building dependency graph" $ pure $ buildGraph targets packageLockJson
+
+-- | Root/workspace entries selected for analysis, shared by 'analyze' and
+-- 'buildGraph'. @Nothing@ means the analysis is unscoped (all entries are
+-- selected), which must preserve pre-scoping output exactly: this happens
+-- when the project has no targets, or when the selection covers every
+-- root/workspace entry (the default when no target filter is applied). A
+-- selection matching no entry yields @Just Set.empty@: no entry marks its
+-- dependencies as direct, so pruning produces an empty graph ('analyze'
+-- warns when this happens).
+scopedSelection :: FoundTargets -> PackageLockV3 -> Maybe (Set PackagePath)
+scopedSelection foundTargets pkgLockV3 = case foundTargets of
+  ProjectWithoutTargets -> Nothing
+  FoundTargets targets ->
+    let targetNames :: Set Text
+        targetNames = Set.map unBuildTarget $ NonEmptySet.toSet targets
+
+        topLevelEntries :: Map PackagePath PackageLockV3Package
+        topLevelEntries = Map.filterWithKey (\k _ -> isTopLevelEntry k) (packages pkgLockV3)
+
+        selected :: Set PackagePath
+        selected = Map.keysSet $ Map.filter (maybe False (`Set.member` targetNames) . plV3PkgName) topLevelEntries
+     in if selected == Map.keysSet topLevelEntries
+          then Nothing
+          else Just selected
+  where
+    isTopLevelEntry :: PackagePath -> Bool
+    isTopLevelEntry = \case
+      PackageLockV3Root -> True
+      PackageLockV3WorkSpace _ -> True
+      PackageLockV3PathKey _ _ -> False
 
 -- | Builds a graph for package lock v3.
 --
@@ -232,9 +271,11 @@ analyze file targets = context "Analyzing Npm Lockfile (v3)" $ do
 --  --only-target / --exclude-target), only the selected root/workspace
 --  entries mark their dependencies as direct, and the graph is pruned to
 --  what is reachable from those directs. Selection matches build target
---  names against the "name" field of root/workspace entries. When all
---  targets are selected (the default), or no entry matches, the whole
---  unscoped graph is produced, preserving pre-scoping output exactly.
+--  names against the "name" field of root/workspace entries. Only when all
+--  targets are selected (the default) or the project has no targets is the
+--  whole unscoped graph produced, preserving pre-scoping output exactly. A
+--  selection matching no entry produces an empty graph ('analyze' warns
+--  when this happens, honoring the user's filter as v1/v2 scoping does).
 --
 --  --
 buildGraph :: FoundTargets -> PackageLockV3 -> Graphing Dependency
@@ -379,38 +420,14 @@ buildGraph foundTargets pkgLockV3 = pruneIfScoped . run . evalGrapher $ do
           Just parentDep -> do
             for_ resolvedDeepDeps $ edge parentDep
   where
-    -- Root/workspace entries selected for analysis. @Nothing@ means the
-    -- analysis is unscoped (all entries are selected), which must preserve
-    -- pre-scoping output exactly. Falls back to unscoped when no entry
-    -- matches any target (e.g. entries missing a "name" field), so a bad
-    -- selection never silently produces an empty graph.
-    scopedSelection :: Maybe (Set PackagePath)
-    scopedSelection = case foundTargets of
-      ProjectWithoutTargets -> Nothing
-      FoundTargets targets ->
-        let targetNames :: Set Text
-            targetNames = Set.map unBuildTarget $ NonEmptySet.toSet targets
-
-            topLevelEntries :: Map PackagePath PackageLockV3Package
-            topLevelEntries = Map.filterWithKey (\k _ -> isTopLevelEntry k) (packages pkgLockV3)
-
-            selected :: Set PackagePath
-            selected = Map.keysSet $ Map.filter (maybe False (`Set.member` targetNames) . plV3PkgName) topLevelEntries
-         in if Set.null selected || selected == Map.keysSet topLevelEntries
-              then Nothing
-              else Just selected
-
-    isTopLevelEntry :: PackagePath -> Bool
-    isTopLevelEntry = \case
-      PackageLockV3Root -> True
-      PackageLockV3WorkSpace _ -> True
-      PackageLockV3PathKey _ _ -> False
+    selection :: Maybe (Set PackagePath)
+    selection = scopedSelection foundTargets pkgLockV3
 
     isScoped :: Bool
-    isScoped = isJust scopedSelection
+    isScoped = isJust selection
 
     isSelected :: PackagePath -> Bool
-    isSelected pkgPath = maybe True (Set.member pkgPath) scopedSelection
+    isSelected pkgPath = maybe True (Set.member pkgPath) selection
 
     pruneIfScoped :: Graphing Dependency -> Graphing Dependency
     pruneIfScoped = if isScoped then Graphing.pruneUnreachable else id

--- a/src/Strategy/Node/Npm/PackageLockV3.hs
+++ b/src/Strategy/Node/Npm/PackageLockV3.hs
@@ -33,7 +33,6 @@ import Data.Map qualified as Map
 import Data.Maybe (catMaybes, isJust, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Data.Set.NonEmpty qualified as NonEmptySet
 import Data.Text (Text, breakOnEnd)
 import Data.Text qualified as Text
 import DepTypes (
@@ -52,7 +51,6 @@ import Path (
   File,
   Path,
  )
-import Types (FoundTargets (..), unBuildTarget)
 
 data PackageLockV3 = PackageLockV3
   { rootPackage :: PackageLockV3Package
@@ -141,8 +139,7 @@ instance FromJSON PackageName where
 
 -- | Describes package and it's dependencies.
 data PackageLockV3Package = PackageLockV3Package
-  { plV3PkgName :: Maybe Text
-  , plV3PkgVersion :: Maybe Text
+  { plV3PkgVersion :: Maybe Text
   , plV3PkgResolved :: NpmLockV3Resolved
   , plV3PkgDependencies :: Map PackageName Text
   , plV3PkgDevDependencies :: Map PackageName Text
@@ -156,8 +153,7 @@ data PackageLockV3Package = PackageLockV3Package
 instance FromJSON PackageLockV3Package where
   parseJSON = withObject "PackageLockV3Package" $ \obj ->
     PackageLockV3Package
-      <$> obj .:? "name"
-      <*> obj .:? "version"
+      <$> obj .:? "version"
       <*> obj .:? "resolved" .!= (NpmLockV3Resolved Nothing)
       <*> obj .:? "dependencies" .!= mempty
       <*> obj .:? "devDependencies" .!= mempty
@@ -174,43 +170,47 @@ instance FromJSON NpmLockV3Resolved where
   parseJSON (Bool _) = pure $ NpmLockV3Resolved Nothing
   parseJSON _ = fail "Expected to contain string or boolean value for 'resolved' field!"
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => Path Abs File -> FoundTargets -> m (Graphing Dependency)
-analyze file targets = context "Analyzing Npm Lockfile (v3)" $ do
+-- | Analyzes a v3 lockfile, optionally scoped to the given root-relative
+-- workspace paths (@""@ for the root project, @"packages/a"@ for a workspace
+-- member), as resolved from the selected build targets by
+-- 'Strategy.Node.resolveNpmV3WorkspacePaths'. @Nothing@ means no target
+-- filter is applied, so the whole unscoped graph is produced.
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m, Has Logger sig m) => Maybe (Set Text) -> Path Abs File -> m (Graphing Dependency)
+analyze selectedPaths file = context "Analyzing Npm Lockfile (v3)" $ do
   packageLockJson <- context "Parsing v3 compatible package-lock.json" $ readContentsJson @PackageLockV3 file
-  case (targets, scopedSelection targets packageLockJson) of
-    (FoundTargets targetNames, Just selected) ->
+  case (selectedPaths, scopedSelection selectedPaths packageLockJson) of
+    (Just paths, Just selected) ->
       when (Set.null selected) $
         logWarn . pretty $
-          "Target filter ("
-            <> Text.intercalate ", " (map unBuildTarget (Set.toList (NonEmptySet.toSet targetNames)))
+          "Target filter (resolved workspace paths: "
+            <> Text.intercalate ", " (Set.toList paths)
             <> ") did not match any root or workspace entry in the v3 lockfile; reporting an empty dependency graph."
     _ -> pure ()
-  context "Building dependency graph" $ pure $ buildGraph targets packageLockJson
+  context "Building dependency graph" $ pure $ buildGraph selectedPaths packageLockJson
 
 -- | Root/workspace entries selected for analysis, shared by 'analyze' and
--- 'buildGraph'. @Nothing@ means the analysis is unscoped (all entries are
--- selected), which must preserve pre-scoping output exactly: this happens
--- when the project has no targets, or when the selection covers every
--- root/workspace entry (the default when no target filter is applied). A
--- selection matching no entry yields @Just Set.empty@: no entry marks its
--- dependencies as direct, so pruning produces an empty graph ('analyze'
--- warns when this happens).
-scopedSelection :: FoundTargets -> PackageLockV3 -> Maybe (Set PackagePath)
-scopedSelection foundTargets pkgLockV3 = case foundTargets of
-  ProjectWithoutTargets -> Nothing
-  FoundTargets targets ->
-    let targetNames :: Set Text
-        targetNames = Set.map unBuildTarget $ NonEmptySet.toSet targets
-
-        topLevelEntries :: Map PackagePath PackageLockV3Package
-        topLevelEntries = Map.filterWithKey (\k _ -> isTopLevelEntry k) (packages pkgLockV3)
-
-        selected :: Set PackagePath
-        selected = Map.keysSet $ Map.filter (maybe False (`Set.member` targetNames) . plV3PkgName) topLevelEntries
-     in if selected == Map.keysSet topLevelEntries
-          then Nothing
-          else Just selected
+-- 'buildGraph'. The given root-relative workspace paths are parsed into the
+-- lockfile's top-level path keys ('PackageLockV3Root' / 'PackageLockV3WorkSpace')
+-- and intersected with the entries actually present in the lockfile.
+-- @Nothing@ means the analysis is unscoped (all entries are selected), which
+-- must preserve pre-scoping output exactly: this happens when no target
+-- filter is applied, or when the selection covers every root/workspace entry
+-- (the default when all targets are selected). A selection matching no entry
+-- yields @Just Set.empty@: no entry marks its dependencies as direct, so
+-- pruning produces an empty graph ('analyze' warns when this happens).
+scopedSelection :: Maybe (Set Text) -> PackageLockV3 -> Maybe (Set PackagePath)
+scopedSelection Nothing _ = Nothing
+scopedSelection (Just paths) pkgLockV3 =
+  if selected == topLevelEntries
+    then Nothing
+    else Just selected
   where
+    topLevelEntries :: Set PackagePath
+    topLevelEntries = Set.filter isTopLevelEntry (Map.keysSet (packages pkgLockV3))
+
+    selected :: Set PackagePath
+    selected = Set.map parsePathKey paths `Set.intersection` topLevelEntries
+
     isTopLevelEntry :: PackagePath -> Bool
     isTopLevelEntry = \case
       PackageLockV3Root -> True
@@ -270,16 +270,20 @@ scopedSelection foundTargets pkgLockV3 = case foundTargets of
 --  When a proper subset of the project's build targets is selected (via
 --  --only-target / --exclude-target), only the selected root/workspace
 --  entries mark their dependencies as direct, and the graph is pruned to
---  what is reachable from those directs. Selection matches build target
---  names against the "name" field of root/workspace entries. Only when all
---  targets are selected (the default) or the project has no targets is the
---  whole unscoped graph produced, preserving pre-scoping output exactly. A
---  selection matching no entry produces an empty graph ('analyze' warns
---  when this happens, honoring the user's filter as v1/v2 scoping does).
+--  what is reachable from those directs. Selected build target names are
+--  resolved to root-relative workspace paths via their package.json
+--  manifests (see 'Strategy.Node.resolveNpmV3WorkspacePaths'), and those
+--  paths are matched against the lockfile's top-level path keys, so
+--  selection works even when a lockfile entry omits its "name" field. Only
+--  when all targets are selected (the default) or the project has no
+--  targets is the whole unscoped graph produced, preserving pre-scoping
+--  output exactly. A selection matching no entry produces an empty graph
+--  ('analyze' warns when this happens, honoring the user's filter as v1/v2
+--  scoping does).
 --
 --  --
-buildGraph :: FoundTargets -> PackageLockV3 -> Graphing Dependency
-buildGraph foundTargets pkgLockV3 = pruneIfScoped . run . evalGrapher $ do
+buildGraph :: Maybe (Set Text) -> PackageLockV3 -> Graphing Dependency
+buildGraph selectedPaths pkgLockV3 = pruneIfScoped . run . evalGrapher $ do
   for_ (Map.toList $ packages pkgLockV3) $ \(pkgPathKey, pkgMetadata) -> do
     case pkgPathKey of
       -- For root package,
@@ -421,7 +425,7 @@ buildGraph foundTargets pkgLockV3 = pruneIfScoped . run . evalGrapher $ do
             for_ resolvedDeepDeps $ edge parentDep
   where
     selection :: Maybe (Set PackagePath)
-    selection = scopedSelection foundTargets pkgLockV3
+    selection = scopedSelection selectedPaths pkgLockV3
 
     isScoped :: Bool
     isScoped = isJust selection

--- a/test/Node/NodeSpec.hs
+++ b/test/Node/NodeSpec.hs
@@ -14,7 +14,7 @@ import DepTypes (DepEnvironment (EnvProduction), Dependency (dependencyEnvironme
 import Graphing qualified
 import Path (Abs, Dir, Path, mkRelDir, mkRelFile, (</>))
 import Path.IO (getCurrentDir)
-import Strategy.Node (NodeProject (NPMLock), discover, extractDepListsForTargets, findWorkspaceBuildTargets, getDeps, pkgGraph)
+import Strategy.Node (NodeProject (NPMLock), discover, extractDepListsForTargets, findWorkspaceBuildTargets, getDeps, pkgGraph, resolveNpmV3WorkspacePaths)
 import Strategy.Node.PackageJson (
   FlatDeps (..),
   Manifest (..),
@@ -60,6 +60,7 @@ spec = do
   npmLockAnalysisSpec currDir
   workspaceBuildTargetsSpec currDir
   extractDepListsForTargetsSpec currDir
+  resolveNpmV3WorkspacePathsSpec currDir
 
 discoveredWorkSpaceProj :: Path Abs Dir -> DiscoveredProject NodeProject
 discoveredWorkSpaceProj currDir =
@@ -280,6 +281,35 @@ extractDepListsForTargetsSpec currDir = describe "extractDepListsForTargets" $ d
             , NodePackage "husky" "^8.0.0"
             ]
     directDeps result `shouldBe` applyTag @Production expectedDirect
+
+resolveNpmV3WorkspacePathsSpec :: Path Abs Dir -> Spec
+resolveNpmV3WorkspacePathsSpec currDir = describe "resolveNpmV3WorkspacePaths" $ do
+  let graph = workspaceGraphWithDeps currDir
+      forTargets names =
+        resolveNpmV3WorkspacePaths
+          (maybe ProjectWithoutTargets FoundTargets . nonEmpty $ Set.fromList (map BuildTarget names))
+          graph
+
+  it "returns Nothing when unscoped" $
+    resolveNpmV3WorkspacePaths ProjectWithoutTargets graph `shouldBe` Nothing
+
+  it "maps a workspace name to its root-relative lockfile path key" $
+    -- pkg-a lives at ./pkg-a, where the folder basename equals the package name,
+    -- so npm omits the lockfile "name"; resolving via package.json still finds it.
+    forTargets ["pkg-a"] `shouldBe` Just (Set.fromList ["pkg-a"])
+
+  it "maps the root target to the empty path key" $
+    forTargets ["workspace-test"] `shouldBe` Just (Set.fromList [""])
+
+  it "maps a nested workspace name to its nested path key" $
+    forTargets ["pkg-b"] `shouldBe` Just (Set.fromList ["nested/pkg-b"])
+
+  it "maps every selected target" $
+    forTargets ["workspace-test", "pkg-a", "pkg-b"]
+      `shouldBe` Just (Set.fromList ["", "pkg-a", "nested/pkg-b"])
+
+  it "resolves no paths when no target matches a manifest" $
+    forTargets ["does-not-exist"] `shouldBe` Just Set.empty
 
 -- | A workspace graph with actual dependencies for testing extractDepListsForTargets.
 workspaceGraphWithDeps :: Path Abs Dir -> PkgJsonGraph

--- a/test/Node/PackageLockV3Spec.hs
+++ b/test/Node/PackageLockV3Spec.hs
@@ -6,7 +6,9 @@ module Node.PackageLockV3Spec (
 
 import Data.Aeson (eitherDecodeFileStrict')
 import Data.Map.Strict qualified as Map
+import Data.Maybe (isNothing)
 import Data.Set qualified as Set
+import Data.Set.NonEmpty qualified as NonEmptySet
 import Data.String.Conversion (toString)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -19,10 +21,12 @@ import DepTypes (
 import Effect.ReadFS (readContentsJson)
 import GraphUtil (
   expectDep,
+  expectDeps,
   expectDirect,
   expectEdge,
  )
 import Graphing (Graphing)
+import Graphing qualified
 import Path (Abs, Dir, File, Path, Rel, mkRelDir, mkRelFile, (</>))
 import Path.IO (getCurrentDir)
 import Strategy.Node.Npm.PackageLockV3 (
@@ -38,6 +42,7 @@ import Strategy.Node.Npm.PackageLockV3 (
  )
 import Test.Effect (it', shouldBe')
 import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, runIO, shouldBe)
+import Types (BuildTarget (BuildTarget), FoundTargets (FoundTargets, ProjectWithoutTargets))
 
 fixtureSimplePackageLockPath :: Path Rel File
 fixtureSimplePackageLockPath = $(mkRelFile "simple-package-lock.json")
@@ -47,6 +52,9 @@ multiLevelVendorLockPath = $(mkRelFile "multi-level-vendor-package-lock.json")
 
 workspaceNestedModulePackageLockPath :: Path Rel File
 workspaceNestedModulePackageLockPath = $(mkRelFile "ws-nested-module-package-lock.json")
+
+workspaceLinksPackageLockPath :: Path Rel File
+workspaceLinksPackageLockPath = $(mkRelFile "workspace-links-package-lock.json")
 
 spec :: Spec
 spec = do
@@ -66,6 +74,10 @@ spec = do
   checkGraph (graphingFixtureDir </> fixtureSimplePackageLockPath) simplePackageLockGraphSpec
   checkGraph (graphingFixtureDir </> workspaceNestedModulePackageLockPath) workspaceNestedModulePackageLockGraphSpec
   checkGraph (graphingFixtureDir </> multiLevelVendorLockPath) multiLevelVendorLockGraphSpec
+
+  -- Target scoping
+  checkGraph (graphingFixtureDir </> fixtureSimplePackageLockPath) simplePackageLockScopingSpec
+  checkGraph (graphingFixtureDir </> workspaceLinksPackageLockPath) workspaceLinksGraphSpec
 
 vendorPrefixesSpec :: Spec
 vendorPrefixesSpec = do
@@ -194,8 +206,11 @@ packageLockParseSpec testDir =
                 (packages pkgLockV3)
       foo `shouldBe'` Nothing
 
-simplePackageLockGraphSpec :: Graphing Dependency -> Spec
-simplePackageLockGraphSpec graph = do
+simplePackageLockGraphSpec :: PackageLockV3 -> Spec
+simplePackageLockGraphSpec pkgLockV3 = do
+  let graph :: Graphing Dependency
+      graph = buildGraph ProjectWithoutTargets pkgLockV3
+
   let hasEdge :: Dependency -> Dependency -> Expectation
       hasEdge = expectEdge graph
 
@@ -349,8 +364,11 @@ simplePackageLockGraphSpec graph = do
       hasEdge (mkProdDep "xml2js@0.4.19") (mkProdDep "sax@1.2.1")
       hasEdge (mkProdDep "xml2js@0.4.19") (mkProdDep "xmlbuilder@9.0.7")
 
-multiLevelVendorLockGraphSpec :: Graphing Dependency -> Spec
-multiLevelVendorLockGraphSpec graph = do
+multiLevelVendorLockGraphSpec :: PackageLockV3 -> Spec
+multiLevelVendorLockGraphSpec pkgLockV3 = do
+  let graph :: Graphing Dependency
+      graph = buildGraph ProjectWithoutTargets pkgLockV3
+
   let hasEdge :: Dependency -> Dependency -> Expectation
       hasEdge = expectEdge graph
 
@@ -376,8 +394,11 @@ multiLevelVendorLockGraphSpec graph = do
       hasEdge (mkProdDep "log4js@6.7.0") (mkProdDep "debug@4.3.4")
       hasEdge (mkProdDep "debug@4.3.4") (mkProdDep "ms@2.1.2")
 
-workspaceNestedModulePackageLockGraphSpec :: Graphing Dependency -> Spec
-workspaceNestedModulePackageLockGraphSpec graph = do
+workspaceNestedModulePackageLockGraphSpec :: PackageLockV3 -> Spec
+workspaceNestedModulePackageLockGraphSpec pkgLockV3 = do
+  let graph :: Graphing Dependency
+      graph = buildGraph ProjectWithoutTargets pkgLockV3
+
   let hasEdge :: Dependency -> Dependency -> Expectation
       hasEdge = expectEdge graph
 
@@ -404,6 +425,146 @@ workspaceNestedModulePackageLockGraphSpec graph = do
       hasDep (mkProdDep "c@1.0.0")
       hasEdge (mkProdDep "b@2.0.0") (mkProdDep "c@1.0.0")
 
+simplePackageLockScopingSpec :: PackageLockV3 -> Spec
+simplePackageLockScopingSpec pkgLockV3 = do
+  describe "buildGraph with target scoping (simple fixture)" $ do
+    it "should only include the selected workspace's dependencies" $ do
+      let graph = buildGraph (mkTargets ["workspace-a-name"]) pkgLockV3
+
+      expectDirect
+        [ mkProdDep "aws-sdk@1.0.0"
+        , mkProdDep "commander@9.2.0"
+        ]
+        graph
+
+      expectDeps
+        [ mkProdDep "aws-sdk@1.0.0"
+        , mkProdDep "commander@9.2.0"
+        , mkProdDep "xml2js@0.2.4"
+        , mkProdDep "xmlbuilder@9.0.7"
+        , mkProdDep "sax@1.2.1"
+        ]
+        graph
+
+      expectEdge graph (mkProdDep "aws-sdk@1.0.0") (mkProdDep "xml2js@0.2.4")
+      expectEdge graph (mkProdDep "xml2js@0.2.4") (mkProdDep "sax@1.2.1")
+
+    it "should only include the root package's dependencies when only the root is selected" $ do
+      let graph = buildGraph (mkTargets ["lockv3"]) pkgLockV3
+
+      expectDirect
+        [ mkProdDep "3@2.1.0"
+        , mkProdDep "aws-sdk@2.1134.0"
+        , mkProdDep "react@18.1.0"
+        , mkProdDep "chalk@5.0.1"
+        , mkDevDep "mocha@10.0.0"
+        ]
+        graph
+
+      expectNoDepNamed "commander" graph
+      expectDep (mkProdDep "aws-sdk@2.1134.0") graph
+      shouldNotHaveDep (mkProdDep "aws-sdk@1.0.0") graph
+      shouldNotHaveDep (mkProdDep "xml2js@0.2.4") graph
+
+    it "should produce the unscoped graph when all targets are selected" $
+      buildGraph (mkTargets ["lockv3", "workspace-a-name"]) pkgLockV3
+        `shouldBe` buildGraph ProjectWithoutTargets pkgLockV3
+
+    it "should fall back to the unscoped graph when no target matches a lockfile entry" $
+      buildGraph (mkTargets ["does-not-exist"]) pkgLockV3
+        `shouldBe` buildGraph ProjectWithoutTargets pkgLockV3
+
+workspaceLinksGraphSpec :: PackageLockV3 -> Spec
+workspaceLinksGraphSpec pkgLockV3 = do
+  describe "buildGraph with cross-workspace links" $ do
+    it "should report link stubs as versionless deps when unscoped (pre-scoping behavior)" $ do
+      let graph = buildGraph ProjectWithoutTargets pkgLockV3
+
+      expectDirect
+        [ mkProdDep "root-only@1.0.0"
+        , mkProdDep "external-a@1.0.0"
+        , mkProdDep "external-b@1.0.0"
+        , mkProdDep "external-c@1.0.0"
+        , mkLinkStubDep "@scope/ws-a" "packages/a"
+        , mkLinkStubDep "@scope/ws-b" "packages/b"
+        ]
+        graph
+
+    it "should attribute a linked sibling workspace's dependencies to the selected workspace" $ do
+      let graph = buildGraph (mkTargets ["@scope/ws-a"]) pkgLockV3
+
+      expectDirect
+        [ mkProdDep "external-a@1.0.0"
+        , mkProdDep "external-b@1.0.0"
+        ]
+        graph
+
+      expectDeps
+        [ mkProdDep "external-a@1.0.0"
+        , mkProdDep "external-b@1.0.0"
+        , mkProdDep "transitive-b@2.0.0"
+        ]
+        graph
+
+      expectEdge graph (mkProdDep "external-b@1.0.0") (mkProdDep "transitive-b@2.0.0")
+      expectNoVersionlessDeps graph
+
+    it "should handle mutually-dependent workspaces without looping" $ do
+      let graph = buildGraph (mkTargets ["@scope/ws-b"]) pkgLockV3
+
+      expectDirect
+        [ mkProdDep "external-b@1.0.0"
+        , mkProdDep "external-a@1.0.0"
+        ]
+        graph
+
+      expectDeps
+        [ mkProdDep "external-a@1.0.0"
+        , mkProdDep "external-b@1.0.0"
+        , mkProdDep "transitive-b@2.0.0"
+        ]
+        graph
+
+      expectNoVersionlessDeps graph
+
+    it "should not attribute sibling workspaces' dependencies to an unrelated workspace" $ do
+      let graph = buildGraph (mkTargets ["@scope/ws-c"]) pkgLockV3
+
+      expectDirect [mkProdDep "external-c@1.0.0"] graph
+      expectDeps [mkProdDep "external-c@1.0.0"] graph
+
+    it "should scope to only the root package's dependencies" $ do
+      let graph = buildGraph (mkTargets ["monorepo-root"]) pkgLockV3
+
+      expectDirect [mkProdDep "root-only@1.0.0"] graph
+      expectDeps [mkProdDep "root-only@1.0.0"] graph
+
+    it "should produce the unscoped graph when all targets are selected" $
+      buildGraph (mkTargets ["monorepo-root", "@scope/ws-a", "@scope/ws-b", "@scope/ws-c"]) pkgLockV3
+        `shouldBe` buildGraph ProjectWithoutTargets pkgLockV3
+
+mkTargets :: [Text] -> FoundTargets
+mkTargets = maybe ProjectWithoutTargets FoundTargets . NonEmptySet.nonEmpty . Set.fromList . map BuildTarget
+
+-- | The versionless dependency currently produced for a workspace link stub
+-- (e.g. @"node_modules/ws-name": { "resolved": "packages/a", "link": true }@)
+-- by the unscoped analysis.
+mkLinkStubDep :: Text -> Text -> Dependency
+mkLinkStubDep name path =
+  Dependency NodeJSType name Nothing [path] (Set.singleton EnvProduction) mempty
+
+expectNoDepNamed :: Text -> Graphing Dependency -> Expectation
+expectNoDepNamed name graph =
+  filter ((== name) . dependencyName) (Graphing.vertexList graph) `shouldBe` []
+
+expectNoVersionlessDeps :: Graphing Dependency -> Expectation
+expectNoVersionlessDeps graph =
+  filter (isNothing . dependencyVersion) (Graphing.vertexList graph) `shouldBe` []
+
+shouldNotHaveDep :: Dependency -> Graphing Dependency -> Expectation
+shouldNotHaveDep dep graph =
+  filter (== dep) (Graphing.vertexList graph) `shouldBe` []
+
 mkProdDep :: Text -> Dependency
 mkProdDep nameAtVersion = mkDep nameAtVersion (Just EnvProduction)
 
@@ -423,10 +584,10 @@ mkDep nameAtVersion env = do
     (maybe mempty Set.singleton env)
     mempty
 
-checkGraph :: Path Abs File -> (Graphing Dependency -> Spec) -> Spec
+checkGraph :: Path Abs File -> (PackageLockV3 -> Spec) -> Spec
 checkGraph pathToFixture buildGraphSpec = do
   maybePkgLockV3 <- runIO $ eitherDecodeFileStrict' (toString pathToFixture)
   case maybePkgLockV3 of
     Left errMsg -> describe "packageLockV3" $ it "should parse lockfile" (expectationFailure errMsg)
     Right pkgLockV3 -> do
-      buildGraphSpec (buildGraph pkgLockV3)
+      buildGraphSpec pkgLockV3

--- a/test/Node/PackageLockV3Spec.hs
+++ b/test/Node/PackageLockV3Spec.hs
@@ -7,8 +7,8 @@ module Node.PackageLockV3Spec (
 import Data.Aeson (eitherDecodeFileStrict')
 import Data.Map.Strict qualified as Map
 import Data.Maybe (isNothing)
+import Data.Set (Set)
 import Data.Set qualified as Set
-import Data.Set.NonEmpty qualified as NonEmptySet
 import Data.String.Conversion (toString)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -42,7 +42,6 @@ import Strategy.Node.Npm.PackageLockV3 (
  )
 import Test.Effect (it', shouldBe')
 import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, runIO, shouldBe)
-import Types (BuildTarget (BuildTarget), FoundTargets (FoundTargets, ProjectWithoutTargets))
 
 fixtureSimplePackageLockPath :: Path Rel File
 fixtureSimplePackageLockPath = $(mkRelFile "simple-package-lock.json")
@@ -55,6 +54,9 @@ workspaceNestedModulePackageLockPath = $(mkRelFile "ws-nested-module-package-loc
 
 workspaceLinksPackageLockPath :: Path Rel File
 workspaceLinksPackageLockPath = $(mkRelFile "workspace-links-package-lock.json")
+
+namelessWorkspacePackageLockPath :: Path Rel File
+namelessWorkspacePackageLockPath = $(mkRelFile "nameless-workspace-package-lock.json")
 
 spec :: Spec
 spec = do
@@ -78,6 +80,7 @@ spec = do
   -- Target scoping
   checkGraph (graphingFixtureDir </> fixtureSimplePackageLockPath) simplePackageLockScopingSpec
   checkGraph (graphingFixtureDir </> workspaceLinksPackageLockPath) workspaceLinksGraphSpec
+  checkGraph (graphingFixtureDir </> namelessWorkspacePackageLockPath) namelessWorkspaceScopingSpec
 
 vendorPrefixesSpec :: Spec
 vendorPrefixesSpec = do
@@ -209,7 +212,7 @@ packageLockParseSpec testDir =
 simplePackageLockGraphSpec :: PackageLockV3 -> Spec
 simplePackageLockGraphSpec pkgLockV3 = do
   let graph :: Graphing Dependency
-      graph = buildGraph ProjectWithoutTargets pkgLockV3
+      graph = buildGraph Nothing pkgLockV3
 
   let hasEdge :: Dependency -> Dependency -> Expectation
       hasEdge = expectEdge graph
@@ -367,7 +370,7 @@ simplePackageLockGraphSpec pkgLockV3 = do
 multiLevelVendorLockGraphSpec :: PackageLockV3 -> Spec
 multiLevelVendorLockGraphSpec pkgLockV3 = do
   let graph :: Graphing Dependency
-      graph = buildGraph ProjectWithoutTargets pkgLockV3
+      graph = buildGraph Nothing pkgLockV3
 
   let hasEdge :: Dependency -> Dependency -> Expectation
       hasEdge = expectEdge graph
@@ -397,7 +400,7 @@ multiLevelVendorLockGraphSpec pkgLockV3 = do
 workspaceNestedModulePackageLockGraphSpec :: PackageLockV3 -> Spec
 workspaceNestedModulePackageLockGraphSpec pkgLockV3 = do
   let graph :: Graphing Dependency
-      graph = buildGraph ProjectWithoutTargets pkgLockV3
+      graph = buildGraph Nothing pkgLockV3
 
   let hasEdge :: Dependency -> Dependency -> Expectation
       hasEdge = expectEdge graph
@@ -429,7 +432,7 @@ simplePackageLockScopingSpec :: PackageLockV3 -> Spec
 simplePackageLockScopingSpec pkgLockV3 = do
   describe "buildGraph with target scoping (simple fixture)" $ do
     it "should only include the selected workspace's dependencies" $ do
-      let graph = buildGraph (mkTargets ["workspace-a-name"]) pkgLockV3
+      let graph = buildGraph (scopeTo ["packages/a"]) pkgLockV3
 
       expectDirect
         [ mkProdDep "aws-sdk@1.0.0"
@@ -450,7 +453,7 @@ simplePackageLockScopingSpec pkgLockV3 = do
       expectEdge graph (mkProdDep "xml2js@0.2.4") (mkProdDep "sax@1.2.1")
 
     it "should only include the root package's dependencies when only the root is selected" $ do
-      let graph = buildGraph (mkTargets ["lockv3"]) pkgLockV3
+      let graph = buildGraph (scopeTo [""]) pkgLockV3
 
       expectDirect
         [ mkProdDep "3@2.1.0"
@@ -467,18 +470,22 @@ simplePackageLockScopingSpec pkgLockV3 = do
       shouldNotHaveDep (mkProdDep "xml2js@0.2.4") graph
 
     it "should produce the unscoped graph when all targets are selected" $
-      buildGraph (mkTargets ["lockv3", "workspace-a-name"]) pkgLockV3
-        `shouldBe` buildGraph ProjectWithoutTargets pkgLockV3
+      buildGraph (scopeTo ["", "packages/a"]) pkgLockV3
+        `shouldBe` buildGraph Nothing pkgLockV3
 
-    it "should produce an empty graph when no target matches a lockfile entry" $
-      buildGraph (mkTargets ["does-not-exist"]) pkgLockV3
+    it "should produce an empty graph when no resolved path matches a lockfile entry" $
+      buildGraph (scopeTo ["packages/does-not-exist"]) pkgLockV3
+        `shouldBe` Graphing.empty
+
+    it "should produce an empty graph when no target resolved to a workspace path" $
+      buildGraph (scopeTo []) pkgLockV3
         `shouldBe` Graphing.empty
 
 workspaceLinksGraphSpec :: PackageLockV3 -> Spec
 workspaceLinksGraphSpec pkgLockV3 = do
   describe "buildGraph with cross-workspace links" $ do
     it "should report link stubs as versionless deps when unscoped (pre-scoping behavior)" $ do
-      let graph = buildGraph ProjectWithoutTargets pkgLockV3
+      let graph = buildGraph Nothing pkgLockV3
 
       expectDirect
         [ mkProdDep "root-only@1.0.0"
@@ -491,7 +498,7 @@ workspaceLinksGraphSpec pkgLockV3 = do
         graph
 
     it "should attribute a linked sibling workspace's dependencies to the selected workspace" $ do
-      let graph = buildGraph (mkTargets ["@scope/ws-a"]) pkgLockV3
+      let graph = buildGraph (scopeTo ["packages/a"]) pkgLockV3
 
       expectDirect
         [ mkProdDep "external-a@1.0.0"
@@ -510,7 +517,7 @@ workspaceLinksGraphSpec pkgLockV3 = do
       expectNoVersionlessDeps graph
 
     it "should handle mutually-dependent workspaces without looping" $ do
-      let graph = buildGraph (mkTargets ["@scope/ws-b"]) pkgLockV3
+      let graph = buildGraph (scopeTo ["packages/b"]) pkgLockV3
 
       expectDirect
         [ mkProdDep "external-b@1.0.0"
@@ -528,23 +535,44 @@ workspaceLinksGraphSpec pkgLockV3 = do
       expectNoVersionlessDeps graph
 
     it "should not attribute sibling workspaces' dependencies to an unrelated workspace" $ do
-      let graph = buildGraph (mkTargets ["@scope/ws-c"]) pkgLockV3
+      let graph = buildGraph (scopeTo ["packages/c"]) pkgLockV3
 
       expectDirect [mkProdDep "external-c@1.0.0"] graph
       expectDeps [mkProdDep "external-c@1.0.0"] graph
 
     it "should scope to only the root package's dependencies" $ do
-      let graph = buildGraph (mkTargets ["monorepo-root"]) pkgLockV3
+      let graph = buildGraph (scopeTo [""]) pkgLockV3
 
       expectDirect [mkProdDep "root-only@1.0.0"] graph
       expectDeps [mkProdDep "root-only@1.0.0"] graph
 
     it "should produce the unscoped graph when all targets are selected" $
-      buildGraph (mkTargets ["monorepo-root", "@scope/ws-a", "@scope/ws-b", "@scope/ws-c"]) pkgLockV3
-        `shouldBe` buildGraph ProjectWithoutTargets pkgLockV3
+      buildGraph (scopeTo ["", "packages/a", "packages/b", "packages/c"]) pkgLockV3
+        `shouldBe` buildGraph Nothing pkgLockV3
 
-mkTargets :: [Text] -> FoundTargets
-mkTargets = maybe ProjectWithoutTargets FoundTargets . NonEmptySet.nonEmpty . Set.fromList . map BuildTarget
+-- | A workspace whose lockfile entry omits the "name" field, as npm does when
+-- the workspace's folder basename equals its package name. Path-based
+-- selection must still scope to it (name-based matching could not).
+namelessWorkspaceScopingSpec :: PackageLockV3 -> Spec
+namelessWorkspaceScopingSpec pkgLockV3 = do
+  describe "buildGraph with a workspace entry that has no name field" $ do
+    it "should scope to the workspace by its lockfile path" $ do
+      let graph = buildGraph (scopeTo ["packages/pkg-a"]) pkgLockV3
+
+      expectDirect [mkProdDep "ws-dep@1.0.0"] graph
+      expectDeps [mkProdDep "ws-dep@1.0.0"] graph
+
+    it "should exclude the nameless workspace's dependencies when only the root is selected" $ do
+      let graph = buildGraph (scopeTo [""]) pkgLockV3
+
+      expectDirect [mkProdDep "root-dep@1.0.0"] graph
+      expectDeps [mkProdDep "root-dep@1.0.0"] graph
+
+-- | Scope 'buildGraph' to the given root-relative workspace paths, as
+-- 'Strategy.Node.resolveNpmV3WorkspacePaths' resolves them from build
+-- target names.
+scopeTo :: [Text] -> Maybe (Set Text)
+scopeTo = Just . Set.fromList
 
 -- | The versionless dependency currently produced for a workspace link stub
 -- (e.g. @"node_modules/ws-name": { "resolved": "packages/a", "link": true }@)

--- a/test/Node/PackageLockV3Spec.hs
+++ b/test/Node/PackageLockV3Spec.hs
@@ -470,9 +470,9 @@ simplePackageLockScopingSpec pkgLockV3 = do
       buildGraph (mkTargets ["lockv3", "workspace-a-name"]) pkgLockV3
         `shouldBe` buildGraph ProjectWithoutTargets pkgLockV3
 
-    it "should fall back to the unscoped graph when no target matches a lockfile entry" $
+    it "should produce an empty graph when no target matches a lockfile entry" $
       buildGraph (mkTargets ["does-not-exist"]) pkgLockV3
-        `shouldBe` buildGraph ProjectWithoutTargets pkgLockV3
+        `shouldBe` Graphing.empty
 
 workspaceLinksGraphSpec :: PackageLockV3 -> Spec
 workspaceLinksGraphSpec pkgLockV3 = do

--- a/test/Node/testdata/lockfileV3/graphing/nameless-workspace-package-lock.json
+++ b/test/Node/testdata/lockfileV3/graphing/nameless-workspace-package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "nameless-ws-root",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nameless-ws-root",
+      "version": "1.0.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "root-dep": "^1.0.0"
+      }
+    },
+    "node_modules/pkg-a": {
+      "resolved": "packages/pkg-a",
+      "link": true
+    },
+    "node_modules/root-dep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/root-dep/-/root-dep-1.0.0.tgz"
+    },
+    "node_modules/ws-dep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ws-dep/-/ws-dep-1.0.0.tgz"
+    },
+    "packages/pkg-a": {
+      "version": "1.0.0",
+      "dependencies": {
+        "ws-dep": "^1.0.0"
+      }
+    }
+  }
+}

--- a/test/Node/testdata/lockfileV3/graphing/workspace-links-package-lock.json
+++ b/test/Node/testdata/lockfileV3/graphing/workspace-links-package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "monorepo-root",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "monorepo-root",
+      "version": "1.0.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "root-only": "^1.0.0"
+      }
+    },
+    "node_modules/@scope/ws-a": {
+      "resolved": "packages/a",
+      "link": true
+    },
+    "node_modules/@scope/ws-b": {
+      "resolved": "packages/b",
+      "link": true
+    },
+    "node_modules/@scope/ws-c": {
+      "resolved": "packages/c",
+      "link": true
+    },
+    "node_modules/external-a": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/external-a/-/external-a-1.0.0.tgz"
+    },
+    "node_modules/external-b": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/external-b/-/external-b-1.0.0.tgz",
+      "dependencies": {
+        "transitive-b": "^2.0.0"
+      }
+    },
+    "node_modules/external-c": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/external-c/-/external-c-1.0.0.tgz"
+    },
+    "node_modules/root-only": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/root-only/-/root-only-1.0.0.tgz"
+    },
+    "node_modules/transitive-b": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/transitive-b/-/transitive-b-2.0.0.tgz"
+    },
+    "packages/a": {
+      "name": "@scope/ws-a",
+      "version": "1.0.0",
+      "dependencies": {
+        "@scope/ws-b": "^2.0.0",
+        "external-a": "^1.0.0"
+      }
+    },
+    "packages/b": {
+      "name": "@scope/ws-b",
+      "version": "2.0.0",
+      "dependencies": {
+        "@scope/ws-a": "^1.0.0",
+        "external-b": "^1.0.0"
+      }
+    },
+    "packages/c": {
+      "name": "@scope/ws-c",
+      "version": "1.0.0",
+      "dependencies": {
+        "external-c": "^1.0.0"
+      }
+    }
+  }
+}

--- a/test/Node/testdata/npm-lock-v3-workspaces/package-lock.json
+++ b/test/Node/testdata/npm-lock-v3-workspaces/package-lock.json
@@ -1,0 +1,268 @@
+{
+  "name": "npm-monorepo-fossa-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm-monorepo-fossa-test",
+      "version": "1.0.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "devDependencies": {
+        "prettier": "^3.2.5",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@fossa-test/api-service": {
+      "resolved": "packages/api-service",
+      "link": true
+    },
+    "node_modules/@fossa-test/cli-tool": {
+      "resolved": "packages/cli-tool",
+      "link": true
+    },
+    "node_modules/@fossa-test/shared-utils": {
+      "resolved": "packages/shared-utils",
+      "link": true
+    },
+    "node_modules/@fossa-test/web-client": {
+      "resolved": "packages/web-client",
+      "link": true
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "packages/api-service": {
+      "name": "@fossa-test/api-service",
+      "version": "1.0.0",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "uuid": "^9.0.1"
+      }
+    },
+    "packages/cli-tool": {
+      "name": "@fossa-test/cli-tool",
+      "version": "1.0.0",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^12.1.0"
+      }
+    },
+    "packages/shared-utils": {
+      "name": "@fossa-test/shared-utils",
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "uuid": "^9.0.1"
+      }
+    },
+    "packages/web-client": {
+      "name": "@fossa-test/web-client",
+      "version": "1.0.0",
+      "dependencies": {
+        "@fossa-test/shared-utils": "^1.0.0",
+        "classnames": "^2.5.1",
+        "react": "^18.3.1"
+      }
+    }
+  }
+}

--- a/test/Node/testdata/npm-lock-v3-workspaces/package.json
+++ b/test/Node/testdata/npm-lock-v3-workspaces/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "npm-monorepo-fossa-test",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Test fixture: npm workspaces monorepo with a v3 root lockfile",
+  "workspaces": [
+    "packages/*"
+  ],
+  "devDependencies": {
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.5"
+  }
+}

--- a/test/Node/testdata/npm-lock-v3-workspaces/packages/api-service/package.json
+++ b/test/Node/testdata/npm-lock-v3-workspaces/packages/api-service/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fossa-test/api-service",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "cors": "^2.8.5",
+    "uuid": "^9.0.1"
+  }
+}

--- a/test/Node/testdata/npm-lock-v3-workspaces/packages/cli-tool/package.json
+++ b/test/Node/testdata/npm-lock-v3-workspaces/packages/cli-tool/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fossa-test/cli-tool",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "chalk": "^4.1.2",
+    "commander": "^12.1.0"
+  }
+}

--- a/test/Node/testdata/npm-lock-v3-workspaces/packages/shared-utils/package.json
+++ b/test/Node/testdata/npm-lock-v3-workspaces/packages/shared-utils/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fossa-test/shared-utils",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "lodash": "^4.17.21",
+    "uuid": "^9.0.1"
+  }
+}

--- a/test/Node/testdata/npm-lock-v3-workspaces/packages/web-client/package.json
+++ b/test/Node/testdata/npm-lock-v3-workspaces/packages/web-client/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fossa-test/web-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@fossa-test/shared-utils": "^1.0.0",
+    "classnames": "^2.5.1",
+    "react": "^18.3.1"
+  }
+}


### PR DESCRIPTION
# Overview

Scopes package-lock.json v3 results per workspace for `--only-target`/`--exclude-target`. Previously the v3 path ignored targets, so every workspace in an npm-workspaces monorepo returned the same blended whole-repo inventory.

- Target names resolve to root-relative workspace paths via their package.json manifests (`resolveNpmV3WorkspacePaths`) and match the lockfile's top-level path keys — so selection works even when an entry omits its `name` (npm does this when the folder basename equals the package name).
- Workspace `link` entries are followed, so a dependency on a sibling workspace resolves to the sibling's real versioned deps, not a versionless link stub.
- Selecting all targets (the default) reproduces the exact pre-scoping graph (tests pin this); a filter matching nothing yields an empty graph plus a warning. npm v1/v2, yarn, pnpm, and bun are untouched.

## Acceptance criteria

`fossa analyze --only-target 'npm@./:<workspace-name>'` on an npm workspaces monorepo with a v3 root lockfile reports only that workspace's dependencies; default analysis output is unchanged.

## Testing plan

- Unit tests in `PackageLockV3Spec`: per-path scoping, all-selected == unscoped equivalence, cross-workspace link following (incl. mutually-dependent workspaces), empty graph for non-matching selections, and a regression for a workspace whose lockfile entry has no `name` field.
- Unit tests in `NodeSpec` for `resolveNpmV3WorkspacePaths` (root → `""`, nested workspace paths).
- Integration test (`NpmLockV3WorkspaceSpec`) runs discovery + analysis end-to-end over a vendored v3 workspaces monorepo fixture and asserts distinct per-workspace results.

## Risks

Dev/prod labeling of shared installs is not re-derived per workspace (`dev` flags in a v3 lockfile are global to the install); scoping only restricts which packages are reported.

## Metrics

N/A

## References

Path-based workspace resolution adopted from #1734.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
