### PR TITLE
Analyze: run a workflow analyzer locally with --x-workflow

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Workflows: `fossa analyze --x-workflow <path>` runs a dependency-usage workflow analyzer through the embedded ficus and records its result in the debug bundle. Nothing is uploaded. ([#1759](https://github.com/fossas/fossa-cli/pull/1759))
 - Diagnostics: When an error or warning group contains multiple errors, each error's `Traceback:` header is now printed on its own line instead of being glued onto the last line of the preceding error message (e.g. `...none passed validationTraceback:`). ([#1758](https://github.com/fossas/fossa-cli/pull/1758))
 
 ## 3.18.2

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Workflows: `fossa analyze --x-workflow <path>` runs a dependency-usage workflow analyzer through the embedded ficus and records its result in the debug bundle. Nothing is uploaded. ([#1759](https://github.com/fossas/fossa-cli/pull/1759))
+- Workflows: `fossa analyze --x-workflow <path>` runs a dependency-usage workflow analyzer through the embedded ficus and records its result in the debug bundle. Nothing is uploaded. ([#1761](https://github.com/fossas/fossa-cli/pull/1761))
 - Diagnostics: When an error or warning group contains multiple errors, each error's `Traceback:` header is now printed on its own line instead of being glued onto the last line of the preceding error message (e.g. `...none passed validationTraceback:`). ([#1758](https://github.com/fossas/fossa-cli/pull/1758))
 
 ## 3.18.2

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -203,6 +203,17 @@ To see the result, run with `--debug` and read `bundleWorkflowResult` out of
 `fossa.debug.json` in the resulting `fossa.debug.zip`. The raw analyzer output
 is preserved alongside it in `fossa.ficus-workflow-stdout.log`.
 
+#### Failure behavior
+
+A workflow that fails — the analyzer exits non-zero, produces no result, or
+the embedded ficus rejects the run — does **not** fail `fossa analyze`. The
+command completes and exits 0; the failure is reported in the log, including
+the tail of ficus's stderr, and `bundleWorkflowResult` in the debug bundle is
+left empty. This is deliberate: a broken experimental analyzer must not block
+the dependency scan and upload. Check the log for
+`The workflow analyzer at <path> did not produce a result` to confirm the run
+happened.
+
 #### Security
 
 This flag executes a program you name, on your machine, against your project.

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -177,6 +177,49 @@ For more detail about how Vendetta works, how to use file filtering during
 scanning, or what information is sent to FOSSA's servers, see
 [the Vendetta feature documentation](../../features/vendetta.md).
 
+### Dependency Usage Analysis with `--x-workflow`
+
+`--x-workflow` runs a dependency-usage workflow analyzer over the project and
+records its result in the debug bundle. The analyzer is a program you name on
+the command line; FOSSA CLI does not ship one yet, so this flag does nothing
+useful unless you already have a bundle to point it at.
+
+Results are not uploaded. Nothing about this flag changes what `fossa analyze`
+sends to FOSSA.
+
+#### Enabling dependency usage analysis
+
+| Name                  | Description                                                                                                                                                                    |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--x-workflow PATH`   | Experimental. Run the dependency-usage workflow analyzer at `PATH` over the project. A `.js`, `.mjs` or `.cjs` path is run under `node`; any other path is run as the program itself. |
+
+A relative `PATH` is resolved against the directory you run `fossa` from, and a
+path that does not exist fails immediately rather than partway through the
+analysis. `--x-workflow` cannot be combined with `--static-only-analysis`,
+which is the kill switch for running third-party tooling on your machine;
+passing both is an error rather than a silent skip.
+
+To see the result, run with `--debug` and read `bundleWorkflowResult` out of
+`fossa.debug.json` in the resulting `fossa.debug.zip`. The raw analyzer output
+is preserved alongside it in `fossa.ficus-workflow-stdout.log`.
+
+#### Security
+
+This flag executes a program you name, on your machine, against your project.
+FOSSA CLI does not sandbox it and does not constrain what it does: it runs with
+your privileges, reads whatever it can read, and may make network requests of
+its own. `--output` suppresses FOSSA CLI's own upload; it cannot suppress a
+child process's traffic.
+
+Only point `--x-workflow` at a program you trust as much as you trust the rest
+of your build.
+
+#### More detail
+
+`--x-workflow` is an experimental option. Refer to the
+[experimental options overview](../experimental/README.md) for what that means
+for support and stability.
+
 ### Experimental Options
 
 _Important: For support and other general information, refer to the [experimental options overview](../experimental/README.md) before using experimental options._

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -182,7 +182,7 @@ scanning, or what information is sent to FOSSA's servers, see
 `--x-workflow` runs a dependency-usage workflow analyzer over the project and
 records its result in the debug bundle. The analyzer is a program you name on
 the command line; FOSSA CLI does not ship one yet, so this flag does nothing
-useful unless you already have a bundle to point it at.
+useful unless you already have an analyzer program or script to point it at.
 
 Results are not uploaded. Nothing about this flag changes what `fossa analyze`
 sends to FOSSA.

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -252,6 +252,7 @@ library
     App.Fossa.EmbeddedBinary
     App.Fossa.Ficus.Analyze
     App.Fossa.Ficus.Types
+    App.Fossa.Ficus.Workflow
     App.Fossa.FirstPartyScan
     App.Fossa.Init
     App.Fossa.Lernie.Analyze

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -673,6 +673,7 @@ test-suite unit-tests
     Extra.ListSpec
     Extra.TextSpec
     Ficus.FicusSpec
+    Ficus.WorkflowProcessSpec
     Ficus.WorkflowSpec
     Fortran.FpmTomlSpec
     Fossa.API.CoreTypesSpec

--- a/spectrometer.cabal
+++ b/spectrometer.cabal
@@ -673,6 +673,7 @@ test-suite unit-tests
     Extra.ListSpec
     Extra.TextSpec
     Ficus.FicusSpec
+    Ficus.WorkflowSpec
     Fortran.FpmTomlSpec
     Fossa.API.CoreTypesSpec
     Fossa.API.TypesSpec

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -68,7 +68,7 @@ import App.Fossa.Config.Analyze qualified as Config
 import App.Fossa.Config.Common (DestinationMeta (..), destinationApiOpts, destinationMetadata)
 import App.Fossa.Ficus.Analyze (analyzeWithFicus)
 import App.Fossa.Ficus.Types (FicusAnalysisResults (vendoredDependencyScanResults), FicusStrategy (FicusStrategySnippetScan, FicusStrategyVendetta), FicusVendoredDependencyScanResults (FicusVendoredDependencyScanResults))
-import App.Fossa.Ficus.Workflow (analyzeWithWorkflow)
+import App.Fossa.Ficus.Workflow qualified as Workflow
 import App.Fossa.FirstPartyScan (runFirstPartyScan)
 import App.Fossa.Lernie.Analyze (analyzeWithLernie)
 import App.Fossa.Lernie.Types (LernieResults (..))
@@ -434,7 +434,7 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   workflowResult <-
     Diag.errorBoundaryIO . diagToDebug $
       traverse_
-        (\analyzer -> Diag.context "x-workflow" $ analyzeWithWorkflow basedir analyzer (Config.debugDir cfg))
+        (\analyzer -> Diag.context "x-workflow" $ Workflow.analyzeWithWorkflow basedir analyzer (Config.debugDir cfg))
         (Config.xWorkflow cfg)
 
   maybeLernieResults <-

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -68,6 +68,7 @@ import App.Fossa.Config.Analyze qualified as Config
 import App.Fossa.Config.Common (DestinationMeta (..), destinationApiOpts, destinationMetadata)
 import App.Fossa.Ficus.Analyze (analyzeWithFicus)
 import App.Fossa.Ficus.Types (FicusAnalysisResults (vendoredDependencyScanResults), FicusStrategy (FicusStrategySnippetScan, FicusStrategyVendetta), FicusVendoredDependencyScanResults (FicusVendoredDependencyScanResults))
+import App.Fossa.Ficus.Workflow (analyzeWithWorkflow)
 import App.Fossa.FirstPartyScan (runFirstPartyScan)
 import App.Fossa.Lernie.Analyze (analyzeWithLernie)
 import App.Fossa.Lernie.Types (LernieResults (..))
@@ -427,6 +428,15 @@ analyze cfg = Diag.context "fossa-analyze" $ do
               (Config.debugDir cfg)
   let ficusResults = join $ resultToMaybe maybeFicusResults
 
+  -- Nothing is uploaded on this path, so a failure is loud but does not hold the
+  -- dependency upload hostage. Revisit when the result is data the user expects
+  -- to arrive.
+  workflowResult <-
+    Diag.errorBoundaryIO . diagToDebug $
+      traverse_
+        (\analyzer -> Diag.context "x-workflow" $ analyzeWithWorkflow basedir analyzer (Config.debugDir cfg))
+        (Config.xWorkflow cfg)
+
   maybeLernieResults <-
     Diag.errorBoundaryIO . diagToDebug $
       if filterIsVSIOnly filters
@@ -458,6 +468,8 @@ analyze cfg = Diag.context "fossa-analyze" $ do
   traverse_ (Diag.flushLogs SevError SevDebug) [maybeLernieResults]
   -- Flush logs from ficus
   traverse_ (Diag.flushLogs SevError SevDebug) [maybeFicusResults]
+  -- Flush logs from the x-workflow run
+  traverse_ (Diag.flushLogs SevError SevDebug) [workflowResult]
 
   maybeFirstPartyScanResults <-
     Diag.errorBoundaryIO . diagToDebug $

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -25,6 +25,7 @@ module App.Fossa.Analyze.Debug (
 where
 
 import App.Fossa.EmbeddedBinary (themisVersion)
+import App.Fossa.Ficus.Types (workflowResultJson)
 import App.Fossa.Reachability.Types (reachabilityEndpointJson, reachabilityRawJson)
 import App.Version (fullVersionDescription)
 import Control.Applicative (asum)
@@ -197,6 +198,7 @@ collectDebugBundle cfg act = do
           , bundleBinaryVersions = binVersions
           , bundleReachabilityRaw = lookUpReachabilityRawScope scope
           , bundleReachabilityEndpoint = lookUpReachabilityEndpointScope scope
+          , bundleWorkflowResult = lookupScope workflowResultJson scope
           , bundleJournals =
               BundleJournals
                 { bundleJournalReadFS = readFSJournal
@@ -254,6 +256,7 @@ data DebugBundle cfg = DebugBundle
   , bundleJournals :: BundleJournals
   , bundleReachabilityRaw :: Maybe Aeson.Value
   , bundleReachabilityEndpoint :: Maybe Aeson.Value
+  , bundleWorkflowResult :: Maybe Aeson.Value
   }
   deriving (Show, Generic)
 

--- a/src/App/Fossa/Analyze/Debug.hs
+++ b/src/App/Fossa/Analyze/Debug.hs
@@ -25,7 +25,7 @@ module App.Fossa.Analyze.Debug (
 where
 
 import App.Fossa.EmbeddedBinary (themisVersion)
-import App.Fossa.Ficus.Types (workflowResultJson)
+import App.Fossa.Ficus.Types qualified as FicusTypes
 import App.Fossa.Reachability.Types (reachabilityEndpointJson, reachabilityRawJson)
 import App.Version (fullVersionDescription)
 import Control.Applicative (asum)
@@ -198,7 +198,7 @@ collectDebugBundle cfg act = do
           , bundleBinaryVersions = binVersions
           , bundleReachabilityRaw = lookUpReachabilityRawScope scope
           , bundleReachabilityEndpoint = lookUpReachabilityEndpointScope scope
-          , bundleWorkflowResult = lookupScope workflowResultJson scope
+          , bundleWorkflowResult = lookupScope FicusTypes.workflowResultJson scope
           , bundleJournals =
               BundleJournals
                 { bundleJournalReadFS = readFSJournal

--- a/src/App/Fossa/Config/Analyze.hs
+++ b/src/App/Fossa/Config/Analyze.hs
@@ -253,6 +253,7 @@ data AnalyzeCliOpts = AnalyzeCliOpts
   , analyzeExperimentalSnippetScan :: Flag ExperimentalSnippetScan
   , analyzeSnippetScan :: Flag SnippetScan
   , analyzeVendetta :: Bool
+  , analyzeWorkflow :: Maybe FilePath
   }
   deriving (Eq, Ord, Show)
 
@@ -294,6 +295,7 @@ data AnalyzeConfig = AnalyzeConfig
   , snippetScan :: Bool
   , debugDir :: Maybe FilePath
   , xVendetta :: Bool
+  , xWorkflow :: Maybe (Path Abs File)
   }
   deriving (Eq, Ord, Show, Generic)
 
@@ -374,6 +376,14 @@ cliParser =
     <*> flagOpt ExperimentalSnippetScan (applyFossaStyle <> long "x-snippet-scan" <> hidden)
     <*> flagOpt SnippetScan (applyFossaStyle <> long "snippet-scan" <> stringToHelpDoc "Enable snippet scanning to identify open source code snippets using fingerprinting.")
     <*> switch (applyFossaStyle <> long "x-vendetta" <> stringToHelpDoc "Experimental flag to enable vendored dependency scanning to identify open source components using file hashing.")
+    <*> optional
+      ( strOption
+          ( applyFossaStyle
+              <> long "x-workflow"
+              <> metavar "PATH"
+              <> stringToHelpDoc "Experimental. Run the dependency-usage workflow analyzer at PATH."
+          )
+      )
   where
     fossaDepsFileHelp :: Maybe (Doc AnsiStyle)
     fossaDepsFileHelp =
@@ -604,6 +614,12 @@ mergeStandardOpts maybeDebugDir maybeConfig envvars cliOpts@AnalyzeCliOpts{..} =
   when (analyzeVendetta && analyzeOutput == Output) $
     fatalText "The --x-vendetta and --output flags cannot be used together. Vendetta scanning requires uploading results to FOSSA and is not compatible with output-only mode."
 
+  -- Checked before the path is resolved: a user who typed both flags should see the
+  -- contradiction, not a file error about a path the CLI was never going to run.
+  case (fromFlag StaticOnlyTactics analyzeStaticOnlyTactics, analyzeWorkflow) of
+    (True, Just _) -> fatalText "--x-workflow runs an analyzer on your machine and cannot be combined with --static-only-analysis"
+    _ -> pure ()
+
   AnalyzeConfig
     <$> basedir
     <*> scanDestination
@@ -628,6 +644,7 @@ mergeStandardOpts maybeDebugDir maybeConfig envvars cliOpts@AnalyzeCliOpts{..} =
     <*> pure snippetScanEnabled
     <*> pure maybeDebugDir
     <*> pure analyzeVendetta
+    <*> traverse validateFile analyzeWorkflow
 
 collectMavenScopeFilters ::
   (Has Diagnostics sig m) =>

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -37,7 +37,9 @@ import App.Types (ProjectRevision (..))
 import Control.Applicative ((<|>))
 import Control.Carrier.Diagnostics (Diagnostics)
 import Control.Concurrent.Async (async, wait)
+import Control.Effect.Exception (bracket)
 import Control.Effect.Lift (Has, Lift, sendIO)
+import Control.Exception (onException)
 import Control.Monad (when)
 import Data.Aeson (decode, decodeStrictText)
 import Data.Aeson qualified as Aeson
@@ -274,30 +276,33 @@ execFicusStreaming workingDir cmd stdinPayload maybeDebugDir debugLogBasename st
 
   logDebugWithTime "Starting Ficus process..."
 
-  (stdoutFile, stderrFile) <- case maybeDebugDir of
-    Just debugDir -> sendIO $ do
-      stdoutH <- openLogFile debugDir "stdout"
-      stderrH <- openLogFile debugDir "stderr"
-      pure (Just stdoutH, Just stderrH)
-    Nothing -> pure (Nothing, Nothing)
-
-  outcome <- sendIO $ withProcessWait processConfig $ \p -> do
-    getCurrentTime >>= \now -> hPutStrLn stderr $ "[TIMING " ++ formatTime defaultTimeLocale "%H:%M:%S.%3q" now ++ "] Ficus process started, beginning stream processing..."
-    -- Start async reading of stderr to prevent blocking
-    stderrAsync <- async $ consumeStderr (getStderr p) stderrFile
-    -- Read stdout in the main thread
-    accumulator <- streamFicusOutput (getStdout p) stdoutFile
-    -- Wait for stderr to finish
-    stdErrLines <- wait stderrAsync
-    exitCode <- waitExitCode p
-    pure (accumulator, exitCode, stdErrLines)
-
-  sendIO $ do
-    traverse_ hClose stdoutFile
-    traverse_ hClose stderrFile
-
-  pure outcome
+  bracket (sendIO openDebugLogs) (sendIO . closeDebugLogs) $ \(stdoutFile, stderrFile) ->
+    sendIO . withProcessWait processConfig $ \p -> do
+      getCurrentTime >>= \now -> hPutStrLn stderr $ "[TIMING " ++ formatTime defaultTimeLocale "%H:%M:%S.%3q" now ++ "] Ficus process started, beginning stream processing..."
+      -- Start async reading of stderr to prevent blocking
+      stderrAsync <- async $ consumeStderr (getStderr p) stderrFile
+      -- Read stdout in the main thread
+      accumulator <- streamFicusOutput (getStdout p) stdoutFile
+      -- Wait for stderr to finish
+      stdErrLines <- wait stderrAsync
+      exitCode <- waitExitCode p
+      pure (accumulator, exitCode, stdErrLines)
   where
+    -- Bracketed: an exception out of the process or the stream handler must not
+    -- leave the debug logs open for the rest of the run.
+    openDebugLogs :: IO (Maybe Handle, Maybe Handle)
+    openDebugLogs = case maybeDebugDir of
+      Nothing -> pure (Nothing, Nothing)
+      Just debugDir -> do
+        stdoutH <- openLogFile debugDir "stdout"
+        stderrH <- openLogFile debugDir "stderr" `onException` hClose stdoutH
+        pure (Just stdoutH, Just stderrH)
+
+    closeDebugLogs :: (Maybe Handle, Maybe Handle) -> IO ()
+    closeDebugLogs (stdoutFile, stderrFile) = do
+      traverse_ hClose stdoutFile
+      traverse_ hClose stderrFile
+
     openLogFile :: FilePath -> Text -> IO Handle
     openLogFile debugDir stream = do
       handle <- openFile (debugDir </> toString (debugLogBasename <> "-" <> stream <> ".log")) WriteMode

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -4,6 +4,8 @@ module App.Fossa.Ficus.Analyze (
   analyzeWithFicus,
   -- Exported for use in hubble
   analyzeWithFicusMain,
+  -- Exported for reuse by other ficus subcommands
+  execFicusStreaming,
   -- Exported for testing
   singletonFicusMessage,
   vendoredDepsToSourceUnit,
@@ -39,6 +41,7 @@ import Control.Effect.Lift (Has, Lift, sendIO)
 import Control.Monad (when)
 import Data.Aeson (decode, decodeStrictText)
 import Data.Aeson qualified as Aeson
+import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BL
 import Data.Conduit ((.|))
 import Data.Conduit qualified as Conduit
@@ -63,11 +66,13 @@ import Srclib.Types (Locator (..), SourceUnit (..), SourceUnitBuild (..), Source
 import System.FilePath ((</>))
 import System.IO (Handle, IOMode (WriteMode), hClose, hPutStrLn, hSetEncoding, openFile, stderr, utf8)
 import System.Process.Typed (
+  byteStringInput,
   createPipe,
   getStderr,
   getStdout,
   proc,
   setStderr,
+  setStdin,
   setStdout,
   setWorkingDir,
   waitExitCode,
@@ -237,129 +242,82 @@ vendoredDepsToSourceUnit deps =
             , "path" Aeson..= path
             ]
 
-runFicus ::
-  ( Has Diagnostics sig m
-  , Has (Lift IO) sig m
+-- | Run ficus with its stdout decoded as a stream of NDJSON observations, both
+-- streams teed to the debug bundle, and stderr drained on its own thread so the
+-- child never blocks on a full pipe.
+--
+-- The caller owns the binary, the command, and what the observations mean. The
+-- exit code is reported, not judged: 'runFicus' has always soft-failed a
+-- non-zero exit and keeps doing so, while newer callers treat it as fatal.
+execFicusStreaming ::
+  forall sig m b.
+  ( Has (Lift IO) sig m
   , Has Logger sig m
   ) =>
+  Path Abs Dir ->
+  Command ->
+  Maybe ByteString ->
   Maybe FilePath ->
-  FicusConfig ->
-  m FicusAnalysisResults
-runFicus maybeDebugDir ficusConfig = do
-  logDebugWithTime "About to extract Ficus binary..."
-  withFicusBinary $ \bin -> do
-    logDebugWithTime "Ficus binary extracted, building command..."
-    cmd <- ficusCommand ficusConfig bin (isJust maybeDebugDir)
-    logDebugWithTime "Executing ficus (streaming)"
-    logDebug $ "Working directory: " <> pretty (toFilePath $ ficusConfigRootDir ficusConfig)
+  -- | Debug-log basename, before the @-stdout.log@ / @-stderr.log@ suffix.
+  Text ->
+  (b -> FicusMessage -> IO b) ->
+  b ->
+  m (b, ExitCode, [Text])
+execFicusStreaming workingDir cmd stdinPayload maybeDebugDir debugLogBasename step seed = do
+  logDebugWithTime "Creating process configuration..."
+  let processConfig =
+        maybe id (setStdin . byteStringInput . BL.fromStrict) stdinPayload
+          . setWorkingDir (toFilePath workingDir)
+          . setStdout createPipe
+          . setStderr createPipe
+          $ proc (toString $ cmdName cmd) (map toString $ cmdArgs cmd)
 
-    logDebugWithTime "Creating process configuration..."
-    let processConfig =
-          setWorkingDir (toFilePath $ ficusConfigRootDir ficusConfig) $
-            setStdout createPipe $
-              setStderr createPipe $
-                proc (toString $ cmdName cmd) (map toString $ cmdArgs cmd)
+  logDebugWithTime "Starting Ficus process..."
 
-    logInfo $ "Running Ficus analysis on " <> pretty (toFilePath $ ficusConfigRootDir ficusConfig)
-    logDebugWithTime "Starting Ficus process..."
+  (stdoutFile, stderrFile) <- case maybeDebugDir of
+    Just debugDir -> sendIO $ do
+      stdoutH <- openLogFile debugDir "stdout"
+      stderrH <- openLogFile debugDir "stderr"
+      pure (Just stdoutH, Just stderrH)
+    Nothing -> pure (Nothing, Nothing)
 
-    -- Create files for teeing output if debug mode is enabled
-    (stdoutFile, stderrFile) <- case maybeDebugDir of
-      Just debugDir -> do
-        sendIO $ do
-          let stdoutPath = debugDir </> "fossa.ficus-stdout.log"
-          let stderrPath = debugDir </> "fossa.ficus-stderr.log"
-          stdoutH <- openFile stdoutPath WriteMode
-          hSetEncoding stdoutH utf8
-          stderrH <- openFile stderrPath WriteMode
-          hSetEncoding stderrH utf8
-          pure (Just stdoutH, Just stderrH)
-      Nothing ->
-        -- No debug mode, don't tee to files
-        pure (Nothing, Nothing)
+  outcome <- sendIO $ withProcessWait processConfig $ \p -> do
+    getCurrentTime >>= \now -> hPutStrLn stderr $ "[TIMING " ++ formatTime defaultTimeLocale "%H:%M:%S.%3q" now ++ "] Ficus process started, beginning stream processing..."
+    -- Start async reading of stderr to prevent blocking
+    stderrAsync <- async $ consumeStderr (getStderr p) stderrFile
+    -- Read stdout in the main thread
+    accumulator <- streamFicusOutput (getStdout p) stdoutFile
+    -- Wait for stderr to finish
+    stdErrLines <- wait stderrAsync
+    exitCode <- waitExitCode p
+    pure (accumulator, exitCode, stdErrLines)
 
-    (result, exitCode, stdErrLines) <- sendIO $ withProcessWait processConfig $ \p -> do
-      getCurrentTime >>= \now -> hPutStrLn stderr $ "[TIMING " ++ formatTime defaultTimeLocale "%H:%M:%S.%3q" now ++ "] Ficus process started, beginning stream processing..."
-      let stdoutHandle = getStdout p
-      let stderrHandle = getStderr p
-      -- Start async reading of stderr to prevent blocking
-      stderrAsync <- async $ consumeStderr stderrHandle stderrFile
-      -- Read stdout in the main thread
-      result <- streamFicusOutput stdoutHandle stdoutFile
-      -- Wait for stderr to finish
-      stdErrLines <- wait stderrAsync
-      exitCode <- waitExitCode p
-      pure (result, exitCode, stdErrLines)
+  sendIO $ do
+    traverse_ hClose stdoutFile
+    traverse_ hClose stderrFile
 
-    sendIO $ do
-      traverse_ hClose stdoutFile
-      traverse_ hClose stderrFile
-
-    if exitCode /= ExitSuccess
-      then do
-        logInfo $
-          "[Ficus] Ficus process returned non-zero exit code. Printing last 50 lines of stderr: " <> pretty (show exitCode)
-        logInfo "\n==== BEGIN Ficus STDERR ====\n"
-        logInfo $ pretty (Text.unlines stdErrLines)
-        logInfo "\n==== END Ficus STDERR ====\n"
-      else logInfo "[Ficus] Ficus exited successfully"
-    pure result
+  pure outcome
   where
-    currentTimeStamp :: IO String
-    currentTimeStamp = do
-      now <- getCurrentTime
-      pure . formatTime defaultTimeLocale "%H:%M:%S.%3q" $ now
+    openLogFile :: FilePath -> Text -> IO Handle
+    openLogFile debugDir stream = do
+      handle <- openFile (debugDir </> toString (debugLogBasename <> "-" <> stream <> ".log")) WriteMode
+      hSetEncoding handle utf8
+      pure handle
 
-    streamFicusOutput :: Handle -> Maybe Handle -> IO FicusAnalysisResults
-    streamFicusOutput handle maybeFile = do
-      accumulator <-
-        Conduit.runConduit $
-          CC.sourceHandle handle
-            .| CC.decodeUtf8Lenient
-            .| CC.linesUnbounded
-            .| CC.mapM
-              ( \line -> do
-                  -- Tee raw line to file if debug mode
-                  traverse_ (\fileH -> hPutStrLn fileH (toString line)) maybeFile
-                  pure line
-              )
-            .| CCL.mapMaybe decodeStrictText
-            .| CC.foldM
-              ( \(currentSnippetResults, currentVendoredDeps) message -> do
-                  -- Log messages as they come, with timestamps
-                  timestamp <- currentTimeStamp
-                  case message of
-                    FicusMessageError err -> do
-                      hPutStrLn stderr $ "[" ++ timestamp ++ "] ERROR " <> toString (displayFicusError err)
-                      pure (currentSnippetResults, currentVendoredDeps)
-                    FicusMessageDebug dbg -> do
-                      hPutStrLn stderr $ "[" ++ timestamp ++ "] DEBUG " <> toString (displayFicusDebug dbg)
-                      pure (currentSnippetResults, currentVendoredDeps)
-                    FicusMessageFinding finding -> do
-                      hPutStrLn stderr $ "[" ++ timestamp ++ "] FINDING " <> toString (displayFicusFinding finding)
-                      let analysisFinding = findingToSnippetScanResult finding
-                      let vendoredDep = findingToVendoredDependency finding
-                      when (isJust currentSnippetResults && isJust analysisFinding) $
-                        hPutStrLn stderr $
-                          "[" ++ timestamp ++ "] ERROR " <> "Unexpected mutliple snippet scan results"
-                      let newSnippetResults = currentSnippetResults <|> analysisFinding
-                      let newVendoredDeps = case vendoredDep of
-                            Just dep -> dep : currentVendoredDeps
-                            Nothing -> currentVendoredDeps
-                      pure (newSnippetResults, newVendoredDeps)
-              )
-              (Nothing, [])
-
-      let (snippetResults, vendoredDeps) = accumulator
-      let vendoredResults = case vendoredDeps of
-            [] -> Nothing
-            deps -> Just . FicusVendoredDependencyScanResults . Just $ vendoredDepsToSourceUnit deps
-
-      pure $
-        FicusAnalysisResults
-          { snippetScanResults = snippetResults
-          , vendoredDependencyScanResults = vendoredResults
-          }
+    streamFicusOutput :: Handle -> Maybe Handle -> IO b
+    streamFicusOutput handle maybeFile =
+      Conduit.runConduit $
+        CC.sourceHandle handle
+          .| CC.decodeUtf8Lenient
+          .| CC.linesUnbounded
+          .| CC.mapM
+            ( \line -> do
+                -- Tee raw line to file if debug mode
+                traverse_ (\fileH -> hPutStrLn fileH (toString line)) maybeFile
+                pure line
+            )
+          .| CCL.mapMaybe decodeStrictText
+          .| CC.foldM step seed
 
     -- Use Conduit with decodeUtf8Lenient to safely handle UTF-8 output from ficus.
     -- This matches the approach used for stdout and prevents crashes on Windows
@@ -384,6 +342,80 @@ runFicus maybeDebugDir ficusConfig = do
               )
               []
       pure (reverse acc)
+
+runFicus ::
+  ( Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  ) =>
+  Maybe FilePath ->
+  FicusConfig ->
+  m FicusAnalysisResults
+runFicus maybeDebugDir ficusConfig = do
+  logDebugWithTime "About to extract Ficus binary..."
+  withFicusBinary $ \bin -> do
+    logDebugWithTime "Ficus binary extracted, building command..."
+    cmd <- ficusCommand ficusConfig bin (isJust maybeDebugDir)
+    logDebugWithTime "Executing ficus (streaming)"
+    logDebug $ "Working directory: " <> pretty (toFilePath rootDir)
+    logInfo $ "Running Ficus analysis on " <> pretty (toFilePath rootDir)
+
+    ((snippetResults, vendoredDeps), exitCode, stdErrLines) <-
+      execFicusStreaming rootDir cmd Nothing maybeDebugDir "fossa.ficus" accumulate (Nothing, [])
+
+    if exitCode /= ExitSuccess
+      then do
+        logInfo $
+          "[Ficus] Ficus process returned non-zero exit code. Printing last 50 lines of stderr: " <> pretty (show exitCode)
+        logInfo "\n==== BEGIN Ficus STDERR ====\n"
+        logInfo $ pretty (Text.unlines stdErrLines)
+        logInfo "\n==== END Ficus STDERR ====\n"
+      else logInfo "[Ficus] Ficus exited successfully"
+
+    let vendoredResults = case vendoredDeps of
+          [] -> Nothing
+          deps -> Just . FicusVendoredDependencyScanResults . Just $ vendoredDepsToSourceUnit deps
+    pure $
+      FicusAnalysisResults
+        { snippetScanResults = snippetResults
+        , vendoredDependencyScanResults = vendoredResults
+        }
+  where
+    rootDir :: Path Abs Dir
+    rootDir = ficusConfigRootDir ficusConfig
+
+    currentTimeStamp :: IO String
+    currentTimeStamp = do
+      now <- getCurrentTime
+      pure . formatTime defaultTimeLocale "%H:%M:%S.%3q" $ now
+
+    accumulate ::
+      (Maybe FicusSnippetScanResults, [FicusVendoredDependency]) ->
+      FicusMessage ->
+      IO (Maybe FicusSnippetScanResults, [FicusVendoredDependency])
+    accumulate (currentSnippetResults, currentVendoredDeps) message = do
+      -- Log messages as they come, with timestamps
+      timestamp <- currentTimeStamp
+      case message of
+        FicusMessageError err -> do
+          hPutStrLn stderr $ "[" ++ timestamp ++ "] ERROR " <> toString (displayFicusError err)
+          pure (currentSnippetResults, currentVendoredDeps)
+        FicusMessageDebug dbg -> do
+          hPutStrLn stderr $ "[" ++ timestamp ++ "] DEBUG " <> toString (displayFicusDebug dbg)
+          pure (currentSnippetResults, currentVendoredDeps)
+        FicusMessageFinding finding -> do
+          hPutStrLn stderr $ "[" ++ timestamp ++ "] FINDING " <> toString (displayFicusFinding finding)
+          let analysisFinding = findingToSnippetScanResult finding
+          let vendoredDep = findingToVendoredDependency finding
+          when (isJust currentSnippetResults && isJust analysisFinding) $
+            hPutStrLn stderr $
+              "[" ++ timestamp ++ "] ERROR " <> "Unexpected mutliple snippet scan results"
+          let newSnippetResults = currentSnippetResults <|> analysisFinding
+          let newVendoredDeps = case vendoredDep of
+                Just dep -> dep : currentVendoredDeps
+                Nothing -> currentVendoredDeps
+          pure (newSnippetResults, newVendoredDeps)
+
     displayFicusDebug :: FicusDebug -> Text
     displayFicusDebug (FicusDebug FicusMessageData{..}) = ficusMessageDataStrategy <> ": " <> ficusMessageDataPayload
     displayFicusError :: FicusError -> Text

--- a/src/App/Fossa/Ficus/Analyze.hs
+++ b/src/App/Fossa/Ficus/Analyze.hs
@@ -276,9 +276,9 @@ execFicusStreaming workingDir cmd stdinPayload maybeDebugDir debugLogBasename st
 
   logDebugWithTime "Starting Ficus process..."
 
-  bracket (sendIO openDebugLogs) (sendIO . closeDebugLogs) $ \(stdoutFile, stderrFile) ->
+  bracket (sendIO openDebugLogs) (sendIO . closeDebugLogs) $ \(stdoutFile, stderrFile) -> do
+    logDebugWithTime "Ficus process started, beginning stream processing..."
     sendIO . withProcessWait processConfig $ \p -> do
-      getCurrentTime >>= \now -> hPutStrLn stderr $ "[TIMING " ++ formatTime defaultTimeLocale "%H:%M:%S.%3q" now ++ "] Ficus process started, beginning stream processing..."
       -- Start async reading of stderr to prevent blocking
       stderrAsync <- async $ consumeStderr (getStderr p) stderrFile
       -- Read stdout in the main thread

--- a/src/App/Fossa/Ficus/Types.hs
+++ b/src/App/Fossa/Ficus/Types.hs
@@ -369,10 +369,12 @@ instance FromJSON WorkflowEvent where
           <*> obj .: "stderrTail"
       other -> fail $ "unknown workflow event type: " <> toString other
 
--- | Findings on any other strategy belong to another consumer.
-findingToWorkflowEvent :: FicusFinding -> Maybe WorkflowEvent
+-- | Findings on any other strategy belong to another consumer. A workflow
+-- payload this version cannot decode comes back as 'Left' holding it verbatim:
+-- dropping it silently reports version skew as "ficus produced no result".
+findingToWorkflowEvent :: FicusFinding -> Maybe (Either Text WorkflowEvent)
 findingToWorkflowEvent (FicusFinding (FicusMessageData strategy payload))
-  | Text.toLower strategy == "workflow" = decodeStrictText payload
+  | Text.toLower strategy == "workflow" = Just $ maybe (Left payload) Right (decodeStrictText payload)
 findingToWorkflowEvent _ = Nothing
 
 -- | Debug-bundle key the workflow result is recorded under.

--- a/src/App/Fossa/Ficus/Types.hs
+++ b/src/App/Fossa/Ficus/Types.hs
@@ -333,7 +333,7 @@ toWorkflowExecutable path
 
     isJsBundle :: Bool
     isJsBundle = case fileExtension path :: Maybe String of
-      Just ext -> ext `elem` [".js", ".mjs", ".cjs"]
+      Just ext -> Text.toLower (toText ext) `elem` [".js", ".mjs", ".cjs"]
       Nothing -> False
 
 -- | What ficus reports about a workflow run, carried as a JSON string in the

--- a/src/App/Fossa/Ficus/Types.hs
+++ b/src/App/Fossa/Ficus/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module App.Fossa.Ficus.Types (
   FicusConfig (..),
   FicusMessage (..),
@@ -22,15 +24,23 @@ module App.Fossa.Ficus.Types (
   FicusVendoredLocation (..),
   ficusVendoredLocationPath,
   FicusVendoredDependencyScanResults (..),
+  WorkflowExecutable (..),
+  WorkflowRunArtifact (..),
+  WorkflowEvent (..),
+  toWorkflowExecutable,
+  findingToWorkflowEvent,
+  workflowResultJson,
 ) where
 
 import App.Types (ProjectRevision)
-import Data.Aeson (FromJSON (parseJSON), Value (Object), withObject, withText)
+import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value (Object), decodeStrictText, object, withObject, withText, (.=))
 import Data.Aeson.Types (Parser, (.:), (.:?))
+import Data.String.Conversion (toString, toText)
 import Data.Text (Text)
+import Data.Text qualified as Text
 import Fossa.API.Types
 import GHC.Generics (Generic)
-import Path (Abs, Dir, Path)
+import Path (Abs, Dir, File, Path, fileExtension, toFilePath)
 import Srclib.Types (SourceUnit)
 import Text.URI
 import Types (GlobFilter)
@@ -271,3 +281,100 @@ data FicusVendettaFlag
   = VendettaCommonFlag FicusAnalysisFlag
   | VendettaBatchLen Int
   deriving (Show, Eq)
+
+-- | The program ficus should run, and the arguments that lead its command line.
+-- ficus appends the target and its own @--output@ after these.
+data WorkflowExecutable = WorkflowExecutable
+  { workflowExecutableProgram :: Text
+  , workflowExecutableArgs :: [Text]
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+-- | @Executable@ is the one type in the run artifact serde does /not/ rename, so
+-- its keys stay lowercase while the artifact around it is camelCase.
+instance ToJSON WorkflowExecutable where
+  toJSON WorkflowExecutable{..} =
+    object
+      [ "program" .= workflowExecutableProgram
+      , "args" .= workflowExecutableArgs
+      ]
+
+-- | The run artifact handed to @ficus x-workflow@ on stdin.
+data WorkflowRunArtifact = WorkflowRunArtifact
+  { workflowArtifactExecutable :: WorkflowExecutable
+  , workflowArtifactTarget :: Path Abs Dir
+  , workflowArtifactWorkingDirectory :: Path Abs Dir
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+-- | @version@ must be exactly 1: ficus rejects any other value rather than
+-- defaulting. @idleTimeoutSeconds@ and @totalTimeoutSeconds@ carry serde
+-- defaults on the ficus side and are deliberately omitted.
+instance ToJSON WorkflowRunArtifact where
+  toJSON WorkflowRunArtifact{..} =
+    object
+      [ "version" .= (1 :: Int)
+      , "executable" .= workflowArtifactExecutable
+      , "target" .= toFilePath workflowArtifactTarget
+      , "workingDirectory" .= toFilePath workflowArtifactWorkingDirectory
+      ]
+
+-- | ficus resolves @program@ to a file and requires the executable bit, so a
+-- plain JS bundle can never be the program itself. A non-JS path passes through
+-- unchanged: that is the wrapper-script escape hatch and the seam for a future
+-- compiled analyzer.
+toWorkflowExecutable :: Path Abs File -> WorkflowExecutable
+toWorkflowExecutable path
+  | isJsBundle = WorkflowExecutable "node" [rendered]
+  | otherwise = WorkflowExecutable rendered []
+  where
+    rendered :: Text
+    rendered = toText $ toFilePath path
+
+    isJsBundle :: Bool
+    isJsBundle = case fileExtension path :: Maybe String of
+      Just ext -> ext `elem` [".js", ".mjs", ".cjs"]
+      Nothing -> False
+
+-- | What ficus reports about a workflow run, carried as a JSON string in the
+-- observation payload of a @workflow@-strategy finding.
+data WorkflowEvent
+  = WorkflowStarted
+      { workflowResolvedProgram :: Text
+      , workflowAnalyzerVersion :: Text
+      }
+  | WorkflowStepCompleted Text
+  | WorkflowResult Value
+  | WorkflowFailed
+      { workflowFailureReason :: Text
+      , workflowFailureStderrTail :: Text
+      }
+  deriving (Eq, Show, Generic)
+
+-- | @exitCode@ and @timeout@ are dropped: both are optional on the wire and
+-- @reason@ already renders them in prose.
+instance FromJSON WorkflowEvent where
+  parseJSON = withObject "WorkflowEvent" $ \obj -> do
+    eventType <- obj .: "type" :: Parser Text
+    case eventType of
+      "workflow-started" ->
+        WorkflowStarted
+          <$> obj .: "resolvedProgram"
+          <*> obj .: "analyzerVersion"
+      "step-completed" -> WorkflowStepCompleted <$> obj .: "step"
+      "workflow-result" -> WorkflowResult <$> obj .: "result"
+      "workflow-failed" ->
+        WorkflowFailed
+          <$> obj .: "reason"
+          <*> obj .: "stderrTail"
+      other -> fail $ "unknown workflow event type: " <> toString other
+
+-- | Findings on any other strategy belong to another consumer.
+findingToWorkflowEvent :: FicusFinding -> Maybe WorkflowEvent
+findingToWorkflowEvent (FicusFinding (FicusMessageData strategy payload))
+  | Text.toLower strategy == "workflow" = decodeStrictText payload
+findingToWorkflowEvent _ = Nothing
+
+-- | Debug-bundle key the workflow result is recorded under.
+workflowResultJson :: Text
+workflowResultJson = "workflow.result.json"

--- a/src/App/Fossa/Ficus/Workflow.hs
+++ b/src/App/Fossa/Ficus/Workflow.hs
@@ -20,6 +20,7 @@ import Control.Effect.Lift (Has, Lift)
 import Control.Effect.Path (withSystemTempDir)
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BL
+import Data.Either (partitionEithers)
 import Data.Foldable (traverse_)
 import Data.Map qualified as Map
 import Data.String.Conversion (decodeUtf8, toText)
@@ -76,9 +77,11 @@ runWorkflowWith cmd target analyzer maybeDebugDir =
         artifactBytes = BL.toStrict $ Aeson.encode artifact
     logDebug $ "Workflow run artifact: " <> pretty (decodeUtf8 artifactBytes :: Text)
 
-    (events, exitCode, stdErrLines) <-
+    (collected, exitCode, stdErrLines) <-
       execFicusStreaming scratch cmd (Just artifactBytes) maybeDebugDir "fossa.ficus-workflow" collectWorkflowEvent []
 
+    let (undecodable, events) = partitionEithers collected
+    traverse_ reportUndecodable undecodable
     traverse_ reportEvent events
     case (exitCode, [value | WorkflowResult value <- events]) of
       (ExitSuccess, result : _) -> do
@@ -87,10 +90,15 @@ runWorkflowWith cmd target analyzer maybeDebugDir =
         logInfo "Workflow analysis complete"
       _ -> failWorkflow analyzer exitCode events stdErrLines
 
-collectWorkflowEvent :: [WorkflowEvent] -> FicusMessage -> IO [WorkflowEvent]
+collectWorkflowEvent :: [Either Text WorkflowEvent] -> FicusMessage -> IO [Either Text WorkflowEvent]
 collectWorkflowEvent acc (FicusMessageFinding finding) =
   pure $ maybe acc ((acc <>) . pure) (findingToWorkflowEvent finding)
 collectWorkflowEvent acc _ = pure acc
+
+-- | Debug level: a payload this version cannot read is version skew, and the
+-- exit code still decides the run.
+reportUndecodable :: (Has Logger sig m) => Text -> m ()
+reportUndecodable payload = logDebug $ "Undecodable workflow observation: " <> pretty payload
 
 reportEvent :: (Has Logger sig m) => WorkflowEvent -> m ()
 reportEvent = \case

--- a/src/App/Fossa/Ficus/Workflow.hs
+++ b/src/App/Fossa/Ficus/Workflow.hs
@@ -23,6 +23,7 @@ import Data.ByteString.Lazy qualified as BL
 import Data.Either (partitionEithers)
 import Data.Foldable (traverse_)
 import Data.Map qualified as Map
+import Data.Maybe (mapMaybe)
 import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -83,12 +84,20 @@ runWorkflowWith cmd target analyzer maybeDebugDir =
     let (undecodable, events) = partitionEithers collected
     traverse_ reportUndecodable undecodable
     traverse_ reportEvent events
-    case (exitCode, [value | WorkflowResult value <- events]) of
+    case (exitCode, mapMaybe workflowResult events) of
       (ExitSuccess, result : _) -> do
         debugMetadata workflowResultJson result
         logDebug $ "Workflow result: " <> pretty (decodeUtf8 (Aeson.encode result) :: Text)
         logInfo "Workflow analysis complete"
       _ -> failWorkflow analyzer exitCode events stdErrLines
+
+workflowResult :: WorkflowEvent -> Maybe Aeson.Value
+workflowResult (WorkflowResult value) = Just value
+workflowResult _ = Nothing
+
+failureReason :: WorkflowEvent -> Maybe Text
+failureReason (WorkflowFailed reason _) = Just reason
+failureReason _ = Nothing
 
 collectWorkflowEvent :: [Either Text WorkflowEvent] -> FicusMessage -> IO [Either Text WorkflowEvent]
 collectWorkflowEvent acc (FicusMessageFinding finding) =
@@ -135,7 +144,7 @@ failWorkflow analyzer exitCode events stdErrLines = do
         <> ")."
 
     reason :: Text
-    reason = case ([r | WorkflowFailed r _ <- events], exitCode) of
+    reason = case (mapMaybe failureReason events, exitCode) of
       (failure : _, _) -> failure
       ([], ExitSuccess) -> "ficus exited successfully but reported no result"
       ([], code) -> "ficus exited with " <> toText (show code)

--- a/src/App/Fossa/Ficus/Workflow.hs
+++ b/src/App/Fossa/Ficus/Workflow.hs
@@ -100,9 +100,11 @@ reportEvent = \case
   WorkflowResult _ -> pure ()
   WorkflowFailed reason _ -> logError $ "Workflow analyzer failed: " <> pretty reason
 
--- | ficus reports a preflight failure only through its exit code, and a clean
--- exit with no result is a bug rather than an empty answer. Both are fatal: the
--- user asked for this run by naming a path, so it must not pass silently.
+-- | Fatal on a non-zero exit or a missing result. ficus emits one terminal
+-- observation per run, so an observation usually supplies the reason, but the
+-- exit code is the signal a truncated stream cannot lose and is what decides.
+-- A clean exit with no result is a bug, not an empty answer: the user asked for
+-- this run by naming a path, so it must not pass silently.
 failWorkflow ::
   ( Has Diagnostics sig m
   , Has Logger sig m

--- a/src/App/Fossa/Ficus/Workflow.hs
+++ b/src/App/Fossa/Ficus/Workflow.hs
@@ -1,0 +1,136 @@
+module App.Fossa.Ficus.Workflow (
+  analyzeWithWorkflow,
+  -- Exported for testing: everything except which binary runs the workflow.
+  runWorkflowWith,
+) where
+
+import App.Fossa.EmbeddedBinary (toPath, withFicusBinary)
+import App.Fossa.Ficus.Analyze (execFicusStreaming)
+import App.Fossa.Ficus.Types (
+  FicusMessage (FicusMessageFinding),
+  WorkflowEvent (..),
+  WorkflowRunArtifact (..),
+  findingToWorkflowEvent,
+  toWorkflowExecutable,
+  workflowResultJson,
+ )
+import Control.Effect.Debug (Debug, debugMetadata)
+import Control.Effect.Diagnostics (Diagnostics, fatalText)
+import Control.Effect.Lift (Has, Lift)
+import Control.Effect.Path (withSystemTempDir)
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as BL
+import Data.Foldable (traverse_)
+import Data.Map qualified as Map
+import Data.String.Conversion (decodeUtf8, toText)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Effect.Exec (AllowErr (Never), Command (..), ExitCode (ExitSuccess))
+import Effect.Logger (Logger, logDebug, logError, logInfo, pretty)
+import Path (Abs, Dir, File, Path, toFilePath)
+
+-- | Run the workflow analyzer at the given path over @target@ through
+-- @ficus x-workflow@, streaming its observations. Nothing is uploaded: the
+-- result lands in the debug bundle and nowhere else.
+analyzeWithWorkflow ::
+  ( Has Debug sig m
+  , Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  ) =>
+  Path Abs Dir ->
+  Path Abs File ->
+  Maybe FilePath ->
+  m ()
+analyzeWithWorkflow target analyzer maybeDebugDir =
+  withFicusBinary $ \bin ->
+    runWorkflowWith (workflowCommand . toText $ toPath bin) target analyzer maybeDebugDir
+
+-- | @--config -@ puts the run artifact on stdin, so it never lands on the
+-- process table.
+workflowCommand :: Text -> Command
+workflowCommand ficus =
+  Command
+    { cmdName = ficus
+    , cmdArgs = ["x-workflow", "--config", "-"]
+    , cmdAllowErr = Never
+    , cmdEnvVars = Map.empty
+    }
+
+runWorkflowWith ::
+  ( Has Debug sig m
+  , Has Diagnostics sig m
+  , Has (Lift IO) sig m
+  , Has Logger sig m
+  ) =>
+  Command ->
+  Path Abs Dir ->
+  Path Abs File ->
+  Maybe FilePath ->
+  m ()
+runWorkflowWith cmd target analyzer maybeDebugDir =
+  -- The child writes a step cache and a per-run temp directory relative to its
+  -- working directory, so it must not be the repository under analysis.
+  withSystemTempDir "fossa-workflow" $ \scratch -> do
+    let artifact = WorkflowRunArtifact (toWorkflowExecutable analyzer) target scratch
+        artifactBytes = BL.toStrict $ Aeson.encode artifact
+    logDebug $ "Workflow run artifact: " <> pretty (decodeUtf8 artifactBytes :: Text)
+
+    (events, exitCode, stdErrLines) <-
+      execFicusStreaming scratch cmd (Just artifactBytes) maybeDebugDir "fossa.ficus-workflow" collectWorkflowEvent []
+
+    traverse_ reportEvent events
+    case (exitCode, [value | WorkflowResult value <- events]) of
+      (ExitSuccess, result : _) -> do
+        debugMetadata workflowResultJson result
+        logDebug $ "Workflow result: " <> pretty (decodeUtf8 (Aeson.encode result) :: Text)
+        logInfo "Workflow analysis complete"
+      _ -> failWorkflow analyzer exitCode events stdErrLines
+
+collectWorkflowEvent :: [WorkflowEvent] -> FicusMessage -> IO [WorkflowEvent]
+collectWorkflowEvent acc (FicusMessageFinding finding) =
+  pure $ maybe acc ((acc <>) . pure) (findingToWorkflowEvent finding)
+collectWorkflowEvent acc _ = pure acc
+
+reportEvent :: (Has Logger sig m) => WorkflowEvent -> m ()
+reportEvent = \case
+  WorkflowStarted resolvedProgram analyzerVersion ->
+    logInfo $ "Running workflow analyzer " <> pretty analyzerVersion <> " (" <> pretty resolvedProgram <> ")"
+  WorkflowStepCompleted step -> logInfo $ "  " <> pretty step <> " completed"
+  WorkflowResult _ -> pure ()
+  WorkflowFailed reason _ -> logError $ "Workflow analyzer failed: " <> pretty reason
+
+-- | ficus reports a preflight failure only through its exit code, and a clean
+-- exit with no result is a bug rather than an empty answer. Both are fatal: the
+-- user asked for this run by naming a path, so it must not pass silently.
+failWorkflow ::
+  ( Has Diagnostics sig m
+  , Has Logger sig m
+  ) =>
+  Path Abs File ->
+  ExitCode ->
+  [WorkflowEvent] ->
+  [Text] ->
+  m ()
+failWorkflow analyzer exitCode events stdErrLines = do
+  logError . pretty $ Text.unlines (summary : stderrTail)
+  fatalText summary
+  where
+    summary :: Text
+    summary =
+      "The workflow analyzer at "
+        <> toText (toFilePath analyzer)
+        <> " did not produce a result ("
+        <> reason
+        <> ")."
+
+    reason :: Text
+    reason = case ([r | WorkflowFailed r _ <- events], exitCode) of
+      (failure : _, _) -> failure
+      ([], ExitSuccess) -> "ficus exited successfully but reported no result"
+      ([], code) -> "ficus exited with " <> toText (show code)
+
+    stderrTail :: [Text]
+    stderrTail
+      | null stdErrLines = []
+      | otherwise = "==== BEGIN ficus stderr ====" : stdErrLines <> ["==== END ficus stderr ===="]

--- a/src/App/Fossa/Ficus/Workflow.hs
+++ b/src/App/Fossa/Ficus/Workflow.hs
@@ -115,7 +115,9 @@ reportEvent = \case
     logInfo $ "Running workflow analyzer " <> pretty analyzerVersion <> " (" <> pretty resolvedProgram <> ")"
   WorkflowStepCompleted step -> logInfo $ "  " <> pretty step <> " completed"
   WorkflowResult _ -> pure ()
-  WorkflowFailed reason _ -> logError $ "Workflow analyzer failed: " <> pretty reason
+  -- 'failWorkflow' renders the reason and fails on it; reporting it here as
+  -- well says the same thing twice before the error itself.
+  WorkflowFailed{} -> pure ()
 
 -- | Fatal on a non-zero exit or a missing result. ficus emits one terminal
 -- observation per run, so an observation usually supplies the reason, but the

--- a/test/App/Fossa/Config/AnalyzeSpec.hs
+++ b/test/App/Fossa/Config/AnalyzeSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module App.Fossa.Config.AnalyzeSpec (spec) where
 
@@ -15,15 +14,22 @@ import App.Fossa.Config.Utils (itShouldFailWhenLabelsExceedFive, itShouldLoadFro
 import App.Fossa.Lernie.Types (OrgWideCustomLicenseConfigPolicy (..))
 import Control.Effect.Diagnostics (Diagnostics, errorBoundary)
 import Control.Effect.Lift (Has, Lift, sendIO)
+import Control.Exception (throw)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Diag.Result (Result (Failure, Success), renderFailure)
 import Discovery.Filters (AllFilters (..), combinedTargets)
 import Effect.Logger (renderIt)
-import Path (Abs, Dir, File, Path, mkAbsFile, mkRelFile, toFilePath, (</>))
+import Path (Abs, Dir, File, Path, parseAbsFile, parseRelFile, toFilePath, (</>))
 import Test.Effect (expectFatal', expectationFailure', it', itWithTempDir', shouldBe', shouldEndWith')
 import Test.Hspec (Spec, describe)
 import Types (DiscoveredProjectType, TargetFilter (TypeTarget))
+
+-- | The fixtures below are valid paths on the platform the tests run on; a
+-- parse failure means the fixture itself is broken, so fail with the parse
+-- error rather than carrying it on to an assertion.
+mustParse :: (Show e) => (String -> Either e p) -> String -> p
+mustParse f s = either (throw . userError . show) id (f s)
 
 envVars :: EnvVars
 envVars =
@@ -38,9 +44,9 @@ envVars =
 
 configPath :: Path Abs File
 #ifdef mingw32_HOST_OS
-configPath = $(mkAbsFile "C:/.fossa.yml")
+configPath = mustParse parseAbsFile "C:/.fossa.yml"
 #else
-configPath = $(mkAbsFile "/tmp/.fossa.yml")
+configPath = mustParse parseAbsFile "/tmp/.fossa.yml"
 #endif
 
 configFileWithTargets :: [Text] -> [Text] -> Bool -> ConfigFile
@@ -187,7 +193,7 @@ spec = do
 -- | Create a file the CLI can resolve, so path resolution is never the reason a test fails.
 writeAnalyzer :: (Has (Lift IO) sig m) => Path Abs Dir -> m (Path Abs File)
 writeAnalyzer tmpDir = do
-  let analyzer = tmpDir </> $(mkRelFile "analyzer.js")
+  let analyzer = tmpDir </> mustParse parseRelFile "analyzer.js"
   sendIO $ writeFile (toFilePath analyzer) "// stub\n"
   pure analyzer
 

--- a/test/App/Fossa/Config/AnalyzeSpec.hs
+++ b/test/App/Fossa/Config/AnalyzeSpec.hs
@@ -4,7 +4,7 @@
 module App.Fossa.Config.AnalyzeSpec (spec) where
 
 import App.Fossa.Config.Analyze (
-  AnalyzeConfig (filterSet),
+  AnalyzeConfig (filterSet, xWorkflow),
   cliParser,
   loadConfig,
   mergeOpts,
@@ -13,10 +13,15 @@ import App.Fossa.Config.ConfigFile (ConfigFile (..), ConfigTargets (..))
 import App.Fossa.Config.EnvironmentVars (EnvVars (..))
 import App.Fossa.Config.Utils (itShouldFailWhenLabelsExceedFive, itShouldLoadFromTheConfiguredBaseDir, parseArgString)
 import App.Fossa.Lernie.Types (OrgWideCustomLicenseConfigPolicy (..))
+import Control.Effect.Diagnostics (Diagnostics, errorBoundary)
+import Control.Effect.Lift (Has, Lift, sendIO)
 import Data.Text (Text)
+import Data.Text qualified as Text
+import Diag.Result (Result (Failure, Success), renderFailure)
 import Discovery.Filters (AllFilters (..), combinedTargets)
-import Path (Abs, File, Path, mkAbsFile)
-import Test.Effect (expectFatal', expectationFailure', it', shouldBe')
+import Effect.Logger (renderIt)
+import Path (Abs, Dir, File, Path, mkAbsFile, mkRelFile, toFilePath, (</>))
+import Test.Effect (expectFatal', expectationFailure', it', itWithTempDir', shouldBe', shouldEndWith')
 import Test.Hspec (Spec, describe)
 import Types (DiscoveredProjectType, TargetFilter (TypeTarget))
 
@@ -152,3 +157,44 @@ spec = do
     it' "should fail when --x-vendetta and --output are used together" $ do
       cliOpts <- parseArgString cliParser "--x-vendetta --output"
       expectFatal' $ mergeOpts Nothing Nothing envVars cliOpts
+
+  describe "--x-workflow" $ do
+    it' "should default to Nothing when the flag is absent" $ do
+      cliOpts <- parseArgString cliParser ""
+      workflow <- xWorkflow <$> mergeOpts Nothing Nothing envVars cliOpts
+      workflow `shouldBe'` Nothing
+
+    itWithTempDir' "should resolve the flag to an absolute path" $ \tmpDir -> do
+      analyzer <- writeAnalyzer tmpDir
+      cliOpts <- parseArgString cliParser $ "--x-workflow " <> toFilePath analyzer
+      workflow <- xWorkflow <$> mergeOpts Nothing Nothing envVars cliOpts
+      case workflow of
+        Nothing -> expectationFailure' "expected --x-workflow to resolve to a path"
+        Just resolved -> toFilePath resolved `shouldEndWith'` "analyzer.js"
+
+    it' "should fail when the named analyzer does not exist" $ do
+      cliOpts <- parseArgString cliParser "--x-workflow /definitely/not/here/analyzer.js"
+      expectFatal' $ mergeOpts Nothing Nothing envVars cliOpts
+
+    itWithTempDir' "should fail when combined with --static-only-analysis" $ \tmpDir -> do
+      analyzer <- writeAnalyzer tmpDir
+      cliOpts <- parseArgString cliParser $ "--static-only-analysis --x-workflow " <> toFilePath analyzer
+      failureText <- renderedFailure $ mergeOpts Nothing Nothing envVars cliOpts
+      case failureText of
+        Nothing -> expectationFailure' "expected --static-only-analysis with --x-workflow to be fatal"
+        Just rendered -> Text.isInfixOf "--static-only-analysis" rendered `shouldBe'` True
+
+-- | Create a file the CLI can resolve, so path resolution is never the reason a test fails.
+writeAnalyzer :: (Has (Lift IO) sig m) => Path Abs Dir -> m (Path Abs File)
+writeAnalyzer tmpDir = do
+  let analyzer = tmpDir </> $(mkRelFile "analyzer.js")
+  sendIO $ writeFile (toFilePath analyzer) "// stub\n"
+  pure analyzer
+
+-- | 'expectFatal'' only reports that a failure happened; the message is what
+-- distinguishes the flag conflict from an unrelated failure on the same path.
+renderedFailure :: (Has (Lift IO) sig m, Has Diagnostics sig m) => m a -> m (Maybe Text)
+renderedFailure act =
+  errorBoundary act >>= \case
+    Failure ws eg -> pure . Just . renderIt $ renderFailure ws eg "An issue occurred"
+    Success _ _ -> pure Nothing

--- a/test/Ficus/WorkflowProcessSpec.hs
+++ b/test/Ficus/WorkflowProcessSpec.hs
@@ -17,7 +17,10 @@ import App.Fossa.Ficus.Types (
   WorkflowRunArtifact (WorkflowRunArtifact),
   findingToWorkflowEvent,
   toWorkflowExecutable,
+  workflowResultJson,
  )
+import App.Fossa.Ficus.Workflow (runWorkflowWith)
+import Control.Carrier.Debug (Scope (scopeMetadata), runDebug)
 import Control.Effect.Lift (Has, Lift, sendIO)
 import Data.Aeson qualified as Aeson
 import Data.ByteString (ByteString)
@@ -28,13 +31,15 @@ import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Effect.Exec (AllowErr (Never), Command (..), ExitCode (ExitFailure, ExitSuccess))
-import Path (Abs, Dir, Path, mkAbsDir, mkAbsFile, mkRelFile, toFilePath, (</>))
+import Path (Abs, Dir, File, Path, mkAbsDir, mkAbsFile, mkRelFile, toFilePath, (</>))
 import System.Directory (getPermissions, setOwnerExecutable, setPermissions)
-import Test.Effect (itWithTempDir', shouldBe', shouldSatisfy')
+import Test.Effect (expectFatal', itWithTempDir', shouldBe', shouldSatisfy')
 import Test.Hspec (Spec, describe)
 
 spec :: Spec
-spec = streamingSpec
+spec = do
+  streamingSpec
+  workflowSpec
 
 -- | ficus's own wire-contract assertion, rebuilt here so the fake speaks exactly
 -- what fossa-cli sees in production (@ficus/tests/it/workflow.rs:308-318@).
@@ -50,6 +55,17 @@ observationEnvelope payload =
             , "payload" Aeson..= payload
             , "strategy" Aeson..= ("workflow" :: Text)
             ]
+      ]
+
+workflowStartedPayload :: Text
+workflowStartedPayload =
+  decodeUtf8 . Aeson.encode $
+    Aeson.object
+      [ "type" Aeson..= ("workflow-started" :: Text)
+      , "ficusVersion" Aeson..= ("0.0.0" :: Text)
+      , "executable" Aeson..= Aeson.object ["program" Aeson..= ("node" :: Text), "args" Aeson..= ([] :: [Text])]
+      , "resolvedProgram" Aeson..= ("/usr/bin/node" :: Text)
+      , "analyzerVersion" Aeson..= ("unknown" :: Text)
       ]
 
 stepCompletedPayload :: Text
@@ -109,6 +125,9 @@ decodedEvents = mapMaybe toEvent
     toEvent (FicusMessageFinding finding) = findingToWorkflowEvent finding
     toEvent _ = Nothing
 
+analyzerBundle :: Path Abs Dir -> Path Abs File
+analyzerBundle dir = dir </> $(mkRelFile "analyzer.js")
+
 streamingSpec :: Spec
 streamingSpec = describe "execFicusStreaming" $ do
   itWithTempDir' "streams observations, delivers the artifact on stdin, and reports success" $ \tmpDir -> do
@@ -134,4 +153,19 @@ streamingSpec = describe "execFicusStreaming" $ do
     stderrLog <- sendIO . readFile . toFilePath $ tmpDir </> $(mkRelFile "fossa.ficus-workflow-stderr.log")
     toText stdoutLog `shouldSatisfy'` Text.isInfixOf (observationEnvelope stepCompletedPayload)
     toText stderrLog `shouldSatisfy'` Text.isInfixOf (decodeUtf8 runArtifactBytes)
+
+workflowSpec :: Spec
+workflowSpec = describe "analyzeWithWorkflow" $ do
+  itWithTempDir' "fails when ficus exits non-zero" $ \tmpDir -> do
+    cmd <- writeFakeFicus tmpDir [stepCompletedPayload] 1
+    expectFatal' $ runWorkflowWith cmd tmpDir (analyzerBundle tmpDir) Nothing
+
+  itWithTempDir' "fails when ficus exits cleanly without a result" $ \tmpDir -> do
+    cmd <- writeFakeFicus tmpDir [stepCompletedPayload] 0
+    expectFatal' $ runWorkflowWith cmd tmpDir (analyzerBundle tmpDir) Nothing
+
+  itWithTempDir' "records the result in the debug bundle on success" $ \tmpDir -> do
+    cmd <- writeFakeFicus tmpDir [workflowStartedPayload, stepCompletedPayload, workflowResultPayload] 0
+    (scope, ()) <- runDebug $ runWorkflowWith cmd tmpDir (analyzerBundle tmpDir) Nothing
+    Map.lookup workflowResultJson (scopeMetadata scope) `shouldBe'` Just expectedResult
 #endif

--- a/test/Ficus/WorkflowProcessSpec.hs
+++ b/test/Ficus/WorkflowProcessSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Ficus.WorkflowProcessSpec (spec) where
 
@@ -23,7 +22,7 @@ import App.Fossa.Ficus.Workflow (runWorkflowWith)
 import Control.Carrier.Debug (Scope (scopeMetadata), runDebug)
 import Control.Effect.Exception (SomeException, try)
 import Control.Effect.Lift (Has, Lift, sendIO)
-import Control.Exception (throwIO)
+import Control.Exception (throw, throwIO)
 import Data.Aeson qualified as Aeson
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BL
@@ -34,10 +33,16 @@ import Data.String.Conversion (decodeUtf8, toString, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Effect.Exec (AllowErr (Never), Command (..), ExitCode (ExitFailure, ExitSuccess))
-import Path (Abs, Dir, File, Path, mkAbsDir, mkAbsFile, mkRelFile, toFilePath, (</>))
+import Path (Abs, Dir, File, Path, parseAbsDir, parseAbsFile, parseRelFile, toFilePath, (</>))
 import System.Directory (getPermissions, setOwnerExecutable, setPermissions)
 import Test.Effect (expectFatal', itWithTempDir', shouldBe', shouldSatisfy')
 import Test.Hspec (Spec, describe)
+
+-- | The fixtures below are valid paths on the platform the tests run on; a
+-- parse failure means the fixture itself is broken, so fail with the parse
+-- error rather than carrying it on to an assertion.
+mustParse :: (Show e) => (String -> Either e p) -> String -> p
+mustParse f s = either (throw . userError . show) id (f s)
 
 spec :: Spec
 spec = do
@@ -101,7 +106,7 @@ fakeFicus payloads exitCode =
 
 writeFakeFicus :: (Has (Lift IO) sig m) => Path Abs Dir -> [Text] -> Int -> m Command
 writeFakeFicus dir payloads exitCode = do
-  let script = dir </> $(mkRelFile "fake-ficus.sh")
+  let script = dir </> mustParse parseRelFile "fake-ficus.sh"
   sendIO $ do
     writeFile (toFilePath script) (toString $ fakeFicus payloads exitCode)
     permissions <- getPermissions (toFilePath script)
@@ -117,7 +122,10 @@ writeFakeFicus dir payloads exitCode = do
 runArtifactBytes :: ByteString
 runArtifactBytes =
   BL.toStrict . Aeson.encode $
-    WorkflowRunArtifact (toWorkflowExecutable $(mkAbsFile "/abs/dist/analyzer.js")) $(mkAbsDir "/abs/repo") $(mkAbsDir "/abs/scratch")
+    WorkflowRunArtifact
+      (toWorkflowExecutable (mustParse parseAbsFile "/abs/dist/analyzer.js"))
+      (mustParse parseAbsDir "/abs/repo")
+      (mustParse parseAbsDir "/abs/scratch")
 
 collectMessages :: [FicusMessage] -> FicusMessage -> IO [FicusMessage]
 collectMessages acc message = pure (acc <> [message])
@@ -134,7 +142,7 @@ decodedEvents = rights . mapMaybe toEvent
     toEvent _ = Nothing
 
 analyzerBundle :: Path Abs Dir -> Path Abs File
-analyzerBundle dir = dir </> $(mkRelFile "analyzer.js")
+analyzerBundle dir = dir </> mustParse parseRelFile "analyzer.js"
 
 streamingSpec :: Spec
 streamingSpec = describe "execFicusStreaming" $ do
@@ -157,8 +165,8 @@ streamingSpec = describe "execFicusStreaming" $ do
     cmd <- writeFakeFicus tmpDir happyPayloads 0
     _ <-
       execFicusStreaming tmpDir cmd (Just runArtifactBytes) (Just $ toFilePath tmpDir) "fossa.ficus-workflow" collectMessages ([] :: [FicusMessage])
-    stdoutLog <- sendIO . readFile . toFilePath $ tmpDir </> $(mkRelFile "fossa.ficus-workflow-stdout.log")
-    stderrLog <- sendIO . readFile . toFilePath $ tmpDir </> $(mkRelFile "fossa.ficus-workflow-stderr.log")
+    stdoutLog <- sendIO . readFile . toFilePath $ tmpDir </> mustParse parseRelFile "fossa.ficus-workflow-stdout.log"
+    stderrLog <- sendIO . readFile . toFilePath $ tmpDir </> mustParse parseRelFile "fossa.ficus-workflow-stderr.log"
     toText stdoutLog `shouldSatisfy'` Text.isInfixOf (observationEnvelope stepCompletedPayload)
     toText stderrLog `shouldSatisfy'` Text.isInfixOf (decodeUtf8 runArtifactBytes)
 
@@ -168,7 +176,7 @@ streamingSpec = describe "execFicusStreaming" $ do
       try $
         execFicusStreaming tmpDir cmd (Just runArtifactBytes) (Just $ toFilePath tmpDir) "fossa.ficus-throwing" explodingStep ([] :: [FicusMessage])
     (outcome :: Either SomeException ([FicusMessage], ExitCode, [Text])) `shouldSatisfy'` isLeft
-    stdoutLog <- sendIO . readFile . toFilePath $ tmpDir </> $(mkRelFile "fossa.ficus-throwing-stdout.log")
+    stdoutLog <- sendIO . readFile . toFilePath $ tmpDir </> mustParse parseRelFile "fossa.ficus-throwing-stdout.log"
     toText stdoutLog `shouldSatisfy'` Text.isInfixOf (observationEnvelope stepCompletedPayload)
 
 workflowSpec :: Spec

--- a/test/Ficus/WorkflowProcessSpec.hs
+++ b/test/Ficus/WorkflowProcessSpec.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Ficus.WorkflowProcessSpec (spec) where
+
+#ifdef mingw32_HOST_OS
+import Test.Hspec (Spec)
+
+-- The fake ficus is a @/bin/sh@ script, which the Windows CI runner does not have.
+spec :: Spec
+spec = pure ()
+#else
+import App.Fossa.Ficus.Analyze (execFicusStreaming)
+import App.Fossa.Ficus.Types (
+  FicusMessage (FicusMessageFinding),
+  WorkflowEvent (WorkflowResult, WorkflowStepCompleted),
+  WorkflowRunArtifact (WorkflowRunArtifact),
+  findingToWorkflowEvent,
+  toWorkflowExecutable,
+ )
+import Control.Effect.Lift (Has, Lift, sendIO)
+import Data.Aeson qualified as Aeson
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as BL
+import Data.Map qualified as Map
+import Data.Maybe (mapMaybe)
+import Data.String.Conversion (decodeUtf8, toString, toText)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Effect.Exec (AllowErr (Never), Command (..), ExitCode (ExitFailure, ExitSuccess))
+import Path (Abs, Dir, Path, mkAbsDir, mkAbsFile, mkRelFile, toFilePath, (</>))
+import System.Directory (getPermissions, setOwnerExecutable, setPermissions)
+import Test.Effect (itWithTempDir', shouldBe', shouldSatisfy')
+import Test.Hspec (Spec, describe)
+
+spec :: Spec
+spec = streamingSpec
+
+-- | ficus's own wire-contract assertion, rebuilt here so the fake speaks exactly
+-- what fossa-cli sees in production (@ficus/tests/it/workflow.rs:308-318@).
+observationEnvelope :: Text -> Text
+observationEnvelope payload =
+  decodeUtf8 . Aeson.encode $
+    Aeson.object
+      [ "version" Aeson..= (1 :: Int)
+      , "level" Aeson..= ("INFO" :: Text)
+      , "observation"
+          Aeson..= Aeson.object
+            [ "kind" Aeson..= ("finding" :: Text)
+            , "payload" Aeson..= payload
+            , "strategy" Aeson..= ("workflow" :: Text)
+            ]
+      ]
+
+stepCompletedPayload :: Text
+stepCompletedPayload =
+  decodeUtf8 . Aeson.encode $
+    Aeson.object ["type" Aeson..= ("step-completed" :: Text), "step" Aeson..= ("module-discovery" :: Text)]
+
+workflowResultPayload :: Text
+workflowResultPayload =
+  decodeUtf8 . Aeson.encode $
+    Aeson.object
+      [ "type" Aeson..= ("workflow-result" :: Text)
+      , "result" Aeson..= expectedResult
+      ]
+
+expectedResult :: Aeson.Value
+expectedResult = Aeson.object ["schemaVersion" Aeson..= (1 :: Int)]
+
+happyPayloads :: [Text]
+happyPayloads = [stepCompletedPayload, workflowResultPayload]
+
+-- | A fake ficus: emits the given observations, copies its stdin to stderr so a
+-- test can prove the run artifact arrived there, and exits with the given code.
+fakeFicus :: [Text] -> Int -> Text
+fakeFicus payloads exitCode =
+  Text.unlines $
+    ["#!/bin/sh"]
+      <> map (\payload -> "printf '%s\\n' '" <> observationEnvelope payload <> "'") payloads
+      <> ["cat >&2", "exit " <> toText (show exitCode)]
+
+writeFakeFicus :: (Has (Lift IO) sig m) => Path Abs Dir -> [Text] -> Int -> m Command
+writeFakeFicus dir payloads exitCode = do
+  let script = dir </> $(mkRelFile "fake-ficus.sh")
+  sendIO $ do
+    writeFile (toFilePath script) (toString $ fakeFicus payloads exitCode)
+    permissions <- getPermissions (toFilePath script)
+    setPermissions (toFilePath script) (setOwnerExecutable True permissions)
+  pure
+    Command
+      { cmdName = toText $ toFilePath script
+      , cmdArgs = []
+      , cmdAllowErr = Never
+      , cmdEnvVars = Map.empty
+      }
+
+runArtifactBytes :: ByteString
+runArtifactBytes =
+  BL.toStrict . Aeson.encode $
+    WorkflowRunArtifact (toWorkflowExecutable $(mkAbsFile "/abs/dist/analyzer.js")) $(mkAbsDir "/abs/repo") $(mkAbsDir "/abs/scratch")
+
+collectMessages :: [FicusMessage] -> FicusMessage -> IO [FicusMessage]
+collectMessages acc message = pure (acc <> [message])
+
+decodedEvents :: [FicusMessage] -> [WorkflowEvent]
+decodedEvents = mapMaybe toEvent
+  where
+    toEvent (FicusMessageFinding finding) = findingToWorkflowEvent finding
+    toEvent _ = Nothing
+
+streamingSpec :: Spec
+streamingSpec = describe "execFicusStreaming" $ do
+  itWithTempDir' "streams observations, delivers the artifact on stdin, and reports success" $ \tmpDir -> do
+    cmd <- writeFakeFicus tmpDir happyPayloads 0
+    (messages, exitCode, stdErrLines) <-
+      execFicusStreaming tmpDir cmd (Just runArtifactBytes) Nothing "fossa.ficus-workflow" collectMessages []
+    decodedEvents messages
+      `shouldBe'` [WorkflowStepCompleted "module-discovery", WorkflowResult expectedResult]
+    stdErrLines `shouldSatisfy'` any (Text.isInfixOf (decodeUtf8 runArtifactBytes))
+    exitCode `shouldBe'` ExitSuccess
+
+  itWithTempDir' "reports a non-zero exit rather than swallowing it" $ \tmpDir -> do
+    cmd <- writeFakeFicus tmpDir happyPayloads 3
+    (_, exitCode, _) <-
+      execFicusStreaming tmpDir cmd (Just runArtifactBytes) Nothing "fossa.ficus-workflow" collectMessages ([] :: [FicusMessage])
+    exitCode `shouldBe'` ExitFailure 3
+
+  itWithTempDir' "writes debug logs under the basename it was given" $ \tmpDir -> do
+    cmd <- writeFakeFicus tmpDir happyPayloads 0
+    _ <-
+      execFicusStreaming tmpDir cmd (Just runArtifactBytes) (Just $ toFilePath tmpDir) "fossa.ficus-workflow" collectMessages ([] :: [FicusMessage])
+    stdoutLog <- sendIO . readFile . toFilePath $ tmpDir </> $(mkRelFile "fossa.ficus-workflow-stdout.log")
+    stderrLog <- sendIO . readFile . toFilePath $ tmpDir </> $(mkRelFile "fossa.ficus-workflow-stderr.log")
+    toText stdoutLog `shouldSatisfy'` Text.isInfixOf (observationEnvelope stepCompletedPayload)
+    toText stderrLog `shouldSatisfy'` Text.isInfixOf (decodeUtf8 runArtifactBytes)
+#endif

--- a/test/Ficus/WorkflowProcessSpec.hs
+++ b/test/Ficus/WorkflowProcessSpec.hs
@@ -25,6 +25,7 @@ import Control.Effect.Lift (Has, Lift, sendIO)
 import Data.Aeson qualified as Aeson
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BL
+import Data.Either (rights)
 import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.String.Conversion (decodeUtf8, toString, toText)
@@ -120,7 +121,7 @@ collectMessages :: [FicusMessage] -> FicusMessage -> IO [FicusMessage]
 collectMessages acc message = pure (acc <> [message])
 
 decodedEvents :: [FicusMessage] -> [WorkflowEvent]
-decodedEvents = mapMaybe toEvent
+decodedEvents = rights . mapMaybe toEvent
   where
     toEvent (FicusMessageFinding finding) = findingToWorkflowEvent finding
     toEvent _ = Nothing

--- a/test/Ficus/WorkflowProcessSpec.hs
+++ b/test/Ficus/WorkflowProcessSpec.hs
@@ -21,11 +21,13 @@ import App.Fossa.Ficus.Types (
  )
 import App.Fossa.Ficus.Workflow (runWorkflowWith)
 import Control.Carrier.Debug (Scope (scopeMetadata), runDebug)
+import Control.Effect.Exception (SomeException, try)
 import Control.Effect.Lift (Has, Lift, sendIO)
+import Control.Exception (throwIO)
 import Data.Aeson qualified as Aeson
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BL
-import Data.Either (rights)
+import Data.Either (isLeft, rights)
 import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.String.Conversion (decodeUtf8, toString, toText)
@@ -120,6 +122,11 @@ runArtifactBytes =
 collectMessages :: [FicusMessage] -> FicusMessage -> IO [FicusMessage]
 collectMessages acc message = pure (acc <> [message])
 
+-- | Fails the stream mid-run, after the first observation has been teed to the
+-- debug log but before the run can end normally.
+explodingStep :: [FicusMessage] -> FicusMessage -> IO [FicusMessage]
+explodingStep _ _ = throwIO $ userError "stream processing exploded"
+
 decodedEvents :: [FicusMessage] -> [WorkflowEvent]
 decodedEvents = rights . mapMaybe toEvent
   where
@@ -154,6 +161,15 @@ streamingSpec = describe "execFicusStreaming" $ do
     stderrLog <- sendIO . readFile . toFilePath $ tmpDir </> $(mkRelFile "fossa.ficus-workflow-stderr.log")
     toText stdoutLog `shouldSatisfy'` Text.isInfixOf (observationEnvelope stepCompletedPayload)
     toText stderrLog `shouldSatisfy'` Text.isInfixOf (decodeUtf8 runArtifactBytes)
+
+  itWithTempDir' "closes the debug logs when stream processing throws" $ \tmpDir -> do
+    cmd <- writeFakeFicus tmpDir happyPayloads 0
+    outcome <-
+      try $
+        execFicusStreaming tmpDir cmd (Just runArtifactBytes) (Just $ toFilePath tmpDir) "fossa.ficus-throwing" explodingStep ([] :: [FicusMessage])
+    (outcome :: Either SomeException ([FicusMessage], ExitCode, [Text])) `shouldSatisfy'` isLeft
+    stdoutLog <- sendIO . readFile . toFilePath $ tmpDir </> $(mkRelFile "fossa.ficus-throwing-stdout.log")
+    toText stdoutLog `shouldSatisfy'` Text.isInfixOf (observationEnvelope stepCompletedPayload)
 
 workflowSpec :: Spec
 workflowSpec = describe "analyzeWithWorkflow" $ do

--- a/test/Ficus/WorkflowSpec.hs
+++ b/test/Ficus/WorkflowSpec.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Ficus.WorkflowSpec (spec) where
+
+import App.Fossa.Ficus.Types (
+  FicusFinding (FicusFinding),
+  FicusMessageData (FicusMessageData),
+  WorkflowEvent (..),
+  WorkflowExecutable (WorkflowExecutable),
+  WorkflowRunArtifact (WorkflowRunArtifact),
+  findingToWorkflowEvent,
+  toWorkflowExecutable,
+ )
+import Data.Aeson qualified as Aeson
+import Data.Either (isLeft)
+import Data.String.Conversion (decodeUtf8, toText)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Path (Abs, Dir, File, Path, mkAbsDir, mkAbsFile, toFilePath)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+targetDir :: Path Abs Dir
+workDir :: Path Abs Dir
+jsBundle :: Path Abs File
+mjsBundle :: Path Abs File
+cjsBundle :: Path Abs File
+nativeAnalyzer :: Path Abs File
+#ifdef mingw32_HOST_OS
+targetDir = $(mkAbsDir "C:/repo")
+workDir = $(mkAbsDir "C:/scratch")
+jsBundle = $(mkAbsFile "C:/dist/analyzer.js")
+mjsBundle = $(mkAbsFile "C:/dist/analyzer.mjs")
+cjsBundle = $(mkAbsFile "C:/dist/analyzer.cjs")
+nativeAnalyzer = $(mkAbsFile "C:/bin/analyzer")
+#else
+targetDir = $(mkAbsDir "/abs/repo")
+workDir = $(mkAbsDir "/abs/scratch")
+jsBundle = $(mkAbsFile "/abs/dist/analyzer.js")
+mjsBundle = $(mkAbsFile "/abs/dist/analyzer.mjs")
+cjsBundle = $(mkAbsFile "/abs/dist/analyzer.cjs")
+nativeAnalyzer = $(mkAbsFile "/usr/local/bin/analyzer")
+#endif
+
+-- | The wire contract with @ficus x-workflow@. Every key name, the schema
+-- version and the inferred program are literal here; only the paths are
+-- rendered, so the same expectation holds on Windows.
+expectedArtifactJson :: Text
+expectedArtifactJson =
+  Text.concat
+    [ "{\"version\":1"
+    , ",\"executable\":{\"program\":\"node\",\"args\":["
+    , jsonString jsBundle
+    , "]}"
+    , ",\"target\":"
+    , jsonString targetDir
+    , ",\"workingDirectory\":"
+    , jsonString workDir
+    , "}"
+    ]
+  where
+    jsonString :: Path Abs t -> Text
+    jsonString = decodeUtf8 . Aeson.encode . toFilePath
+
+payloadFinding :: Text -> FicusFinding
+payloadFinding = FicusFinding . FicusMessageData "workflow"
+
+spec :: Spec
+spec = do
+  describe "run artifact encoding" $ do
+    it "matches the JSON ficus parses" $ do
+      let artifact = WorkflowRunArtifact (toWorkflowExecutable jsBundle) targetDir workDir
+      Just (Aeson.toJSON artifact) `shouldBe` Aeson.decodeStrictText expectedArtifactJson
+
+  describe "program inference" $ do
+    it "runs a .js bundle under node" $
+      toWorkflowExecutable jsBundle `shouldBe` WorkflowExecutable "node" [toText $ toFilePath jsBundle]
+
+    it "runs a .mjs bundle under node" $
+      toWorkflowExecutable mjsBundle `shouldBe` WorkflowExecutable "node" [toText $ toFilePath mjsBundle]
+
+    it "runs a .cjs bundle under node" $
+      toWorkflowExecutable cjsBundle `shouldBe` WorkflowExecutable "node" [toText $ toFilePath cjsBundle]
+
+    it "passes any other path through as the program itself" $
+      toWorkflowExecutable nativeAnalyzer `shouldBe` WorkflowExecutable (toText $ toFilePath nativeAnalyzer) []
+
+  describe "workflow event decoding" $ do
+    it "decodes workflow-started" $
+      findingToWorkflowEvent (payloadFinding "{\"type\":\"workflow-started\",\"ficusVersion\":\"1.2.3\",\"executable\":{\"program\":\"node\",\"args\":[]},\"resolvedProgram\":\"/usr/bin/node\",\"analyzerVersion\":\"unknown\"}")
+        `shouldBe` Just (WorkflowStarted "/usr/bin/node" "unknown")
+
+    it "decodes step-completed" $
+      findingToWorkflowEvent (payloadFinding "{\"type\":\"step-completed\",\"step\":\"module-discovery\"}")
+        `shouldBe` Just (WorkflowStepCompleted "module-discovery")
+
+    it "decodes workflow-result" $
+      findingToWorkflowEvent (payloadFinding "{\"type\":\"workflow-result\",\"result\":{\"schemaVersion\":1,\"packages\":[]}}")
+        `shouldBe` Just (WorkflowResult (Aeson.object ["schemaVersion" Aeson..= (1 :: Int), "packages" Aeson..= ([] :: [Aeson.Value])]))
+
+    it "decodes workflow-failed carrying an exitCode" $
+      findingToWorkflowEvent (payloadFinding "{\"type\":\"workflow-failed\",\"reason\":\"workflow executable exited with code 3\",\"exitCode\":3,\"stderrTail\":\"boom\"}")
+        `shouldBe` Just (WorkflowFailed "workflow executable exited with code 3" "boom")
+
+    it "decodes workflow-failed carrying a timeout" $
+      findingToWorkflowEvent (payloadFinding "{\"type\":\"workflow-failed\",\"reason\":\"workflow executable ran longer than 900 seconds\",\"timeout\":\"total\",\"stderrTail\":\"boom\"}")
+        `shouldBe` Just (WorkflowFailed "workflow executable ran longer than 900 seconds" "boom")
+
+    it "ignores findings from another strategy" $
+      findingToWorkflowEvent (FicusFinding (FicusMessageData "vendetta" "{\"type\":\"step-completed\",\"step\":\"module-discovery\"}"))
+        `shouldBe` Nothing
+
+    it "rejects an unrecognised event type rather than decoding it" $
+      (Aeson.eitherDecodeStrictText "{\"type\":\"workflow-adjourned\"}" :: Either String WorkflowEvent)
+        `shouldSatisfy` isLeft

--- a/test/Ficus/WorkflowSpec.hs
+++ b/test/Ficus/WorkflowSpec.hs
@@ -25,6 +25,7 @@ workDir :: Path Abs Dir
 jsBundle :: Path Abs File
 mjsBundle :: Path Abs File
 cjsBundle :: Path Abs File
+upperJsBundle :: Path Abs File
 nativeAnalyzer :: Path Abs File
 #ifdef mingw32_HOST_OS
 targetDir = $(mkAbsDir "C:/repo")
@@ -32,6 +33,7 @@ workDir = $(mkAbsDir "C:/scratch")
 jsBundle = $(mkAbsFile "C:/dist/analyzer.js")
 mjsBundle = $(mkAbsFile "C:/dist/analyzer.mjs")
 cjsBundle = $(mkAbsFile "C:/dist/analyzer.cjs")
+upperJsBundle = $(mkAbsFile "C:/dist/analyzer.JS")
 nativeAnalyzer = $(mkAbsFile "C:/bin/analyzer")
 #else
 targetDir = $(mkAbsDir "/abs/repo")
@@ -39,6 +41,7 @@ workDir = $(mkAbsDir "/abs/scratch")
 jsBundle = $(mkAbsFile "/abs/dist/analyzer.js")
 mjsBundle = $(mkAbsFile "/abs/dist/analyzer.mjs")
 cjsBundle = $(mkAbsFile "/abs/dist/analyzer.cjs")
+upperJsBundle = $(mkAbsFile "/abs/dist/analyzer.JS")
 nativeAnalyzer = $(mkAbsFile "/usr/local/bin/analyzer")
 #endif
 
@@ -81,6 +84,9 @@ spec = do
 
     it "runs a .cjs bundle under node" $
       toWorkflowExecutable cjsBundle `shouldBe` WorkflowExecutable "node" [toText $ toFilePath cjsBundle]
+
+    it "runs an uppercase .JS bundle under node" $
+      toWorkflowExecutable upperJsBundle `shouldBe` WorkflowExecutable "node" [toText $ toFilePath upperJsBundle]
 
     it "passes any other path through as the program itself" $
       toWorkflowExecutable nativeAnalyzer `shouldBe` WorkflowExecutable (toText $ toFilePath nativeAnalyzer) []

--- a/test/Ficus/WorkflowSpec.hs
+++ b/test/Ficus/WorkflowSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Ficus.WorkflowSpec (spec) where
 
@@ -12,13 +11,20 @@ import App.Fossa.Ficus.Types (
   findingToWorkflowEvent,
   toWorkflowExecutable,
  )
+import Control.Exception (throw)
 import Data.Aeson qualified as Aeson
 import Data.Either (isLeft)
 import Data.String.Conversion (decodeUtf8, toText)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Path (Abs, Dir, File, Path, mkAbsDir, mkAbsFile, toFilePath)
+import Path (Abs, Dir, File, Path, parseAbsDir, parseAbsFile, toFilePath)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+-- | The fixtures below are valid paths only on the platform they are written
+-- for; a parse failure means the fixture itself is broken, so fail with the
+-- parse error rather than carrying it on to an assertion.
+mustParse :: (Show e) => (String -> Either e p) -> String -> p
+mustParse f s = either (throw . userError . show) id (f s)
 
 targetDir :: Path Abs Dir
 workDir :: Path Abs Dir
@@ -28,21 +34,21 @@ cjsBundle :: Path Abs File
 upperJsBundle :: Path Abs File
 nativeAnalyzer :: Path Abs File
 #ifdef mingw32_HOST_OS
-targetDir = $(mkAbsDir "C:/repo")
-workDir = $(mkAbsDir "C:/scratch")
-jsBundle = $(mkAbsFile "C:/dist/analyzer.js")
-mjsBundle = $(mkAbsFile "C:/dist/analyzer.mjs")
-cjsBundle = $(mkAbsFile "C:/dist/analyzer.cjs")
-upperJsBundle = $(mkAbsFile "C:/dist/analyzer.JS")
-nativeAnalyzer = $(mkAbsFile "C:/bin/analyzer")
+targetDir = mustParse parseAbsDir "C:/repo"
+workDir = mustParse parseAbsDir "C:/scratch"
+jsBundle = mustParse parseAbsFile "C:/dist/analyzer.js"
+mjsBundle = mustParse parseAbsFile "C:/dist/analyzer.mjs"
+cjsBundle = mustParse parseAbsFile "C:/dist/analyzer.cjs"
+upperJsBundle = mustParse parseAbsFile "C:/dist/analyzer.JS"
+nativeAnalyzer = mustParse parseAbsFile "C:/bin/analyzer"
 #else
-targetDir = $(mkAbsDir "/abs/repo")
-workDir = $(mkAbsDir "/abs/scratch")
-jsBundle = $(mkAbsFile "/abs/dist/analyzer.js")
-mjsBundle = $(mkAbsFile "/abs/dist/analyzer.mjs")
-cjsBundle = $(mkAbsFile "/abs/dist/analyzer.cjs")
-upperJsBundle = $(mkAbsFile "/abs/dist/analyzer.JS")
-nativeAnalyzer = $(mkAbsFile "/usr/local/bin/analyzer")
+targetDir = mustParse parseAbsDir "/abs/repo"
+workDir = mustParse parseAbsDir "/abs/scratch"
+jsBundle = mustParse parseAbsFile "/abs/dist/analyzer.js"
+mjsBundle = mustParse parseAbsFile "/abs/dist/analyzer.mjs"
+cjsBundle = mustParse parseAbsFile "/abs/dist/analyzer.cjs"
+upperJsBundle = mustParse parseAbsFile "/abs/dist/analyzer.JS"
+nativeAnalyzer = mustParse parseAbsFile "/usr/local/bin/analyzer"
 #endif
 
 -- | The wire contract with @ficus x-workflow@. Every key name, the schema

--- a/test/Ficus/WorkflowSpec.hs
+++ b/test/Ficus/WorkflowSpec.hs
@@ -94,27 +94,31 @@ spec = do
   describe "workflow event decoding" $ do
     it "decodes workflow-started" $
       findingToWorkflowEvent (payloadFinding "{\"type\":\"workflow-started\",\"ficusVersion\":\"1.2.3\",\"executable\":{\"program\":\"node\",\"args\":[]},\"resolvedProgram\":\"/usr/bin/node\",\"analyzerVersion\":\"unknown\"}")
-        `shouldBe` Just (WorkflowStarted "/usr/bin/node" "unknown")
+        `shouldBe` Just (Right (WorkflowStarted "/usr/bin/node" "unknown"))
 
     it "decodes step-completed" $
       findingToWorkflowEvent (payloadFinding "{\"type\":\"step-completed\",\"step\":\"module-discovery\"}")
-        `shouldBe` Just (WorkflowStepCompleted "module-discovery")
+        `shouldBe` Just (Right (WorkflowStepCompleted "module-discovery"))
 
     it "decodes workflow-result" $
       findingToWorkflowEvent (payloadFinding "{\"type\":\"workflow-result\",\"result\":{\"schemaVersion\":1,\"packages\":[]}}")
-        `shouldBe` Just (WorkflowResult (Aeson.object ["schemaVersion" Aeson..= (1 :: Int), "packages" Aeson..= ([] :: [Aeson.Value])]))
+        `shouldBe` Just (Right (WorkflowResult (Aeson.object ["schemaVersion" Aeson..= (1 :: Int), "packages" Aeson..= ([] :: [Aeson.Value])])))
 
     it "decodes workflow-failed carrying an exitCode" $
       findingToWorkflowEvent (payloadFinding "{\"type\":\"workflow-failed\",\"reason\":\"workflow executable exited with code 3\",\"exitCode\":3,\"stderrTail\":\"boom\"}")
-        `shouldBe` Just (WorkflowFailed "workflow executable exited with code 3" "boom")
+        `shouldBe` Just (Right (WorkflowFailed "workflow executable exited with code 3" "boom"))
 
     it "decodes workflow-failed carrying a timeout" $
       findingToWorkflowEvent (payloadFinding "{\"type\":\"workflow-failed\",\"reason\":\"workflow executable ran longer than 900 seconds\",\"timeout\":\"total\",\"stderrTail\":\"boom\"}")
-        `shouldBe` Just (WorkflowFailed "workflow executable ran longer than 900 seconds" "boom")
+        `shouldBe` Just (Right (WorkflowFailed "workflow executable ran longer than 900 seconds" "boom"))
 
     it "ignores findings from another strategy" $
       findingToWorkflowEvent (FicusFinding (FicusMessageData "vendetta" "{\"type\":\"step-completed\",\"step\":\"module-discovery\"}"))
         `shouldBe` Nothing
+
+    it "keeps the raw payload of a workflow finding it cannot decode" $
+      findingToWorkflowEvent (payloadFinding "{\"type\":\"workflow-adjourned\"}")
+        `shouldBe` Just (Left "{\"type\":\"workflow-adjourned\"}")
 
     it "rejects an unrecognised event type rather than decoding it" $
       (Aeson.eitherDecodeStrictText "{\"type\":\"workflow-adjourned\"}" :: Either String WorkflowEvent)

--- a/test/Test/Fixtures.hs
+++ b/test/Test/Fixtures.hs
@@ -718,6 +718,7 @@ standardAnalyzeConfig =
     , ANZ.snippetScan = False
     , ANZ.debugDir = Nothing
     , ANZ.xVendetta = False
+    , ANZ.xWorkflow = Nothing
     }
 
 sampleJarParsedContent :: Text


### PR DESCRIPTION
# Overview

This PR adds an experimental `--x-workflow PATH` flag to `fossa analyze`. When it's set, the CLI builds a run artifact describing the analyzer to run, hands that artifact to the embedded `ficus` binary's `x-workflow` subcommand on stdin, streams the NDJSON observations ficus emits back, and records the workflow result in the debug bundle.

Nothing is uploaded. No endpoint accepts a workflow result yet, so this slice runs the analyzer locally and reports what happened — it does not change what `fossa analyze` sends to FOSSA. This is the CLI half of a runtime for running analysis workflows on the user's own machine; the ficus half, which adds the `x-workflow` subcommand and the run-artifact schema, is a corresponding change in the `ficus` repository (https://github.com/fossas/ficus/pull/188) and must be in the vendored binary for this flag to work.

The pieces:

- `--x-workflow PATH` on `fossa analyze`, resolved to an absolute path at config time. It's a config-time error to combine it with `--static-only-analysis`, matching the existing conflict with first-party scans.
- `App.Fossa.Ficus.Types` gains the run-artifact types (`WorkflowRunArtifact`, `WorkflowExecutable`) and the workflow event types the analyzer streams back (`WorkflowEvent`).
- `runFicus` is generalized in place into an exported `execFicusStreaming`, so the workflow path reuses the existing spawn/tee/stream machinery instead of adding a second spawner. Snippet-scan and vendetta behavior is unchanged.
- `App.Fossa.Ficus.Workflow` builds the artifact, runs the command, reports the streamed events, and stores the result under `bundleWorkflowResult` in the debug bundle.

A few decisions worth calling out for review:

**The CLI names the executable, not ficus.** ficus spawns whatever the run artifact tells it to, so choosing the program is the caller's job. A `.js`/`.mjs`/`.cjs` path is invoked as `node <path>`; any other path is used as the program directly. That split is forced rather than stylistic: ficus resolves `program` to a file and requires the executable bit, so a plain JS bundle can never be the program itself. The non-JS passthrough is both the wrapper-script escape hatch and the seam for a future bundled binary.

**The run artifact goes over stdin (`--config -`), deliberately**, so anything in it stays off the process table.

**A non-zero exit is fatal regardless of which observations arrived.** The pre-existing ficus path soft-fails a non-zero exit and keeps doing so; this path does not, because a run that silently succeeded while doing nothing is exactly the failure mode this feature exists to avoid. A clean exit with no result is fatal for the same reason. ficus also emits a terminal observation per run, but the exit code is what decides here: it is the one signal a truncated stream cannot lose. The failure is loud but scoped — it goes to stderr through the same error-boundary and `flushLogs` path ficus's own errors already use, so it does not hold the dependency upload hostage. It does not appear in the scan summary; widening `AnalysisScanResult` to carry it was deliberately left out of a change this size.

**ficus runs in a temp scratch directory, not the project.** The child writes a step cache and a per-run temp directory relative to its working directory, so it must not be the repository under analysis.

`--x-` is this repo's established experimental prefix (`--x-snippet-scan`, `--x-vendetta`): opt-in, exempt from semver guarantees, and removable in a patch release. The docs say so explicitly and point at the experimental options overview.

Out of scope, so review doesn't widen into it: uploading results anywhere, vendoring or embedding an analyzer bundle, entitlement or org gating, dependency-scope classification, and any server-side change. The analyzer this runs today ships deliberate stub steps, so this PR proves execution and plumbing rather than analysis.

## Acceptance criteria

- `fossa analyze --x-workflow ./analyzer.js` runs the named analyzer through the embedded ficus, logs the analyzer version, logs each completed step as it arrives, and finishes with `Workflow analysis complete`.
- With `--debug`, the result is readable as `bundleWorkflowResult` in `fossa.debug.json` inside `fossa.debug.zip`, and the raw analyzer stream is preserved as `fossa.ficus-workflow-stdout.log` / `fossa.ficus-workflow-stderr.log`.
- Nothing about the upload changes. Source units, endpoints, and payloads are identical with and without the flag.
- A path that doesn't exist fails immediately at config time, not partway through analysis.
- `--x-workflow` together with `--static-only-analysis` is an error naming both flags, not a silent skip.
- A failed or empty workflow run fails the command with a message naming the analyzer and the reason, with the tail of ficus's stderr in the log.
- Without `--x-workflow`, `fossa analyze` behaves exactly as before, including `--x-snippet-scan` and `--x-vendetta`.

## Not yet verified end to end

> [!IMPORTANT]
> The wiring is unit-tested and mutation-checked, but it has never run against a real ficus that understands `x-workflow`, because no published ficus carries it yet. `vendor_download.sh` requires a `GITHUB_TOKEN` unavailable here, and the ficus it fetches predates the corresponding change.
>
> Specifically unverified: invoking a program that exits non-zero (`--x-workflow /bin/false`), the full setup/trigger/inspect walk, and the debug-bundle diff.
>
> **This PR cannot be fully validated until a ficus build carrying the `x-workflow` subcommand is published as a vendored asset.** That is a later and separate event from the ficus change merging — merging it alone does not make this testable.

A reviewer does not have to wait for that, though. Build ficus from the branch carrying `x-workflow`, drop the binary at `vendor-bins/ficus`, and the end-to-end walk in step 4 below runs today. That is the same substitution PR #1680 used to review a ficus-dependent change before its binary shipped.

The sequencing is a real dependency between two changes, not a disclaimer. Merging this on the assumption that it works end to end against a stock checkout today would be wrong.

## Testing plan

Automated:

1. `cabal test unit-tests` — 22 new examples across `Ficus.WorkflowSpec` (run-artifact encoding, `.js`/`.mjs`/`.cjs` vs. passthrough program inference, event decoding including rejection of an unknown event type), `Ficus.WorkflowProcessSpec` (a fake ficus shell script: streaming, stdin delivery, non-zero exit reporting, debug-log basenames, and the three `analyzeWithWorkflow` outcomes), and four new `--x-workflow` cases in `App.Fossa.Config.AnalyzeSpec`.

   For the record on this run: at `HEAD` the suite reports 1501 examples with 37 failures; on `origin/master` in the identical environment it reports 1479 examples with 37 failures and an identical failure-name list. All 37 are vendor binaries missing because `vendor_download.sh` had not been run — they are not regressions, and all 22 new examples pass.

2. `make check-fmt-haskell` (fourmolu plus `cabal-fmt --check`) is clean, and `make fmt-haskell` is a byte-for-byte no-op. `make lint-haskell` reports `No hints`. `cargo fmt --check` and `cargo clippy` are clean.

3. Every new test was mutation-checked: renaming `workingDirectory` in the run artifact, emptying the stdin payload, replacing `failWorkflow` with `pure ()`, and removing the `--static-only-analysis` check each fail the corresponding test.

Manual. Steps 1 through 3 were run here against the real built binary. Steps 4 and 5 need a ficus that carries `x-workflow`, and have not been run — see the section above for how to get one today.

1. Build the CLI and confirm the flag renders:

   ```sh
   ./vendor_download.sh
   make build
   cabal run fossa -- analyze --help | grep x-workflow
   ```

2. Negative case, missing file — fails immediately with a path error, before any analysis runs:

   ```sh
   cabal run fossa -- analyze --output --x-workflow /definitely/not/here/analyzer.js /path/to/project
   ```

3. Negative case, flag conflict — fails at config time with a message naming both flags:

   ```sh
   cabal run fossa -- analyze --output --static-only-analysis --x-workflow ./analyzer.js /path/to/project
   ```

4. End to end. You need a ficus binary that carries the subcommand and a workflow analyzer bundle to point at. Until a build is published as a vendored asset, build ficus from the branch carrying `x-workflow` and substitute it:

   ```sh
   cd /path/to/ficus && cargo build --release
   cp /path/to/ficus/target/release/ficus /path/to/fossa-cli/vendor-bins/ficus
   ./vendor-bins/ficus x-workflow --help   # should succeed before going further
   ```

   Then run the analysis:

   ```sh
   cabal run fossa -- analyze --output --debug --x-workflow /path/to/analyzer.js /path/to/project
   ```

   Expect `Running workflow analyzer <version> (<program>)`, a line per completed step, then `Workflow analysis complete`. Then check the result landed and the upload didn't change:

   ```sh
   unzip -p fossa.debug.zip fossa.debug.json | jq '.bundleWorkflowResult'
   ```

5. Regression check that the shared spawner still behaves: run `--x-snippet-scan` and `--x-vendetta` as you would today and confirm output and debug logs are unchanged.

## Risks

- **This flag executes a program the user names, on their machine, with their privileges, against their project.** The CLI does not sandbox it and does not constrain what it does, including network access — `--output` suppresses the CLI's own upload, not a child process's traffic. The docs say this plainly under a Security heading. The `--static-only-analysis` conflict exists because that flag is the opt-out from exactly this, and this executes code.
- We could not verify the analyzer's network behavior from this repo, so the docs make no claim about egress in either direction.
- `execFicusStreaming` is the riskiest hunk: it's `runFicus` generalized in place, so a mistake there would show up in snippet-scan and vendetta rather than in the new flag. The generalization is parameterization (working directory, command, optional stdin, debug-log basename, fold step and seed) with the process setup, teeing, stderr draining, and soft exit-code handling preserved; please give that diff a careful read anyway.
- The run artifact's wire shape is pinned against ficus's parser, including `version: 1` (ficus rejects anything else rather than defaulting) and the lowercase key casing inside `executable`. If the ficus schema moves, this breaks at runtime rather than at compile time. `Ficus.WorkflowProcessSpec` rebuilds ficus's own observation envelope assertion locally to catch drift on the reply direction.
- Environment honesty: this was built and tested in `ghcr.io/fossas/haskell-dev-tools:9.8.4`, this repo's own CI image, on arm64. Linux is covered locally; the macOS and Windows legs are first exercised by CI. `Ficus.WorkflowProcessSpec` compiles to a no-op on Windows because its fake ficus is a `/bin/sh` script, so that spec's coverage is POSIX-only by construction.

## Metrics

Nothing to track yet, and nothing worth adding in this PR. The flag is opt-in, experimental, and uploads nothing, so there's no server-side signal to count. Once workflow results have somewhere to go, usage becomes measurable at that endpoint.

## References

- Corresponding change in the `ficus` repository, adding the `x-workflow` subcommand and the run-artifact schema. The vendored ficus binary must contain it for this flag to do anything.
- [`fossa analyze` reference: Dependency Usage Analysis with `--x-workflow`](./docs/references/subcommands/analyze.md)
- [Experimental options overview](./docs/references/experimental/README.md)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`.
- [ ] If this PR added docs, I added links as appropriate to the user manual's ToC in `docs/README.ms` and gave consideration to how discoverable or not my documentation is. — no new page: the new section lives in `docs/references/subcommands/analyze.md`, which is already linked from the ToC.
- [x] If this change is externally visible, I updated `Changelog.md`. If this PR did not mark a release, I added my changes into an `## Unreleased` section at the top.
- [ ] If I made changes to `.fossa.yml` or `fossa-deps.{json.yml}`, I updated `docs/references/files/*.schema.json` AND I have updated example files used by `fossa init` command. You may also need to update these if you have added/removed new dependency type (e.g. `pip`) or analysis target type (e.g. `poetry`). — no config-file or dependency-type changes.
- [x] If I made changes to a subcommand's options, I updated `docs/references/subcommands/<subcommand>.md`.
