### PR TITLE
CI: install liblzma-dev for the dependency scan

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -11,6 +11,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # The `lzma` package has a manual `pkgconfig` flag that cabal cannot turn
+      # off, so solving the install plan requires `liblzma.pc` to be present.
+      # The Linux build job gets this from its Alpine container; this job runs
+      # on a bare runner, so install it explicitly.
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config liblzma-dev
+
       - name: Install and set GHC and Cabal versions
         # The first line works around a ghcup issue:
         # https://github.com/actions/runner-images/issues/7061#issuecomment-1422639889


### PR DESCRIPTION
# Overview

The `dependency-scan` job has been failing at `fossa analyze --only-target cabal` with a solver error:

```
[__3] rejecting: lzma:+pkgconfig (conflict: pkg-config package liblzma>=5.2.2, not found in the pkg-config database)
[__3] rejecting: lzma:-pkgconfig (manual flag can only be changed explicitly)
```

The `lzma` package declares its `pkgconfig` flag as manual, so cabal cannot turn it off during solving. That means solving requires `liblzma.pc`, which ships in `liblzma-dev`. The cabal analyzer runs `cabal v2-build all --dry-run`, which solves, so the scan fails before it can read the install plan.

The Linux build job in `build-all.yml` never hit this because it runs inside the `fossa/haskell-static-alpine` container, which already has the development headers. The dependency scan runs on a bare `ubuntu-latest` runner, whose image carries the `liblzma5` runtime but not the `.pc` file. This PR installs `pkg-config` and `liblzma-dev` before GHC and cabal are set up.

## Acceptance criteria

The `dependency-scan` job solves the cabal install plan and uploads results instead of erroring out.

## Testing plan

1. Push this branch and let the `Dependency scan` workflow run.
2. Confirm the `Run dependency scan` step reports both the cabal and cargo targets and exits zero.
3. Confirm the `Check for scan results` step passes.

To reproduce the failure locally, run `cabal v2-build all --dry-run` on a machine without `liblzma-dev` and watch the same `Cabal-7107` conflict set appear.

## Risks

This is not verified by a local run. My reasoning comes from the solver's own conflict set and the container difference between the two jobs, so the CI run on this branch is the real check.

Installing `liblzma-dev` shifts the scanned system dependency surface slightly, but the cabal target reads the install plan rather than system packages, so the reported dependency graph should not change.

## Metrics

Not applicable.

## References

None.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense). This is a CI workflow change; the workflow run itself is the test.
- [x] If this PR introduced a user-visible change, I added documentation into `docs/`. No user-visible change.
- [x] If this PR added docs, I added links as appropriate to the user manual's ToC. No docs added.
- [x] If this change is externally visible, I updated `Changelog.md`. Not externally visible.
- [x] If I made changes to `.fossa.yml` or `fossa-deps.{json,yml}`, I updated the schemas. No such changes.
- [x] If I made changes to a subcommand's options, I updated the subcommand docs. No such changes.