### PR TITLE
Handle traits argument in Swift package dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Setuptools: projects containing only requirements.txt files no longer emit a spurious `Failed to parse python file` / `No setup.py found in this project` warning; setup.py is only analyzed when it exists.
+- Swift: Add support for packages with a `traits` argument
 
 ## 3.18.0
 

--- a/src/Strategy/Swift/PackageSwift.hs
+++ b/src/Strategy/Swift/PackageSwift.hs
@@ -95,6 +95,9 @@ isEndLine '\n' = True
 isEndLine '\r' = True
 isEndLine _ = False
 
+parseStringArray :: Parser [Text]
+parseStringArray = betweenSquareBrackets (sepEndBy parseQuotedText (symbol ","))
+
 -- | Represents https://developer.apple.com/documentation/packagedescription/version
 data SwiftVersion = SwiftVersion
   { parts :: [Text]
@@ -126,9 +129,6 @@ parseVersionConstructor = (symbol "Version") >> assembleParts <$> parseParts
         Just ("buildMetadataIdentifiers") -> (Just . BuildMetadataIdentifiers) <$> parseStringArray
         -- Unknown key -- Not reachable in practice, but consume the value of any unknown keys so the parser continues
         _ -> Nothing <$ (void parseStringArray <|> void parseQuotedText <|> void (some digitChar))
-
-    parseStringArray :: Parser [Text]
-    parseStringArray = betweenSquareBrackets (sepEndBy parseQuotedText (symbol ","))
 
     assembleParts :: [SwiftVersionPart] -> SwiftVersion
     assembleParts =
@@ -249,6 +249,8 @@ parsePackageDep = try parsePathDep <|> parseGitDep
               , ClosedInterval <$> parseRange "..."
               , RhsHalfOpenInterval <$> parseRange "..<"
               ]
+      _ <- maybeComma
+      _ <- optional $ parseKeyValue "traits" $ void parseStringArray
       _ <- symbol ")"
       pure $ GitSource $ SwiftPackageGitDep url (versionRequirement)
 

--- a/test/Swift/PackageSwiftSpec.hs
+++ b/test/Swift/PackageSwiftSpec.hs
@@ -71,6 +71,8 @@ expectedSwiftPackage =
       , -- range
         gitDepWithRhsHalfOpenInterval "https://github.com/LeoNatan/LNPopupController.git" "2.5.0" "2.5.6"
       , gitDepWithClosedRange "https://github.com/Polidea/RxBluetoothKit.git" "3.0.5" "3.0.7"
+      , -- traits
+        gitDepFrom "https://github.com/example/banana.git" "3.2.2"
       , -- version constructor
         gitDepFrom "https://github.com/example/example.git" "1.7.0-a.b+x.banana"
       , gitDepUpToNextMinor "https://github.com/example/example2.git" "13.99.123+abcd"

--- a/test/Swift/testdata/Package.full.swift
+++ b/test/Swift/testdata/Package.full.swift
@@ -53,6 +53,11 @@ let package = Package(
         .package(url: "https://github.com/LeoNatan/LNPopupController.git", "2.5.0"..<"2.5.6"),
         .package(url: "https://github.com/Polidea/RxBluetoothKit.git", "3.0.5"..."3.0.7"),
 
+        // traits
+        .package(url: "https://github.com/example/banana.git", .from("3.2.2"),  traits: [
+            "SomeTrait"
+        ]),
+
         // version constructor
         .package(url: "https://github.com/example/example.git", .from(Version(1, 7, 0, prereleaseIdentifiers: ["a", "b"], buildMetadataIdentifiers: ["x", "banana"]))),
         .package(url: "https://github.com/example/example2.git", .upToNextMinor(from: Version(13, 99, 123, buildMetadataIdentifiers: ["abcd"]))),

--- a/test/Swift/testdata/Package.swift
+++ b/test/Swift/testdata/Package.swift
@@ -64,6 +64,11 @@ let package = Package(
         // range
         .package(url: "https://github.com/LeoNatan/LNPopupController.git", "2.5.0"..<"2.5.6"),
         .package(url: "https://github.com/Polidea/RxBluetoothKit.git", "3.0.5"..."3.0.7"),
+
+        // traits
+        .package(url: "https://github.com/example/banana.git", .from("3.2.2"),  traits: [
+            "SomeTrait"
+        ]),
  
         // version constructor
         .package(url: "https://github.com/example/example.git", .from(Version(1, 7, 0, prereleaseIdentifiers: ["a", "b"], buildMetadataIdentifiers: ["x", "banana"]))),


### PR DESCRIPTION
# Overview
More recent versions of Swift let you pass a `traits` parameter to a `.package()` dependency. Our parser fail on this. Read, and then ignore the value of this field if it's set.

## Acceptance criteria
The Package.swift from the ticket can be analyzed successfully.

## Testing plan
- Put the Package.swift from the ticket in a directory.
- Run `cabal run fossa -- analyze --output $YOUR_DIR` and confirm we find the dependency correctly.

## Risks

_Highlight any areas that you're unsure of, want feedback on, or want reviewers to pay particular attention to._

_Example: I'm not sure I did X correctly, can reviewers please double-check that for me?_

## Metrics

_Is this change something that can or should be tracked? If so, can we do it today? And how? If its easy, do it_

## References

- [ANE-3093](https://fossa.atlassian.net/browse/ANE-3093): Package.swift parser fails on Swift 6.1 package traits (.package(url:from:traits:))

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [ ] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is.
- [ ] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`).
- [ ] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.


[ANE-3093]: https://fossa.atlassian.net/browse/ANE-3093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ