### PR TITLE
[ANE-2836] Fix bun dependency filtering for transitive dev dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # FOSSA CLI Changelog
 
+## Unreleased
+
+- Bun: Dependencies reachable only through a `devDependencies` entry are now reported as development dependencies instead of production dependencies.
+
 ## 3.17.17
 
 - License Scanning: Detect an OFL-1.1 license notice correctly ([#1742](https://github.com/fossas/fossa-cli/pull/1742))

--- a/docs/references/strategies/languages/nodejs/bun.md
+++ b/docs/references/strategies/languages/nodejs/bun.md
@@ -62,10 +62,7 @@ File, link, workspace, root, and module resolutions are excluded.
 
 - Dependencies declared in `devDependencies` of any workspace are labeled as development dependencies.
 - Dependencies declared in `dependencies` or `optionalDependencies` of any workspace are labeled as production dependencies.
-- Those labels propagate along the graph edges: a transitive dependency carries the
-  environments of every declared dependency it is reachable from. A package reachable
-  only through a `devDependencies` entry is labeled as a development dependency, and a
-  package reachable from both a production and a development declaration carries both.
+- Transitive dependencies inherit the environments of the dependencies that pull them in.
 - When the same package appears in both `dependencies` and `devDependencies` across
   different workspaces, both environments are recorded on a single graph vertex
   (environments accumulate rather than creating duplicate entries).

--- a/docs/references/strategies/languages/nodejs/bun.md
+++ b/docs/references/strategies/languages/nodejs/bun.md
@@ -62,6 +62,10 @@ File, link, workspace, root, and module resolutions are excluded.
 
 - Dependencies declared in `devDependencies` of any workspace are labeled as development dependencies.
 - Dependencies declared in `dependencies` or `optionalDependencies` of any workspace are labeled as production dependencies.
+- Those labels propagate along the graph edges: a transitive dependency carries the
+  environments of every declared dependency it is reachable from. A package reachable
+  only through a `devDependencies` entry is labeled as a development dependency, and a
+  package reachable from both a production and a development declaration carries both.
 - When the same package appears in both `dependencies` and `devDependencies` across
   different workspaces, both environments are recorded on a single graph vertex
   (environments accumulate rather than creating duplicate entries).

--- a/src/Strategy/Node/Bun/BunLock.hs
+++ b/src/Strategy/Node/Bun/BunLock.hs
@@ -38,6 +38,7 @@ import DepTypes (
   DepType (GitType, NodeJSType),
   Dependency (..),
   VerConstraint (CEq),
+  hydrateDepEnvs,
   insertEnvironment,
  )
 import Effect.Grapher (LabeledGrapher, deep, direct, edge, label, run, withLabeling)
@@ -198,19 +199,19 @@ analyze file = do
 -- | Build a dependency graph from a parsed bun lockfile.
 --
 -- Strategy:
---   1. Collect all dev dependency names across all workspaces.
---   2. For each workspace, mark its declared dependencies as direct
+--   1. For each workspace, mark its declared dependencies as direct
 --      and label them with their environment.
---   3. For each supported package (npm, git), add it as a deep dependency,
---      label it with its inferred environment, and create edges to its
---      transitive dependencies.
+--   2. For each supported package (npm, git), add it as a deep dependency
+--      and create edges to its transitive dependencies.
 --      Unsupported types (workspace, file, link, root, module) are excluded.
+--   3. Propagate the environments of the direct dependencies along the edges,
+--      so a package inherits every environment it can be reached from.
 --
 -- Uses 'LabeledGrapher' so that vertices are environment-agnostic and
 -- environments accumulate as labels, avoiding duplicate vertices when
 -- the same package appears in both prod and dev across workspaces.
 buildGraph :: BunLockfile -> Graphing Dependency
-buildGraph lockfile = run . withLabeling vertexToDependency $ do
+buildGraph lockfile = hydrateDepEnvs . run . withLabeling vertexToDependency $ do
   for_ allWorkspaces $ \workspace -> do
     markDirectDeps EnvProduction workspace.wsDependencies
     markDirectDeps EnvDevelopment workspace.wsDevDependencies
@@ -218,10 +219,7 @@ buildGraph lockfile = run . withLabeling vertexToDependency $ do
 
   for_ (packages lockfile) $ \pkg ->
     for_ (toVertex pkg) $ \parentVertex -> do
-      let (name, _) = parseResolution (pkgResolution pkg)
-          inferredEnv = if Set.member name devDepNames then EnvDevelopment else EnvProduction
       deep parentVertex
-      label parentVertex (BunDepEnv inferredEnv)
       for_ (transitiveDepNames pkg) $ \childName ->
         case Map.lookup childName (packages lockfile) of
           Nothing -> pure ()
@@ -231,9 +229,6 @@ buildGraph lockfile = run . withLabeling vertexToDependency $ do
   where
     allWorkspaces :: [BunWorkspace]
     allWorkspaces = Map.elems $ workspaces lockfile
-
-    devDepNames :: Set.Set PackageName
-    devDepNames = Set.fromList $ concatMap (Map.keys . wsDevDependencies) allWorkspaces
 
     markDirectDeps :: (Has (LabeledGrapher BunDepVertex BunDepLabel) sig m) => DepEnvironment -> Map PackageName VersionConstraint -> m ()
     markDirectDeps env deps =

--- a/test/Bun/BunLockSpec.hs
+++ b/test/Bun/BunLockSpec.hs
@@ -119,8 +119,16 @@ dependenciesSpec path =
           expectEdge graph (mkProdDep "express" "4.18.2") (mkProdDep "accepts" "1.3.8")
           expectEdge graph (mkProdDep "accepts" "1.3.8") (mkProdDep "mime-types" "2.1.35")
 
-        it "labels transitive deps of dev deps as production" $ do
-          expectEdge graph (mkDevDep "typescript" "5.3.3") (mkProdDep "semver" "7.6.0")
+        it "labels transitive deps of dev deps as development" $
+          expectEdge graph (mkDevDep "typescript" "5.3.3") (mkDevDep "semver" "7.6.0")
+
+        it "labels a dev-only chain as development at every depth" $ do
+          expectEdge graph (mkDevDep "semver" "7.6.0") (mkDevDep "lru-cache" "6.0.0")
+          expectEdge graph (mkDevDep "lru-cache" "6.0.0") (mkDevDep "yallist" "4.0.0")
+
+        it "labels a dep reached from both a production and a dev root with both environments" $ do
+          expectEdge graph (mkProdDep "mime-types" "2.1.35") (mkBothEnvsDep "ms" "2.1.3")
+          expectEdge graph (mkDevDep "semver" "7.6.0") (mkBothEnvsDep "ms" "2.1.3")
 
 -- | Workspaces: multiple workspaces, workspace refs, and workspace
 -- package filtering from the final graph.

--- a/test/Bun/testdata/dependencies/bun.lock
+++ b/test/Bun/testdata/dependencies/bun.lock
@@ -17,9 +17,12 @@
   "packages": {
     "express": ["express@4.18.2", "", { "dependencies": { "accepts": "~1.3.8" } }, "sha512-fake=="],
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34" } }, "sha512-fake=="],
-    "mime-types": ["mime-types@2.1.35", "", {}, "sha512-fake=="],
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-fake=="],
     "typescript": ["typescript@5.3.3", "", { "dependencies": { "semver": "^7.5.0" } }, "sha512-fake=="],
-    "semver": ["semver@7.6.0", "", {}, "sha512-fake=="],
+    "semver": ["semver@7.6.0", "", { "dependencies": { "lru-cache": "^6.0.0", "ms": "^2.1.3" } }, "sha512-fake=="],
+    "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-fake=="],
+    "yallist": ["yallist@4.0.0", "", {}, "sha512-fake=="],
+    "ms": ["ms@2.1.3", "", {}, "sha512-fake=="],
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-fake=="],
   },
 }


### PR DESCRIPTION
# Overview

We added a bun strategy in 3.16.0. It marks a package as dev if its name shows up in a workspace's `devDependencies` and production otherwise, so anything pulled in by a dev dependency looks like production. A fresh `bun init` project has no production dependencies and we report three. This PR labels only the declared dependencies and propagates those environments down the graph, the way the yarn and pnpm strategies already do.

## Acceptance criteria

- Dependencies only reachable through `devDependencies` are filtered out
- Dependencies reachable from both prod and dev keep both and are still reported

## Testing plan

```sh
mkdir -p /tmp/bun-devdeps && cd /tmp/bun-devdeps
bun init -y  # only devDependency is @types/bun, no production deps
```

Then from the fossa-cli checkout:

```sh
cabal run fossa -- analyze /tmp/bun-devdeps --output --only-target bun \
  | jq -r '[.sourceUnits[].Build.Dependencies[].locator] | sort | .[]'
```

On master you get `@types/node`, `bun-types` and `undici-types`. On this branch you get nothing. Add a real dependency with `bun add express@4` and rerun: master reports 70 packages, this branch reports the same minus those three.

## Risks

This fixes an existing issue; little to no risk.

## Metrics

None

## References

- [ANE-2836](https://fossa.atlassian.net/browse/ANE-2836): Bun CLI strategy does not filter transitive devDependencies
- [#1651](https://github.com/fossas/fossa-cli/issues/1651): customer report and repro

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-2836]: https://fossa.atlassian.net/browse/ANE-2836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ