### PR TITLE
Python: report installed dependency versions, and pick range bounds by kind (ANE-3089)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # FOSSA CLI Changelog
 
-## 3.17.18
+## Unreleased
 
 - Dependency versions: When a dependency declares a version range rather than a single version, the version reported no longer depends on the order the bounds were written in. `cryptography<60.0.0, >=46.0.3` and `cryptography>=46.0.3, <60.0.0` both now report `46.0.3`; previously the first reported `60.0.0`, a version the range excludes.
 - Python: `requirements.txt` and `setup.py` dependencies are now reported at the version installed in the environment, when `python` and `pip` are available. Previously a dependency declaring a range was reported at one of its bounds, and a dependency declaring no version at all was reported with no version, even though the CLI had already read the installed version from `pip show` to build the dependency graph.

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 ## 3.17.18
 
 - Dependency versions: When a dependency declares a version range rather than a single version, the version reported no longer depends on the order the bounds were written in. `cryptography<60.0.0, >=46.0.3` and `cryptography>=46.0.3, <60.0.0` both now report `46.0.3`; previously the first reported `60.0.0`, a version the range excludes.
+- Python: `requirements.txt` and `setup.py` dependencies are now reported at the version installed in the environment, when `python` and `pip` are available. Previously a dependency declaring a range was reported at one of its bounds, and a dependency declaring no version at all was reported with no version, even though the CLI had already read the installed version from `pip show` to build the dependency graph.
+- Python: Package names are now matched using [PEP 503](https://peps.python.org/pep-0503/#normalized-names) normalization, so `Zope.Interface`, `zope_interface`, and `zope-interface` are recognized as the same package.
 
 ## 3.17.17
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## 3.17.18
+
+- Dependency versions: When a dependency declares a version range rather than a single version, the version reported no longer depends on the order the bounds were written in. `cryptography<60.0.0, >=46.0.3` and `cryptography>=46.0.3, <60.0.0` both now report `46.0.3`; previously the first reported `60.0.0`, a version the range excludes.
+
 ## 3.17.17
 
 - License Scanning: Detect an OFL-1.1 license notice correctly ([#1742](https://github.com/fossas/fossa-cli/pull/1742))

--- a/docs/references/strategies/languages/python/setuptools.md
+++ b/docs/references/strategies/languages/python/setuptools.md
@@ -37,6 +37,15 @@ Dependencies found in requirements.txt have a spec defined by
 markers (e.g. python version, OS, ...). The resulting graph contains packages
 tagged with environment markers.
 
+Where a dependency declares a version range rather than a single version, the
+CLI reports the version installed in the environment it is run in, which it
+reads from `python -m pip list` and `python -m pip show`. This is the same data
+used to find transitive dependencies, so running the CLI inside the project's
+virtual environment matters for versions as well as for edges. If neither
+`python` nor `pip` is available, the CLI falls back to reporting the lowest
+version the range allows: `cryptography>=46.0.3, <60.0.0` is reported as
+`46.0.3`.
+
 ## Analysis: setup.py
 
 ### Installed packages

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -734,6 +734,7 @@ test-suite unit-tests
     Scala.SbtDependencyTreeParsingSpec
     Scala.SbtDependencyTreeSpec
     Sqlite.SqliteSpec
+    Srclib.ConverterSpec
     Srclib.TypesSpec
     Swift.PackageResolvedSpec
     Swift.PackageSwiftSpec

--- a/src/Srclib/Converter.hs
+++ b/src/Srclib/Converter.hs
@@ -14,7 +14,6 @@ import Prelude
 
 import Algebra.Graph.AdjacencyMap qualified as AM
 import App.Fossa.Analyze.Project (ProjectResult (..))
-import Control.Applicative ((<|>))
 import Data.Aeson qualified as Aeson
 import Data.Set qualified as Set
 import Data.String.Conversion (toText)
@@ -134,18 +133,57 @@ toLocator dep =
     , locatorRevision = verConstraintToRevision =<< dependencyVersion dep
     }
 
+-- | Choose the single revision that best stands in for a version constraint.
+--
+-- A locator carries one revision, but a constraint may describe a whole range,
+-- so something has to be discarded. 'bestRevision' ranks the candidates and
+-- keeps the best one rather than the leftmost, so that @>=1.0, <2.0@ and
+-- @<2.0, >=1.0@ produce the same answer. Picking the leftmost meant the
+-- reported version depended on the order the bounds happened to be written in,
+-- and an upper bound written first won --- reporting @<2.0@ as @2.0@, the one
+-- version the range explicitly excludes.
 verConstraintToRevision :: VerConstraint -> Maybe Text
-verConstraintToRevision = \case
-  CEq ver -> Just ver
+verConstraintToRevision = fmap fst . bestRevision
+
+-- | How faithfully a revision pulled out of a constraint represents that
+-- constraint. The derived 'Ord' instance follows constructor order, so
+-- constructors listed later are better candidates.
+data RevisionQuality
+  = -- | An exclusive upper bound, e.g. @<2.0@. Not a version the range admits,
+    -- and frequently not a version that was ever published.
+    ExclusiveUpper
+  | -- | An exclusive lower bound, e.g. @>1.0@. Also outside the range.
+    ExclusiveLower
+  | -- | An inclusive upper bound, e.g. @<=2.0@: the newest version allowed.
+    InclusiveUpper
+  | -- | An inclusive lower bound, e.g. @>=1.0@: the oldest version allowed.
+    InclusiveLower
+  | -- | The constraint named one version outright.
+    Exact
+  deriving (Eq, Ord)
+
+-- | Extract the best available revision from a constraint, tagged with how good
+-- a stand-in it is. Ties keep the left-hand candidate.
+bestRevision :: VerConstraint -> Maybe (Text, RevisionQuality)
+bestRevision = \case
+  CEq ver -> Just (ver, Exact)
+  -- ~=1.2 means >=1.2, ==1.*, so the version named is an inclusive lower bound.
+  CCompatible ver -> Just (ver, InclusiveLower)
+  CGreaterOrEq ver -> Just (ver, InclusiveLower)
+  CGreater ver -> Just (ver, ExclusiveLower)
+  CLessOrEq ver -> Just (ver, InclusiveUpper)
+  CLess ver -> Just (ver, ExclusiveUpper)
   CURI _ -> Nothing -- we can't represent this in a locator
-  CCompatible ver -> Just ver
-  CAnd a b -> verConstraintToRevision a <|> verConstraintToRevision b
-  COr a b -> verConstraintToRevision a <|> verConstraintToRevision b
-  CLess ver -> Just ver -- ugh
-  CLessOrEq ver -> Just ver -- ugh
-  CGreater ver -> Just ver -- ugh
-  CGreaterOrEq ver -> Just ver -- ugh
   CNot _ -> Nothing -- we can't represent this in a locator
+  CAnd a b -> better (bestRevision a) (bestRevision b)
+  -- For a disjunction the ranking is arbitrary rather than principled: the
+  -- branches are alternative ranges, and nothing in the constraint says which
+  -- one is installed. We reuse it so the result is at least order-independent.
+  COr a b -> better (bestRevision a) (bestRevision b)
+  where
+    better Nothing y = y
+    better x Nothing = x
+    better (Just x) (Just y) = Just $ if snd y > snd x then y else x
 
 depTypeToFetcher :: DepType -> Text
 depTypeToFetcher = \case

--- a/src/Strategy/Python/Poetry/Common.hs
+++ b/src/Strategy/Python/Poetry/Common.hs
@@ -15,7 +15,7 @@ import Data.Map (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
-import Data.Text (Text, replace, toLower)
+import Data.Text (Text)
 import DepTypes (
   DepEnvironment (EnvDevelopment, EnvOther, EnvProduction, EnvTesting),
   DepType (GitType, PipType, URLType),
@@ -42,7 +42,7 @@ import Strategy.Python.Poetry.PyProject (
   allPoetryNonProductionDeps,
   toDependencyVersion,
  )
-import Strategy.Python.Util (reqToDependency)
+import Strategy.Python.Util (reqToDependency, toCanonicalName)
 
 -- | Gets build backend of pyproject.
 getPoetryBuildBackend :: PyProject -> Maybe Text
@@ -186,26 +186,6 @@ poetrytoDependency depEnvs name deps =
     depEnvironment = depEnvs
     depLocations = []
     depTags = Map.empty
-
--- | Converts text to canonical python name for dependency.
--- Relevant Docs: https://www.python.org/dev/peps/pep-0426/#id28
--- Poetry Code: https://github.com/python-poetry/poetry/blob/master/poetry/utils/helpers.py#L35
---
--- Poetry performs this operation inconsistently at the time of writing for package name and it's dependencies
--- within the lock file.
---
---  ```toml
---  [package.dependencies]
---  MarkupSafe = ">=2.0"
---  ....
---
--- [[package]]
--- name = "markupsafe"
--- version = "2.0.1"
--- ...
--- ```
-toCanonicalName :: Text -> Text
-toCanonicalName t = toLower $ replace "_" "-" (replace "." "-" t)
 
 -- | Maps poetry lock package to map of package name and associated dependency.
 makePackageToLockDependencyMap :: [PackageName] -> [PoetryLockPackage] -> Map.Map PackageName Dependency

--- a/src/Strategy/Python/Util.hs
+++ b/src/Strategy/Python/Util.hs
@@ -9,6 +9,7 @@ module Strategy.Python.Util (
   reqName,
   requirementParser,
   reqToDependency,
+  toCanonicalName,
   toConstraint,
 ) where
 
@@ -32,6 +33,22 @@ import Text.Megaparsec.Char
 import Text.URI qualified as URI
 import Toml qualified
 import Toml.Schema qualified
+
+-- | Normalize a Python package name per [PEP 503][pep-503]: collapse runs of
+-- @-@, @_@, and @.@ into a single @-@, then lowercase. @Zope.Interface@ and
+-- @zope_interface@ both become @zope-interface@.
+--
+-- Package names reach us from several sources that disagree on punctuation and
+-- case --- a requirements.txt line, a poetry.lock entry, @pip list@ output ---
+-- so they have to be normalized before they can be compared.
+--
+-- [pep-503]: https://peps.python.org/pep-0503/#normalized-names
+toCanonicalName :: Text -> Text
+toCanonicalName =
+  Text.toLower
+    . Text.intercalate "-"
+    . filter (not . Text.null)
+    . Text.split (\c -> c == '-' || c == '_' || c == '.')
 
 pkgToReq :: PythonPackage -> Req
 pkgToReq p =
@@ -66,11 +83,12 @@ buildGraphSetupFile maybePackages pyPackageName pyReqs cfgPackageName cfgReqs = 
   where
     addDeps :: [PythonPackage] -> Maybe Text -> [Req] -> GrapherC Req Identity ()
     addDeps packages maybeName reqs = do
+      let resolved = map (withInstalledVersion packages) reqs
       case maybeName of
-        Nothing -> for_ reqs direct
+        Nothing -> for_ resolved direct
         Just packageName ->
-          case (find (\p -> Text.toLower (pkgName p) == Text.toLower (packageName)) packages) of
-            Nothing -> for_ reqs direct
+          case (find (\p -> toCanonicalName (pkgName p) == toCanonicalName packageName) packages) of
+            Nothing -> for_ resolved direct
             Just pkg ->
               for_ (requires pkg) $ \c -> do
                 let r = pkgToReq c
@@ -83,15 +101,42 @@ buildGraph maybePackages reqs = do
     case maybePackages of
       Nothing -> Graphing.fromList reqs
       Just packages -> do
+        -- Resolve the whole list up front so that @direct@ below and the parent
+        -- looked up by @findParent@ are the same value. The grapher keys nodes
+        -- on 'Req', whose 'Eq' instance covers the version, so resolving in one
+        -- place and not the other would produce two nodes for the same package
+        -- --- one carrying the edges, one carrying the declared range.
+        let resolved = map (withInstalledVersion packages) reqs
         run . evalGrapher $ do
-          for_ reqs direct
+          for_ resolved direct
           for_ packages $ \p -> do
-            case findParent (pkgName p) of
+            case findParent resolved (pkgName p) of
               Just parent -> addChildren parent p
               Nothing -> pure ()
   where
-    findParent :: Text -> Maybe Req
-    findParent packageName = find (\r -> Text.toLower (reqName r) == Text.toLower (packageName)) reqs
+    findParent :: [Req] -> Text -> Maybe Req
+    findParent rs packageName = find (\r -> toCanonicalName (reqName r) == toCanonicalName packageName) rs
+
+-- | Replace a requirement's declared version constraint with the version that
+-- pip reports as installed, when the package is present in the environment.
+--
+-- A manifest records the versions a project /accepts/; pip records the version
+-- that is /there/. Only the latter can become a locator revision honestly,
+-- because a locator holds one revision and collapsing a range down to one is
+-- always a guess --- @cryptography>=46.0.3, <60.0.0@ gives us no way to know
+-- which release was installed.
+--
+-- Extras and the environment marker are carried through untouched: they
+-- describe the requirement, not the version it resolved to, and 'reqToDependency'
+-- turns the marker into the dependency's tags.
+withInstalledVersion :: [PythonPackage] -> Req -> Req
+withInstalledVersion packages = \case
+  -- A URL requirement names its source outright; there is no range to replace.
+  r@UrlReq{} -> r
+  r@(NameReq name extras _ marker) ->
+    case find (\p -> toCanonicalName (pkgName p) == toCanonicalName name) packages of
+      Nothing -> r
+      Just pkg -> NameReq name extras (Just [Version OpEq (pkgVersion pkg)]) marker
 
 addChildren :: (Has (Grapher Req) sig m) => Req -> PythonPackage -> m ()
 addChildren parent pkg = do

--- a/test/Python/Poetry/CommonSpec.hs
+++ b/test/Python/Poetry/CommonSpec.hs
@@ -7,7 +7,7 @@ import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
 import DepTypes (DepEnvironment (..), DepType (..), Dependency (..), VerConstraint (..))
-import Strategy.Python.Poetry.Common (getPoetryBuildBackend, makePackageToLockDependencyMap, pyProjectDeps, supportedPoetryLockDep, supportedPyProjectDep, toCanonicalName)
+import Strategy.Python.Poetry.Common (getPoetryBuildBackend, makePackageToLockDependencyMap, pyProjectDeps, supportedPoetryLockDep, supportedPyProjectDep)
 import Strategy.Python.Poetry.PoetryLock (
   ObjectVersion (..),
   PackageName (..),
@@ -162,12 +162,6 @@ spec = do
   emptyContents <- runIO (TIO.readFile "test/Python/Poetry/testdata/pyproject2.toml")
   pep621Contents <- runIO (TIO.readFile "test/Python/Poetry/testdata/pep621/pyproject.toml")
   pep621MixedContents <- runIO (TIO.readFile "test/Python/Poetry/testdata/pep621-mixed/pyproject.toml")
-
-  describe "toCanonicalName" $ do
-    it "should convert text to lowercase" $
-      toCanonicalName "GreatScore" `shouldBe` "greatscore"
-    it "should replace underscore (_) to hyphens (-)" $
-      toCanonicalName "my_oh_so_great_pkg" `shouldBe` "my-oh-so-great-pkg"
 
   describe "getDependencies" $ do
     it "should get all dependencies" $

--- a/test/Python/ReqTxtSpec.hs
+++ b/test/Python/ReqTxtSpec.hs
@@ -5,10 +5,13 @@ module Python.ReqTxtSpec (
 ) where
 
 import Control.Monad (void)
+import Data.Foldable (find)
 import Data.Map.Strict qualified as Map
+import Data.Text (Text)
 import DepTypes
 import Effect.Grapher
 import Graphing (Graphing)
+import Graphing qualified
 import Strategy.Python.Pip (PythonPackage (..))
 import Strategy.Python.Util
 import Text.URI.QQ (uri)
@@ -106,6 +109,20 @@ expectedDeps =
       )
   ]
 
+-- | What the graph looks like when pip reports the installed packages: the
+-- declared constraints on pkgOne and pkgTwo give way to the versions actually
+-- present, and their transitive dependencies appear.
+expectedInstalledDeps :: [ExpectedDependency]
+expectedInstalledDeps = map resolve expectedDeps
+  where
+    resolve (ExpectedDependency (dep, children)) =
+      ExpectedDependency (withInstalled dep, children)
+
+    withInstalled dep = case dependencyName dep of
+      "pkgOne" -> dep{dependencyVersion = Just (CEq "1.0.0")}
+      "pkgTwo" -> dep{dependencyVersion = Just (CEq "1")}
+      _ -> dep
+
 traverseDirect :: [ExpectedDependency] -> Graphing Dependency
 traverseDirect deps = run . evalGrapher $ do
   traverse
@@ -142,4 +159,69 @@ spec =
     it "should only report transitive dependencies for packages found in req.txt" $ do
       let result = buildGraph (Just installedPackages) setupPyInput
 
-      result `shouldBe` traverseDirectAndDeep expectedDeps
+      result `shouldBe` traverseDirectAndDeep expectedInstalledDeps
+
+    it "should report the installed version rather than a declared range" $ do
+      -- pkgOne is declared as ">=1.0.0, <2.0.0" but installed at 1.0.0. A
+      -- locator can only carry one revision, and the environment knows which
+      -- one is actually there.
+      let result = buildGraph (Just installedPackages) setupPyInput
+
+      versionOf "pkgOne" result `shouldBe` Just (Just (CEq "1.0.0"))
+
+    it "should report the installed version regardless of bound order" $ do
+      -- The declared range says the same thing either way round, so the
+      -- reported version must not depend on which bound was written first.
+      let lowerFirst = [NameReq "pkgOne" Nothing (Just [Version OpGtEq "1.0.0", Version OpLt "2.0.0"]) Nothing]
+          upperFirst = [NameReq "pkgOne" Nothing (Just [Version OpLt "2.0.0", Version OpGtEq "1.0.0"]) Nothing]
+
+      versionOf "pkgOne" (buildGraph (Just installedPackages) upperFirst)
+        `shouldBe` versionOf "pkgOne" (buildGraph (Just installedPackages) lowerFirst)
+
+    it "should fill in a version for a requirement that declares none" $ do
+      -- A bare package name on a requirements.txt line otherwise produces a
+      -- locator with no revision at all.
+      let result = buildGraph (Just installedPackages) setupPyInput
+
+      versionOf "pkgTwo" result `shouldBe` Just (Just (CEq "1"))
+
+    it "should match installed packages by their canonical name" $ do
+      -- PEP 503: "Zope.Interface", "zope_interface" and "zope-interface" all
+      -- name the same package.
+      let reqs = [NameReq "Zope.Interface" Nothing (Just [Version OpGtEq "5.0"]) Nothing]
+          installed = [PythonPackage "zope-interface" "5.4.0" []]
+
+      versionOf "Zope.Interface" (buildGraph (Just installed) reqs)
+        `shouldBe` Just (Just (CEq "5.4.0"))
+
+    it "should preserve environment markers when substituting a version" $ do
+      -- The marker becomes the dependency's tags, and describes the
+      -- requirement rather than the version it resolved to.
+      let marker = MarkerExpr "sys_platform" (MarkerOperator OpEq) "linux"
+          reqs = [NameReq "pkgOne" Nothing (Just [Version OpGtEq "1.0.0"]) (Just marker)]
+          result = buildGraph (Just installedPackages) reqs
+
+      tagsOf "pkgOne" result `shouldBe` Just (Map.fromList [("sys_platform", ["linux"])])
+
+    it "should leave a URL requirement alone" $ do
+      let reqs = [UrlReq "pkgOne" Nothing [uri|https://example.com|] Nothing]
+
+      versionOf "pkgOne" (buildGraph (Just installedPackages) reqs)
+        `shouldBe` Just (Just (CURI "https://example.com"))
+
+    it "should keep the declared constraint when pip reports nothing" $ do
+      let result = buildGraph Nothing setupPyInput
+
+      versionOf "pkgOne" result `shouldBe` Just (Just (CAnd (CGreaterOrEq "1.0.0") (CLess "2.0.0")))
+
+-- | Look up a dependency by name and return its version, or 'Nothing' if no
+-- dependency by that name is in the graph.
+versionOf :: Text -> Graphing Dependency -> Maybe (Maybe VerConstraint)
+versionOf name = fmap dependencyVersion . findDep name
+
+-- | Look up a dependency by name and return its tags.
+tagsOf :: Text -> Graphing Dependency -> Maybe (Map.Map Text [Text])
+tagsOf name = fmap dependencyTags . findDep name
+
+findDep :: Text -> Graphing Dependency -> Maybe Dependency
+findDep name = find ((== name) . dependencyName) . Graphing.vertexList

--- a/test/Python/RequirementsSpec.hs
+++ b/test/Python/RequirementsSpec.hs
@@ -9,7 +9,7 @@ import Data.Text.IO qualified as TIO
 import DepTypes
 import GraphUtil (expectDeps)
 import Strategy.Python.ReqTxt (requirementsTxtParser)
-import Strategy.Python.Util (buildGraph, requirementParser)
+import Strategy.Python.Util (buildGraph, requirementParser, toCanonicalName)
 import Test.Hspec qualified as T
 import Test.Hspec.Megaparsec
 import Text.Megaparsec
@@ -82,6 +82,20 @@ depFour =
 
 spec :: T.Spec
 spec = do
+  T.describe "toCanonicalName" $ do
+    T.it "should convert text to lowercase" $
+      toCanonicalName "GreatScore" `T.shouldBe` "greatscore"
+    T.it "should replace underscores and dots with hyphens" $ do
+      toCanonicalName "my_oh_so_great_pkg" `T.shouldBe` "my-oh-so-great-pkg"
+      toCanonicalName "zope.interface" `T.shouldBe` "zope-interface"
+    T.it "should collapse a run of separators into a single hyphen" $ do
+      -- PEP 503 normalizes on `[-_.]+`, so adjacent separators are one hyphen.
+      toCanonicalName "foo__bar" `T.shouldBe` "foo-bar"
+      toCanonicalName "foo._-bar" `T.shouldBe` "foo-bar"
+    T.it "should treat every spelling of a name as the same package" $ do
+      let spellings = ["Zope.Interface", "zope_interface", "zope-interface", "ZOPE.INTERFACE"]
+      map toCanonicalName spellings `T.shouldBe` replicate (length spellings) "zope-interface"
+
   T.describe "requirementParser" $
     T.it "can parse the edge case examples" $
       traverse_ (\input -> runParser requirementParser "" `shouldSucceedOn` input) examples

--- a/test/Srclib/ConverterSpec.hs
+++ b/test/Srclib/ConverterSpec.hs
@@ -1,0 +1,59 @@
+module Srclib.ConverterSpec (spec) where
+
+import DepTypes (
+  VerConstraint (..),
+ )
+import Srclib.Converter (verConstraintToRevision)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = do
+  describe "verConstraintToRevision" $ do
+    it "should use the version named by an exact constraint" $ do
+      verConstraintToRevision (CEq "1.2.3") `shouldBe` Just "1.2.3"
+
+    it "should use the version named by a compatible-release constraint" $ do
+      verConstraintToRevision (CCompatible "1.2") `shouldBe` Just "1.2"
+
+    it "should have no revision for a URI or an exclusion" $ do
+      verConstraintToRevision (CURI "https://example.com/pkg.tar.gz") `shouldBe` Nothing
+      verConstraintToRevision (CNot "1.5") `shouldBe` Nothing
+
+    it "should fall back to a lone bound when that is all there is" $ do
+      verConstraintToRevision (CGreaterOrEq "1.0") `shouldBe` Just "1.0"
+      verConstraintToRevision (CGreater "1.0") `shouldBe` Just "1.0"
+      verConstraintToRevision (CLessOrEq "2.0") `shouldBe` Just "2.0"
+      verConstraintToRevision (CLess "2.0") `shouldBe` Just "2.0"
+
+    -- The bug this ranking exists to fix: a range reported a different version
+    -- depending on which bound the author happened to write first, and an
+    -- upper bound written first won. `cryptography<60.0.0, >=46.0.3` reported
+    -- 60.0.0 --- a version the range excludes, and one that does not exist.
+    it "should prefer the lower bound of a range regardless of bound order" $ do
+      let lowerFirst = CAnd (CGreaterOrEq "46.0.3") (CLess "60.0.0")
+          upperFirst = CAnd (CLess "60.0.0") (CGreaterOrEq "46.0.3")
+      verConstraintToRevision lowerFirst `shouldBe` Just "46.0.3"
+      verConstraintToRevision upperFirst `shouldBe` Just "46.0.3"
+      verConstraintToRevision upperFirst `shouldBe` verConstraintToRevision lowerFirst
+
+    it "should prefer an exact version over any bound, in either position" $ do
+      verConstraintToRevision (CAnd (CGreaterOrEq "1.0") (CEq "1.5")) `shouldBe` Just "1.5"
+      verConstraintToRevision (CAnd (CEq "1.5") (CGreaterOrEq "1.0")) `shouldBe` Just "1.5"
+
+    it "should prefer a bound the range admits over one it excludes" $ do
+      -- >1.0 excludes 1.0 but <=2.0 admits 2.0, so 2.0 is the only candidate
+      -- that actually satisfies the constraint.
+      verConstraintToRevision (CAnd (CGreater "1.0") (CLessOrEq "2.0")) `shouldBe` Just "2.0"
+      verConstraintToRevision (CAnd (CLessOrEq "2.0") (CGreater "1.0")) `shouldBe` Just "2.0"
+
+    it "should skip constraints that have no revision to offer" $ do
+      let withExclusion = CAnd (CLess "2.0") (CAnd (CNot "1.5") (CGreaterOrEq "1.0"))
+      verConstraintToRevision withExclusion `shouldBe` Just "1.0"
+
+    it "should be order-independent for a disjunction too" $ do
+      let leftFirst = COr (CLess "2.0") (CGreaterOrEq "3.0")
+          rightFirst = COr (CGreaterOrEq "3.0") (CLess "2.0")
+      verConstraintToRevision leftFirst `shouldBe` verConstraintToRevision rightFirst
+
+    it "should keep the first of two equally good candidates" $ do
+      verConstraintToRevision (COr (CEq "6.1") (CEq "6.2")) `shouldBe` Just "6.1"


### PR DESCRIPTION
# Overview

A Python dependency declared as a version range was reported at whichever bound the author happened to write first. Given a requirements.txt line of `cryptography<60.0.0, >=46.0.3`, the CLI reported `pip+cryptography$60.0.0` — the exclusive upper bound, which is the one version the range explicitly forbids, and which is not a release that exists. Writing the same range as `cryptography>=46.0.3, <60.0.0` reported `46.0.3`.

There are two separate causes, and this PR fixes both.

The first is in `verConstraintToRevision`, which turns a version constraint into the single revision a locator can carry. Its `CAnd` case took the leftmost candidate that produced a version, and every bound operator was equally willing to answer, so the result depended on source order. It now ranks candidates by what kind of bound produced them — exact, then inclusive lower, inclusive upper, exclusive lower, exclusive upper — and keeps the best rather than the first. This is not Python-specific: Poetry's comma operator and Elixir's `and` build the same conjunctions.

The second is bigger, and is why the reported version was wrong even in the "good" ordering. When `python` and `pip` are available, the setuptools strategy already runs `pip list` and `pip show` to find transitive dependencies and edges. It had the installed version of every direct dependency in hand and discarded it, reporting a bound from the manifest instead. In the scan directory I used to reproduce this, the installed cryptography was `44.0.1` — neither of the two answers the CLI gave. The edges to cffi and pycparser came from `pip show cryptography`, so the true version was sitting in the very data used to build them. Direct requirements now take the installed version, with extras and environment markers preserved.

While doing that I hoisted `toCanonicalName` out of `Strategy.Python.Poetry.Common` into `Strategy.Python.Util`, where both the Poetry and setuptools strategies can reach it, and made it collapse runs of separators the way [PEP 503](https://peps.python.org/pep-0503/#normalized-names) specifies. Package-name matching in the setuptools strategy was previously a bare `toLower`, so `zope.interface` and `zope-interface` did not match.

## Acceptance criteria

When users scan a Python project whose requirements.txt or setup.py declares version ranges:

- The reported version no longer depends on the order the bounds were written in.
- With `python` and `pip` available, dependencies are reported at the version actually installed in the environment.
- A requirement that declares no version at all — a bare `requests` line — now gets a version, where previously it produced a locator with no revision. This is common in real requirements.txt files and is probably the widest-reaching effect of this PR.
- Without `python` or `pip`, which covers `--static-only-analysis` and container scans, a range falls back to the lowest version it allows rather than an upper bound.

## Testing plan

Automated coverage is in `test/Srclib/ConverterSpec.hs` (new — this function had no tests at all) and `test/Python/ReqTxtSpec.hs`. Below is the manual check, which is what actually demonstrates the behavior.

**Setup.** Create a scan directory with these two files:

`setup.py`:

```python
from setuptools import setup

setup(
    name="repro-ane-3089",
    version="0.0.1",
)
```

`requirements.txt`:

```txt
cryptography<60.0.0, >=46.0.3
```

Install a version of cryptography that differs from what the file declares, so that the manifest and the environment disagree and you can see which one is reported:

```bash
python -m venv .venv && source .venv/bin/activate
pip install 'cryptography==44.0.1'
```

**1. Upper bound written first, with pip available.** Run `fossa analyze --output | jq -r '.sourceUnits[0].Build.Dependencies[].locator'`.

Expect `pip+cryptography$44.0.1` — the installed version. On `master` this reports `pip+cryptography$60.0.0`.

**2. Lower bound written first.** Change the line to `cryptography>=46.0.3, <60.0.0` and run the same command.

Expect `pip+cryptography$44.0.1` again. The reported version must not change when only the bound order changes. On `master` this reports `pip+cryptography$46.0.3`, so the two orderings disagree.

**3. No version declared at all.** Change the line to just `cryptography` and run the same command.

Expect `pip+cryptography$44.0.1`. On `master` this reports `pip+cryptography$` with no revision.

**4. Without pip, both bound orders.** Run `fossa analyze --output --static-only-analysis` against each of the two orderings from steps 1 and 2.

Expect `pip+cryptography$46.0.3` for both — no environment to consult, so the CLI falls back to the lowest version the range allows. On `master` the upper-bound-first ordering reports `60.0.0` here.

**5. Transitive dependencies still resolve.** In any of the runs above, check the full dependency list.

Expect `cffi` and `pycparser` to appear with concrete versions, and `pip+cryptography$44.0.1` to have an `imports` edge to `pip+cffi$...`. This confirms the direct dependency and the graph node carrying the edges are the same node, rather than the package appearing twice.

## Risks

**Reporting the installed version overrides an exact pin.** If requirements.txt says `requests==2.25.1` and the environment has `2.30.0`, this now reports `2.30.0`. In a healthy scan — pinned file, clean venv, `pip install -r` actually run — the two agree and nothing changes. It only differs when the environment has drifted from the manifest, and in that case the environment is what ships. I think this is right, and it is consistent with the CLI already trusting pip for the entire transitive closure, but it is the judgment call in this PR most worth a second opinion.

**Ranking bounds for `COr` is arbitrary rather than principled.** For a conjunction the branches are complementary bounds on one range, so ranking them means something. For a disjunction they are alternative ranges and nothing in the constraint says which is installed. I applied the same ranking anyway so the result is at least order-independent, and said so in a comment. Open to just leaving `COr` left-biased instead.

**The PEP 503 change alters Poetry matching.** `toCanonicalName` now collapses separator runs, so `foo__bar` canonicalizes to `foo-bar` instead of `foo--bar`. Poetry is the only existing caller. Rare, and the old result looks like a bug, but it is a behavior change outside the ticket's scope.

## Metrics

Not readily trackable today. The effect worth knowing is how often a reported Python version changes for a given project between CLI versions, which would need a comparison across scans on the server side rather than anything the CLI can emit.

## References

- [ANE-3089](https://fossa.atlassian.net/browse/ANE-3089): Pip version bounds reported inconsistently.

Two follow-ups I deliberately left out, both worth their own tickets:

- **Warn when the installed version does not satisfy the declared range.** This is exactly the state of my repro directory — 44.0.1 installed against `>=46.0.3` means that environment was never `pip install -r`'d, which makes the transitive graph suspect too. It needs a PEP 440 comparator, and neither `semver` nor `versions` in our dependency set implements PEP 440's ordering rules for epochs and pre/post/dev releases. Writing one is larger than this whole PR.
- **`COr` binds tighter than `CAnd` in the Poetry and Elixir constraint parsers.** `makeExprParser` takes its operator table in descending precedence, and both tables list the OR operator first — `src/Strategy/Python/Poetry/PyProject.hs:389` and `src/Strategy/Elixir/MixTree.hs:454`. In both Poetry and Hex, AND binds tighter, so `>=2.0,<3.0 || >=3.2,<4.0` should parse as two ranges and currently does not. The current grouping is asserted as correct in `test/Python/Poetry/PyProjectSpec.hs:207` and `test/Elixir/MixTreeSpec.hs:479`, so fixing it means rewriting passing tests.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is. — _no new pages, only edits to the existing `setuptools.md`, which is already linked._
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. — _n/a._
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`. — _n/a, no option changes._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ANE-3089]: https://fossa.atlassian.net/browse/ANE-3089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ