### PR TITLE
Change timeout from default 30s to 1 minute

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.17.16
+
+- Container analysis: Stop the CLI from getting stuck for over an hour on container analysis with JARs
+
 ## 3.17.15
 
 - Node: Workspaces declared with a leading `./` (for example `./packages/*`) are now matched, so their members are analyzed and their production dependencies are no longer dropped from the results. ([#1733](https://github.com/fossas/fossa-cli/pull/1733))

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 3.17.16
 
-- Container analysis: Stop the CLI from getting stuck for over an hour on container analysis with JARs
+- Container analysis: more robust timeouts for container analyses involving jar fingerprinting
 
 ## 3.17.15
 

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -15,7 +15,7 @@ import Control.Effect.Lift (Lift, sendIO)
 import Data.Default.Class (def)
 import Fossa.API.Types (ApiOpts)
 import Network.Connection (TLSSettings (TLSSettingsSimple, settingClientSupported))
-import Network.HTTP.Client (Manager, ManagerSettings, newManager)
+import Network.HTTP.Client (Manager, ManagerSettings (managerResponseTimeout), newManager, responseTimeoutMicro)
 import Network.HTTP.Client.TLS (mkManagerSettings)
 import Network.TLS (EMSMode (AllowEMS), Supported (supportedExtendedMainSecret))
 
@@ -53,7 +53,10 @@ runFossaApiClient apiOpts action = do
     $ action
   where
     allowEMSManager :: ManagerSettings
-    allowEMSManager = mkManagerSettings emsTLSSettings Nothing
+    allowEMSManager =
+      (mkManagerSettings emsTLSSettings Nothing)
+        { managerResponseTimeout = responseTimeoutMicro (60 * 1000000)
+        }
 
     interpreter =
       interpret

--- a/src/Network/HTTP/Req/Extra.hs
+++ b/src/Network/HTTP/Req/Extra.hs
@@ -58,7 +58,7 @@ httpConfigRetryTimeouts =
   where
     statusCodeOf = statusCode . responseStatus
 
--- | Retry every 5 seconds 3 times at max
+-- | Retry every 10 seconds 3 times at max
 retryPolicy :: RetryPolicy
 retryPolicy = limitRetries numRetries <> constantDelay tenSeconds
   where

--- a/src/Network/HTTP/Req/Extra.hs
+++ b/src/Network/HTTP/Req/Extra.hs
@@ -62,7 +62,7 @@ httpConfigRetryTimeouts =
 retryPolicy :: RetryPolicy
 retryPolicy = limitRetries numRetries <> constantDelay tenSeconds
   where
-    -- ten minutes
+    -- three retries
     numRetries :: Int
     numRetries = 3
 

--- a/src/Network/HTTP/Req/Extra.hs
+++ b/src/Network/HTTP/Req/Extra.hs
@@ -3,7 +3,7 @@ module Network.HTTP.Req.Extra (
 ) where
 
 import Control.Exception (SomeException, fromException)
-import Control.Retry (RetryPolicy, RetryStatus, constantDelay, limitRetriesByCumulativeDelay)
+import Control.Retry (RetryPolicy, RetryStatus, constantDelay, limitRetries)
 import Network.HTTP.Client (HttpException (HttpExceptionRequest), HttpExceptionContent (ConnectionTimeout, ResponseTimeout), Response (responseStatus))
 import Network.HTTP.Req (
   HttpConfig (
@@ -58,17 +58,17 @@ httpConfigRetryTimeouts =
   where
     statusCodeOf = statusCode . responseStatus
 
--- | Retry every 5 seconds for up to 10 minutes
+-- | Retry every 5 seconds 3 times at max
 retryPolicy :: RetryPolicy
-retryPolicy = limitRetriesByCumulativeDelay tenMinutes (constantDelay fiveSeconds)
+retryPolicy = limitRetries numRetries <> constantDelay tenSeconds
   where
     -- ten minutes
-    tenMinutes :: Int
-    tenMinutes = 10 * 60 * 1_000_000
+    numRetries :: Int
+    numRetries = 3
 
-    -- five seconds
-    fiveSeconds :: Int
-    fiveSeconds = 5 * 1_000_000
+    -- ten seconds
+    tenSeconds :: Int
+    tenSeconds = 10 * 1_000_000
 
 -- | True if the exception represnts timeout, otherwise False.
 isTimeout :: RetryStatus -> SomeException -> Bool


### PR DESCRIPTION
# Overview

The CLI has a default HTTP timeout of 30 seconds which is causing a continuous loop of 70 minutes in [ANE-3083](https://fossa.atlassian.net/jira/software/c/projects/ANE/boards/66?selectedIssue=ANE-3083). This PR adds an explicit timeout of 1 minute instead of 30 seconds. The jars in containers query still gives 429 errors and no JARs show up in the scan but we don't get stuck for 70 minutes at least. After 70 mins, we switch to the Core logic which doesn't scan JARs anyways.

## Acceptance criteria

- [x] Container analysis stops hanging on JAR analysis

## Testing plan

Build the CLI and run container analyze for `hazelcast/management-center:latest`. It should get through within about a minute instead of getting stuck. 

## Risks

Should be low risk since the timeout isn't that much higher but since it's global, it could affect other things. 

## Metrics

The time for a request shows up in this [Datadog span dashboard](https://app.datadoghq.com/apm/traces?query=service%3Asparkle%20resource_name%3A%22upload%22&agg_m=_dd.trace_duration_ms&agg_m_source=base&agg_t=avg&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_span.count%2C%40_duration.by_service&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count&fromUser=false&graphType=span_list&historicalData=false&messageDisplay=inline&shouldShowLegend=true&sort=desc&spanType=all&spanViewType=metadata&storage=driveline&target-span=a&trace_group_by_from=root&traceQuery=a&view=traces&viz=stream&start=1785545223109&end=1785546123109&paused=false), even local testing ones

## References

[ANE-3083](https://fossa.atlassian.net/jira/software/c/projects/ANE/boards/66?selectedIssue=ANE-3083)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-3083]: https://fossa.atlassian.net/browse/ANE-3083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANE-3083]: https://fossa.atlassian.net/browse/ANE-3083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ