### PR TITLE
[ANE-3062] Support workspace target scoping for npm v3 lockfiles

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.17.15
+
+- npm: Scoping a scan to a single workspace build target (`--only-target`) now works for v3 `package-lock.json` files (npm v9+). Previously each workspace returned the full repo-wide dependency set instead of its own. ([#1734](https://github.com/fossas/fossa-cli/pull/1734))
+
 ## 3.17.14
 
 - Licensing: Detect Unicode 3.0 license. ([#1731](https://github.com/fossas/fossa-cli/pull/1731))

--- a/docs/references/strategies/languages/nodejs/npm-lockfile.md
+++ b/docs/references/strategies/languages/nodejs/npm-lockfile.md
@@ -36,10 +36,11 @@ included in the analysis.
 When no filtering is applied, all targets are selected and all dependencies
 from every workspace package are included in the analysis.
 
-> Note: Target-level dependency scoping is only supported for lockfile version 1
-> (npm v5–v6) and version 2 (npm v7–v8). Version 3 lockfiles (npm v9+) will
-> show workspace build targets, but filtering to specific targets does not yet
-> scope the dependency results.
+> Note: Selecting a workspace target scopes the analysis to that workspace's own
+> declared dependencies and their transitive closure. Dependencies contributed
+> only by other, unselected workspaces are excluded. A dependency reachable only
+> through a sibling workspace (one workspace that depends on another) is not
+> pulled into the selected workspace's results.
 
 ## Analysis (for lockFile version 3)
 

--- a/src/Strategy/Node.hs
+++ b/src/Strategy/Node.hs
@@ -9,6 +9,7 @@ module Strategy.Node (
   getDeps,
   findWorkspaceBuildTargets,
   extractDepListsForTargets,
+  resolveNpmV3WorkspacePaths,
 ) where
 
 import Algebra.Graph.AdjacencyMap qualified as AM
@@ -39,7 +40,7 @@ import Data.Maybe (catMaybes, isJust, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Set.NonEmpty qualified as NonEmptySet
-import Data.String.Conversion (decodeUtf8, toString)
+import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Tagged (applyTag)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -73,6 +74,7 @@ import Path (
   Rel,
   mkRelFile,
   parent,
+  stripProperPrefix,
   toFilePath,
   (</>),
  )
@@ -99,6 +101,7 @@ import Strategy.Node.Pnpm.PnpmLock qualified as PnpmLock
 import Strategy.Node.Pnpm.Workspace (PnpmWorkspace (workspaceSpecs))
 import Strategy.Node.YarnV1.YarnLock qualified as V1
 import Strategy.Node.YarnV2.YarnLock qualified as V2
+import System.FilePath qualified as FP
 import Types (
   BuildTarget (BuildTarget),
   DependencyResults (DependencyResults),
@@ -222,7 +225,7 @@ analyzeNpmLock :: (Has Diagnostics sig m, Has ReadFS sig m) => FoundTargets -> M
 analyzeNpmLock targets (Manifest npmLockFile) graph = do
   npmLockVersion <- detectNpmLockVersion npmLockFile
   result <- case npmLockVersion of
-    NpmLockV3Compatible -> PackageLockV3.analyze npmLockFile
+    NpmLockV3Compatible -> PackageLockV3.analyze (resolveNpmV3WorkspacePaths targets graph) npmLockFile
     NpmLockV1Compatible -> PackageLock.analyze npmLockFile (extractDepListsForTargets targets graph) (findWorkspaceNames graph)
   pure $ DependencyResults result Complete [npmLockFile]
 
@@ -306,6 +309,36 @@ findWorkspaceNames PkgJsonGraph{..} =
 
     workspaceNames :: [Text]
     workspaceNames = mapMaybe (packageName <=< flip Map.lookup jsonLookup) childManifests
+
+-- | Map selected build targets (workspace package names) to the root-relative
+-- path keys npm v3 lockfiles use: @""@ for the root, @"packages/a"@ for a
+-- member. 'Nothing' means no target filter, so no scoping is applied.
+resolveNpmV3WorkspacePaths :: FoundTargets -> PkgJsonGraph -> Maybe (Set Text)
+resolveNpmV3WorkspacePaths ProjectWithoutTargets _ = Nothing
+resolveNpmV3WorkspacePaths (FoundTargets targets) graph@PkgJsonGraph{..} =
+  case findWorkspaceRootManifest graph of
+    Left _ -> Nothing
+    Right (Manifest rootManifest) ->
+      Just $ Set.fromList [path | (name, path) <- namePathPairs, name `Set.member` targetNames]
+      where
+        rootDir = parent rootManifest
+        targetNames = Set.map unBuildTarget (NonEmptySet.toSet targets)
+
+        namePathPairs :: [(Text, Text)]
+        namePathPairs =
+          [ (name, manifestToWorkspacePath m)
+          | (Manifest m, pj) <- Map.toList jsonLookup
+          , Just name <- [packageName pj]
+          ]
+
+        manifestToWorkspacePath :: Path Abs File -> Text
+        manifestToWorkspacePath m =
+          let manifestDir = parent m
+           in if manifestDir == rootDir
+                then ""
+                -- npm keys workspaces with forward slashes on every OS, so
+                -- normalize the platform separator before matching.
+                else maybe "" (Text.replace "\\" "/" . toText . FP.dropTrailingPathSeparator . toFilePath) (stripProperPrefix rootDir manifestDir)
 
 extractDepLists :: PkgJsonGraph -> FlatDeps
 extractDepLists PkgJsonGraph{..} = foldMap extractSingle $ Map.elems jsonLookup

--- a/src/Strategy/Node/Npm/PackageLockV3.hs
+++ b/src/Strategy/Node/Npm/PackageLockV3.hs
@@ -15,7 +15,7 @@ module Strategy.Node.Npm.PackageLockV3 (
 
 import Control.Algebra (Has)
 import Control.Effect.Diagnostics (Diagnostics, context)
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Data.Aeson (
   FromJSON (parseJSON),
   FromJSONKey (fromJSONKey),
@@ -42,7 +42,7 @@ import DepTypes (
  )
 import Effect.Grapher (direct, edge, evalGrapher, run)
 import Effect.ReadFS (ReadFS, readContentsJson)
-import Graphing (Graphing)
+import Graphing (Graphing, pruneUnreachable)
 import Path (
   Abs,
   File,
@@ -165,10 +165,13 @@ instance FromJSON NpmLockV3Resolved where
   parseJSON (Bool _) = pure $ NpmLockV3Resolved Nothing
   parseJSON _ = fail "Expected to contain string or boolean value for 'resolved' field!"
 
-analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Path Abs File -> m (Graphing Dependency)
-analyze file = context "Analyzing Npm Lockfile (v3)" $ do
+analyze :: (Has ReadFS sig m, Has Diagnostics sig m) => Maybe (Set.Set Text) -> Path Abs File -> m (Graphing Dependency)
+analyze selectedPaths file = context "Analyzing Npm Lockfile (v3)" $ do
   packageLockJson <- context "Parsing v3 compatible package-lock.json" $ readContentsJson @PackageLockV3 file
-  context "Building dependency graph" $ pure $ buildGraph packageLockJson
+  -- When scoping, prune here so a target with no direct deps yields an empty
+  -- graph. Otherwise mkResult sees an empty direct set and falls back to
+  -- returning the whole graph unpruned.
+  context "Building dependency graph" $ pure $ maybe id (const pruneUnreachable) selectedPaths $ buildGraph selectedPaths packageLockJson
 
 -- | Builds a graph for package lock v3.
 --
@@ -219,8 +222,8 @@ analyze file = context "Analyzing Npm Lockfile (v3)" $ do
 --    - http://npm.github.io/how-npm-works-docs/npm3/how-npm3-works.html
 --
 --  --
-buildGraph :: PackageLockV3 -> Graphing Dependency
-buildGraph pkgLockV3 = run . evalGrapher $ do
+buildGraph :: Maybe (Set.Set Text) -> PackageLockV3 -> Graphing Dependency
+buildGraph selectedPaths pkgLockV3 = run . evalGrapher $ do
   for_ (Map.toList $ packages pkgLockV3) $ \(pkgPathKey, pkgMetadata) -> do
     case pkgPathKey of
       -- For root package,
@@ -264,7 +267,7 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
         let resolvedDeps :: [Dependency]
             resolvedDeps = mapMaybe toDependency directDeps
 
-        traverse_ direct resolvedDeps
+        when (isSelectedPath "") $ traverse_ direct resolvedDeps
 
       -- For workspace packages, for instance:
       --
@@ -303,7 +306,7 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
         let resolvedDeps :: [Dependency]
             resolvedDeps = mapMaybe toDependency directDeps
 
-        traverse_ direct resolvedDeps
+        when (isSelectedPath workspaceRootPath) $ traverse_ direct resolvedDeps
 
       -- For typical dependency packages, for instance:
       --
@@ -352,6 +355,12 @@ buildGraph pkgLockV3 = run . evalGrapher $ do
           Just parentDep -> do
             for_ resolvedDeepDeps $ edge parentDep
   where
+    -- Deps of unselected entries stay non-direct and are dropped downstream by
+    -- Graphing.pruneUnreachable (in mkResult), which keeps only deps reachable
+    -- from a direct dep. Nothing means no target filter, so every entry is kept.
+    isSelectedPath :: Text -> Bool
+    isSelectedPath path = maybe True (Set.member path) selectedPaths
+
     -- Prefer resolution path in following order of precedent:
     --
     --  1) {prefix}/node_modules/{pkgName}

--- a/test/Node/NodeSpec.hs
+++ b/test/Node/NodeSpec.hs
@@ -13,7 +13,7 @@ import Data.Tagged (applyTag)
 import Graphing qualified
 import Path (Abs, Dir, Path, mkRelDir, mkRelFile, (</>))
 import Path.IO (getCurrentDir)
-import Strategy.Node (NodeProject (NPMLock), discover, extractDepListsForTargets, findWorkspaceBuildTargets, getDeps)
+import Strategy.Node (NodeProject (NPMLock), discover, extractDepListsForTargets, findWorkspaceBuildTargets, getDeps, resolveNpmV3WorkspacePaths)
 import Strategy.Node.PackageJson (
   FlatDeps (..),
   Manifest (..),
@@ -57,6 +57,7 @@ spec = do
   npmLockAnalysisSpec currDir
   workspaceBuildTargetsSpec currDir
   extractDepListsForTargetsSpec currDir
+  resolveNpmV3WorkspacePathsSpec currDir
 
 discoveredWorkSpaceProj :: Path Abs Dir -> DiscoveredProject NodeProject
 discoveredWorkSpaceProj currDir =
@@ -237,6 +238,32 @@ extractDepListsForTargetsSpec currDir = describe "extractDepListsForTargets" $ d
             , NodePackage "husky" "^8.0.0"
             ]
     directDeps result `shouldBe` applyTag @Production expectedDirect
+
+resolveNpmV3WorkspacePathsSpec :: Path Abs Dir -> Spec
+resolveNpmV3WorkspacePathsSpec currDir = describe "resolveNpmV3WorkspacePaths" $ do
+  let graph = workspaceGraphWithDeps currDir
+      forTargets names =
+        resolveNpmV3WorkspacePaths
+          (maybe ProjectWithoutTargets FoundTargets . nonEmpty $ Set.fromList (map BuildTarget names))
+          graph
+
+  it "returns Nothing when unscoped" $
+    resolveNpmV3WorkspacePaths ProjectWithoutTargets graph `shouldBe` Nothing
+
+  it "maps a workspace name to its root-relative lockfile path key" $
+    -- pkg-a lives at ./pkg-a, where the folder basename equals the package name,
+    -- so npm omits the lockfile "name"; resolving via package.json still finds it.
+    forTargets ["pkg-a"] `shouldBe` Just (Set.fromList ["pkg-a"])
+
+  it "maps the root target to the empty path key" $
+    forTargets ["workspace-test"] `shouldBe` Just (Set.fromList [""])
+
+  it "maps a nested workspace name to its nested path key" $
+    forTargets ["pkg-b"] `shouldBe` Just (Set.fromList ["nested/pkg-b"])
+
+  it "maps every selected target" $
+    forTargets ["workspace-test", "pkg-a", "pkg-b"]
+      `shouldBe` Just (Set.fromList ["", "pkg-a", "nested/pkg-b"])
 
 -- | A workspace graph with actual dependencies for testing extractDepListsForTargets.
 workspaceGraphWithDeps :: Path Abs Dir -> PkgJsonGraph

--- a/test/Node/PackageLockV3Spec.hs
+++ b/test/Node/PackageLockV3Spec.hs
@@ -19,10 +19,12 @@ import DepTypes (
 import Effect.ReadFS (readContentsJson)
 import GraphUtil (
   expectDep,
+  expectDeps',
   expectDirect,
   expectEdge,
  )
 import Graphing (Graphing)
+import Graphing qualified
 import Path (Abs, Dir, File, Path, Rel, mkRelDir, mkRelFile, (</>))
 import Path.IO (getCurrentDir)
 import Strategy.Node.Npm.PackageLockV3 (
@@ -31,13 +33,14 @@ import Strategy.Node.Npm.PackageLockV3 (
   PackageLockV3Package (plV3PkgResolved),
   PackageName (PackageName),
   PackagePath (PackageLockV3PathKey, PackageLockV3Root, PackageLockV3WorkSpace),
+  analyze,
   buildGraph,
   isV3Compatible,
   parsePathKey,
   vendorPrefixes,
  )
 import Test.Effect (it', shouldBe')
-import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, runIO, shouldBe)
+import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, runIO, shouldBe, shouldNotContain)
 
 fixtureSimplePackageLockPath :: Path Rel File
 fixtureSimplePackageLockPath = $(mkRelFile "simple-package-lock.json")
@@ -47,6 +50,9 @@ multiLevelVendorLockPath = $(mkRelFile "multi-level-vendor-package-lock.json")
 
 workspaceNestedModulePackageLockPath :: Path Rel File
 workspaceNestedModulePackageLockPath = $(mkRelFile "ws-nested-module-package-lock.json")
+
+emptyWorkspaceLockPath :: Path Rel File
+emptyWorkspaceLockPath = $(mkRelFile "empty-workspace-package-lock.json")
 
 spec :: Spec
 spec = do
@@ -66,6 +72,10 @@ spec = do
   checkGraph (graphingFixtureDir </> fixtureSimplePackageLockPath) simplePackageLockGraphSpec
   checkGraph (graphingFixtureDir </> workspaceNestedModulePackageLockPath) workspaceNestedModulePackageLockGraphSpec
   checkGraph (graphingFixtureDir </> multiLevelVendorLockPath) multiLevelVendorLockGraphSpec
+
+  -- Scoping to a single workspace path
+  checkScopedGraph (Set.fromList ["packages/a"]) (graphingFixtureDir </> fixtureSimplePackageLockPath) scopedToWorkspaceAGraphSpec
+  emptyWorkspaceScopeSpec (graphingFixtureDir </> emptyWorkspaceLockPath)
 
 vendorPrefixesSpec :: Spec
 vendorPrefixesSpec = do
@@ -404,6 +414,43 @@ workspaceNestedModulePackageLockGraphSpec graph = do
       hasDep (mkProdDep "c@1.0.0")
       hasEdge (mkProdDep "b@2.0.0") (mkProdDep "c@1.0.0")
 
+scopedToWorkspaceAGraphSpec :: Graphing Dependency -> Spec
+scopedToWorkspaceAGraphSpec graph =
+  describe "buildGraph scoped to workspace a" $ do
+    it "should mark only the selected workspace's dependencies as direct" $
+      -- └─┬ workspace-a-name@2.0.0 -> ./packages/a
+      --   ├── aws-sdk@1.0.0
+      --   └── commander@9.2.0
+      expectDirect
+        [ mkProdDep "aws-sdk@1.0.0"
+        , mkProdDep "commander@9.2.0"
+        ]
+        graph
+
+    it "should keep the selected workspace's transitive closure" $ do
+      let pruned = Graphing.pruneUnreachable graph
+      expectDep (mkProdDep "commander@9.2.0") pruned
+      expectDep (mkProdDep "aws-sdk@1.0.0") pruned
+      expectDep (mkProdDep "xml2js@0.2.4") pruned
+      expectDep (mkProdDep "sax@1.2.1") pruned
+      expectDep (mkProdDep "xmlbuilder@9.0.7") pruned
+
+    it "should drop dependencies contributed only by unselected packages" $ do
+      let pruned = Graphing.pruneUnreachable graph
+      Graphing.vertexList pruned `shouldNotContain` [mkProdDep "react@18.1.0"]
+      Graphing.vertexList pruned `shouldNotContain` [mkProdDep "aws-sdk@2.1134.0"]
+      Graphing.vertexList pruned `shouldNotContain` [mkDevDep "mocha@10.0.0"]
+
+emptyWorkspaceScopeSpec :: Path Abs File -> Spec
+emptyWorkspaceScopeSpec fixture = describe "analyze scoped to a dependency-free workspace" $ do
+  it' "returns an empty graph rather than the full repo graph" $ do
+    graph <- analyze (Just (Set.fromList ["packages/empty"])) fixture
+    expectDeps' [] graph
+
+  it' "still reports a scoped workspace's own closure" $ do
+    graph <- analyze (Just (Set.fromList [""])) fixture
+    expectDeps' [mkProdDep "a@1.0.0", mkProdDep "b@1.0.0"] graph
+
 mkProdDep :: Text -> Dependency
 mkProdDep nameAtVersion = mkDep nameAtVersion (Just EnvProduction)
 
@@ -429,4 +476,13 @@ checkGraph pathToFixture buildGraphSpec = do
   case maybePkgLockV3 of
     Left errMsg -> describe "packageLockV3" $ it "should parse lockfile" (expectationFailure errMsg)
     Right pkgLockV3 -> do
-      buildGraphSpec (buildGraph pkgLockV3)
+      buildGraphSpec (buildGraph Nothing pkgLockV3)
+
+-- | Like 'checkGraph', but scopes the graph to the given workspace path keys
+-- (as they appear in the lockfile's @packages@ map) before handing it to the spec.
+checkScopedGraph :: Set.Set Text -> Path Abs File -> (Graphing Dependency -> Spec) -> Spec
+checkScopedGraph selectedPaths pathToFixture buildGraphSpec = do
+  maybePkgLockV3 <- runIO $ eitherDecodeFileStrict' (toString pathToFixture)
+  case maybePkgLockV3 of
+    Left errMsg -> describe "packageLockV3 (scoped)" $ it "should parse lockfile" (expectationFailure errMsg)
+    Right pkgLockV3 -> buildGraphSpec (buildGraph (Just selectedPaths) pkgLockV3)

--- a/test/Node/testdata/lockfileV3/graphing/empty-workspace-package-lock.json
+++ b/test/Node/testdata/lockfileV3/graphing/empty-workspace-package-lock.json
@@ -1,0 +1,33 @@
+{
+    "name": "root-with-empty-ws",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "root-with-empty-ws",
+            "version": "1.0.0",
+            "workspaces": [
+                "packages/*"
+            ],
+            "dependencies": {
+                "a": "^1.0.0"
+            }
+        },
+        "packages/empty": {
+            "name": "empty-ws",
+            "version": "1.0.0"
+        },
+        "node_modules/a": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/a/-/a-1.0.0.tgz",
+            "dependencies": {
+                "b": "^1.0.0"
+            }
+        },
+        "node_modules/b": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/b/-/b-1.0.0.tgz"
+        }
+    }
+}


### PR DESCRIPTION
# Overview

For an npm-workspaces monorepo with a single root `package-lock.json` (lockfileVersion 3), `--only-target 'npm@./:<workspace>'` had no effect: every workspace target returned the same full graph for the whole repo. v1 and v2 lockfiles already scoped to the selected targets; v3 analysis ignored them.

This threads the selected build targets into the v3 analyzer: each target is resolved to its workspace via `package.json`, and the graph is pruned to the union of the selected targets' closures. Scoping to a workspace does not fold in the root package's own dependencies, matching v1 and yarn; select the root target alongside the workspace for both.

## Acceptance criteria

`fossa analyze --only-target 'npm@./:<workspace>'` on a v3-lockfile monorepo returns only that workspace's dependencies, resolved from the shared lockfile.

## Testing plan

1. Build a two-workspace monorepo with distinct deps and a v3 lockfile (needs npm 9+ so the lockfile is v3):
   ```sh
   mkdir -p /tmp/mono/packages/pkg-a /tmp/mono/packages/pkg-b
   echo '{"name":"mono","workspaces":["packages/*"]}' > /tmp/mono/package.json
   echo '{"name":"pkg-a","version":"1.0.0","dependencies":{"is-odd":"3.0.1"}}' > /tmp/mono/packages/pkg-a/package.json
   echo '{"name":"pkg-b","version":"1.0.0","dependencies":{"is-even":"1.0.0"}}' > /tmp/mono/packages/pkg-b/package.json
   npm install --package-lock-only --prefix /tmp/mono
   ```

2. From the fossa-cli checkout, scope to each workspace and compare direct deps:
   ```sh
   cabal run fossa -- analyze -o --only-target 'npm@./:pkg-a' /tmp/mono 2>/dev/null | jq '[.sourceUnits[].Build.Imports[]]'
   cabal run fossa -- analyze -o --only-target 'npm@./:pkg-b' /tmp/mono 2>/dev/null | jq '[.sourceUnits[].Build.Imports[]]'
   ```

3. Against `master`, both print the same full set. With this branch, `pkg-a` prints `["npm+is-odd$3.0.1"]` and `pkg-b` prints `["npm+is-even$1.0.0"]`.

## Risks

Workspace names are matched by the workspace `package.json` name, not the lockfile's `name` field, which npm omits when a folder basename equals its package name. A dependency reached only through a sibling workspace that the selected workspace links to is not pulled in; this is documented in `npm-lockfile.md`. The no-filter path and non-workspace projects are unchanged.

## Metrics

None.

## References

- [ANE-3062](https://fossa.atlassian.net/browse/ANE-3062): Target-level dependency scoping for NPM lockfile v3. Scopes to the selected targets only; unlike the ticket's expected-(b), a workspace scope does not auto-include root deps (select the root target for those).

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.

Docs change is a note in the existing `npm-lockfile.md` (already in the ToC); no new page, schema, or subcommand-option changes. Changelog entry under a new `## 3.17.15` section since this is intended to ship as the next release.

[ANE-3062]: https://fossa.atlassian.net/browse/ANE-3062
