### PR TITLE
Analyze: upload the --x-workflow result to the analysis service

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Workflows: `fossa analyze --x-workflow <path>` runs a dependency-usage workflow analyzer through the embedded ficus and records its result in the debug bundle. Nothing is uploaded. ([#1761](https://github.com/fossas/fossa-cli/pull/1761))
+- Workflows: the `--x-workflow` result is uploaded to FOSSA against the analyzed revision once the dependency upload succeeds; `--output` runs still upload nothing. ([#1762](https://github.com/fossas/fossa-cli/pull/1762))
 - Diagnostics: When an error or warning group contains multiple errors, each error's `Traceback:` header is now printed on its own line instead of being glued onto the last line of the preceding error message (e.g. `...none passed validationTraceback:`). ([#1758](https://github.com/fossas/fossa-cli/pull/1758))
 
 ## 3.18.2

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Workflows: `fossa analyze --x-workflow <path>` runs a dependency-usage workflow analyzer through the embedded ficus and records its result in the debug bundle. Nothing is uploaded. ([#1761](https://github.com/fossas/fossa-cli/pull/1761))
+- Workflows: `fossa analyze --x-workflow <path>` runs a dependency-usage workflow analyzer through the embedded ficus and records its result in the debug bundle. ([#1761](https://github.com/fossas/fossa-cli/pull/1761))
 - Workflows: the `--x-workflow` result is uploaded to FOSSA against the analyzed revision once the dependency upload succeeds; `--output` runs still upload nothing. ([#1762](https://github.com/fossas/fossa-cli/pull/1762))
 - Diagnostics: When an error or warning group contains multiple errors, each error's `Traceback:` header is now printed on its own line instead of being glued onto the last line of the preceding error message (e.g. `...none passed validationTraceback:`). ([#1758](https://github.com/fossas/fossa-cli/pull/1758))
 

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -208,14 +208,22 @@ is preserved alongside it in `fossa.ficus-workflow-stdout.log`.
 
 #### Failure behavior
 
-A workflow that fails — the analyzer exits non-zero, produces no result, or
-the embedded ficus rejects the run — does **not** fail `fossa analyze`. The
-command completes and exits 0; the failure is reported in the log, including
-the tail of ficus's stderr, and `bundleWorkflowResult` in the debug bundle is
-left empty. This is deliberate: a broken experimental analyzer must not block
-the dependency scan and upload. Check the log for
+`--x-workflow` has two distinct failure modes, and only one of them is silent.
+
+A workflow *run* that fails — the analyzer exits non-zero, produces no
+result, or the embedded ficus rejects the run — does **not** fail `fossa
+analyze`. The command still exits 0; the failure is reported in the log,
+including the tail of ficus's stderr, and `bundleWorkflowResult` in the debug
+bundle is left empty. This is deliberate: a broken experimental analyzer must
+not block the dependency scan and upload. Check the log for
 `The workflow analyzer at <path> did not produce a result` to confirm the run
 happened.
+
+A workflow result that fails to *upload* is different: it fails `fossa
+analyze` with a non-zero exit, as noted above. By the time that upload is
+attempted, the dependency upload has already succeeded and its report link
+already printed, so nothing already sent is lost — but the command itself
+reports failure, and CI sees the run as failed.
 
 #### Security
 

--- a/docs/references/subcommands/analyze.md
+++ b/docs/references/subcommands/analyze.md
@@ -179,13 +179,16 @@ scanning, or what information is sent to FOSSA's servers, see
 
 ### Dependency Usage Analysis with `--x-workflow`
 
-`--x-workflow` runs a dependency-usage workflow analyzer over the project and
-records its result in the debug bundle. The analyzer is a program you name on
+`--x-workflow` runs a dependency-usage workflow analyzer over the project,
+records its result in the debug bundle, and uploads it to FOSSA against the
+same revision as the dependency upload. The analyzer is a program you name on
 the command line; FOSSA CLI does not ship one yet, so this flag does nothing
 useful unless you already have an analyzer program or script to point it at.
 
-Results are not uploaded. Nothing about this flag changes what `fossa analyze`
-sends to FOSSA.
+The result is uploaded only when the analysis itself is uploaded, after the
+dependency upload succeeds; with `--output` nothing is sent. A result that
+fails to upload fails the run, but the dependency upload has already landed by
+then. Nothing else about this flag changes what `fossa analyze` sends to FOSSA.
 
 #### Enabling dependency usage analysis
 

--- a/src/App/Fossa/Analyze.hs
+++ b/src/App/Fossa/Analyze.hs
@@ -10,6 +10,7 @@ module App.Fossa.Analyze (
   -- * Helpers
   toProjectResult,
   applyFiltersToProject,
+  sendToDestination,
 
   -- * Fork alias translation (for testing)
 
@@ -428,14 +429,15 @@ analyze cfg = Diag.context "fossa-analyze" $ do
               (Config.debugDir cfg)
   let ficusResults = join $ resultToMaybe maybeFicusResults
 
-  -- Nothing is uploaded on this path, so a failure is loud but does not hold the
-  -- dependency upload hostage. Revisit when the result is data the user expects
-  -- to arrive.
+  -- A failed run is loud but does not hold the dependency upload hostage. The
+  -- result itself is uploaded from 'uploadSuccessfulAnalysis', because only the
+  -- locator the server issues there identifies the revision to the consumer.
   workflowResult <-
     Diag.errorBoundaryIO . diagToDebug $
-      traverse_
+      traverse
         (\analyzer -> Diag.context "x-workflow" $ Workflow.analyzeWithWorkflow basedir analyzer (Config.debugDir cfg))
         (Config.xWorkflow cfg)
+  let workflowData = join $ resultToMaybe workflowResult
 
   maybeLernieResults <-
     Diag.errorBoundaryIO . diagToDebug $
@@ -569,26 +571,36 @@ analyze cfg = Diag.context "fossa-analyze" $ do
       (False, FilteredAll) -> Diag.warn ErrFilteredAllProjects $> emptyScanUnits
       (True, FilteredAll) -> Diag.warn ErrOnlyKeywordSearchResultsFound $> emptyScanUnits
       (_, CountedScanUnits scanUnits) -> pure scanUnits
-  sendToDestination outputResult iatAssertion destination basedir jsonOutput revision scanUnits reachabilityUnits ficusResults
+  let doUpload (DestinationMeta (apiOpts, metadata)) =
+        Diag.context "upload-results"
+          . runFossaApiClient apiOpts
+          $ do
+            locator <- uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnits reachabilityUnits ficusResults workflowData
+            doAssertRevisionBinaries iatAssertion locator
+  sendToDestination doUpload destination outputResult
 
   pure outputResult
   where
-    sendToDestination result iatAssertion destination basedir jsonOutput revision scanUnits reachabilityUnits ficusResults =
-      let doUpload (DestinationMeta (apiOpts, metadata)) =
-            Diag.context "upload-results"
-              . runFossaApiClient apiOpts
-              $ do
-                locator <- uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnits reachabilityUnits ficusResults
-                doAssertRevisionBinaries iatAssertion locator
-       in case destination of
-            OutputStdout -> logStdout . decodeUtf8 $ Aeson.encode result
-            UploadScan meta -> doUpload meta
-            OutputAndUpload meta -> do
-              logStdout . decodeUtf8 $ Aeson.encode result
-              doUpload meta
-
     emptyScanUnits :: ScanUnits
     emptyScanUnits = SourceUnitOnly []
+
+-- | 'OutputStdout' has no API session and no server-issued locator, so nothing
+-- reaches the server from that branch, the workflow result included.
+sendToDestination ::
+  ( Has (Lift IO) sig m
+  , Has Logger sig m
+  ) =>
+  (DestinationMeta -> m ()) ->
+  ScanDestination ->
+  Aeson.Value ->
+  m ()
+sendToDestination upload destination result =
+  case destination of
+    OutputStdout -> logStdout . decodeUtf8 $ Aeson.encode result
+    UploadScan meta -> upload meta
+    OutputAndUpload meta -> do
+      logStdout . decodeUtf8 $ Aeson.encode result
+      upload meta
 
 toProjectResult :: DiscoveredProjectScan -> Maybe ProjectResult
 toProjectResult (SkippedDueToProvidedFilter _) = Nothing

--- a/src/App/Fossa/Analyze/Upload.hs
+++ b/src/App/Fossa/Analyze/Upload.hs
@@ -37,6 +37,7 @@ import Control.Effect.FossaApiClient (
   getSignedFirstPartyScanUrl,
   uploadAnalysis,
   uploadAnalysisWithFirstPartyLicenses,
+  uploadAnalysisWorkflow,
   uploadContributors,
   uploadFirstPartyScanResult,
  )
@@ -62,7 +63,7 @@ import Effect.Logger (
   logStdout,
   viaShow,
  )
-import Fossa.API.Types (Organization (orgSupportsReachability), Project (projectIsMonorepo), UploadResponse (..), orgFileUpload)
+import Fossa.API.Types (AnalysisWorkflowId (AnalysisWorkflowId), Organization (orgSupportsReachability), Project (projectIsMonorepo), UploadResponse (..), orgFileUpload)
 import Path (Abs, Dir, Path)
 import Srclib.Types (
   FullSourceUnit,
@@ -108,8 +109,9 @@ uploadSuccessfulAnalysis ::
   ScanUnits ->
   [SourceUnitReachability] ->
   Maybe FicusAnalysisResults ->
+  Maybe Aeson.Value ->
   m Locator
-uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnits reachabilityUnits ficusResults =
+uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnits reachabilityUnits ficusResults workflowData =
   context "Uploading analysis" $ do
     dieOnMonorepoUpload revision
     org <- getOrganization
@@ -150,6 +152,8 @@ uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnit
     -- Warn on contributor errors, never fail
     void . recover $ tryUploadContributors basedir (uploadLocator uploadResult)
 
+    uploadWorkflowResult locator workflowData
+
     when (fromFlag JsonOutput jsonOutput) $ do
       summary <-
         context "Analysis ran successfully, but the server returned invalid metadata" $
@@ -157,6 +161,23 @@ uploadSuccessfulAnalysis (BaseDir basedir) metadata jsonOutput revision scanUnit
       logStdout . decodeUtf8 $ Aeson.encode summary
 
     pure locator
+
+-- | The user asked for this result by naming an analyzer, so an upload that
+-- does not land fails the run rather than passing quietly. By this point the
+-- dependency upload has already succeeded and its report link is printed, so
+-- the failure costs nothing that was already sent.
+uploadWorkflowResult ::
+  ( Has Diagnostics sig m
+  , Has FossaApiClient sig m
+  , Has Logger sig m
+  ) =>
+  Locator ->
+  Maybe Aeson.Value ->
+  m ()
+uploadWorkflowResult locator = traverse_ $ \workflowData ->
+  context "Uploading workflow result" $ do
+    AnalysisWorkflowId workflowId <- uploadAnalysisWorkflow locator workflowData
+    logInfo $ "Uploaded workflow result for " <> pretty (renderLocator locator) <> " (id " <> pretty workflowId <> ")"
 
 uploadAnalysisWithFirstPartyLicensesToS3AndCore ::
   ( Has Diagnostics sig m

--- a/src/App/Fossa/Ficus/Workflow.hs
+++ b/src/App/Fossa/Ficus/Workflow.hs
@@ -32,8 +32,9 @@ import Effect.Logger (Logger, logDebug, logError, logInfo, pretty)
 import Path (Abs, Dir, File, Path, toFilePath)
 
 -- | Run the workflow analyzer at the given path over @target@ through
--- @ficus x-workflow@, streaming its observations. Nothing is uploaded: the
--- result lands in the debug bundle and nowhere else.
+-- @ficus x-workflow@, streaming its observations. The result is recorded in
+-- the debug bundle and returned for upload once the server has issued the
+-- revision locator; nothing is sent from here.
 analyzeWithWorkflow ::
   ( Has Debug sig m
   , Has Diagnostics sig m
@@ -43,7 +44,7 @@ analyzeWithWorkflow ::
   Path Abs Dir ->
   Path Abs File ->
   Maybe FilePath ->
-  m ()
+  m Aeson.Value
 analyzeWithWorkflow target analyzer maybeDebugDir =
   withFicusBinary $ \bin ->
     runWorkflowWith (workflowCommand . toText $ toPath bin) target analyzer maybeDebugDir
@@ -69,7 +70,7 @@ runWorkflowWith ::
   Path Abs Dir ->
   Path Abs File ->
   Maybe FilePath ->
-  m ()
+  m Aeson.Value
 runWorkflowWith cmd target analyzer maybeDebugDir =
   -- The child writes a step cache and a per-run temp directory relative to its
   -- working directory, so it must not be the repository under analysis.
@@ -89,6 +90,7 @@ runWorkflowWith cmd target analyzer maybeDebugDir =
         debugMetadata workflowResultJson result
         logDebug $ "Workflow result: " <> pretty (decodeUtf8 (Aeson.encode result) :: Text)
         logInfo "Workflow analysis complete"
+        pure result
       _ -> failWorkflow analyzer exitCode events stdErrLines
 
 workflowResult :: WorkflowEvent -> Maybe Aeson.Value
@@ -132,7 +134,7 @@ failWorkflow ::
   ExitCode ->
   [WorkflowEvent] ->
   [Text] ->
-  m ()
+  m a
 failWorkflow analyzer exitCode events stdErrLines = do
   logError . pretty $ Text.unlines (summary : stderrTail)
   fatalText summary

--- a/src/Control/Carrier/FossaApiClient.hs
+++ b/src/Control/Carrier/FossaApiClient.hs
@@ -101,6 +101,7 @@ runFossaApiClient apiOpts action = do
             -- Reachability
             UploadContentForReachability content -> Core.uploadReachabilityContent content
             UploadBuildForReachability rev metadata content -> Core.uploadReachabilityBuild rev metadata content
+            UploadAnalysisWorkflow locator workflowData -> Core.uploadAnalysisWorkflow locator workflowData
             GetTokenType -> Core.getTokenType
             GetCustomBuildPermissons rev metadata -> Core.getCustomBuildPermissions rev metadata
             -- Release Group

--- a/src/Control/Carrier/FossaApiClient/Internal/Core.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/Core.hs
@@ -36,6 +36,7 @@ module Control.Carrier.FossaApiClient.Internal.Core (
   addTeamProjects,
   updateRevision,
   getOrgLabels,
+  uploadAnalysisWorkflow,
 ) where
 
 import App.Fossa.Config.Report (ReportOutputFormat)
@@ -49,10 +50,12 @@ import Control.Effect.FossaApiClient (PackageRevision (..))
 import Control.Effect.Reader (Reader, ask)
 import Control.Monad (void)
 import Data.Aeson (ToJSON)
+import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy (ByteString)
 import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
 import Fossa.API.Types (
+  AnalysisWorkflowId,
   ApiOpts,
   Archive,
   Build,
@@ -92,6 +95,17 @@ getTokenType ::
 getTokenType = do
   apiOpts <- ask
   API.getTokenType apiOpts
+
+uploadAnalysisWorkflow ::
+  ( API.APIClientEffs sig m
+  , Has (Reader ApiOpts) sig m
+  ) =>
+  Locator ->
+  Aeson.Value ->
+  m AnalysisWorkflowId
+uploadAnalysisWorkflow locator workflowData = do
+  apiOpts <- ask
+  API.uploadAnalysisWorkflow apiOpts locator workflowData
 
 getCustomBuildPermissions ::
   ( API.APIClientEffs sig m

--- a/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
+++ b/src/Control/Carrier/FossaApiClient/Internal/FossaAPIV1.hs
@@ -43,6 +43,7 @@ module Control.Carrier.FossaApiClient.Internal.FossaAPIV1 (
   alreadyAnalyzedPathRevision,
   getTokenType,
   getCustomBuildUploadPermissions,
+  uploadAnalysisWorkflow,
   AnalysisService (..),
   APIClientEffs,
 
@@ -162,6 +163,8 @@ import Effect.Logger (
  )
 import Errata (Errata (..), errataSimple)
 import Fossa.API.Types (
+  AnalysisWorkflowId,
+  AnalysisWorkflowUpload (AnalysisWorkflowUpload),
   AnalyzedPathDependenciesResp,
   ApiOpts,
   Archive,
@@ -1561,6 +1564,29 @@ getEndpointVersion apiOpts = fossaReq $ do
   case parseXML (decodeUtf8 body) of
     Left err -> fatalText (xmlErrorPretty err)
     Right (appManifest :: AppManifest) -> pure $ endpointAppVersion appManifest
+
+---- Analysis workflow
+
+-- | The analysis service sits behind the same ingress path prefix as
+-- 'containerUploadUrl' for 'Sparkle': a plain path route, so the request and
+-- its bearer token arrive unchanged and the service resolves the org from the
+-- token.
+analysisWorkflowsEndpoint :: Url 'Https -> Url 'Https
+analysisWorkflowsEndpoint baseUrl = baseUrl /: "api" /: "proxy" /: "analysis" /: "api" /: "v1" /: "analysis-workflows"
+
+uploadAnalysisWorkflow ::
+  APIClientEffs sig m =>
+  ApiOpts ->
+  Locator ->
+  Aeson.Value ->
+  m AnalysisWorkflowId
+uploadAnalysisWorkflow apiOpts locator workflowData = fossaReq $ do
+  (baseUrl, baseOpts) <- useApiOpts apiOpts
+  let envelope = AnalysisWorkflowUpload locator workflowData
+  response <-
+    context ("Uploading the workflow result for " <> renderLocator locator) $
+      req POST (analysisWorkflowsEndpoint baseUrl) (ReqBodyJson envelope) jsonResponse baseOpts
+  pure (responseBody response)
 
 ---- Path Dependency
 

--- a/src/Control/Effect/FossaApiClient.hs
+++ b/src/Control/Effect/FossaApiClient.hs
@@ -24,6 +24,7 @@ module Control.Effect.FossaApiClient (
   getSignedFirstPartyScanUrl,
   getSignedLicenseScanUrl,
   uploadPathDependencyScan,
+  uploadAnalysisWorkflow,
   getSignedUploadUrl,
   getVsiInferences,
   getVsiScanAnalysisStatus,
@@ -71,12 +72,14 @@ import App.Types (ComponentUploadFileType, DependencyRebuild, FileUpload, Locato
 import Container.Types qualified as NativeContainer
 import Control.Algebra (Has)
 import Control.Carrier.Simple (Simple, sendSimple)
+import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy (ByteString)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Text (Text)
 import Fossa.API.Types (
+  AnalysisWorkflowId,
   AnalyzedPathDependency,
   ApiOpts,
   Archive,
@@ -171,6 +174,7 @@ data FossaApiClientF a where
   UploadFirstPartyScanResult :: SignedURL -> NE.NonEmpty FullSourceUnit -> FossaApiClientF ()
   UploadContentForReachability :: ByteString -> FossaApiClientF (Text)
   UploadBuildForReachability :: ProjectRevision -> ProjectMetadata -> [SourceUnitReachability] -> FossaApiClientF ()
+  UploadAnalysisWorkflow :: Locator -> Aeson.Value -> FossaApiClientF AnalysisWorkflowId
   DeleteReleaseGroup :: Int -> FossaApiClientF ()
   DeleteReleaseGroupRelease :: Int -> Int -> FossaApiClientF ()
   CreateReleaseGroup :: CoreTypes.CreateReleaseGroupRequest -> FossaApiClientF CoreTypes.CreateReleaseGroupResponse
@@ -263,6 +267,12 @@ getSignedLicenseScanUrl = sendSimple . GetSignedLicenseScanUrl
 
 uploadPathDependencyScan :: Has FossaApiClient sig m => PackageRevision -> ProjectRevision -> FileUpload -> m PathDependencyUpload
 uploadPathDependencyScan pkgRev projectRevision uploadKind = sendSimple $ GetPathDependencyScanUrl pkgRev projectRevision uploadKind
+
+-- | Stores a workflow result against a revision in the analysis service. The
+-- locator must be the server-issued one from 'UploadResponse', never one
+-- rendered client-side; see 'Fossa.API.Types.AnalysisWorkflowUpload'.
+uploadAnalysisWorkflow :: Has FossaApiClient sig m => Locator -> Aeson.Value -> m AnalysisWorkflowId
+uploadAnalysisWorkflow locator workflowData = sendSimple $ UploadAnalysisWorkflow locator workflowData
 
 finalizeLicenseScan :: Has FossaApiClient sig m => ArchiveComponents -> m ()
 finalizeLicenseScan = sendSimple . FinalizeLicenseScan

--- a/src/Fossa/API/Types.hs
+++ b/src/Fossa/API/Types.hs
@@ -35,6 +35,8 @@ module Fossa.API.Types (
   PathDependencyFinalizeReq (..),
   AnalyzedPathDependenciesResp (..),
   AnalyzedPathDependency (..),
+  AnalysisWorkflowUpload (..),
+  AnalysisWorkflowId (..),
   TokenType (..),
   TokenTypeResponse (..),
   Subscription (..),
@@ -859,6 +861,33 @@ useApiOpts opts = case useURI serverURI of
 
 authHeader :: ApiKey -> Option 'Https
 authHeader key = header "Authorization" (encodeUtf8 ("Bearer " <> unApiKey key))
+
+--- Analysis workflow
+
+-- | Envelope for @POST /api/proxy/analysis/api/v1/analysis-workflows@.
+--
+-- The locator must be the one the server returned for the revision upload
+-- ('uploadLocator'): core reads the row back by its own org-scoped
+-- @custom+<orgId>/<project>$<revision>@ string, and the analysis service matches
+-- it byte for byte. A locator rendered client-side has no org id, so its row
+-- is never found and nothing on either side reports it.
+data AnalysisWorkflowUpload = AnalysisWorkflowUpload
+  { analysisWorkflowLocator :: Locator
+  , analysisWorkflowData :: Value
+  }
+
+instance ToJSON AnalysisWorkflowUpload where
+  toJSON AnalysisWorkflowUpload{..} =
+    object
+      [ "revision_locator" .= analysisWorkflowLocator
+      , "workflow_data" .= analysisWorkflowData
+      ]
+
+newtype AnalysisWorkflowId = AnalysisWorkflowId {unAnalysisWorkflowId :: Text}
+  deriving (Eq, Ord, Show)
+
+instance FromJSON AnalysisWorkflowId where
+  parseJSON = withObject "AnalysisWorkflowId" $ \obj -> AnalysisWorkflowId <$> obj .: "id"
 
 --- Path Dependency
 

--- a/test/App/Fossa/Analyze/UploadSpec.hs
+++ b/test/App/Fossa/Analyze/UploadSpec.hs
@@ -11,9 +11,11 @@ import Control.Carrier.Simple (interpret)
 import Control.Effect.Diagnostics (fatalText)
 import Control.Effect.FossaApiClient (FossaApiClientF (..), PackageRevision (..))
 import Control.Effect.Git (GitF (FetchGitContributors))
+import Data.Aeson ((.=))
+import Data.Aeson qualified as Aeson
 import Data.Flag (toFlag)
 import Data.List.NonEmpty qualified as NE
-import Fossa.API.Types (Organization (..), Project (..), UploadResponse (..))
+import Fossa.API.Types (AnalysisWorkflowId (AnalysisWorkflowId), Organization (..), Project (..), UploadResponse (..))
 import Srclib.Types (FullSourceUnit (..), LicenseUnitInfo (..), Locator, emptyLicenseUnitData)
 import Test.Effect (expectFatal', it', shouldBe')
 import Test.Fixtures qualified as Fixtures
@@ -59,6 +61,15 @@ expectAnalysisUploadSuccess = UploadAnalysis Fixtures.projectRevision Fixtures.p
 expectContributorUploadSuccess :: Has MockApi sig m => m ()
 expectContributorUploadSuccess =
   UploadContributors expectedLocator Fixtures.contributors `alwaysReturns` ()
+
+workflowData :: Aeson.Value
+workflowData = Aeson.object ["modules" .= (3 :: Int)]
+
+-- | The workflow upload must carry the locator the server issued, not one
+-- rendered from the project name and revision.
+expectWorkflowUploadSuccess :: Has MockApi sig m => m ()
+expectWorkflowUploadSuccess =
+  UploadAnalysisWorkflow expectedLocator workflowData `returnsOnce` AnalysisWorkflowId "workflow-1"
 
 expectFirstPartyAnalysisUploadSuccess :: FileUpload -> Has MockApi sig m => m ()
 expectFirstPartyAnalysisUploadSuccess uploadKind = do
@@ -141,6 +152,7 @@ uploadSuccessfulAnalysisSpec = do
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
               Nothing
+              Nothing
           locator `shouldBe'` expectedLocator
       -- Currently our StdOut logging just writes directly to StdOut, so this is
       -- just checking it doesn't fail.  In the future we should extract that so
@@ -160,6 +172,7 @@ uploadSuccessfulAnalysisSpec = do
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
               Nothing
+              Nothing
           locator `shouldBe'` expectedLocator
       it' "performs reachability upload, if organization supports reachability"
         . withGit mockGit
@@ -177,6 +190,7 @@ uploadSuccessfulAnalysisSpec = do
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
               Nothing
+              Nothing
           locator `shouldBe'` expectedLocator
 
       it' "aborts when uploading to a monorepo"
@@ -191,6 +205,7 @@ uploadSuccessfulAnalysisSpec = do
             Fixtures.projectRevision
             (SourceUnitOnly Fixtures.sourceUnits)
             mempty
+            Nothing
             Nothing
       it' "continues if fetching the project fails"
         . withGit mockGit
@@ -210,6 +225,7 @@ uploadSuccessfulAnalysisSpec = do
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
               Nothing
+              Nothing
           locator `shouldBe'` expectedLocator
       it' "continues if fetching contributors fails"
         . withGit (\_ -> fatalText "Mocked failure of fetching contributors from git")
@@ -224,6 +240,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
+              Nothing
               Nothing
           locator `shouldBe'` expectedLocator
       it' "continues if uploading contributors fails"
@@ -240,6 +257,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (SourceUnitOnly Fixtures.sourceUnits)
               mempty
+              Nothing
               Nothing
           locator `shouldBe'` expectedLocator
       it' "uploads to S3 and to /api/builds/custom_with_first_party_licenses if there are licenses"
@@ -259,6 +277,7 @@ uploadSuccessfulAnalysisSpec = do
               (SourceAndLicenseUnits Fixtures.sourceUnits Fixtures.firstLicenseSourceUnit)
               mempty
               Nothing
+              Nothing
           locator `shouldBe'` expectedLocator
 
       it' "uploads to S3 and to /api/builds/custom_with_first_party_licenses if there are licenses and no targets were found"
@@ -277,6 +296,7 @@ uploadSuccessfulAnalysisSpec = do
               Fixtures.projectRevision
               (LicenseSourceUnitOnly Fixtures.firstLicenseSourceUnit)
               mempty
+              Nothing
               Nothing
           locator `shouldBe'` expectedLocator
 
@@ -299,7 +319,50 @@ uploadSuccessfulAnalysisSpec = do
               (SourceAndLicenseUnits Fixtures.sourceUnits Fixtures.firstLicenseSourceUnit)
               mempty
               Nothing
+              Nothing
           locator `shouldBe'` expectedLocator
+
+workflowUploadSpec :: Spec
+workflowUploadSpec =
+  describe
+    "uploadSuccessfulAnalysis with a workflow result"
+    $ do
+      baseDir <- runIO Fixtures.baseDir
+      it' "uploads the workflow result against the server-issued locator"
+        . withGit mockGit
+        $ do
+          expectGetSuccess
+          expectAnalysisUploadSuccess
+          expectContributorUploadSuccess
+          expectWorkflowUploadSuccess
+          locator <-
+            uploadSuccessfulAnalysis
+              baseDir
+              Fixtures.projectMetadata
+              (toFlag (JsonOutput) False)
+              Fixtures.projectRevision
+              (SourceUnitOnly Fixtures.sourceUnits)
+              mempty
+              Nothing
+              (Just workflowData)
+          locator `shouldBe'` expectedLocator
+      it' "fails the run when the workflow result does not land"
+        . withGit mockGit
+        $ do
+          expectGetSuccess
+          expectAnalysisUploadSuccess
+          expectContributorUploadSuccess
+          UploadAnalysisWorkflow expectedLocator workflowData `fails` "analysis service unavailable"
+          expectFatal' $
+            uploadSuccessfulAnalysis
+              baseDir
+              Fixtures.projectMetadata
+              (toFlag (JsonOutput) False)
+              Fixtures.projectRevision
+              (SourceUnitOnly Fixtures.sourceUnits)
+              mempty
+              Nothing
+              (Just workflowData)
 
 mergeSourceAndLicenseUnitsSpec :: Spec
 mergeSourceAndLicenseUnitsSpec =
@@ -313,5 +376,7 @@ mergeSourceAndLicenseUnitsSpec =
 spec :: Spec
 spec = do
   uploadSuccessfulAnalysisSpec
+
+  workflowUploadSpec
 
   mergeSourceAndLicenseUnitsSpec

--- a/test/App/Fossa/AnalyzeSpec.hs
+++ b/test/App/Fossa/AnalyzeSpec.hs
@@ -1,25 +1,54 @@
 module App.Fossa.AnalyzeSpec (spec) where
 
+import App.Fossa.Analyze (sendToDestination)
 import App.Fossa.Analyze.Discover (DiscoverFunc, discoverFuncs)
 import App.Fossa.Config.Analyze (StrategyConfig)
+import App.Fossa.Config.Common (DestinationMeta (DestinationMeta), ScanDestination (..))
 import App.Types (Mode, OverrideDynamicAnalysisBinary)
 import Control.Carrier.Debug (DebugC)
 import Control.Carrier.Diagnostics (DiagnosticsC)
 import Control.Carrier.Reader (ReaderC)
 import Control.Carrier.Stack (StackC)
+import Control.Carrier.State.Strict (runState)
 import Control.Carrier.Telemetry (TelemetryC)
+import Control.Effect.State (modify)
+import Data.Aeson qualified as Aeson
 import Discovery.Filters (AllFilters, MavenScopeFilters)
 import Effect.Exec (ExecIOC)
 import Effect.Logger (LoggerC)
 import Effect.ReadFS (ReadFSIOC)
+import Test.Effect (it', shouldBe')
+import Test.Fixtures qualified as Fixtures
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Type.Operator (type ($))
 
 type SomeMonad = TelemetryC $ ReaderC OverrideDynamicAnalysisBinary $ ReaderC StrategyConfig $ ReaderC MavenScopeFilters $ ReaderC Mode $ ReaderC AllFilters $ DebugC $ DiagnosticsC $ LoggerC $ ExecIOC $ ReadFSIOC $ StackC IO
 
 spec :: Spec
-spec =
+spec = do
   -- this test only exists to prevent merging the commented out analyzers
   describe "Discovery function list" $
     it "should be length 36" $
       length (discoverFuncs :: [DiscoverFunc SomeMonad]) `shouldBe` 36
+
+  sendToDestinationSpec
+
+-- | Runs under the mock API with no expectations, so any request the stdout
+-- branch made would fail the test on top of the upload count.
+sendToDestinationSpec :: Spec
+sendToDestinationSpec = describe "sendToDestination" $ do
+  let meta = DestinationMeta (Fixtures.apiOpts, Fixtures.projectMetadata)
+      result = Aeson.object []
+      countUploads destination = runState (0 :: Int) $ sendToDestination (\_ -> modify ((+ 1) :: Int -> Int)) destination result
+
+  it' "uploads nothing when the destination is stdout" $ do
+    (uploads, ()) <- countUploads OutputStdout
+    uploads `shouldBe'` 0
+
+  it' "uploads once for an upload destination" $ do
+    (uploads, ()) <- countUploads (UploadScan meta)
+    uploads `shouldBe'` 1
+
+  it' "uploads once when also writing to stdout" $ do
+    (uploads, ()) <- countUploads (OutputAndUpload meta)
+    uploads `shouldBe'` 1

--- a/test/Ficus/WorkflowProcessSpec.hs
+++ b/test/Ficus/WorkflowProcessSpec.hs
@@ -189,8 +189,9 @@ workflowSpec = describe "analyzeWithWorkflow" $ do
     cmd <- writeFakeFicus tmpDir [stepCompletedPayload] 0
     expectFatal' $ runWorkflowWith cmd tmpDir (analyzerBundle tmpDir) Nothing
 
-  itWithTempDir' "records the result in the debug bundle on success" $ \tmpDir -> do
+  itWithTempDir' "returns the result and records it in the debug bundle on success" $ \tmpDir -> do
     cmd <- writeFakeFicus tmpDir [workflowStartedPayload, stepCompletedPayload, workflowResultPayload] 0
-    (scope, ()) <- runDebug $ runWorkflowWith cmd tmpDir (analyzerBundle tmpDir) Nothing
+    (scope, result) <- runDebug $ runWorkflowWith cmd tmpDir (analyzerBundle tmpDir) Nothing
+    result `shouldBe'` expectedResult
     Map.lookup workflowResultJson (scopeMetadata scope) `shouldBe'` Just expectedResult
 #endif

--- a/test/Fossa/API/TypesSpec.hs
+++ b/test/Fossa/API/TypesSpec.hs
@@ -4,9 +4,10 @@ import Data.Aeson (FromJSON, ToJSON, Value (Object), fromJSON, toJSON)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Text (Text)
-import Fossa.API.Types (Issue (..), IssueRule (..), IssueSummaryRevision (..), IssueSummaryTarget (..), IssueType (..), Issues (..), IssuesSummary (..), Organization (..))
+import Fossa.API.Types (AnalysisWorkflowId (AnalysisWorkflowId), AnalysisWorkflowUpload (AnalysisWorkflowUpload), Issue (..), IssueRule (..), IssueSummaryRevision (..), IssueSummaryTarget (..), IssueType (..), Issues (..), IssuesSummary (..), Organization (..))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+import Srclib.Types (Locator (Locator))
 import Test.Hspec
 import Test.Hspec.Hedgehog
 import Prelude
@@ -14,11 +15,25 @@ import Prelude
 spec :: Spec
 spec = do
   organizationParsingSpec
+  analysisWorkflowSpec
   describe "Issues ToJSON/FromJSON instances" $ do
     it "are roundtrippable" $
       hedgehog $ do
         issues <- forAll genIssues
         roundtripJson issues
+
+-- | The wire contract with the analysis service: an envelope whose locator is
+-- the server's org-scoped string, rendered verbatim.
+analysisWorkflowSpec :: Spec
+analysisWorkflowSpec = describe "analysis workflow API types" $ do
+  it "encodes the upload as the envelope the analysis service parses" $ do
+    let locator = Locator "custom" "123/github.com/fossas/repo" (Just "abc123")
+        workflowData = Object $ KeyMap.fromList [("modules", Aeson.Number 3)]
+    Aeson.encode (AnalysisWorkflowUpload locator workflowData)
+      `shouldBe` "{\"revision_locator\":\"custom+123/github.com/fossas/repo$abc123\",\"workflow_data\":{\"modules\":3}}"
+
+  it "reads the id the analysis service returns" $
+    Aeson.decode "{\"id\":\"42\"}" `shouldBe` Just (AnalysisWorkflowId "42")
 
 organizationParsingSpec :: Spec
 organizationParsingSpec = describe "Organization JSON parsing" $ do

--- a/test/Test/MockApi.hs
+++ b/test/Test/MockApi.hs
@@ -235,6 +235,7 @@ matchExpectation a@(FinalizeLicenseScanForPathDependency{}) (ApiExpectation _ re
 matchExpectation a@(GetAnalyzedPathRevisions{}) (ApiExpectation _ requestExpectation b@(GetAnalyzedPathRevisions{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(UploadContentForReachability{}) (ApiExpectation _ requestExpectation b@(UploadContentForReachability{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(UploadBuildForReachability{}) (ApiExpectation _ requestExpectation b@(UploadBuildForReachability{}) resp) = checkResult requestExpectation a b resp
+matchExpectation a@(UploadAnalysisWorkflow{}) (ApiExpectation _ requestExpectation b@(UploadAnalysisWorkflow{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetTokenType{}) (ApiExpectation _ requestExpectation b@(GetTokenType{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(GetCustomBuildPermissons{}) (ApiExpectation _ requestExpectation b@(GetCustomBuildPermissons{}) resp) = checkResult requestExpectation a b resp
 matchExpectation a@(DeleteReleaseGroup{}) (ApiExpectation _ requestExpectation b@(DeleteReleaseGroup{}) resp) = checkResult requestExpectation a b resp


### PR DESCRIPTION
# Overview

Stacked on #1761: the base is `cf/x-workflow-cli-wiring`, not `master`, so the diff shown here is only this change. Rebase onto `master` once #1761 merges.

#1761 runs the `--x-workflow` analyzer and records the result in the debug bundle. This PR uploads it. The result goes to the analysis service as `POST /api/proxy/analysis/api/v1/analysis-workflows` with body `{"revision_locator": <locator>, "workflow_data": <result>}`, and the service answers `201 {"id": ...}`. The route is the same bare ingress prefix `containerUploadUrl Sparkle` already uses from this client: no rewrite, no header changes, so the CLI's own API key passes through and the service resolves the org from it.

Two decisions carry the whole PR.

**The locator is the server's, never the CLI's.** Core reads the row back by its own `Revision.locator`, which is `custom+<orgId>/<project>$<rev>`. Everything the CLI renders itself via `renderLocator (Locator "custom" projectName ...)`, the pattern at nine other call sites including the adjacent ficus one, has no org id. The service stores and matches the string byte for byte, so a client-built locator gets a 201, core's lookup 404s, core's consumer is fail-open, and nothing errors anywhere. The only org-scoped locator the CLI ever holds is `uploadLocator` from the dependency upload response, so the POST uses that and nothing else. The envelope type's doc comment records this so the next person doesn't reach for `renderLocator`.

**So the call site moves into `uploadSuccessfulAnalysis`.** The analyzer still runs where #1761 put it, before the upload and outside the API client; it now returns the result instead of `()`. The POST happens after the dependency upload has landed and its report link is printed, so a failed workflow upload cannot cost anything already sent, but it does fail the run: the user asked for this result by naming an analyzer, and a run that quietly dropped it is the failure mode this feature exists to avoid. A failed analyzer *run* keeps #1761's semantics (logged at error, dependency upload proceeds, no POST). `--output` has no API session and no locator, so it uploads nothing; there is no fallback.

Plumbing: `AnalysisWorkflowUpload` / `AnalysisWorkflowId` in `Fossa.API.Types`, `uploadAnalysisWorkflow` in `FossaAPIV1` modelled on `getUploadURLForPathDependency`, an `UploadAnalysisWorkflow` effect constructor with the usual Core wrapper, carrier dispatch, and mock matcher, and `sendToDestination` lifted to a top-level function that takes the upload action so the destination dispatch is testable.

**Redirects.** ficus re-POSTs to `Location` itself on 301/302 (fossas/ficus#146). What `req` does here: `httpConfigRetryTimeouts` is `defaultHttpConfig` plus a retry policy, so redirects are followed (count 10), and http-client rewrites a POST to GET on 302/303. That is the CLI's existing behavior for every POST it makes, including the dependency upload this one follows. The ficus change was about customer-side forward proxies, not our ingress: the ingress route is a plain path prefix and the service route is an exact typed path, and neither redirects. So this PR does not special-case it; a customer proxy that 302s POSTs would already break `fossa analyze` before this call runs. Worth knowing, not worth diverging from the rest of the client for.

Out of scope: ficus, new-horizons, core, and Sparkle; anything on #1761 beyond stacking; vendoring the analyzer; entitlement gating; what `fossa analyze` already uploads.

## Acceptance criteria

- `fossa analyze --x-workflow ./analyzer.js` in upload mode uploads dependencies as before, then logs `Uploaded workflow result for custom+<orgId>/<project>$<rev> (id <id>)`, and core's `getAnalysisWorkflowMetadata` for that revision finds the row.
- The POSTed `revision_locator` is byte-identical to `SELECT locator FROM revisions` for that upload. Do not verify by GETting it back with the same string; that passes for the wrong string too.
- With `--output`, no request reaches `/api/proxy/analysis/`.
- A workflow upload failure prints the diagnostic and exits non-zero; the dependency upload and its report link are already there.
- A failed analyzer run behaves exactly as on #1761.
- Without `--x-workflow`, nothing changes.

## Testing plan

Ran in `ghcr.io/fossas/haskell-dev-tools:9.8.4`:

- `fourmolu --mode check`, `hlint`, `cabal-fmt --check`: clean.
- `cabal test unit-tests`: 1511 examples, 37 failures, all the pre-existing missing-vendor-binary set on `origin/master` (same list, checked by diff), 0 new.

New tests, each mutation-checked (break the code, confirm red):

| Test | Mutation | Result |
|---|---|---|
| `Fossa.API.TypesSpec`: envelope golden bytes | rename the `revision_locator` key | red |
| `UploadSpec`: uploads against the server-issued locator | build the locator from `projectName`/`projectRevision` | red; failure names `custom+testProjectName$testRevision` |
| `UploadSpec`: fails the run when the upload does not land | wrap the POST in `recover` | red |
| `AnalyzeSpec`: `sendToDestination` uploads once | upload twice on `UploadScan` | red |
| `WorkflowProcessSpec`: returns the result | return `Aeson.Null` | red |

The stdout test runs under the mock API with zero expectations, so any request from that branch fails it. I could not write a compiling mutation that uploads from the stdout branch, because there is no `DestinationMeta` to upload with; that is the type-level version of the same guarantee, and the test is there to catch a future seam that adds one.

Not run end to end: same constraint as #1761 (no vendored ficus with `x-workflow` here), plus this needs a Sparkle carrying fossas/sparkle#1380 and a core carrying fossas/FOSSA#18874. The walk once those line up: upload mode against staging, then compare the POSTed locator to core's `revisions.locator` for that build.

## Risks

- The locator contract is the whole risk, and it fails silently by design of the consumer. The unit test pins the server-issued locator; the acceptance step above is the only way to check it against real data.
- Ordering: the POST runs before the `--json` summary and before the IAT binary assertion, so a failed POST skips both. Intentional (a success summary should mean everything landed), but say so if you disagree.

## Metrics

None added. The `Uploaded workflow result` info line and `bundleWorkflowResult` in the debug bundle are the observability today.

## References

- #1761 (base of this stack)
- fossas/ficus#188, fossas/new-horizons#2509, fossas/sparkle#1380, fossas/FOSSA#18874
- fossas/ficus#146 (redirect handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuyMinx7mYLWANRniWrixE
